### PR TITLE
chore: bundle aws sdk dependencies and specify output files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10731,8 +10731,8 @@
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "@amzn/dex-internal-sdk": "*",
-        "@aws-sdk/credential-provider-node": "^3.800.0"
+        "@amzn/dex-internal-sdk": "^0.1.0",
+        "@aws-sdk/credential-provider-node": "^3.856.0"
       },
       "peerDependenciesMeta": {
         "@amzn/dex-internal-sdk": {

--- a/packages/lambda-durable-functions-sdk-js/.gitignore
+++ b/packages/lambda-durable-functions-sdk-js/.gitignore
@@ -7,3 +7,4 @@
 .aws-sam/*
 *.zip
 .DS_Store
+*.tgz

--- a/packages/lambda-durable-functions-sdk-js/build.js
+++ b/packages/lambda-durable-functions-sdk-js/build.js
@@ -8,15 +8,11 @@ rimraf.sync("./dist");
 
 console.log("📦 Building library with peer dependencies as external...\n");
 
-// Step 1: Identify all dependencies that should be external
+// Identify all dependencies that should be external
 const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf8"));
 const externalDependencies = [
-  // Runtime dependencies (if any)
-  ...Object.keys(packageJson.dependencies || {}),
   // Peer dependencies (should always be external)
   ...Object.keys(packageJson.peerDependencies || {}),
-  // Always external
-  "aws-sdk",
 ];
 
 console.log("📋 External dependencies (not bundled):");
@@ -24,7 +20,7 @@ externalDependencies.forEach((dep) => {
   console.log(`   🚫 ${dep}`);
 });
 
-// Step 2: Build library code bundle (with all dependencies marked as external)
+// Build library code bundle (with all dependencies marked as external)
 console.log("\n📚 Building library code bundle...");
 const libResult = esbuild.buildSync({
   entryPoints: ["./src/index.ts"],
@@ -33,7 +29,6 @@ const libResult = esbuild.buildSync({
   target: "node16",
   format: "cjs",
   outfile: "./dist/index.js",
-  external: externalDependencies, // Mark all dependencies as external
   metafile: true,
 });
 
@@ -109,11 +104,9 @@ function generateBundleReport(libMetafile) {
   console.log("\n💡 Installation Instructions for Users:");
   console.log("======================================");
   console.log("Users will need to install peer dependencies separately:");
-  externalDependencies
-    .filter((dep) => dep !== "aws-sdk")
-    .forEach((dep) => {
-      console.log(`   npm install ${dep}`);
-    });
+  externalDependencies.forEach((dep) => {
+    console.log(`   npm install ${dep}`);
+  });
 
   return { libOutput, totalLibSize, totalLibOutput };
 }

--- a/packages/lambda-durable-functions-sdk-js/bundle-size-history.json
+++ b/packages/lambda-durable-functions-sdk-js/bundle-size-history.json
@@ -193,5 +193,10 @@
     "timestamp": "2025-09-04T17:42:40.403Z",
     "size": 214426,
     "gitCommit": "9801dc79f2a4a980f971e2de1b85aa23b4c7a579"
+  },
+  {
+    "timestamp": "2025-09-08T21:59:04.907Z",
+    "size": 1079899,
+    "gitCommit": "7d4903a88ad2069fe70fcd286c50f7c467ac8425"
   }
 ]

--- a/packages/lambda-durable-functions-sdk-js/package.json
+++ b/packages/lambda-durable-functions-sdk-js/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prebuild": "npm run lint:fix",
     "build": "npm run build:dev",
@@ -24,7 +27,8 @@
     "lint:fix": "prettier --write . && eslint src --ext .ts --fix",
     "prepublishOnly": "npm test && npm run lint && npm run build",
     "run-locally": "ts-node --transpile-only ./src/run-durable.ts",
-    "clean": "rm -rf node_modules dist"
+    "clean": "rm -rf node_modules dist",
+    "prepack": "npm run build"
   },
   "lint-staged": {
     "./src/**/*.ts": [
@@ -56,18 +60,9 @@
     "tsx": "^4.19.3",
     "typescript": "^5.7.3"
   },
-  "dependencies": {},
-  "peerDependencies": {
+  "dependencies": {
     "@amzn/dex-internal-sdk": "*",
     "@aws-sdk/credential-provider-node": "^3.800.0"
-  },
-  "peerDependenciesMeta": {
-    "@amzn/dex-internal-sdk": {
-      "optional": false
-    },
-    "@aws-sdk/credential-provider-node": {
-      "optional": false
-    }
   },
   "private": true
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Bundling the Language SDK as a standalone package so that it can be consumed directly for others to use with only the `.tgz` file.

This will also make it easier to consume internally, as we can just run `npm pack` and copy it internally to use.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change


### Testing

#### Unit Tests
Have unit tests been written for these changes? N/A

#### Integration Tests
Have integration tests been written for these changes? N/A

#### Examples
Has a new example been added for the change? (if applicable) No
