### PR TITLE
fix(testing-sdk): update checkpoint update validator to be more accurate

### DIFF
--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/operation-type/validate-step-operation.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/operation-type/validate-step-operation.ts
@@ -32,14 +32,9 @@ export function validateStepOperation(
   update: OperationUpdate,
   operation: Operation | undefined
 ): void {
-  if (!operation) {
-    // Always allow a transition from non-existent -> any state (at-least-once semantics).
-    return;
-  }
-
   switch (update.Action) {
     case OperationAction.START:
-      if (!allowedStatusToStart.includes(operation.Status)) {
+      if (operation && !allowedStatusToStart.includes(operation.Status)) {
         throw new InvalidParameterValueException({
           message: "Invalid current STEP state to start.",
           $metadata: {},
@@ -48,7 +43,7 @@ export function validateStepOperation(
       break;
     case OperationAction.FAIL:
     case OperationAction.SUCCEED:
-      if (!allowedStatusToClose.includes(operation.Status)) {
+      if (operation && !allowedStatusToClose.includes(operation.Status)) {
         throw new InvalidParameterValueException({
           message: "Invalid current STEP state to close.",
           $metadata: {},
@@ -68,7 +63,7 @@ export function validateStepOperation(
       }
       break;
     case OperationAction.RETRY:
-      if (!allowedStatusToReattempt.includes(operation.Status)) {
+      if (operation && !allowedStatusToReattempt.includes(operation.Status)) {
         throw new InvalidParameterValueException({
           message: "Invalid current STEP state to re-attempt.",
           $metadata: {},


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Based on recent changes in the backend, updating the testing library checkpoint validator to match.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change


### Testing

#### Unit Tests
Have unit tests been written for these changes? Yes

#### Integration Tests
Have integration tests been written for these changes? No

#### Examples
Has a new example been added for the change? (if applicable) N/A
