### PR TITLE
refactor(testing-sdk): rename getCompletedOperations to getOperations

### DIFF
--- a/packages/examples/src/examples/__tests__/block-example.test.ts
+++ b/packages/examples/src/examples/__tests__/block-example.test.ts
@@ -52,7 +52,7 @@ describe("block-example", () => {
     // Verify execution completed successfully
     expect(execution.getResult()).toBeDefined();
 
-    const completedOperations = execution.getCompletedOperations();
+    const completedOperations = execution.getOperations();
     const waitOp = completedOperations.find(
       (op) =>
         op.getType() === OperationType.WAIT &&

--- a/packages/examples/src/examples/__tests__/comprehensive-operations.test.ts
+++ b/packages/examples/src/examples/__tests__/comprehensive-operations.test.ts
@@ -109,6 +109,6 @@ describe("comprehensive-operations", () => {
 
     // Verify execution completed successfully
     expect(execution.getResult()).toBeDefined();
-    expect(execution.getCompletedOperations().length).toBeGreaterThan(0);
+    expect(execution.getOperations().length).toBeGreaterThan(0);
   });
 });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/durable-test-runner.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/durable-test-runner.ts
@@ -70,7 +70,7 @@ export interface TestResultError {
 
 export interface TestResult<T> {
   // Returns a list of all completed operations
-  getCompletedOperations(params?: {
+  getOperations(params?: {
     // Filter by operation status (completed, failed, etc.)
     status: OperationStatus;
   }): OperationWithData[];
@@ -96,7 +96,7 @@ export interface TestResult<T> {
 export interface Invocation {
   id: string;
   // Get completed steps in this invocation
-  getCompletedOperations(params?: {
+  getOperations(params?: {
     status: OperationStatus;
   }): OperationWithData[];
 }

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/callback-operations.integration.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/callback-operations.integration.test.ts
@@ -71,7 +71,7 @@ describe("Callback Operations Integration", () => {
     });
 
     // Verify the callback operation was tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(1);
     expect(completedOperations[0].getType()).toBe(OperationType.CALLBACK);
   });
@@ -303,7 +303,7 @@ describe("Callback Operations Integration", () => {
     });
 
     // Verify all callback operations were tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(3);
     expect(
       completedOperations.every((op) => op.getType() === OperationType.CALLBACK)
@@ -362,7 +362,7 @@ describe("Callback Operations Integration", () => {
     });
 
     // Verify all operations were tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(3);
 
     const operationTypes = completedOperations.map((op) => op.getType());

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -37,7 +37,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Verify operations were tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(1);
 
     // Verify MockOperation data can be accessed
@@ -100,7 +100,7 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(typeof resultData.timestamp).toBe("number");
 
     // Should have no operations for simple execution
-    expect(result.getCompletedOperations()).toHaveLength(0);
+    expect(result.getOperations()).toHaveLength(0);
     // Should have exactly one invocation for simple execution
     expect(result.getInvocations()).toHaveLength(1);
   });
@@ -135,7 +135,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Should have tracked multiple wait operations
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(2);
 
     // Verify MockOperation data for both wait operations
@@ -173,7 +173,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Should have tracked step operation
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(1);
 
     // Verify MockOperation data for step operation
@@ -266,7 +266,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Should have tracked step operation
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(2);
 
     // Verify MockOperation data for context operation
@@ -316,7 +316,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Verify operations were tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(1);
 
     // Verify retries
@@ -362,7 +362,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Verify operations were tracked
-    const completedOperations = result.getCompletedOperations();
+    const completedOperations = result.getOperations();
     expect(completedOperations.length).toEqual(1);
 
     // Verify retries
@@ -411,7 +411,7 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(result.getResult()).toEqual("parent-context");
 
     // Should have tracked step operation
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(6);
 
     const parentChildren = parentContextStep.getChildOperations();
@@ -475,7 +475,7 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(typeof resultData.result.timestamp).toBe("number");
 
     // Verify that operations were tracked
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
 
     // Verify the invocations were tracked - should be exactly 3 invocations
     const invocations = result.getInvocations();
@@ -504,7 +504,7 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // For each invocation, get its operations
     const invocationOperations = invocations.map((inv) =>
-      inv.getCompletedOperations().map((op) => op.getOperationData()?.Id)
+      inv.getOperations().map((op) => op.getOperationData()?.Id)
     );
 
     // Verify exact operations in each invocation
@@ -556,7 +556,7 @@ describe("LocalDurableTestRunner Integration", () => {
     });
 
     // Verify all operations completed successfully
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     console.log(operations.map((operation) => operation.getOperationData()));
     expect(operations).toHaveLength(8); // 3 parallel waits + 3 parallel contexts + 1 parallel operation + 1 step
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
@@ -61,7 +61,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     });
 
     // Should have tracked only parent operation since child was mocked
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(2);
 
     // Verify MockOperation data for context operation
@@ -107,7 +107,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
       message: "Mocked error",
     });
 
-    const operations = result.getCompletedOperations();
+    const operations = result.getOperations();
     expect(operations.length).toEqual(1);
   });
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -153,7 +153,7 @@ describe("WaitForCallback Operations Integration", () => {
       });
 
       // Should have no succeeded operations since submitter failed before callback was created
