### PR TITLE
feat: add running operations tracking to prevent unsafe termination

### DIFF
--- a/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -138,8 +138,19 @@ describe("Durable Context", () => {
       mockParentContext,
       expect.any(Function), // createStepId
       expect.any(Function), // createContextLogger
+      expect.any(Function), // addRunningOperation
+      expect.any(Function), // removeRunningOperation
     );
     expect(mockStepHandler).toHaveBeenCalledWith("test-step", stepFn, options);
+  });
+
+  test("should have hasRunningOperations method that returns false initially", () => {
+    const durableContext = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+
+    expect(durableContext.hasRunningOperations()).toBe(false);
   });
 
   test("should call block handler when runInChildContext method is invoked", () => {

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -83,6 +83,8 @@ describe("Step Handler", () => {
       mockParentContext,
       createStepId,
       createMockEnrichedLogger,
+      jest.fn(), // addRunningOperation
+      jest.fn(), // removeRunningOperation
     );
 
     // Reset the mock for retryPresets.default

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
@@ -81,6 +81,8 @@ describe("WaitForCondition Handler", () => {
       mockCheckpoint,
       createStepId,
       createMockEnrichedLogger,
+      jest.fn(), // addRunningOperation
+      jest.fn(), // removeRunningOperation
     );
   });
 

--- a/packages/lambda-durable-functions-sdk-js/src/types/index.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/types/index.ts
@@ -87,6 +87,7 @@ export type DurableExecutionInvocationOutput =
 export interface DurableContext extends Context {
   _stepPrefix?: string;
   _stepCounter: number;
+  hasRunningOperations(): boolean;
   step: <T>(
     nameOrFn: string | undefined | StepFunc<T>,
     fnOrOptions?: StepFunc<T> | StepConfig<T>,


### PR DESCRIPTION
## Running Operations Tracking

### **What We Built:**
1. hasRunningOperations() method - Clean API to check if critical operations are running
2. Internal tracking system - addRunningOperation() / removeRunningOperation() with Set-based storage
3. Automatic cleanup - try/finally blocks ensure operations are removed even on errors

### **Where We Added Tracking (Only 2 Operations):**

✅ ctx.step:
• **Executes user code** 
• **Critical for workflow state** - if interrupted, workflow state becomes inconsistent

✅ ctx.waitForCondition:
• **Executes user condition checks** 
• **Critical for workflow logic** - if interrupted, condition evaluation becomes unreliable

### **Why NOT Other Operations:**

❌ ctx.runInChildContext - Safe to interrupt, just context management
❌ ctx.wait - Simple timer, no user code execution
❌ ctx.createCallback - Just creates callback config, no execution
❌ ctx.waitForCallback - Uses ctx.step internally, so already tracked automatically
❌ ctx.map/parallel/executeConcurrently - Use ctx.runInChildContext internally, which is safe to interrupt

### **Key Insight:**
We only needed to add tracking to the 2 fundamental operations that execute user code:
• ctx.step - Direct user code execution
• ctx.waitForCondition - User condition evaluation

All other operations either:
• Are safe to interrupt (context/config operations)
• Delegate to tracked operations (so get protection automatically)

### **The Result:**
```typescript
// Safe termination check
if (durableContext.hasRunningOperations()) {
  return; // Critical user code is running - wait
}
terminate(); // Safe to terminate
```

Surgical precision - Only the 2 operations that actually execute user code are tracked! 🎯