### PR TITLE
feat: replace ADAPTIVE_EMPTY_RESULT with ReplayChildren flag

### DIFF
--- a/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
+++ b/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
@@ -298,22 +298,24 @@ describe("Run In Child Context Integration Tests", () => {
     expect(checkpointCalls[1].data.Updates[0].Name).toBe(
       "test-large-child-context",
     );
-    expect(checkpointCalls[1].data.Updates[0].Payload).toBe(
-      "__LARGE_PAYLOAD__",
-    );
+    expect(checkpointCalls[1].data.Updates[0].Payload).toBe("");
+    expect(checkpointCalls[1].data.Updates[0].ContextOptions).toEqual({
+      ReplayChildren: true,
+    });
   });
 
-  test("should re-execute on replay when adaptive mode has empty result", async () => {
+  test("should re-execute on replay when ReplayChildren is true", async () => {
     const largePayload = "x".repeat(300 * 1024); // 300KB string
     let executionCount = 0;
 
-    // Set up completed step data with empty result (simulating large payload checkpoint)
+    // Set up completed step data with ReplayChildren flag
     mockExecutionContext._stepData = {
       [hashId("1")]: {
         Id: "1",
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {
-          Result: "__LARGE_PAYLOAD__", // Empty string indicates large payload in adaptive mode
+          Result: "[Large payload summary]",
+          ReplayChildren: true, // This triggers re-execution
         },
       },
     };

--- a/lambda-durable-functions-sdk-js/src/types/index.ts
+++ b/lambda-durable-functions-sdk-js/src/types/index.ts
@@ -187,6 +187,9 @@ export interface StepConfig<T> {
 export interface ChildConfig<T = any> {
   serdes?: Serdes<T>;
   subType?: string;
+  // summaryGenerator Will be used internall to create a summary for 
+  // ctx.map and ctx.parallel when result is big
+  summaryGenerator?: (result: T) => string; 
 }
 
 export interface CreateCallbackConfig {


### PR DESCRIPTION
# ReplayChildren Implementation for Run-in-Child-Context Handler

This change replaces the previous `ADAPTIVE_EMPTY_RESULT` marker approach with `ReplayChildren` flag mechanism for handling large payloads in child context operations.

## Key Changes

### 1. **ChildConfig Interface Enhancement**
- Added `summaryGenerator?: (result: T) => string` option
- summaryGenerator Will be used internall to create a summary for ctx.map and ctx.parallel when result is big
- **Note**: `summaryGenerator` receives the **raw result** (before serialization)

### 2. **Checkpoint Behavior Update**
- **Before**: Used magic string `"__LARGE_PAYLOAD__"` as payload marker
- **After**: Uses `ContextOptions: { ReplayChildren: true }` flag with empty string payload (or custom summary)

### 3. **Replay Detection Logic**
- **Before**: `if (result === ADAPTIVE_EMPTY_RESULT)`
- **After**: `if (stepData?.ContextDetails?.ReplayChildren)`

### 4. **Data Flow Details**
- **Size Check**: Uses **serialized result** (after `serdes.serialize()`) to determine if payload > 256KB
- **summaryGenerator**: Receives **raw result** (before serialization) for flexible summary creation

## Workflow Diagram

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    Child Context Execution Flow                             │
└─────────────────────────────────────────────────────────────────────────────┘

                              ┌─────────────────┐
                              │  Execute Child  │
                              │    Context      │
                              └─────────┬───────┘
                                        │
                              ┌─────────▼───────┐
                              │ Raw Result (T)  │
                              │                 │
                              └─────────┬───────┘
                                        │
                              ┌─────────▼───────┐
                              │ Apply Serdes    │
                              │ Serialization   │
                              │ result → string │
                              └─────────┬───────┘
                                        │
                              ┌─────────▼───────┐
                              │ Check Serialized│
                              │ Payload Size    │
                              │ > 256KB?        │
                              └─────┬───────┬───┘
                                    │       │
                               NO   │       │ YES
                                    │       │
                    ┌───────────────▼─┐   ┌─▼──────────────────┐
                    │ Normal          │   │ Large Payload      │
                    │ Checkpoint      │   │ Handling           │
                    │                 │   │                    │
                    │ Payload:        │   │ ReplayChildren:    │
                    │ serialized data │   │ true               │
                    │ ReplayChildren: │   │                    │
                    │ undefined       │   │                    │
                    └───────────────┬─┘   └─┬──────────────────┘
                                    │       │
                                    │   ┌───▼──────────────────┐
                                    │   │ summaryGenerator     │
                                    │   │ provided?            │
                                    │   │ (gets RAW result)    │
                                    │   └───┬──────────┬───────┘
                                    │       │          │
                                    │   YES │          │ NO
                                    │       │          │
                                    │   ┌───▼────┐ ┌───▼────┐
                                    │   │Custom  │ │Empty   │
                                    │   │Summary │ │String  │
                                    │   │from    │ │""      │
                                    │   │raw data│ │        │
                                    │   └───┬────┘ └───┬────┘
                                    │       │          │
                                    └───────┼──────────┘
                                            │
                              ┌─────────────▼─────────────┐
                              │     Checkpoint Saved      │
                              └─────────────┬─────────────┘
                                            │
                              ┌─────────────▼─────────────┐
                              │      On Replay...         │
                              └─────────────┬─────────────┘
                                            │
                              ┌─────────────▼─────────────┐
                              │ Check ReplayChildren      │
                              │ flag in ContextDetails    │
                              └─────┬───────────┬─────────┘
                                    │           │
                               FALSE│           │TRUE
                                    │           │
                    ┌───────────────▼─┐   ┌─────▼──────────────┐
                    │ Return Cached   │   │ Re-execute Child   │
                    │ Result from     │   │ Context Function   │
                    │ Checkpoint      │   │ (Reconstruct       │
                    │ (deserialize)   │   │ Full Result)       │
                    └─────────────────┘   └────────────────────┘
```

## Data Flow Summary

1. **Execute** child context function → Raw result `T`
2. **Serialize** result using serdes → `string`
3. **Check size** of serialized string
4. **If large**: Call `summaryGenerator(rawResult)` → custom summary
5. **Checkpoint** with ReplayChildren flag and summary/empty payload
6. **On replay**: Check ReplayChildren flag to decide re-execution


### Checklist

- [Y] I have filled out every section of the PR template
- [Y] I have thoroughly tested this change


### Testing

#### Unit Tests
Yes