-      const succeededOperations = result.getCompletedOperations({
+      const succeededOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(succeededOperations.length).toEqual(0);
@@ -197,7 +197,7 @@ describe("WaitForCallback Operations Integration", () => {
       });
 
       // Should have no succeeded operations since submitter failed
-      const succeededOperations = result.getCompletedOperations({
+      const succeededOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(succeededOperations.length).toEqual(0);
@@ -262,7 +262,7 @@ describe("WaitForCallback Operations Integration", () => {
 
       expect(receivedCallbackId).toBeDefined();
 
-      const completedOperations = result.getCompletedOperations();
+      const completedOperations = result.getOperations();
       expect(completedOperations.length).toEqual(3);
     });
 
@@ -427,7 +427,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(sideEffectCounter).toBe(9);
 
       // Should have no succeeded operations since submitter failed
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toEqual(0);
@@ -497,7 +497,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(receivedCallbackId).toBeDefined();
 
       // Should have completed operations with successful callback
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(0);
@@ -578,7 +578,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(resultData.callbackId).toBeDefined();
 
       // Should have completed operations with successful callback
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(0);
@@ -738,7 +738,7 @@ describe("WaitForCallback Operations Integration", () => {
       });
 
       // Verify all callback operations were tracked
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(2);
@@ -833,7 +833,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(typeof resultData.finalStep.timestamp).toBe("number");
 
       // Verify all operations were tracked - should have wait, step, waitForCallback, wait, step
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBe(5);
@@ -935,7 +935,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(childCallbackId).toBeDefined();
       expect(parentCallbackId).not.toBe(childCallbackId);
 
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBe(7);
@@ -1021,7 +1021,7 @@ describe("WaitForCallback Operations Integration", () => {
 
       // Verify operations distribution across invocations
       const invocationOperations = invocations.map(
-        (inv) => inv.getCompletedOperations().length
+        (inv) => inv.getOperations().length
       );
 
       expect(invocationOperations).toHaveLength(5);
@@ -1182,7 +1182,7 @@ describe("WaitForCallback Operations Integration", () => {
       ).toBe(3);
 
       // Should have tracked all operations
-      const completedOperations = result.getCompletedOperations();
+      const completedOperations = result.getOperations();
       expect(completedOperations.length).toBe(12);
     });
   });
@@ -1251,7 +1251,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(receivedCallbackId).toBeDefined();
 
       // Should have completed operations with successful callback
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(0);
@@ -1387,7 +1387,7 @@ describe("WaitForCallback Operations Integration", () => {
       expect(receivedCallbackId).toBeDefined();
 
       // Should have completed operations with successful callback
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(0);
@@ -1453,7 +1453,7 @@ describe("WaitForCallback Operations Integration", () => {
       });
 
       // Should have completed operations since mocks were used
-      const completedOperations = result.getCompletedOperations({
+      const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(completedOperations.length).toBeGreaterThan(0);
@@ -1500,7 +1500,7 @@ describe("WaitForCallback Operations Integration", () => {
         error: "Mocked callback failure",
       });
 
-      const completedOperations = result.getCompletedOperations();
+      const completedOperations = result.getOperations();
       expect(completedOperations.length).toBeGreaterThan(0);
     });
   });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
@@ -67,7 +67,7 @@ describe("LocalDurableTestRunner", () => {
 
     mockResultFormatter = {
       formatTestResult: jest.fn().mockReturnValue({
-        getCompletedOperations: jest.fn().mockReturnValue([]),
+        getOperations: jest.fn().mockReturnValue([]),
         getInvocations: jest.fn().mockReturnValue([]),
         getResult: jest.fn().mockReturnValue({ data: { success: true } }),
       }),

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
@@ -40,7 +40,7 @@ describe("ResultFormatter", () => {
         }),
       ];
 
-      mockOperationStorage.getCompletedOperations.mockReturnValue(
+      mockOperationStorage.getOperations.mockReturnValue(
         mockOperations
       );
 
@@ -51,8 +51,8 @@ describe("ResultFormatter", () => {
 
       // Create mock invocations
       const mockInvocations = [
-        { id: "inv-1", getCompletedOperations: jest.fn() },
-        { id: "inv-2", getCompletedOperations: jest.fn() },
+        { id: "inv-1", getOperations: jest.fn() },
+        { id: "inv-2", getOperations: jest.fn() },
       ];
 
       const testResult = resultFormatter.formatTestResult(
@@ -61,7 +61,7 @@ describe("ResultFormatter", () => {
         mockInvocations
       );
 
-      expect(testResult.getCompletedOperations()).toEqual(mockOperations);
+      expect(testResult.getOperations()).toEqual(mockOperations);
       expect(testResult.getInvocations()).toEqual(mockInvocations);
       expect(testResult.getResult()).toEqual({
         success: true,
@@ -99,7 +99,7 @@ describe("ResultFormatter", () => {
       );
 
       const mockOperations = [succeededOp, failedOp];
-      mockOperationStorage.getCompletedOperations.mockReturnValue(
+      mockOperationStorage.getOperations.mockReturnValue(
         mockOperations
       );
 
@@ -115,14 +115,14 @@ describe("ResultFormatter", () => {
       );
 
       // Test filtering by SUCCEEDED status
-      const succeededOps = testResult.getCompletedOperations({
+      const succeededOps = testResult.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
       expect(succeededOps).toHaveLength(1);
       expect(succeededOps[0].getStatus()).toBe(OperationStatus.SUCCEEDED);
 
       // Test filtering by FAILED status
-      const failedOps = testResult.getCompletedOperations({
+      const failedOps = testResult.getOperations({
         status: OperationStatus.FAILED,
       });
       expect(failedOps).toHaveLength(1);
@@ -130,7 +130,7 @@ describe("ResultFormatter", () => {
     });
 
     it("should pass invocations from parameters to test result", () => {
-      mockOperationStorage.getCompletedOperations.mockReturnValue([]);
+      mockOperationStorage.getOperations.mockReturnValue([]);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -140,15 +140,15 @@ describe("ResultFormatter", () => {
       const mockInvocations = [
         {
           id: "inv-1",
-          getCompletedOperations: jest.fn().mockReturnValue([]),
+          getOperations: jest.fn().mockReturnValue([]),
         },
         {
           id: "inv-2",
-          getCompletedOperations: jest.fn().mockReturnValue([]),
+          getOperations: jest.fn().mockReturnValue([]),
         },
         {
           id: "inv-3",
-          getCompletedOperations: jest.fn().mockReturnValue([]),
+          getOperations: jest.fn().mockReturnValue([]),
         },
       ];
 
@@ -167,7 +167,7 @@ describe("ResultFormatter", () => {
     });
 
     it("should handle undefined value", () => {
-      mockOperationStorage.getCompletedOperations.mockReturnValue([]);
+      mockOperationStorage.getOperations.mockReturnValue([]);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -184,7 +184,7 @@ describe("ResultFormatter", () => {
     });
 
     it("should handle non-JSON value by returning raw value", () => {
-      mockOperationStorage.getCompletedOperations.mockReturnValue([]);
+      mockOperationStorage.getOperations.mockReturnValue([]);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -201,7 +201,7 @@ describe("ResultFormatter", () => {
     });
 
     it("should handle invalid JSON by returning raw value", () => {
-      mockOperationStorage.getCompletedOperations.mockReturnValue([]);
+      mockOperationStorage.getOperations.mockReturnValue([]);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -246,7 +246,7 @@ describe("ResultFormatter", () => {
           )
       );
 
-      mockOperationStorage.getCompletedOperations.mockReturnValue(
+      mockOperationStorage.getOperations.mockReturnValue(
         mockOperations
       );
 
@@ -261,8 +261,8 @@ describe("ResultFormatter", () => {
         []
       );
 
-      expect(testResult.getCompletedOperations()).toEqual(mockOperations);
-      expect(mockOperationStorage.getCompletedOperations).toHaveBeenCalledTimes(
+      expect(testResult.getOperations()).toEqual(mockOperations);
+      expect(mockOperationStorage.getOperations).toHaveBeenCalledTimes(
         1
       );
     });
@@ -270,7 +270,7 @@ describe("ResultFormatter", () => {
 
   describe("formatExecutionResult", () => {
     it("should handle complex nested JSON data", () => {
-      mockOperationStorage.getCompletedOperations.mockReturnValue([]);
+      mockOperationStorage.getOperations.mockReturnValue([]);
 
       const complexData = {
         success: true,

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
@@ -798,9 +798,9 @@ describe("TestExecutionOrchestrator", () => {
       expect(invocations[0]?.id).toBe(firstInvocationId);
       expect(invocations[1]?.id).toBe(secondInvocationId);
 
-      // Verify each invocation has the getCompletedOperations function
-      expect(typeof invocations[0]?.getCompletedOperations).toBe("function");
-      expect(typeof invocations[1]?.getCompletedOperations).toBe("function");
+      // Verify each invocation has the getOperations function
+      expect(typeof invocations[0]?.getOperations).toBe("function");
+      expect(typeof invocations[1]?.getOperations).toBe("function");
     });
 
     it("should reset invocations when starting a new execution", async () => {
@@ -895,11 +895,11 @@ describe("TestExecutionOrchestrator", () => {
       jest.spyOn(mockOperationResult, "getStatus").mockReturnValue("SUCCEEDED");
 
       jest
-        .spyOn(mockOperationStorage, "getCompletedOperations")
+        .spyOn(mockOperationStorage, "getOperations")
         .mockReturnValue([mockOperationResult]);
 
       // Now get operations for the invocation
-      const ops = invocations[0]?.getCompletedOperations();
+      const ops = invocations[0]?.getOperations();
       expect(ops).toHaveLength(1);
       expect(ops[0]?.getId()).toBe(operationId);
     });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
@@ -72,7 +72,7 @@ describe("InvocationTracker", () => {
       const op1 = createMockOperation("op1");
       const op2 = createMockOperation("op2");
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([op1, op2]);
 
       // Verify that operation mappings are cleared
@@ -88,7 +88,7 @@ describe("InvocationTracker", () => {
       const invocation = invocationTracker.createInvocation(invocationId);
 
       expect(invocation.id).toBe(invocationId);
-      expect(typeof invocation.getCompletedOperations).toBe("function");
+      expect(typeof invocation.getOperations).toBe("function");
     });
 
     it("should add the created invocation to the invocations list", () => {
@@ -127,7 +127,7 @@ describe("InvocationTracker", () => {
       // Setup an operation in storage
       const mockOperation = createMockOperation(operationId);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([mockOperation]);
 
       // Associate the operation with the invocation
@@ -150,7 +150,7 @@ describe("InvocationTracker", () => {
       // Setup an operation in storage
       const mockOperation = createMockOperation(operationId);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([mockOperation]);
 
       // Associate the operation with both invocations
@@ -182,7 +182,7 @@ describe("InvocationTracker", () => {
       const mockOperation1 = createMockOperation(operationId1);
       const mockOperation2 = createMockOperation(operationId2);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([mockOperation1, mockOperation2]);
 
       // Associate both operations with the invocation
@@ -207,7 +207,7 @@ describe("InvocationTracker", () => {
       // Setup an operation in storage
       const mockOperation = createMockOperation(operationId);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([mockOperation]);
 
       // Associate the same operation twice
@@ -238,7 +238,7 @@ describe("InvocationTracker", () => {
       const op3 = createMockOperation("op3", OperationStatus.SUCCEEDED);
 
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([op1, op2, op3]);
 
       // Associate operations with invocations
@@ -316,9 +316,9 @@ describe("InvocationTracker", () => {
       // Override the getId method to return undefined
       jest.spyOn(mockOpWithoutId, "getId").mockReturnValue(undefined);
 
-      const allOps = operationStorage.getCompletedOperations();
+      const allOps = operationStorage.getOperations();
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([...allOps, mockOpWithoutId]);
 
       // Even with the invalid operation, we should still get our valid ones
@@ -332,7 +332,7 @@ describe("InvocationTracker", () => {
     });
   });
 
-  describe("invocation.getCompletedOperations", () => {
+  describe("invocation.getOperations", () => {
     it("should return operations when called without status filter", () => {
       const invocationId = createInvocationId("test-invocation");
       const operationId = "test-operation";
@@ -340,7 +340,7 @@ describe("InvocationTracker", () => {
       // Setup an operation in storage
       const mockOperation = createMockOperation(operationId);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([mockOperation]);
 
       // Associate operation with invocation
@@ -349,8 +349,8 @@ describe("InvocationTracker", () => {
       // Get invocation
       const invocation = invocationTracker.createInvocation(invocationId);
 
-      // Call getCompletedOperations without a status filter
-      const operations = invocation.getCompletedOperations();
+      // Call getOperations without a status filter
+      const operations = invocation.getOperations();
 
       expect(operations.length).toBe(1);
       expect(operations[0].getId()).toBe(operationId);
@@ -363,7 +363,7 @@ describe("InvocationTracker", () => {
       const successOp = createMockOperation("op1", OperationStatus.SUCCEEDED);
       const failedOp = createMockOperation("op2", OperationStatus.FAILED);
       jest
-        .spyOn(operationStorage, "getCompletedOperations")
+        .spyOn(operationStorage, "getOperations")
         .mockReturnValue([successOp, failedOp]);
 
       // Associate operations with invocation
@@ -373,11 +373,11 @@ describe("InvocationTracker", () => {
       // Get invocation
       const invocation = invocationTracker.createInvocation(invocationId);
 
-      // Call getCompletedOperations with a status filter
-      const succeededOps = invocation.getCompletedOperations({
+      // Call getOperations with a status filter
+      const succeededOps = invocation.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
-      const failedOps = invocation.getCompletedOperations({
+      const failedOps = invocation.getOperations({
         status: OperationStatus.FAILED,
       });
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-storage.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-storage.test.ts
@@ -60,7 +60,7 @@ describe("OperationStorage", () => {
         mockCallback
       );
 
-      expect(storage.getCompletedOperations()).toEqual([]);
+      expect(storage.getOperations()).toEqual([]);
     });
   });
 
@@ -74,7 +74,7 @@ describe("OperationStorage", () => {
 
       storage.populateOperations(sampleOperations);
 
-      expect(storage.getCompletedOperations()).toHaveLength(
+      expect(storage.getOperations()).toHaveLength(
         sampleOperations.length
       );
     });
@@ -96,7 +96,7 @@ describe("OperationStorage", () => {
         })
       );
 
-      expect(storage.getCompletedOperations()).toHaveLength(
+      expect(storage.getOperations()).toHaveLength(
         sampleOperations.length
       );
     });
@@ -112,7 +112,7 @@ describe("OperationStorage", () => {
 
       storage.populateOperations(sampleOperations);
 
-      expect(storage.getCompletedOperations()).toHaveLength(
+      expect(storage.getOperations()).toHaveLength(
         sampleOperations.length
       );
     });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/invocation-tracker.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/invocation-tracker.ts
@@ -33,7 +33,7 @@ export class InvocationTracker {
   createInvocation(invocationId: InvocationId): Invocation {
     const invocation: Invocation = {
       id: invocationId,
-      getCompletedOperations: (params?) => {
+      getOperations: (params?) => {
         return this.getOperationsForInvocation(invocationId, params?.status);
       },
     };
@@ -85,7 +85,7 @@ export class InvocationTracker {
     const opIds = this.invocationOperationsMap.get(invocationId) ?? new Set();
     // Filter by operation ID (belonging to this invocation)
     const operations = this.operationStorage
-      .getCompletedOperations()
+      .getOperations()
       .filter((op) => {
         const id = op.getId();
         return (

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-storage.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-storage.ts
@@ -49,7 +49,7 @@ export class OperationStorage {
     return false; // No data found
   }
 
-  getCompletedOperations(): OperationWithData[] {
+  getOperations(): OperationWithData[] {
     return (
       this.indexedOperations
         .getOperations()

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/result-formatter.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/result-formatter.ts
@@ -27,13 +27,13 @@ export class ResultFormatter<ResultType> {
     invocations: Invocation[]
   ): TestResult<ResultType> {
     return {
-      getCompletedOperations: (params) => {
+      getOperations: (params) => {
         if (params) {
           return operationStorage
-            .getCompletedOperations()
+            .getOperations()
             .filter((op) => op.getStatus() === params.status);
         }
-        return operationStorage.getCompletedOperations();
+        return operationStorage.getOperations();
       },
       getInvocations() {
         return invocations;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Renaming getCompletedOperations to getOperations, since it works with all operations and not just completed ones.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change


### Testing

#### Unit Tests
Have unit tests been written for these changes? N/A

#### Integration Tests
Have integration tests been written for these changes? N/A

#### Examples
Has a new example been added for the change? (if applicable) N/A
