### PR TITLE
Fix/wait handler scheduled timestamp

### DIFF
--- a/packages/lambda-durable-functions-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -36,7 +36,7 @@ export const createWaitHandler = (
 
     // Main wait logic - can be re-executed if step data changes
     while (true) {
-      const stepData = context.getStepData(stepId);
+      let stepData = context.getStepData(stepId);
       if (stepData?.Status === OperationStatus.SUCCEEDED) {
         log(context.isVerbose, "⏭️", "Wait already completed:", { stepId });
         return;
@@ -75,6 +75,8 @@ export const createWaitHandler = (
       }
 
       // There are ongoing operations - wait before continuing
+      // Refresh stepData after checkpoint to get ScheduledTimestamp
+      stepData = context.getStepData(stepId);
       await waitBeforeContinue({
         checkHasRunningOperations: true,
         checkStepStatus: true,

--- a/packages/lambda-durable-functions-sdk-js/src/utils/checkpoint/checkpoint.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/utils/checkpoint/checkpoint.ts
@@ -241,12 +241,7 @@ class CheckpointHandler {
         // Store operation with the already-hashed ID from backend
         this.context._stepData[operation.Id] = operation;
 
-        log(this.context.isVerbose, "📝", "Updated stepData entry:", {
-          id: operation.Id,
-          status: operation.Status,
-          type: operation.Type,
-          name: operation.Name,
-        });
+        log(this.context.isVerbose, "📝", "Updated stepData entry:", operation);
       }
     });
 

--- a/packages/lambda-durable-functions-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
@@ -62,6 +62,23 @@ describe("waitBeforeContinue", () => {
     expect(result.timerExpired).toBe(true);
   });
 
+  test("should resolve when timer expires in future", async () => {
+    const futureTime = new Date(Date.now() + 50); // 50ms in future
+
+    const result = await waitBeforeContinue({
+      checkHasRunningOperations: false,
+      checkStepStatus: false,
+      checkTimer: true,
+      scheduledTimestamp: futureTime,
+      stepId: "test-step",
+      context: mockContext,
+      hasRunningOperations: mockHasRunningOperations,
+    });
+
+    expect(result.reason).toBe("timer");
+    expect(result.timerExpired).toBe(true);
+  });
+
   test("should resolve when step status changes", async () => {
     let stepStatus: OperationStatus = OperationStatus.STARTED;
     mockContext.getStepData.mockImplementation(


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

refresh stepData after checkpoint to get ScheduledTimestamp
    
    - Fix wait handler to refresh stepData after checkpoint call
    - Ensures ScheduledTimestamp is available for waitBeforeContinue timer logic
    - Add debug logging for operations in checkpoint response
    
    Fixes issue where checkpoint.force() wasn't called when wait timer expired
    because ScheduledTimestamp was undefined due to stale stepData reference.

### Checklist

- [Y] I have filled out every section of the PR template
- [Y] I have thoroughly tested this change


### Testing

Yes