### PR TITLE
Set private=true in package.json to prevent accidental publishes to n…

### DIFF
--- a/dex-internal-sdk/package.json
+++ b/dex-internal-sdk/package.json
@@ -84,5 +84,6 @@
   },
   "react-native": {
     "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.native"
-  }
+  },
+  "private": true
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -54,5 +54,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.29.0"
-  }
+  },
+  "private": true
 }

--- a/lambda-durable-functions-sdk-js/package.json
+++ b/lambda-durable-functions-sdk-js/package.json
@@ -67,5 +67,6 @@
     "@aws-sdk/credential-provider-node": {
       "optional": false
     }
-  }
+  },
+  "private": true
 }

--- a/lambda-durable-functions-testing-sdk-js/package.json
+++ b/lambda-durable-functions-testing-sdk-js/package.json
@@ -59,5 +59,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix"
-  }
+  },
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "bugs": {
     "url": "https://github.com/aws/lambda-durable-functions-js/issues"
   },
-  "private": true,
   "homepage": "https://github.com/aws/lambda-durable-functions-js/blob/test-hsilan/README.md",
   "devDependencies": {
     "@eslint/compat": "^1.3.0",
@@ -55,5 +54,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
…pm registry

*Issue #, if available:*

*Description of changes:* Set `"private": true` in package.json to prevent accidental publishes to  npm registry


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
