### PR TITLE
chore: add missing structure for waits, hopefully last one

### DIFF
--- a/.github/model/lambda.json
+++ b/.github/model/lambda.json
@@ -6432,6 +6432,12 @@
         "Error":{"shape":"ErrorObject"}
       }
     },
+    "WaitCancelledDetails":{
+      "type":"structure",
+      "members":{
+        "Error":{"shape":"EventError"}
+      }
+    },
     "WaitDetails":{
       "type":"structure",
       "members":{

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'packages/lambda-durable-functions-sdk-js/**'
       - 'packages/examples/**'
       - '.github/workflows/integration-tests.yml'
+      - '.github/model/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description
One last update to the history event structures -- also now we can see in the integration test run the full execution history!

### Demo/Screenshots
Look at integration test runs -- can see full execution history for each example now.

### Checklist

- [X] I have filled out every section of the PR template
- [X] I have thoroughly tested this change

