### PR TITLE
Fix/avoid redundant checkpoints

### DIFF
--- a/packages/lambda-durable-functions-sdk-js/bundle-size-history.json
+++ b/packages/lambda-durable-functions-sdk-js/bundle-size-history.json
@@ -188,5 +188,10 @@
     "timestamp": "2025-09-03T22:20:22.674Z",
     "size": 213216,
     "gitCommit": "c0034633240ceb29e00fd34c67f0d33cfe0a6714"
+  },
+  {
+    "timestamp": "2025-09-04T17:42:40.403Z",
+    "size": 214426,
+    "gitCommit": "9801dc79f2a4a980f971e2de1b85aa23b4c7a579"
   }
 ]

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -815,13 +815,13 @@ describe("Mock Integration", () => {
   test("should use custom summaryGenerator for large payloads", async () => {
     const largePayload = { data: "x".repeat(300000) };
     const childFn = jest.fn().mockResolvedValue(largePayload);
-    const summaryGenerator = jest.fn().mockReturnValue("Custom summary of large data");
+    const summaryGenerator = jest
+      .fn()
+      .mockReturnValue("Custom summary of large data");
 
-    await runInChildContextHandler(
-      TEST_CONSTANTS.CHILD_CONTEXT_NAME,
-      childFn,
-      { summaryGenerator },
-    );
+    await runInChildContextHandler(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn, {
+      summaryGenerator,
+    });
 
     expect(summaryGenerator).toHaveBeenCalledWith(largePayload);
     expect(mockCheckpoint).toHaveBeenNthCalledWith(

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -181,20 +181,20 @@ export const executeChildContext = async <T>(
     // Check if payload is too large for adaptive mode
     let payloadToCheckpoint = serializedResult;
     let replayChildren = false;
-    
+
     if (
       serializedResult &&
       Buffer.byteLength(serializedResult, "utf8") > CHECKPOINT_SIZE_LIMIT
     ) {
       replayChildren = true;
-      
+
       // Use summary generator if provided, otherwise use empty string
       if (options?.summaryGenerator) {
         payloadToCheckpoint = options.summaryGenerator(result);
       } else {
         payloadToCheckpoint = "";
       }
-      
+
       log(
         context.isVerbose,
         "📦",

--- a/packages/lambda-durable-functions-sdk-js/src/types/index.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/types/index.ts
@@ -187,9 +187,9 @@ export interface StepConfig<T> {
 export interface ChildConfig<T = any> {
   serdes?: Serdes<T>;
   subType?: string;
-  // summaryGenerator Will be used internall to create a summary for 
+  // summaryGenerator will be used internally to create a summary for
   // ctx.map and ctx.parallel when result is big
-  summaryGenerator?: (result: T) => string; 
+  summaryGenerator?: (result: T) => string;
 }
 
 export interface CreateCallbackConfig {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

SIM ticket: DAR-SDK-242

### Description

- Skip START checkpoint when operation status is already STARTED to prevent redundant checkpointing on retries
- Add READY status support for state restoration in wait-for-condition handler to maintain state continuity across timer completions
- Replace hardcoded Action strings with OperationAction constants (START, SUCCEED, RETRY) for type safety
- Add test for PENDING status scenarios in both step-handler and wait-for-condition-handler

### Checklist

- [Y] I have filled out every section of the PR template
- [Y] I have thoroughly tested this change


### Testing

#### Unit Tests
Yes
