### PR TITLE
feat(testing-sdk): Support `ReplayChildren` for context operations

### DIFF
--- a/dex-internal-sdk/.gitignore
+++ b/dex-internal-sdk/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 /build
 /dist
-/dist-cjs
 /coverage
 .husky
 *.iml

--- a/dex-internal-sdk/dist-types/commands/CheckpointDurableExecutionCommand.d.ts
+++ b/dex-internal-sdk/dist-types/commands/CheckpointDurableExecutionCommand.d.ts
@@ -78,6 +78,9 @@ declare const CheckpointDurableExecutionCommand_base: {
  *           "STRING_VALUE",
  *         ],
  *       },
+ *       ContextOptions: { // ContextOptions
+ *         ReplayChildren: true || false,
+ *       },
  *       StepOptions: { // StepOptions
  *         NextAttemptDelaySeconds: Number("int"),
  *       },
@@ -116,6 +119,7 @@ declare const CheckpointDurableExecutionCommand_base: {
  * //           InputPayload: "STRING_VALUE",
  * //         },
  * //         ContextDetails: { // ContextDetails
+ * //           ReplayChildren: true || false,
  * //           Result: "STRING_VALUE",
  * //           Error: { // ErrorObject
  * //             ErrorMessage: "STRING_VALUE",

--- a/dex-internal-sdk/dist-types/commands/GetDurableExecutionStateCommand.d.ts
+++ b/dex-internal-sdk/dist-types/commands/GetDurableExecutionStateCommand.d.ts
@@ -81,6 +81,7 @@ declare const GetDurableExecutionStateCommand_base: {
  * //         InputPayload: "STRING_VALUE",
  * //       },
  * //       ContextDetails: { // ContextDetails
+ * //         ReplayChildren: true || false,
  * //         Result: "STRING_VALUE",
  * //         Error: { // ErrorObject
  * //           ErrorMessage: "STRING_VALUE",

--- a/dex-internal-sdk/dist-types/models/models_0.d.ts
+++ b/dex-internal-sdk/dist-types/models/models_0.d.ts
@@ -160,6 +160,12 @@ export type OperationAction =
 /**
  * @public
  */
+export interface ContextOptions {
+  ReplayChildren?: boolean | undefined;
+}
+/**
+ * @public
+ */
 export interface InvokeOptions {
   FunctionName?: string | undefined;
   FunctionQualifier?: string | undefined;
@@ -205,6 +211,7 @@ export interface OperationUpdate {
   Action?: OperationAction | undefined;
   Payload?: string | undefined;
   Error?: ErrorObject | undefined;
+  ContextOptions?: ContextOptions | undefined;
   StepOptions?: StepOptions | undefined;
   WaitOptions?: WaitOptions | undefined;
   CallbackOptions?: CallbackOptions | undefined;
@@ -234,6 +241,7 @@ export declare const CheckpointDurableExecutionRequestFilterSensitiveLog: (
  * @public
  */
 export interface ContextDetails {
+  ReplayChildren?: boolean | undefined;
   Result?: string | undefined;
   Error?: ErrorObject | undefined;
 }

--- a/dex-internal-sdk/package.json
+++ b/dex-internal-sdk/package.json
@@ -8,12 +8,12 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
-    "clean": "node_modules/.bin/rimraf ./dist-* && rimraf *.tsbuildinfo || exit 0",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo || exit 0",
     "prepack": "npm run clean && npm run build"
   },
-  "main": "dist-cjs/index.js",
+  "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",
-  "module": "dist-es/index.js",
+  "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
     "tslib": "^2.6.2",

--- a/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/__tests__/checkpoint-server.test.ts
+++ b/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/__tests__/checkpoint-server.test.ts
@@ -349,10 +349,7 @@ describe("checkpoint-server", () => {
       ];
 
       const mockStorage = {
-        operationDataMap: new Map([
-          ["op1", { operation: mockOperations[0] }],
-          ["op2", { operation: mockOperations[1] }],
-        ]),
+        getState: jest.fn().mockReturnValue(mockOperations),
       };
 
       mockExecutionManager.getCheckpointsByToken.mockReturnValueOnce({

--- a/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/checkpoint-server.ts
+++ b/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/checkpoint-server.ts
@@ -189,12 +189,8 @@ export async function startCheckpointServer(port: number) {
       return;
     }
 
-    const operations = Array.from(
-      executionData.storage.operationDataMap.values()
-    ).map((operationData) => operationData.operation);
-
     const output: GetDurableExecutionStateResponse = {
-      Operations: operations,
+      Operations: executionData.storage.getState(),
       NextMarker: undefined,
     };
 


### PR DESCRIPTION
*Description of changes:*

Adding support for `ReplayChildren` for context operations in testing library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
