### PR TITLE
feat(testing-sdk): support history events in local runner

### DIFF
--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/__tests__/checkpoint-server.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/__tests__/checkpoint-server.test.ts
@@ -153,6 +153,7 @@ describe("checkpoint-server", () => {
           {
             operation: { Id: "op1", Type: OperationType.STEP },
             update: { Id: "op1", Type: OperationType.STEP },
+            events: [],
           },
         ]);
 
@@ -172,6 +173,7 @@ describe("checkpoint-server", () => {
       expect(response.body).toEqual({
         operations: [
           {
+            events: [],
             operation: { Id: "op1", Type: OperationType.STEP },
             update: { Id: "op1", Type: OperationType.STEP },
           },
@@ -230,50 +232,6 @@ describe("checkpoint-server", () => {
       ).toHaveBeenCalledWith(executionId);
       expect(mockStorage.updateOperation).toHaveBeenCalledWith(operationId, {
         Status: status,
-      });
-    });
-
-    it("should complete operation with action and return the updated operation", async () => {
-      const executionId = "test-execution-id";
-      const operationId = "test-operation-id";
-      const action = "SUCCEED";
-
-      const mockCompletedOperation = {
-        operation: {
-          Id: operationId,
-          Status: OperationStatus.SUCCEEDED,
-        },
-        update: {
-          Id: operationId,
-          Action: action,
-        },
-      };
-
-      const mockStorage = {
-        completeOperation: jest.fn().mockReturnValue(mockCompletedOperation),
-        hasOperation: jest.fn().mockReturnValue(true),
-      } as unknown as CheckpointManager;
-
-      mockExecutionManager.getCheckpointsByExecution.mockReturnValueOnce(
-        mockStorage
-      );
-
-      const response = await request(server)
-        .post(
-          `${API_PATHS.UPDATE_CHECKPOINT_DATA}/${executionId}/${operationId}`
-        )
-        .send({ action });
-
-      expect(response.body).toEqual({
-        operation: mockCompletedOperation,
-      });
-      expect(response.status).toBe(200);
-      expect(
-        mockExecutionManager.getCheckpointsByExecution
-      ).toHaveBeenCalledWith(executionId);
-      expect(mockStorage.completeOperation).toHaveBeenCalledWith({
-        Id: operationId,
-        Action: action,
       });
     });
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/handlers/callbacks.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/handlers/callbacks.ts
@@ -1,10 +1,10 @@
 import {
-  OperationStatus,
   InvalidParameterValueException,
   ErrorObject,
 } from "@amzn/dex-internal-sdk";
 import { RequestHandler } from "express";
 import { createCallbackId } from "../utils/tagged-strings";
+import { CompleteCallbackStatus } from "../storage/callback-manager";
 
 export const handleCallbackFailure: RequestHandler<
   { callbackId: string },
@@ -29,7 +29,7 @@ export const handleCallbackFailure: RequestHandler<
         CallbackId: callbackId,
         Error: input,
       },
-      OperationStatus.FAILED
+      CompleteCallbackStatus.FAILED
     );
   } catch (err) {
     if (err instanceof InvalidParameterValueException) {
@@ -37,6 +37,7 @@ export const handleCallbackFailure: RequestHandler<
       res.status(400).json({
         message: err.message,
       });
+      return;
     } else {
       throw err;
     }
@@ -80,7 +81,7 @@ export const handleCallbackSuccess: RequestHandler<
         CallbackId: callbackId,
         Result: result,
       },
-      OperationStatus.SUCCEEDED
+      CompleteCallbackStatus.SUCCEEDED
     );
   } catch (err) {
     if (err instanceof InvalidParameterValueException) {

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/storage/__tests__/event-processor.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/storage/__tests__/event-processor.test.ts
@@ -1,0 +1,558 @@
+import {
+  OperationUpdate,
+  OperationAction,
+  OperationType,
+  Operation,
+  EventType,
+} from "@amzn/dex-internal-sdk";
+import { EventProcessor } from "../event-processor";
+import * as historyEventDetails from "../../utils/history-event-details";
+
+// Mock the history-event-details module
+jest.mock("../../utils/history-event-details");
+
+describe("EventProcessor", () => {
+  let eventProcessor: EventProcessor;
+  const mockGetHistoryEventDetail = jest.mocked(
+    historyEventDetails.getHistoryEventDetail
+  );
+
+  beforeEach(() => {
+    eventProcessor = new EventProcessor();
+    jest.clearAllMocks();
+  });
+
+  it("should create an instance without execution timeout", () => {
+    const processor = new EventProcessor();
+    expect(processor).toBeInstanceOf(EventProcessor);
+  });
+
+  describe("createHistoryEvent", () => {
+    it("should create a history event with correct properties", () => {
+      const eventType = EventType.ExecutionStarted;
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+        ParentId: "parent-id",
+      };
+      const detailPlace = "ExecutionStartedDetails" as const;
+      const details = {
+        Input: { Payload: "test-payload" },
+        ExecutionTimeout: 3600,
+      };
+
+      const result = eventProcessor.createHistoryEvent(
+        eventType,
+        operation,
+        detailPlace,
+        details
+      );
+
+      expect(result).toEqual({
+        EventType: eventType,
+        SubType: operation.SubType,
+        EventId: 1,
+        Id: operation.Id,
+        Name: operation.Name,
+        EventTimestamp: expect.any(Date),
+        ParentId: operation.ParentId,
+        [detailPlace]: details,
+      });
+    });
+
+    it("should increment event ID for subsequent events", () => {
+      const eventType = EventType.ExecutionStarted;
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+      };
+      const detailPlace = "ExecutionStartedDetails" as const;
+      const details = {
+        Input: { Payload: "test-payload" },
+        ExecutionTimeout: 3600,
+      };
+
+      const firstEvent = eventProcessor.createHistoryEvent(
+        eventType,
+        operation,
+        detailPlace,
+        details
+      );
+      const secondEvent = eventProcessor.createHistoryEvent(
+        eventType,
+        operation,
+        detailPlace,
+        details
+      );
+
+      expect(firstEvent.EventId).toBe(1);
+      expect(secondEvent.EventId).toBe(2);
+    });
+
+    it("should handle different detail types", () => {
+      const eventType = EventType.ExecutionFailed;
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+      };
+      const detailPlace = "ExecutionFailedDetails" as const;
+      const details = {
+        Error: {
+          Payload: {
+            ErrorType: "TestError",
+            ErrorMessage: "Test error message",
+          },
+        },
+      };
+
+      const result = eventProcessor.createHistoryEvent(
+        eventType,
+        operation,
+        detailPlace,
+        details
+      );
+
+      expect(result.ExecutionFailedDetails).toEqual(details);
+    });
+  });
+
+  describe("processUpdate", () => {
+    const mockHistoryDetails = {
+      eventType: EventType.ExecutionStarted,
+      detailPlace: "ExecutionStartedDetails" as const,
+      getDetails: jest.fn(),
+    };
+
+    beforeEach(() => {
+      mockGetHistoryEventDetail.mockReturnValue(mockHistoryDetails);
+      mockHistoryDetails.getDetails.mockReturnValue({
+        Input: { Payload: "test-payload" },
+        ExecutionTimeout: 3600,
+      });
+    });
+
+    it("should process update and create history event", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        ParentId: "parent-id",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      const result = eventProcessor.processUpdate(update, operation);
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.START,
+        OperationType.EXECUTION
+      );
+      expect(mockHistoryDetails.getDetails).toHaveBeenCalledWith(
+        update,
+        operation,
+        { executionTimeout: undefined }
+      );
+      expect(result).toEqual({
+        EventType: EventType.ExecutionStarted,
+        SubType: update.SubType,
+        EventId: 1,
+        Id: update.Id,
+        Name: update.Name,
+        EventTimestamp: expect.any(Date),
+        ParentId: update.ParentId,
+        ExecutionStartedDetails: {
+          Input: { Payload: "test-payload" },
+          ExecutionTimeout: 3600,
+        },
+      });
+    });
+
+    it("should pass execution timeout to getDetails", () => {
+      const processorWithTimeout = new EventProcessor(7200);
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      processorWithTimeout.processUpdate(update, operation);
+
+      expect(mockHistoryDetails.getDetails).toHaveBeenCalledWith(
+        update,
+        operation,
+        { executionTimeout: 7200 }
+      );
+    });
+
+    it("should throw error when Action is missing", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      expect(() => eventProcessor.processUpdate(update, operation)).toThrow(
+        "Could not create history event with Action=undefined and Type=EXECUTION"
+      );
+    });
+
+    it("should throw error when operation Type is missing", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        SubType: "operation-subtype",
+      };
+
+      expect(() => eventProcessor.processUpdate(update, operation)).toThrow(
+        "Could not create history event with Action=START and Type=undefined"
+      );
+    });
+
+    it("should increment event ID for multiple updates", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      const firstResult = eventProcessor.processUpdate(update, operation);
+      const secondResult = eventProcessor.processUpdate(update, operation);
+
+      expect(firstResult.EventId).toBe(1);
+      expect(secondResult.EventId).toBe(2);
+    });
+
+    it("should handle different operation types", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.STEP,
+        SubType: "operation-subtype",
+      };
+
+      eventProcessor.processUpdate(update, operation);
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.START,
+        OperationType.STEP
+      );
+    });
+
+    it("should handle different action types", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.FAIL,
+        SubType: "update-subtype",
+        Error: { ErrorType: "TestError", ErrorMessage: "Test error" },
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      eventProcessor.processUpdate(update, operation);
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.FAIL,
+        OperationType.EXECUTION
+      );
+    });
+  });
+
+  describe("getHistoryDetailsFromUpdate", () => {
+    const mockHistoryDetails = {
+      eventType: EventType.ExecutionStarted,
+      detailPlace: "ExecutionStartedDetails" as const,
+      getDetails: jest.fn(),
+    };
+
+    beforeEach(() => {
+      mockGetHistoryEventDetail.mockReturnValue(mockHistoryDetails);
+    });
+
+    it("should return history details for valid action and type", () => {
+      const result = EventProcessor.getHistoryDetailsFromUpdate(
+        OperationAction.START,
+        OperationType.EXECUTION
+      );
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.START,
+        OperationType.EXECUTION
+      );
+      expect(result).toBe(mockHistoryDetails);
+    });
+
+    it("should throw error when history details not found", () => {
+      mockGetHistoryEventDetail.mockReturnValue(undefined);
+
+      expect(() =>
+        EventProcessor.getHistoryDetailsFromUpdate(
+          OperationAction.START,
+          OperationType.EXECUTION
+        )
+      ).toThrow(
+        "Could not create history event with Action=START and Type=EXECUTION"
+      );
+    });
+
+    it("should handle different combinations of action and type", () => {
+      EventProcessor.getHistoryDetailsFromUpdate(
+        OperationAction.SUCCEED,
+        OperationType.STEP
+      );
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.SUCCEED,
+        OperationType.STEP
+      );
+    });
+
+    it("should handle FAIL action with CONTEXT type", () => {
+      EventProcessor.getHistoryDetailsFromUpdate(
+        OperationAction.FAIL,
+        OperationType.CONTEXT
+      );
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.FAIL,
+        OperationType.CONTEXT
+      );
+    });
+
+    it("should handle RETRY action with STEP type", () => {
+      EventProcessor.getHistoryDetailsFromUpdate(
+        OperationAction.RETRY,
+        OperationType.STEP
+      );
+
+      expect(mockGetHistoryEventDetail).toHaveBeenCalledWith(
+        OperationAction.RETRY,
+        OperationType.STEP
+      );
+    });
+  });
+
+  describe("event ID management", () => {
+    it("should maintain separate event ID counters for different instances", () => {
+      const processor1 = new EventProcessor();
+      const processor2 = new EventProcessor();
+
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+      };
+
+      const event1 = processor1.createHistoryEvent(
+        EventType.ExecutionStarted,
+        operation,
+        "ExecutionStartedDetails",
+        { Input: { Payload: "test" } }
+      );
+
+      const event2 = processor2.createHistoryEvent(
+        EventType.ExecutionStarted,
+        operation,
+        "ExecutionStartedDetails",
+        { Input: { Payload: "test" } }
+      );
+
+      expect(event1.EventId).toBe(1);
+      expect(event2.EventId).toBe(1);
+    });
+
+    it("should continue incrementing event ID across different method calls", () => {
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+      };
+
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+        Payload: "test-payload",
+      };
+
+      mockGetHistoryEventDetail.mockReturnValue({
+        eventType: EventType.ExecutionStarted,
+        detailPlace: "ExecutionStartedDetails" as const,
+        getDetails: jest.fn().mockReturnValue({
+          Input: { Payload: "test-payload" },
+        }),
+      });
+
+      // Create event using createHistoryEvent
+      const event1 = eventProcessor.createHistoryEvent(
+        EventType.ExecutionStarted,
+        operation,
+        "ExecutionStartedDetails",
+        { Input: { Payload: "test" } }
+      );
+
+      // Create event using processUpdate
+      const event2 = eventProcessor.processUpdate(update, operation);
+
+      // Create another event using createHistoryEvent
+      const event3 = eventProcessor.createHistoryEvent(
+        EventType.ExecutionSucceeded,
+        operation,
+        "ExecutionSucceededDetails",
+        { Result: { Payload: "result" } }
+      );
+
+      expect(event1.EventId).toBe(1);
+      expect(event2.EventId).toBe(2);
+      expect(event3.EventId).toBe(3);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty strings in update and operation", () => {
+      const update: OperationUpdate = {
+        Id: "",
+        Name: "",
+        Action: OperationAction.START,
+        SubType: "",
+        Payload: "",
+      };
+
+      const operation: Operation = {
+        Id: "",
+        Name: "",
+        Type: OperationType.EXECUTION,
+        SubType: "",
+      };
+
+      mockGetHistoryEventDetail.mockReturnValue({
+        eventType: EventType.ExecutionStarted,
+        detailPlace: "ExecutionStartedDetails" as const,
+        getDetails: jest.fn().mockReturnValue({
+          Input: { Payload: "" },
+        }),
+      });
+
+      const result = eventProcessor.processUpdate(update, operation);
+
+      expect(result.Id).toBe("");
+      expect(result.Name).toBe("");
+      expect(result.SubType).toBe("");
+    });
+
+    it("should handle undefined optional fields", () => {
+      const update: OperationUpdate = {
+        Id: "update-id",
+        Name: "update-name",
+        Action: OperationAction.START,
+        SubType: "update-subtype",
+      };
+
+      const operation: Operation = {
+        Id: "operation-id",
+        Name: "operation-name",
+        Type: OperationType.EXECUTION,
+        SubType: "operation-subtype",
+      };
+
+      mockGetHistoryEventDetail.mockReturnValue({
+        eventType: EventType.ExecutionStarted,
+        detailPlace: "ExecutionStartedDetails" as const,
+        getDetails: jest.fn().mockReturnValue({
+          Input: { Payload: undefined },
+        }),
+      });
+
+      const result = eventProcessor.processUpdate(update, operation);
+
+      expect(result.ParentId).toBeUndefined();
+      expect(result.ExecutionStartedDetails?.Input?.Payload).toBeUndefined();
+    });
+
+    it("should handle undefined values in details", () => {
+      const operation: Operation = {
+        Id: "test-id",
+        Name: "test-operation",
+        Type: OperationType.EXECUTION,
+        SubType: "test-subtype",
+      };
+
+      const details = {
+        Input: { Payload: undefined },
+        ExecutionTimeout: undefined,
+      };
+
+      const result = eventProcessor.createHistoryEvent(
+        EventType.ExecutionStarted,
+        operation,
+        "ExecutionStartedDetails",
+        details
+      );
+
+      expect(result.ExecutionStartedDetails).toEqual(details);
+    });
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/storage/event-processor.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/storage/event-processor.ts
@@ -1,0 +1,164 @@
+import {
+  OperationUpdate,
+  Event,
+  OperationAction,
+  OperationType,
+  Operation,
+  EventType,
+} from "@amzn/dex-internal-sdk";
+import {
+  getHistoryEventDetail,
+  HistoryEventDetail,
+} from "../utils/history-event-details";
+
+/**
+ * Processes operation updates and transforms them into properly formatted history events.
+ *
+ * The EventProcessor is responsible for:
+ * - Generating unique event IDs for each history event
+ * - Converting operation updates into standardized Event objects
+ * - Managing execution timeout metadata
+ * - Ensuring proper event structure and timestamps
+ */
+export class EventProcessor {
+  /** Auto-incrementing counter for generating unique event IDs */
+  private eventId = 1;
+
+  /**
+   * Creates a new EventProcessor instance.
+   *
+   * @param executionTimeout - Optional execution timeout in seconds that will be included in event metadata
+   */
+  constructor(private readonly executionTimeout?: number) {}
+
+  /**
+   * Creates a history event with the specified details and operation context.
+   *
+   * This method provides a low-level interface for creating events when you have
+   * pre-computed event details. This is required when creating history events for things like completed callbacks
+   * or completed wait steps. For most use cases, `processUpdate` is used when an update checkpoint exists.
+   *
+   * @template T - The key of the Event type that corresponds to the specific event detail type
+   * @param eventType - The type of event being created
+   * @param operation - The operation context providing metadata like ID, name, and parent relationships
+   * @param detailPlace - The property name in the Event type where the details should be placed
+   * @param details - The event-specific details to include
+   * @returns A complete Event object with auto-generated ID and timestamp
+   *
+   * @example
+   * ```typescript
+   * const event = processor.createHistoryEvent(
+   *   EventType.ExecutionStarted,
+   *   operation,
+   *   "ExecutionStartedDetails",
+   *   { Input: { Payload: "test" }, ExecutionTimeout: 300 }
+   * );
+   * ```
+   */
+  createHistoryEvent<T extends keyof Event>(
+    eventType: EventType,
+    operation: Operation,
+    detailPlace: T,
+    details: Event[T]
+  ): Event {
+    return {
+      EventType: eventType,
+      SubType: operation.SubType,
+      EventId: this.eventId++,
+      Id: operation.Id,
+      Name: operation.Name,
+      EventTimestamp: new Date(),
+      ParentId: operation.ParentId,
+      [detailPlace]: details,
+    };
+  }
+
+  /**
+   * Processes an operation update and generates the corresponding history event.
+   *
+   * This is the primary method for converting operation updates into history events.
+   * It automatically determines the correct event type and details based on the
+   * operation's action and type, then generates a properly formatted Event object.
+   *
+   * @param update - The operation update containing the action, payload, and options
+   * @param operation - The operation context providing metadata and current state
+   * @returns A complete Event object representing the operation update
+   *
+   * @throws {Error} When the update lacks required Action or the operation lacks required Type
+   * @throws {Error} When no history event handler exists for the Action-Type combination
+   *
+   * @example
+   * ```typescript
+   * const event = processor.processUpdate(
+   *   { Action: OperationAction.START, Payload: "input data" },
+   *   { Type: OperationType.EXECUTION, Id: "exec-1", Name: "MyExecution" }
+   * );
+   * ```
+   */
+  processUpdate(update: OperationUpdate, operation: Operation): Event {
+    if (!update.Action || !operation.Type) {
+      throw new Error(
+        `Could not create history event with Action=${update.Action} and Type=${operation.Type}`
+      );
+    }
+
+    const historyDetails = EventProcessor.getHistoryDetailsFromUpdate(
+      update.Action,
+      operation.Type
+    );
+
+    return {
+      EventType: historyDetails.eventType,
+      SubType: update.SubType,
+      EventId: this.eventId++,
+      Id: update.Id,
+      Name: update.Name,
+      EventTimestamp: new Date(),
+      ParentId: update.ParentId,
+      [historyDetails.detailPlace]: historyDetails.getDetails(
+        update,
+        operation,
+        {
+          executionTimeout: this.executionTimeout,
+        }
+      ),
+    };
+  }
+
+  /**
+   * Retrieves the appropriate history event detail handler for a given action-type combination.
+   *
+   * This static method provides a way to validate that a specific operation action and type
+   * combination is supported and to retrieve the corresponding event detail handler.
+   *
+   * @template Action - The operation action (START, FAIL, SUCCEED, RETRY)
+   * @template Type - The operation type (EXECUTION, CALLBACK, CONTEXT, INVOKE, STEP, WAIT)
+   * @param action - The action being performed on the operation
+   * @param type - The type of operation being performed
+   * @returns The corresponding HistoryEventDetail handler
+   *
+   * @throws {Error} When no handler exists for the specified action-type combination
+   *
+   * @example
+   * ```typescript
+   * const handler = EventProcessor.getHistoryDetailsFromUpdate(
+   *   OperationAction.START,
+   *   OperationType.EXECUTION
+   * );
+   * // handler contains eventType, detailPlace, and getDetails function
+   * ```
+   */
+  static getHistoryDetailsFromUpdate<
+    Action extends OperationAction,
+    Type extends OperationType,
+  >(action: Action, type: Type): HistoryEventDetail<Action, Type> {
+    const historyDetails = getHistoryEventDetail(action, type);
+    if (!historyDetails) {
+      throw new Error(
+        `Could not create history event with Action=${action} and Type=${type}`
+      );
+    }
+
+    return historyDetails;
+  }
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/utils/__tests__/history-event-details.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/utils/__tests__/history-event-details.test.ts
@@ -1,0 +1,579 @@
+import {
+  OperationAction,
+  OperationUpdate,
+  EventType,
+  OperationType,
+  Operation,
+  ErrorObject,
+} from "@amzn/dex-internal-sdk";
+import { getHistoryEventDetail } from "../history-event-details";
+
+describe("history-event-details", () => {
+  const mockMetadata = {
+    executionTimeout: 300,
+  };
+
+  const createMockErrorObject = (): ErrorObject => ({
+    ErrorMessage: "test-error",
+    ErrorType: "TestError",
+    ErrorData: "test-error-data",
+    StackTrace: ["Error: test-error", "at test (test.js:1:1)"],
+  });
+
+  const createMockUpdate = (
+    overrides: Partial<OperationUpdate> = {}
+  ): OperationUpdate => ({
+    Payload: "test-payload",
+    Error: createMockErrorObject(),
+    CallbackOptions: {
+      TimeoutSeconds: 60,
+      HeartbeatTimeoutSeconds: 30,
+    },
+    InvokeOptions: {
+      FunctionName: "test-function",
+      DurableExecutionName: "test-execution",
+    },
+    StepOptions: {
+      NextAttemptDelaySeconds: 5,
+    },
+    WaitOptions: {
+      WaitSeconds: 10,
+    },
+    ...overrides,
+  });
+
+  const createMockOperation = (
+    overrides: Partial<Operation> = {}
+  ): Operation => ({
+    CallbackDetails: {
+      CallbackId: "test-callback-id",
+    },
+    StepDetails: {
+      Attempt: 2,
+    },
+    ...overrides,
+  });
+
+  describe("getHistoryEventDetail", () => {
+    it("should return undefined for unknown action-type combinations", () => {
+      const result = getHistoryEventDetail(
+        "UNKNOWN" as OperationAction,
+        "UNKNOWN" as OperationType
+      );
+      expect(result).toBeUndefined();
+    });
+
+    describe("EXECUTION operations", () => {
+      it("should return correct details for START-EXECUTION", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.EXECUTION
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ExecutionStarted);
+        expect(detail!.detailPlace).toBe("ExecutionStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Input: {
+            Payload: "test-payload",
+          },
+          ExecutionTimeout: 300,
+        });
+      });
+
+      it("should return correct details for FAIL-EXECUTION", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.FAIL,
+          OperationType.EXECUTION
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ExecutionFailed);
+        expect(detail!.detailPlace).toBe("ExecutionFailedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Error: {
+            Payload: createMockErrorObject(),
+          },
+        });
+      });
+
+      it("should return correct details for SUCCEED-EXECUTION", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.SUCCEED,
+          OperationType.EXECUTION
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ExecutionSucceeded);
+        expect(detail!.detailPlace).toBe("ExecutionSucceededDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Result: {
+            Payload: "test-payload",
+          },
+        });
+      });
+    });
+
+    describe("CALLBACK operations", () => {
+      it("should return correct details for START-CALLBACK", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.CALLBACK
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.CallbackStarted);
+        expect(detail!.detailPlace).toBe("CallbackStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          CallbackId: "test-callback-id",
+          Timeout: 60,
+          HeartbeatTimeout: 30,
+          Input: {
+            Payload: "test-payload",
+          },
+        });
+      });
+
+      it("should handle missing callback details", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.CALLBACK
+        );
+        const update = createMockUpdate();
+        const operation = createMockOperation({ CallbackDetails: undefined });
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          CallbackId: undefined,
+          Timeout: 60,
+          HeartbeatTimeout: 30,
+          Input: {
+            Payload: "test-payload",
+          },
+        });
+      });
+
+      it("should handle missing callback options", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.CALLBACK
+        );
+        const update = createMockUpdate({ CallbackOptions: undefined });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          CallbackId: "test-callback-id",
+          Timeout: undefined,
+          HeartbeatTimeout: undefined,
+          Input: {
+            Payload: "test-payload",
+          },
+        });
+      });
+    });
+
+    describe("CONTEXT operations", () => {
+      it("should return correct details for START-CONTEXT", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.CONTEXT
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ContextStarted);
+        expect(detail!.detailPlace).toBe("ContextStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({});
+      });
+
+      it("should return correct details for FAIL-CONTEXT", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.FAIL,
+          OperationType.CONTEXT
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ContextFailed);
+        expect(detail!.detailPlace).toBe("ContextFailedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Error: {
+            Payload: createMockErrorObject(),
+          },
+        });
+      });
+
+      it("should return correct details for SUCCEED-CONTEXT", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.SUCCEED,
+          OperationType.CONTEXT
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.ContextSucceeded);
+        expect(detail!.detailPlace).toBe("ContextSucceededDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Result: {
+            Payload: "test-payload",
+          },
+        });
+      });
+    });
+
+    describe("INVOKE operations", () => {
+      it("should return correct details for START-INVOKE", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.INVOKE
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.InvokeStarted);
+        expect(detail!.detailPlace).toBe("InvokeStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Input: {
+            Payload: "test-payload",
+          },
+          FunctionArn: "test-function",
+          DurableExecutionArn: "test-execution",
+        });
+      });
+
+      it("should handle missing invoke options", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.INVOKE
+        );
+        const update = createMockUpdate({ InvokeOptions: undefined });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Input: {
+            Payload: "test-payload",
+          },
+          FunctionArn: undefined,
+          DurableExecutionArn: undefined,
+        });
+      });
+    });
+
+    describe("STEP operations", () => {
+      it("should return correct details for START-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.STEP
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.StepStarted);
+        expect(detail!.detailPlace).toBe("StepStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({});
+      });
+
+      it("should return correct details for RETRY-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.RETRY,
+          OperationType.STEP
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.StepStarted);
+        expect(detail!.detailPlace).toBe("StepStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({});
+      });
+
+      it("should return correct details for FAIL-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.FAIL,
+          OperationType.STEP
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.StepFailed);
+        expect(detail!.detailPlace).toBe("StepFailedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Error: {
+            Payload: createMockErrorObject(),
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: 5,
+            CurrentAttempt: 2,
+          },
+        });
+      });
+
+      it("should handle missing step details in FAIL-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.FAIL,
+          OperationType.STEP
+        );
+        const update = createMockUpdate();
+        const operation = createMockOperation({ StepDetails: undefined });
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Error: {
+            Payload: createMockErrorObject(),
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: 5,
+            CurrentAttempt: undefined,
+          },
+        });
+      });
+
+      it("should handle missing step options in FAIL-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.FAIL,
+          OperationType.STEP
+        );
+        const update = createMockUpdate({ StepOptions: undefined });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Error: {
+            Payload: createMockErrorObject(),
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: undefined,
+            CurrentAttempt: 2,
+          },
+        });
+      });
+
+      it("should return correct details for SUCCEED-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.SUCCEED,
+          OperationType.STEP
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.StepSucceeded);
+        expect(detail!.detailPlace).toBe("StepSucceededDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Result: {
+            Payload: "test-payload",
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: 5,
+            CurrentAttempt: 2,
+          },
+        });
+      });
+
+      it("should handle missing step details in SUCCEED-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.SUCCEED,
+          OperationType.STEP
+        );
+        const update = createMockUpdate();
+        const operation = createMockOperation({ StepDetails: undefined });
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Result: {
+            Payload: "test-payload",
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: 5,
+            CurrentAttempt: undefined,
+          },
+        });
+      });
+
+      it("should handle missing step options in SUCCEED-STEP", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.SUCCEED,
+          OperationType.STEP
+        );
+        const update = createMockUpdate({ StepOptions: undefined });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        expect(details).toEqual({
+          Result: {
+            Payload: "test-payload",
+          },
+          RetryDetails: {
+            NextAttemptDelaySeconds: undefined,
+            CurrentAttempt: 2,
+          },
+        });
+      });
+    });
+
+    describe("WAIT operations", () => {
+      beforeEach(() => {
+        // Mock Date to ensure consistent test results
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date("2023-01-01T00:00:00.000Z"));
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it("should return correct details for START-WAIT", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.WAIT
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.eventType).toBe(EventType.WaitStarted);
+        expect(detail!.detailPlace).toBe("WaitStartedDetails");
+
+        const update = createMockUpdate();
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        const expectedEndTime = new Date("2023-01-01T00:00:10.000Z"); // 10 seconds later
+
+        expect(details).toEqual({
+          Duration: 10,
+          ScheduledEndTimestamp: expectedEndTime,
+        });
+      });
+
+      it("should handle missing wait options", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.WAIT
+        );
+        const update = createMockUpdate({ WaitOptions: undefined });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        const expectedEndTime = new Date("2023-01-01T00:00:00.000Z"); // No additional time
+
+        expect(details).toEqual({
+          Duration: undefined,
+          ScheduledEndTimestamp: expectedEndTime,
+        });
+      });
+
+      it("should handle zero wait seconds", () => {
+        const detail = getHistoryEventDetail(
+          OperationAction.START,
+          OperationType.WAIT
+        );
+        const update = createMockUpdate({
+          WaitOptions: {
+            WaitSeconds: 0,
+          },
+        });
+        const operation = createMockOperation();
+        const details = detail!.getDetails(update, operation, mockMetadata);
+
+        const expectedEndTime = new Date("2023-01-01T00:00:00.000Z"); // No additional time
+
+        expect(details).toEqual({
+          Duration: 0,
+          ScheduledEndTimestamp: expectedEndTime,
+        });
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty metadata", () => {
+      const detail = getHistoryEventDetail(
+        OperationAction.START,
+        OperationType.EXECUTION
+      );
+      const update = createMockUpdate();
+      const operation = createMockOperation();
+      const details = detail!.getDetails(update, operation, {});
+
+      expect(details).toEqual({
+        Input: {
+          Payload: "test-payload",
+        },
+        ExecutionTimeout: undefined,
+      });
+    });
+
+    it("should handle empty update object", () => {
+      const detail = getHistoryEventDetail(
+        OperationAction.FAIL,
+        OperationType.EXECUTION
+      );
+      const update = {} as OperationUpdate;
+      const operation = createMockOperation();
+      const details = detail!.getDetails(update, operation, mockMetadata);
+
+      expect(details).toEqual({
+        Error: {
+          Payload: undefined,
+        },
+      });
+    });
+
+    it("should handle empty operation object", () => {
+      const detail = getHistoryEventDetail(
+        OperationAction.START,
+        OperationType.CALLBACK
+      );
+      const update = createMockUpdate();
+      const operation = {} as Operation;
+      const details = detail!.getDetails(update, operation, mockMetadata);
+
+      expect(details).toEqual({
+        CallbackId: undefined,
+        Timeout: 60,
+        HeartbeatTimeout: 30,
+        Input: {
+          Payload: "test-payload",
+        },
+      });
+    });
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/utils/history-event-details.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/utils/history-event-details.ts
@@ -1,0 +1,243 @@
+import {
+  OperationAction,
+  OperationUpdate,
+  Event,
+  OperationType,
+  EventType,
+  Operation,
+} from "@amzn/dex-internal-sdk";
+
+/**
+ * Metadata required for generating event details.
+ */
+interface DetailsMetadata {
+  /** Optional execution timeout in seconds */
+  executionTimeout?: number;
+}
+
+/**
+ * Represents the structure for history event details with type-safe event detail extraction.
+ * 
+ * @template T - The key of the Event type that corresponds to the specific event detail type
+ */
+export interface HistoryEventDetails<T extends keyof Event> {
+  /** The type of event this detail handler processes */
+  eventType: EventType;
+  /** The property name in the Event type where these details should be placed */
+  detailPlace: T;
+  /** Function that generates the event details from operation data */
+  getDetails: (
+    update: OperationUpdate,
+    operation: Operation,
+    metadata: DetailsMetadata
+  ) => Event[T];
+}
+
+/**
+ * Factory function to create a HistoryEventDetails object with proper typing.
+ * 
+ * @template T - The key of the Event type that corresponds to the specific event detail type
+ * @param eventType - The type of event this detail handler processes
+ * @param detailPlace - The property name in the Event type where these details should be placed
+ * @param getDetails - Function that generates the event details from operation data
+ * @returns A properly typed HistoryEventDetails object
+ */
+function createEventDetails<T extends keyof Event>(
+  eventType: EventType,
+  detailPlace: T,
+  getDetails: (
+    update: OperationUpdate,
+    operation: Operation,
+    metadata: DetailsMetadata
+  ) => Event[T]
+): HistoryEventDetails<T> {
+  return { eventType, detailPlace, getDetails };
+}
+
+/**
+ * Type alias for retrieving the correct HistoryEventDetails type based on operation action and type.
+ * 
+ * @template Action - The operation action (START, FAIL, SUCCEED, RETRY)
+ * @template Type - The operation type (EXECUTION, CALLBACK, CONTEXT, INVOKE, STEP, WAIT)
+ */
+export type HistoryEventDetail<
+  Action extends OperationAction,
+  Type extends OperationType,
+> = (typeof historyEventDetailMap)[`${Action}-${Type}`];
+
+/**
+ * Mapping of operation action-type combinations to their corresponding history event details.
+ * 
+ * This map provides handlers for all supported combinations of OperationAction and OperationType,
+ * defining how to transform operation updates into properly formatted history events.
+ * 
+ * Supported operation combinations:
+ * - Execution: START, FAIL, SUCCEED
+ * - Callback: START
+ * - Context: START, FAIL, SUCCEED  
+ * - Invoke: START
+ * - Step: START, RETRY, FAIL, SUCCEED
+ * - Wait: START
+ */
+const historyEventDetailMap = {
+  // Execution events
+  [`${OperationAction.START}-${OperationType.EXECUTION}`]: createEventDetails(
+    EventType.ExecutionStarted,
+    "ExecutionStartedDetails",
+    (update, _, metadata) => ({
+      Input: {
+        Payload: update.Payload,
+      },
+      ExecutionTimeout: metadata.executionTimeout,
+    })
+  ),
+  [`${OperationAction.FAIL}-${OperationType.EXECUTION}`]: createEventDetails(
+    EventType.ExecutionFailed,
+    "ExecutionFailedDetails",
+    (update) => ({
+      Error: {
+        Payload: update.Error,
+      },
+    })
+  ),
+  [`${OperationAction.SUCCEED}-${OperationType.EXECUTION}`]: createEventDetails(
+    EventType.ExecutionSucceeded,
+    "ExecutionSucceededDetails",
+    (update) => ({
+      Result: {
+        Payload: update.Payload,
+      },
+    })
+  ),
+
+  // Callback events
+  [`${OperationAction.START}-${OperationType.CALLBACK}`]: createEventDetails(
+    EventType.CallbackStarted,
+    "CallbackStartedDetails",
+    (update, operation) => ({
+      CallbackId: operation.CallbackDetails?.CallbackId,
+      Timeout: update.CallbackOptions?.TimeoutSeconds,
+      HeartbeatTimeout: update.CallbackOptions?.HeartbeatTimeoutSeconds,
+      Input: {
+        Payload: update.Payload,
+      },
+    })
+  ),
+
+  // Context events
+  [`${OperationAction.START}-${OperationType.CONTEXT}`]: createEventDetails(
+    EventType.ContextStarted,
+    "ContextStartedDetails",
+    () => ({})
+  ),
+  [`${OperationAction.FAIL}-${OperationType.CONTEXT}`]: createEventDetails(
+    EventType.ContextFailed,
+    "ContextFailedDetails",
+    (update) => ({
+      Error: {
+        Payload: update.Error,
+      },
+    })
+  ),
+  [`${OperationAction.SUCCEED}-${OperationType.CONTEXT}`]: createEventDetails(
+    EventType.ContextSucceeded,
+    "ContextSucceededDetails",
+    (update) => ({
+      Result: {
+        Payload: update.Payload,
+      },
+    })
+  ),
+
+  // Invoke events
+  [`${OperationAction.START}-${OperationType.INVOKE}`]: createEventDetails(
+    EventType.InvokeStarted,
+    "InvokeStartedDetails",
+    (update) => ({
+      Input: {
+        Payload: update.Payload,
+      },
+      FunctionArn: update.InvokeOptions?.FunctionName,
+      DurableExecutionArn: update.InvokeOptions?.DurableExecutionName,
+    })
+  ),
+
+  // Step events
+  [`${OperationAction.START}-${OperationType.STEP}`]: createEventDetails(
+    EventType.StepStarted,
+    "StepStartedDetails",
+    () => ({})
+  ),
+  [`${OperationAction.RETRY}-${OperationType.STEP}`]: createEventDetails(
+    EventType.StepStarted,
+    "StepStartedDetails",
+    () => ({})
+  ),
+  [`${OperationAction.FAIL}-${OperationType.STEP}`]: createEventDetails(
+    EventType.StepFailed,
+    "StepFailedDetails",
+    (update, operation) => ({
+      Error: {
+        Payload: update.Error,
+      },
+      RetryDetails: {
+        NextAttemptDelaySeconds: update.StepOptions?.NextAttemptDelaySeconds,
+        CurrentAttempt: operation.StepDetails?.Attempt,
+      },
+    })
+  ),
+  [`${OperationAction.SUCCEED}-${OperationType.STEP}`]: createEventDetails(
+    EventType.StepSucceeded,
+    "StepSucceededDetails",
+    (update, operation) => ({
+      Result: {
+        Payload: update.Payload,
+      },
+      RetryDetails: {
+        NextAttemptDelaySeconds: update.StepOptions?.NextAttemptDelaySeconds,
+        CurrentAttempt: operation.StepDetails?.Attempt,
+      },
+    })
+  ),
+
+  // Wait events
+  [`${OperationAction.START}-${OperationType.WAIT}`]: createEventDetails(
+    EventType.WaitStarted,
+    "WaitStartedDetails",
+    (update) => {
+      const scheduledEndTimestamp = new Date();
+      scheduledEndTimestamp.setSeconds(
+        scheduledEndTimestamp.getSeconds() +
+          (update.WaitOptions?.WaitSeconds ?? 0)
+      );
+      return {
+        Duration: update.WaitOptions?.WaitSeconds,
+        ScheduledEndTimestamp: scheduledEndTimestamp,
+      };
+    }
+  ),
+} satisfies Record<string, HistoryEventDetails<keyof Event>>;
+
+/**
+ * Retrieves the appropriate history event detail handler for a given operation action and type.
+ * 
+ * @template Action - The operation action (START, FAIL, SUCCEED, RETRY)
+ * @template Type - The operation type (EXECUTION, CALLBACK, CONTEXT, INVOKE, STEP, WAIT)
+ * @param action - The action being performed on the operation
+ * @param type - The type of operation being performed
+ * @returns The corresponding HistoryEventDetails handler, or undefined if no handler exists for the combination
+ * 
+ * @example
+ * ```typescript
+ * const handler = getHistoryEventDetail(OperationAction.START, OperationType.EXECUTION);
+ * if (handler) {
+ *   const eventDetails = handler.getDetails(update, operation, metadata);
+ * }
+ * ```
+ */
+export function getHistoryEventDetail<
+  Action extends OperationAction,
+  Type extends OperationType,
+>(action: Action, type: Type): HistoryEventDetail<Action, Type> | undefined {
+  return historyEventDetailMap[`${action}-${type}`];
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/__tests__/checkpoint-durable-execution-input-validator.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/__tests__/checkpoint-durable-execution-input-validator.test.ts
@@ -30,6 +30,7 @@ describe("validateCheckpointUpdates", () => {
       Type: type,
       Action: OperationAction.START,
     },
+    events: [],
   });
 
   describe("null/empty updates", () => {

--- a/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/checkpoint-durable-execution-input-validator.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/checkpoint-server/validators/checkpoint-durable-execution-input-validator.ts
@@ -12,7 +12,7 @@ import { validateInvokeOperation } from "./operation-type/validate-invoke-operat
 import { validateStepOperation } from "./operation-type/validate-step-operation";
 import { validateWaitOperation } from "./operation-type/validate-wait-operation";
 import { validateValidActionsByOperationType } from "./valid-actions-by-operation-type-validator";
-import { CheckpointOperation } from "../storage/checkpoint-manager";
+import { OperationEvents } from "../../test-runner/common/operations/operation-with-data";
 
 const MAX_ERROR_PAYLOAD_SIZE_BYTES = 32768; // 32KB
 
@@ -26,7 +26,7 @@ const MAX_ERROR_PAYLOAD_SIZE_BYTES = 32768; // 32KB
  */
 export function validateCheckpointUpdates(
   updates: OperationUpdate[] | undefined,
-  checkpointOperations: Map<string, CheckpointOperation>
+  checkpointOperations: Map<string, OperationEvents>
 ): void {
   if (!updates?.length) {
     return;
@@ -79,7 +79,7 @@ function validateConflictingExecutionUpdate(updates: OperationUpdate[]): void {
  */
 function validateOperationUpdate(
   operationUpdate: OperationUpdate,
-  checkpointOperations: Map<string, CheckpointOperation>
+  checkpointOperations: Map<string, OperationEvents>
 ): void {
   // Validates that the operation payload sizes are not too large
   validatePayloadSizes(operationUpdate);
@@ -129,7 +129,7 @@ function validatePayloadSizes(operationUpdate: OperationUpdate): void {
  */
 function validateParentIdAndDuplicateId(
   operationUpdates: OperationUpdate[],
-  checkpointOperations: Map<string, CheckpointOperation>
+  checkpointOperations: Map<string, OperationEvents>
 ): void {
   const operationsStarted = new Map<string, OperationUpdate>();
   const lastUpdatesSeen = new Map<string, OperationUpdate>();
@@ -207,7 +207,7 @@ function isInvalidDuplicateUpdate(
  * @returns true if parent is valid or no parent is specified, false otherwise
  */
 function isValidParentForUpdate(
-  checkpointOperations: Map<string, CheckpointOperation>,
+  checkpointOperations: Map<string, OperationEvents>,
   operationUpdate: OperationUpdate,
   operationsStarted: Map<string, OperationUpdate>
 ): boolean {

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/__tests__/indexed-operations.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/__tests__/indexed-operations.test.ts
@@ -10,7 +10,7 @@ describe("IndexedOperations", () => {
         Name: "operation1",
         Status: OperationStatus.SUCCEEDED,
       },
-      update: {},
+      events: [],
     },
     {
       operation: {
@@ -18,7 +18,7 @@ describe("IndexedOperations", () => {
         Name: "operation2",
         Status: OperationStatus.SUCCEEDED,
       },
-      update: {},
+      events: [],
     },
     {
       operation: {
@@ -26,7 +26,7 @@ describe("IndexedOperations", () => {
         Name: "operation1", // Same name as first operation
         Status: OperationStatus.FAILED,
       },
-      update: {},
+      events: [],
     },
   ];
 
@@ -64,7 +64,7 @@ describe("IndexedOperations", () => {
       indexed.addOperations([
         {
           operation: initialOperation,
-          update: {},
+          events: [],
         },
       ]);
 
@@ -83,7 +83,7 @@ describe("IndexedOperations", () => {
       indexed.addOperations([
         {
           operation: updatedOperation,
-          update: {},
+          events: [],
         },
       ]);
 
@@ -113,7 +113,7 @@ describe("IndexedOperations", () => {
             Name: "operation1",
             Status: OperationStatus.STARTED,
           },
-          update: {},
+          events: [],
         },
         {
           operation: {
@@ -121,7 +121,7 @@ describe("IndexedOperations", () => {
             Name: "operation2",
             Status: OperationStatus.STARTED,
           },
-          update: {},
+          events: [],
         },
         {
           operation: {
@@ -129,7 +129,7 @@ describe("IndexedOperations", () => {
             Name: "operation1-updated",
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         }, // Same ID as first operation
       ];
 
@@ -159,7 +159,7 @@ describe("IndexedOperations", () => {
           Name: "original-name",
           Status: OperationStatus.STARTED,
         },
-        update: {},
+        events: [],
       };
       indexed.addOperations([initialOperation]);
 
@@ -176,7 +176,7 @@ describe("IndexedOperations", () => {
           Name: "updated-name",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
       indexed.addOperations([updatedOperation]);
 
@@ -207,7 +207,7 @@ describe("IndexedOperations", () => {
             Name: "operation1",
             Status: OperationStatus.STARTED,
           },
-          update: {},
+          events: [],
         },
         {
           operation: {
@@ -215,7 +215,7 @@ describe("IndexedOperations", () => {
             Name: "operation2",
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ];
 
@@ -240,7 +240,7 @@ describe("IndexedOperations", () => {
           Name: "operation1-updated",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       indexed.addOperations([updatedOp1]);
@@ -268,7 +268,7 @@ describe("IndexedOperations", () => {
         indexed.addOperations([
           {
             operation: operationWithoutId,
-            update: {},
+            events: [],
           },
         ]);
       }).toThrow("Cannot add operation without an ID");
@@ -282,7 +282,7 @@ describe("IndexedOperations", () => {
           Name: undefined,
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       indexed.addOperations([operationWithEmptyId]);
@@ -299,7 +299,7 @@ describe("IndexedOperations", () => {
           Name: "",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       indexed.addOperations([operationWithEmptyName]);
@@ -391,7 +391,7 @@ describe("IndexedOperations", () => {
           Name: "parent-operation",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       },
       {
         operation: {
@@ -400,16 +400,16 @@ describe("IndexedOperations", () => {
           ParentId: "parent1",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       },
       {
         operation: {
-          Id: "child2", 
+          Id: "child2",
           Name: "child-operation-2",
           ParentId: "parent1",
           Status: OperationStatus.FAILED,
         },
-        update: {},
+        events: [],
       },
       {
         operation: {
@@ -417,16 +417,16 @@ describe("IndexedOperations", () => {
           Name: "orphan-operation",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       },
       {
         operation: {
           Id: "child3",
-          Name: "child-operation-3", 
+          Name: "child-operation-3",
           ParentId: "different-parent",
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       },
     ];
 
@@ -449,16 +449,16 @@ describe("IndexedOperations", () => {
       const children = indexed.getOperationChildren("parent1");
 
       expect(children).toHaveLength(2);
-      expect(children.map(c => c.operation.Id)).toContain("child1");
-      expect(children.map(c => c.operation.Id)).toContain("child2");
+      expect(children.map((c) => c.operation.Id)).toContain("child1");
+      expect(children.map((c) => c.operation.Id)).toContain("child2");
     });
 
     it("should return child operations with correct data", () => {
       const indexed = new IndexedOperations(parentChildOperations);
       const children = indexed.getOperationChildren("parent1");
 
-      const child1 = children.find(c => c.operation.Id === "child1");
-      const child2 = children.find(c => c.operation.Id === "child2");
+      const child1 = children.find((c) => c.operation.Id === "child1");
+      const child2 = children.find((c) => c.operation.Id === "child2");
 
       expect(child1).toBeDefined();
       expect(child1?.operation.Name).toBe("child-operation-1");
@@ -487,7 +487,7 @@ describe("IndexedOperations", () => {
             Name: "operation1",
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
       const children = indexed.getOperationChildren("op1");
@@ -497,7 +497,7 @@ describe("IndexedOperations", () => {
 
     it("should handle parent-child relationships when operations are added later", () => {
       const indexed = new IndexedOperations([]);
-      
+
       // Initially no children
       expect(indexed.getOperationChildren("parent1")).toEqual([]);
 
@@ -511,7 +511,7 @@ describe("IndexedOperations", () => {
 
     it("should throw error when trying to change operation parent", () => {
       const indexed = new IndexedOperations(parentChildOperations);
-      
+
       // Initially child1 has parent1
       const initialChildren = indexed.getOperationChildren("parent1");
       expect(initialChildren).toHaveLength(2);
@@ -526,16 +526,18 @@ describe("IndexedOperations", () => {
               ParentId: "new-parent", // Different parent
               Status: OperationStatus.SUCCEEDED,
             },
-            update: {},
+            events: [],
           },
         ]);
-      }).toThrow("Cannot change ParentId of operation child1 from parent1 to new-parent");
+      }).toThrow(
+        "Cannot change ParentId of operation child1 from parent1 to new-parent"
+      );
 
       // parent1 should still have both children (no change)
       const parent1Children = indexed.getOperationChildren("parent1");
       expect(parent1Children).toHaveLength(2);
-      expect(parent1Children.map(c => c.operation.Id)).toContain("child1");
-      expect(parent1Children.map(c => c.operation.Id)).toContain("child2");
+      expect(parent1Children.map((c) => c.operation.Id)).toContain("child1");
+      expect(parent1Children.map((c) => c.operation.Id)).toContain("child2");
     });
 
     it("should handle operations with undefined ParentId", () => {
@@ -547,10 +549,10 @@ describe("IndexedOperations", () => {
             ParentId: undefined,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
-      
+
       // Should not crash and should return empty array for any parent
       expect(indexed.getOperationChildren("any-parent")).toEqual([]);
     });
@@ -564,10 +566,10 @@ describe("IndexedOperations", () => {
             ParentId: "", // Empty string parent ID
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
-      
+
       // Should work with empty string as parent ID
       const children = indexed.getOperationChildren("");
       expect(children).toHaveLength(1);

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/indexed-operations.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/indexed-operations.ts
@@ -1,4 +1,4 @@
-import { CheckpointOperation } from "../../checkpoint-server/storage/checkpoint-manager";
+import { OperationEvents } from "./operations/operation-with-data";
 
 /**
  * Optimized way of retrieving operations by id and name/index.
@@ -6,25 +6,25 @@ import { CheckpointOperation } from "../../checkpoint-server/storage/checkpoint-
  * Avoids re-iterating over the operations list every time an operation needs to be fetched.
  */
 export class IndexedOperations {
-  private readonly operationsById = new Map<string, CheckpointOperation>();
+  private readonly operationsById = new Map<string, OperationEvents>();
   private readonly operationsByName = new Map<
     string,
-    Map<string, CheckpointOperation>
+    Map<string, OperationEvents>
   >();
   private readonly operationsByParentId = new Map<
     string,
-    Map<string, CheckpointOperation>
+    Map<string, OperationEvents>
   >();
 
-  constructor(operations: CheckpointOperation[]) {
+  constructor(operations: OperationEvents[]) {
     this.addOperations(operations);
   }
 
-  getOperations(): CheckpointOperation[] {
+  getOperations(): OperationEvents[] {
     return Array.from(this.operationsById.values());
   }
 
-  addOperations(checkpointOperations: CheckpointOperation[]) {
+  addOperations(checkpointOperations: OperationEvents[]) {
     for (const checkpointOperation of checkpointOperations) {
       const { operation } = checkpointOperation;
       if (operation.Id === undefined) {
@@ -50,7 +50,7 @@ export class IndexedOperations {
       if (operation.Name !== undefined) {
         const nameOps =
           this.operationsByName.get(operation.Name) ??
-          new Map<string, CheckpointOperation>();
+          new Map<string, OperationEvents>();
         nameOps.set(operation.Id, checkpointOperation);
         this.operationsByName.set(operation.Name, nameOps);
       }
@@ -58,14 +58,14 @@ export class IndexedOperations {
       if (operation.ParentId !== undefined) {
         const childOperations =
           this.operationsByParentId.get(operation.ParentId) ??
-          new Map<string, CheckpointOperation>();
+          new Map<string, OperationEvents>();
         childOperations.set(operation.Id, checkpointOperation);
         this.operationsByParentId.set(operation.ParentId, childOperations);
       }
     }
   }
 
-  getOperationChildren(id: string): CheckpointOperation[] {
+  getOperationChildren(id: string): OperationEvents[] {
     const operations = this.operationsByParentId.get(id);
     return operations ? Array.from(operations.values()) : [];
   }
@@ -75,12 +75,12 @@ export class IndexedOperations {
    * @param id The operation ID
    * @returns The operation with the matching ID
    */
-  getById(id: string): CheckpointOperation | undefined {
+  getById(id: string): OperationEvents | undefined {
     const operation = this.operationsById.get(id);
     return operation;
   }
 
-  getByIndex(index: number): CheckpointOperation | undefined {
+  getByIndex(index: number): OperationEvents | undefined {
     return this.getOperations().at(index);
   }
 
@@ -90,7 +90,7 @@ export class IndexedOperations {
    * @param index The index of the operation among operations with the same name. Defaults to 0
    * @returns The operation at the specified name and index
    */
-  getByNameAndIndex(name: string, index = 0): CheckpointOperation | undefined {
+  getByNameAndIndex(name: string, index = 0): OperationEvents | undefined {
     const operations = this.operationsByName.get(name);
     return operations ? Array.from(operations.values()).at(index) : undefined;
   }

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/operations/__tests__/operation-with-data.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/operations/__tests__/operation-with-data.test.ts
@@ -40,7 +40,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getOperationData()).toStrictEqual(operationData);
@@ -62,7 +62,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getContextDetails()).toThrow(
@@ -91,7 +91,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const contextDetails = operation.getContextDetails();
@@ -122,7 +122,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const contextDetails = operation.getContextDetails();
@@ -153,7 +153,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const contextDetails = operation.getContextDetails();
@@ -184,7 +184,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const contextDetails = operation.getContextDetails();
@@ -218,7 +218,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const contextDetails = operation.getContextDetails();
@@ -244,7 +244,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getStepDetails()).toThrow(
@@ -272,7 +272,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const stepDetails = operation.getStepDetails();
@@ -314,7 +314,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const result = operation.getStepDetails();
@@ -351,7 +351,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const result = operation.getStepDetails();
@@ -388,7 +388,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const result = operation.getStepDetails();
@@ -418,7 +418,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const result = operation.getStepDetails();
@@ -447,7 +447,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getCallbackDetails()).toThrow(
@@ -472,7 +472,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getCallbackDetails()).toThrow(
@@ -499,7 +499,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const callbackDetails = operation.getCallbackDetails();
@@ -532,7 +532,7 @@ describe("OperationWithData", () => {
               Error: { ErrorMessage: "Wait callback error" },
             },
           },
-          update: {},
+          events: [],
         },
       ];
 
@@ -555,7 +555,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const callbackDetails = operation.getCallbackDetails();
@@ -574,7 +574,7 @@ describe("OperationWithData", () => {
             Name: "child-step-op",
             Type: OperationType.STEP, // Not CALLBACK
           },
-          update: {},
+          events: [],
         },
       ];
 
@@ -597,7 +597,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getCallbackDetails()).toThrow(
@@ -625,7 +625,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getCallbackDetails()).toThrow(
@@ -644,7 +644,7 @@ describe("OperationWithData", () => {
               CallbackId: undefined, // Missing CallbackId
             },
           },
-          update: {},
+          events: [],
         },
       ];
 
@@ -667,7 +667,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getCallbackDetails()).toThrow(
@@ -691,7 +691,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(() => operation.getWaitDetails()).toThrow(
@@ -713,16 +713,25 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {
-          WaitOptions: {
-            WaitSeconds: 30,
+        events: [
+          {
+            WaitStartedDetails: {
+              Duration: 30,
+              ScheduledEndTimestamp: new Date("2025-09-10T22:53:25.217Z"),
+            },
           },
-        },
+          {
+            WaitSucceededDetails: {
+              Duration: 30,
+            },
+          },
+        ],
       });
 
       const waitDetails = operation.getWaitDetails();
       expect(waitDetails).toEqual({
         waitSeconds: 30,
+        scheduledEndTimestamp: new Date("2025-09-10T22:53:25.217Z"),
       });
     });
 
@@ -750,7 +759,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getId()).toBe("test-operation-id");
@@ -777,7 +786,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getName()).toBe("test-operation-name");
@@ -805,7 +814,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getType()).toBe(OperationType.STEP);
@@ -832,7 +841,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getStatus()).toBe(OperationStatus.SUCCEEDED);
@@ -861,7 +870,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getStartTimestamp()).toBe(startTime);
@@ -890,7 +899,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getEndTimestamp()).toBe(endTime);
@@ -918,7 +927,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getParentId()).toBe("parent-123");
@@ -947,7 +956,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.getSubType()).toBe(OperationSubType.WAIT_FOR_CALLBACK);
@@ -976,7 +985,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.isWaitForCallback()).toBe(true);
@@ -996,7 +1005,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.isWaitForCallback()).toBe(false);
@@ -1016,7 +1025,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.isCallback()).toBe(true);
@@ -1036,7 +1045,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       expect(operation.isCallback()).toBe(false);
@@ -1087,7 +1096,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
 
         expect(() => operation.sendCallbackSuccess("test-result")).toThrow(
@@ -1110,7 +1119,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
 
         expect(() => operation.sendCallbackSuccess("test-result")).toThrow(
@@ -1135,7 +1144,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
 
         expect(() => operation.sendCallbackSuccess("test-result")).toThrow(
@@ -1162,7 +1171,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         mockClient.send.mockResolvedValue({ success: true });
 
@@ -1197,7 +1206,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         const clientError = new Error("Client error");
         mockClient.send.mockRejectedValue(clientError);
@@ -1226,7 +1235,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         mockClient.send.mockResolvedValue({ failure: true });
 
@@ -1266,7 +1275,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         mockClient.send.mockResolvedValue({ sent: true });
 
@@ -1303,7 +1312,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         const clientError = new Error("Client failure error");
         mockClient.send.mockRejectedValue(clientError);
@@ -1336,7 +1345,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         mockClient.send.mockResolvedValue({ heartbeat: true });
 
@@ -1370,7 +1379,7 @@ describe("OperationWithData", () => {
 
         operation.populateData({
           operation: operationData,
-          update: {},
+          events: [],
         });
         const clientError = new Error("Heartbeat client error");
         mockClient.send.mockRejectedValue(clientError);
@@ -1414,11 +1423,11 @@ describe("OperationWithData", () => {
 
         operation1.populateData({
           operation: operationData1,
-          update: {},
+          events: [],
         });
         operation2.populateData({
           operation: operationData2,
-          update: {},
+          events: [],
         });
 
         mockClient.send.mockResolvedValue({ success: true });
@@ -1463,7 +1472,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.STARTED,
         },
-        update: {},
+        events: [],
       };
 
       // Populate data first with STARTED status
@@ -1487,7 +1496,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       // Populate data first with SUCCEEDED status (which is COMPLETED)
@@ -1511,13 +1520,13 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.STARTED, // Data exists but has STARTED status
         },
-        update: {},
+        events: [],
       };
       const finalData = {
         operation: {
           Status: OperationStatus.SUCCEEDED, // Final status is SUCCEEDED (COMPLETED)
         },
-        update: {},
+        events: [],
       };
 
       // Populate with STARTED status initially
@@ -1552,7 +1561,7 @@ describe("OperationWithData", () => {
           Name: "test-operation",
           // No Status field - should always wait
         },
-        update: {},
+        events: [],
       };
       const finalData = {
         operation: {
@@ -1560,7 +1569,7 @@ describe("OperationWithData", () => {
           Name: "test-operation",
           Status: OperationStatus.STARTED,
         },
-        update: {},
+        events: [],
       };
 
       // Populate with data that has no status
@@ -1597,7 +1606,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       // Don't populate data initially - this will trigger wait manager call
@@ -1628,7 +1637,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       // Don't populate data initially - this will trigger wait manager call
@@ -1669,7 +1678,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       // Mock wait manager to simulate async population
@@ -1715,7 +1724,7 @@ describe("OperationWithData", () => {
         operation: {
           Status: OperationStatus.SUCCEEDED,
         },
-        update: {},
+        events: [],
       };
 
       // First call - no data, should wait
@@ -1747,11 +1756,11 @@ describe("OperationWithData", () => {
       const mockChildOperations = [
         {
           operation: { Id: "child-1", Name: "child-op-1" },
-          update: {},
+          events: [],
         },
         {
           operation: { Id: "child-2", Name: "child-op-2" },
-          update: {},
+          events: [],
         },
       ];
 
@@ -1772,7 +1781,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const childOperations = operation.getChildOperations();
@@ -1822,7 +1831,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const childOperations = operation.getChildOperations();
@@ -1841,7 +1850,7 @@ describe("OperationWithData", () => {
             Name: "step-child",
             Type: OperationType.STEP,
           },
-          update: {},
+          events: [],
         },
       ];
 
@@ -1862,7 +1871,7 @@ describe("OperationWithData", () => {
 
       operation.populateData({
         operation: operationData,
-        update: {},
+        events: [],
       });
 
       const childOperations = operation.getChildOperations();

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -140,7 +140,13 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // Verify MockOperation data for both wait operations
     expect(firstWait.getWaitDetails()?.waitSeconds).toBe(50);
+    expect(firstWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
+      Date
+    );
     expect(secondWait.getWaitDetails()?.waitSeconds).toBe(50);
+    expect(secondWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
+      Date
+    );
   });
 
   it("should handle step operations with MockOperation assertions", async () => {
@@ -277,6 +283,9 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // Verify wait step
     expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(1);
+    expect(waitStep.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
+      Date
+    );
   });
 
   it("should handle steps with retry and failure", async () => {

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
@@ -36,13 +36,11 @@ describe("ResultFormatter", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         }),
       ];
 
-      mockOperationStorage.getOperations.mockReturnValue(
-        mockOperations
-      );
+      mockOperationStorage.getOperations.mockReturnValue(mockOperations);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -80,7 +78,7 @@ describe("ResultFormatter", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         }
       );
 
@@ -94,14 +92,12 @@ describe("ResultFormatter", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.FAILED,
           },
-          update: {},
+          events: [],
         }
       );
 
       const mockOperations = [succeededOp, failedOp];
-      mockOperationStorage.getOperations.mockReturnValue(
-        mockOperations
-      );
+      mockOperationStorage.getOperations.mockReturnValue(mockOperations);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -227,6 +223,7 @@ describe("ResultFormatter", () => {
             Type: OperationType.STEP,
           },
           update: {},
+          events: [],
         },
         {
           operation: {
@@ -236,6 +233,7 @@ describe("ResultFormatter", () => {
             Type: OperationType.WAIT,
           },
           update: {},
+          events: [],
         },
       ].map(
         (checkpointOperation) =>
@@ -246,9 +244,7 @@ describe("ResultFormatter", () => {
           )
       );
 
-      mockOperationStorage.getOperations.mockReturnValue(
-        mockOperations
-      );
+      mockOperationStorage.getOperations.mockReturnValue(mockOperations);
 
       const lambdaResponse: TestExecutionResult = {
         status: OperationStatus.SUCCEEDED,
@@ -262,9 +258,7 @@ describe("ResultFormatter", () => {
       );
 
       expect(testResult.getOperations()).toEqual(mockOperations);
-      expect(mockOperationStorage.getOperations).toHaveBeenCalledTimes(
-        1
-      );
+      expect(mockOperationStorage.getOperations).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
@@ -133,6 +133,7 @@ describe("TestExecutionOrchestrator", () => {
             Payload: result,
             Error: error,
           },
+          events: [],
         },
       ] satisfies CheckpointOperation[],
       operationInvocationIdMap: {
@@ -180,6 +181,7 @@ describe("TestExecutionOrchestrator", () => {
               Payload: "execution-result",
               Action: OperationAction.SUCCEED,
             },
+            events: [],
           },
         ] satisfies CheckpointOperation[];
 
@@ -236,6 +238,7 @@ describe("TestExecutionOrchestrator", () => {
               },
               Action: OperationAction.FAIL,
             },
+            events: [],
           },
         ] satisfies CheckpointOperation[];
 
@@ -292,6 +295,7 @@ describe("TestExecutionOrchestrator", () => {
               Payload: "execution-result",
               Action: OperationAction.SUCCEED,
             },
+            events: [],
           },
         ] satisfies CheckpointOperation[];
 
@@ -347,6 +351,7 @@ describe("TestExecutionOrchestrator", () => {
               Payload: "execution-result", // this will get ignored, since invocation completed without any result
               Action: OperationAction.SUCCEED,
             },
+            events: [],
           },
         ] satisfies CheckpointOperation[];
 
@@ -413,6 +418,7 @@ describe("TestExecutionOrchestrator", () => {
               Name: "operation1",
               Payload: "execution-result",
             },
+            events: [],
           },
         ] satisfies CheckpointOperation[];
 
@@ -1382,7 +1388,7 @@ describe("TestExecutionOrchestrator", () => {
       expect(checkpointApi.updateCheckpointData).toHaveBeenCalledWith({
         executionId: mockExecutionId,
         operationId: "param-test-wait",
-        action: OperationAction.SUCCEED,
+        status: OperationStatus.SUCCEEDED,
       });
 
       // Verify new invocation was started

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/api-client/__tests__/checkpoint-api-client.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/api-client/__tests__/checkpoint-api-client.test.ts
@@ -1,5 +1,5 @@
 import { CheckpointApiClient } from "../checkpoint-api-client";
-import { OperationAction, OperationStatus } from "@amzn/dex-internal-sdk";
+import { OperationStatus } from "@amzn/dex-internal-sdk";
 import {
   API_PATHS,
   HTTP_METHODS,
@@ -206,34 +206,6 @@ describe("CheckpointApiClient", () => {
   });
 
   describe("updateCheckpointData", () => {
-    it("should make a POST request to the correct endpoint with action", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue({}),
-      });
-
-      await apiClient.updateCheckpointData({
-        executionId: mockExecutionId,
-        operationId: mockOperationId,
-        action: OperationAction.SUCCEED,
-      });
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${mockBaseUrl}${API_PATHS.UPDATE_CHECKPOINT_DATA}/${mockExecutionId}/${mockOperationId}`,
-        {
-          method: HTTP_METHODS.POST,
-          body: JSON.stringify({
-            action: OperationAction.SUCCEED,
-            status: undefined,
-          }),
-          headers: {
-            "Content-Type": "application/json",
-          },
-          signal: undefined,
-        }
-      );
-    });
-
     it("should make a POST request to the correct endpoint with status", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -274,7 +246,7 @@ describe("CheckpointApiClient", () => {
         apiClient.updateCheckpointData({
           executionId: mockExecutionId,
           operationId: mockOperationId,
-          action: OperationAction.SUCCEED,
+          status: OperationStatus.SUCCEEDED,
         })
       ).rejects.toThrow(
         `Error making HTTP request to ${API_PATHS.UPDATE_CHECKPOINT_DATA}/${mockExecutionId}/${mockOperationId}: status: 404, ${errorMessage}`

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/api-client/checkpoint-api-client.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/api-client/checkpoint-api-client.ts
@@ -3,7 +3,7 @@ import {
   OperationInvocationIdMap,
 } from "../../../checkpoint-server/storage/checkpoint-manager";
 import { InvocationResult } from "../../../checkpoint-server/storage/execution-manager";
-import { OperationAction, OperationStatus } from "@amzn/dex-internal-sdk";
+import { OperationStatus } from "@amzn/dex-internal-sdk";
 import {
   API_PATHS,
   HTTP_METHODS,
@@ -52,32 +52,23 @@ export class CheckpointApiClient {
   }
 
   /**
-   * Update checkpoint data for a specific operation.
-   * 
-   * This method supports two types of updates:
-   * - Action-based updates: Used to complete operations with a specific action (SUCCEED, FAIL, RETRY)
-   * - Status-based updates: Used to update the operation status directly (e.g., READY, PENDING)
-   * 
-   * Exactly one of `action` or `status` must be provided in the params object.
-   * 
+   * Update checkpoint data for a specific operation with the intended status.
+   *
    * @param params Object containing update parameters
    * @param params.executionId The execution ID containing the operation
    * @param params.operationId The specific operation ID to update
-   * @param params.action Optional operation action to apply (mutually exclusive with status)
-   * @param params.status Optional operation status to set (mutually exclusive with action)
+   * @param params.status Optional operation status to set
    * @throws {Error} When the API request fails or returns a non-success status
    */
   async updateCheckpointData(params: {
     executionId: ExecutionId;
     operationId: string;
-    action?: OperationAction;
-    status?: OperationStatus;
+    status: OperationStatus;
   }): Promise<void> {
     return this.makeRequest({
       path: getUpdateCheckpointDataPath(params.executionId, params.operationId),
       method: HTTP_METHODS.POST,
       body: JSON.stringify({
-        action: params.action,
         status: params.status,
       }),
     });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
@@ -5,7 +5,7 @@ import { createInvocationId } from "../../../../checkpoint-server/utils/tagged-s
 import { OperationWaitManager } from "../operation-wait-manager";
 import { IndexedOperations } from "../../../common/indexed-operations";
 import { MockOperation } from "../mock-operation";
-import { CheckpointOperation } from "../../../../checkpoint-server/storage/checkpoint-manager";
+import { OperationEvents } from "../../../common/operations/operation-with-data";
 
 describe("InvocationTracker", () => {
   let waitManager: OperationWaitManager;
@@ -19,14 +19,14 @@ describe("InvocationTracker", () => {
     status: OperationStatus = OperationStatus.SUCCEEDED
   ): MockOperation => {
     const operation = new MockOperation({ id }, waitManager, indexedOperations);
-    const checkpointOp: CheckpointOperation = {
+    const checkpointOp: OperationEvents = {
       operation: {
         Id: id,
         Status: status,
         Type: OperationType.STEP,
         Name: `operation-${id}`,
       },
-      update: {},
+      events: [],
     };
     operation.populateData(checkpointOp);
     return operation;

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-storage.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-storage.test.ts
@@ -2,9 +2,9 @@ import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
 import { OperationStorage } from "../operation-storage";
 import { OperationWaitManager } from "../operation-wait-manager";
 import { MockOperation } from "../mock-operation";
-import { CheckpointOperation } from "../../../../checkpoint-server/storage/checkpoint-manager";
 import { createExecutionId } from "../../../../checkpoint-server/utils/tagged-strings";
 import { IndexedOperations } from "../../../common/indexed-operations";
+import { OperationEvents } from "../../../common/operations/operation-with-data";
 
 // Mock the OperationWaitManager
 jest.mock("../operation-wait-manager");
@@ -15,7 +15,7 @@ describe("OperationStorage", () => {
   let mockCallback: jest.Mock;
 
   // Sample operations for testing
-  const sampleOperations: CheckpointOperation[] = [
+  const sampleOperations: OperationEvents[] = [
     {
       operation: {
         Id: "op1",
@@ -23,7 +23,7 @@ describe("OperationStorage", () => {
         Type: OperationType.STEP,
         Status: OperationStatus.SUCCEEDED,
       },
-      update: {},
+      events: [],
     },
     {
       operation: {
@@ -32,7 +32,7 @@ describe("OperationStorage", () => {
         Type: OperationType.WAIT,
         Status: OperationStatus.SUCCEEDED,
       },
-      update: {},
+      events: [],
     },
     {
       operation: {
@@ -41,7 +41,7 @@ describe("OperationStorage", () => {
         Type: OperationType.CALLBACK,
         Status: OperationStatus.FAILED,
       },
-      update: {},
+      events: [],
     },
   ];
 
@@ -92,7 +92,7 @@ describe("OperationStorage", () => {
             Id: "Execution-operation-id",
             Type: OperationType.EXECUTION,
           },
-          update: {},
+          events: [],
         })
       );
 
@@ -304,7 +304,7 @@ describe("OperationStorage", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
 
@@ -364,7 +364,7 @@ describe("OperationStorage", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
 
@@ -400,7 +400,7 @@ describe("OperationStorage", () => {
             Name: "", // Empty string name
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
 
@@ -436,7 +436,7 @@ describe("OperationStorage", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
         {
           operation: {
@@ -445,7 +445,7 @@ describe("OperationStorage", () => {
             Type: OperationType.WAIT,
             Status: OperationStatus.SUCCEEDED,
           },
-          update: {},
+          events: [],
         },
       ]);
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-wait-manager.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/operation-wait-manager.test.ts
@@ -2,8 +2,10 @@ import { OperationWaitManager } from "../operation-wait-manager";
 import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
 import { WaitingOperationStatus } from "../../../durable-test-runner";
 import { IndexedOperations } from "../../../common/indexed-operations";
-import { CheckpointOperation } from "../../../../checkpoint-server/storage/checkpoint-manager";
-import { OperationWithData } from "../../../common/operations/operation-with-data";
+import {
+  OperationEvents,
+  OperationWithData,
+} from "../../../common/operations/operation-with-data";
 import { OperationSubType } from "@amzn/durable-executions-language-sdk";
 
 describe("OperationWaitManager", () => {
@@ -21,10 +23,9 @@ describe("OperationWaitManager", () => {
         Type: OperationType.STEP,
         Status: OperationStatus.PENDING,
       },
-      update: {},
+      events: [],
     });
   });
-
 
   // Helper function to trigger operation resolution
   const triggerOperationResolution = (
@@ -38,7 +39,7 @@ describe("OperationWaitManager", () => {
         ...originalData,
         Status: status,
       },
-      update: {},
+      events: [],
     };
 
     // Use populateData to update the same operation object
@@ -202,7 +203,7 @@ describe("OperationWaitManager", () => {
               Type: OperationType.STEP,
               // Status is undefined
             },
-            update: {},
+            events: [],
           }
         );
 
@@ -272,7 +273,7 @@ describe("OperationWaitManager", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.PENDING,
           },
-          update: {},
+          events: [],
         }
       );
       void waitManager.waitForOperation(
@@ -310,7 +311,7 @@ describe("OperationWaitManager", () => {
             Type: OperationType.STEP,
             Status: OperationStatus.PENDING,
           },
-          update: {},
+          events: [],
         }
       );
 
@@ -346,7 +347,7 @@ describe("OperationWaitManager", () => {
           SubType: OperationSubType.WAIT_FOR_CALLBACK,
           Status: status,
         },
-        update: {},
+        events: [],
       });
 
     // Helper function to create a regular (non-waitForCallback) operation
@@ -360,35 +361,35 @@ describe("OperationWaitManager", () => {
           Type: OperationType.STEP,
           Status: status,
         },
-        update: {},
+        events: [],
       });
 
     // Helper function to create a callback checkpoint operation
     const createCallbackCheckpointOperation = (
       parentId: string,
       status: OperationStatus = OperationStatus.SUCCEEDED
-    ): CheckpointOperation => ({
+    ): OperationEvents => ({
       operation: {
         Id: "callback-op-id",
         Type: OperationType.CALLBACK,
         ParentId: parentId,
         Status: status,
       },
-      update: {},
+      events: [],
     });
 
     // Helper function to create a non-callback checkpoint operation
     const createNonCallbackCheckpointOperation = (
       type: OperationType = OperationType.STEP,
       parentId?: string
-    ): CheckpointOperation => ({
+    ): OperationEvents => ({
       operation: {
         Id: "non-callback-op-id",
         Type: type,
         ParentId: parentId,
         Status: OperationStatus.SUCCEEDED,
       },
-      update: {},
+      events: [],
     });
 
     describe("handleCheckpointReceived with callback operations", () => {
@@ -531,14 +532,14 @@ describe("OperationWaitManager", () => {
         );
 
         // Act - Trigger callback operation without ParentId
-        const callbackWithoutParent: CheckpointOperation = {
+        const callbackWithoutParent: OperationEvents = {
           operation: {
             Id: "callback-op-id",
             Type: OperationType.CALLBACK,
             Status: OperationStatus.SUCCEEDED,
             // ParentId is undefined
           },
-          update: {},
+          events: [],
         };
         waitManager.handleCheckpointReceived([callbackWithoutParent], []);
 
@@ -592,7 +593,7 @@ describe("OperationWaitManager", () => {
               Type: OperationType.STEP,
               Status: OperationStatus.SUCCEEDED,
             },
-            update: {},
+            events: [],
           }
         );
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-storage.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-storage.ts
@@ -1,8 +1,7 @@
 import { MockOperation } from "./mock-operation";
 import { IndexedOperations } from "../../common/indexed-operations";
-import { CheckpointOperation } from "../../../checkpoint-server/storage/checkpoint-manager";
 import { ExecutionId } from "../../../checkpoint-server/utils/tagged-strings";
-import { OperationWithData } from "../../common/operations/operation-with-data";
+import { OperationEvents, OperationWithData } from "../../common/operations/operation-with-data";
 import { OperationType } from "@amzn/dex-internal-sdk";
 import { DurableOperation } from "../../durable-test-runner";
 import { OperationWaitManager } from "./operation-wait-manager";
@@ -14,7 +13,7 @@ export class OperationStorage {
     private readonly waitManager: OperationWaitManager,
     private readonly indexedOperations: IndexedOperations,
     private readonly onCheckpointReceived: (
-      checkpointOperationsReceived: CheckpointOperation[],
+      checkpointOperationsReceived: OperationEvents[],
       trackedDurableOperations: DurableOperation<unknown>[]
     ) => void
   ) {}
@@ -76,7 +75,7 @@ export class OperationStorage {
    * Will be run every time checkpoint data is received.
    * @param newCheckpointOperations
    */
-  populateOperations(newCheckpointOperations: CheckpointOperation[]): void {
+  populateOperations(newCheckpointOperations: OperationEvents[]): void {
     if (!newCheckpointOperations.length) {
       return;
     }

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-wait-manager.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/operation-wait-manager.ts
@@ -8,7 +8,7 @@ import {
   WaitingOperationStatus,
 } from "../../durable-test-runner";
 import { doesStatusMatch } from "./status-matcher";
-import { CheckpointOperation } from "../../../checkpoint-server/storage/checkpoint-manager";
+import { OperationEvents } from "../../common/operations/operation-with-data";
 
 interface WaitingOperation {
   operation: DurableOperation<unknown>;
@@ -56,7 +56,7 @@ export class OperationWaitManager {
    * @param trackedDurableOperations Operations that just got populated with data
    */
   handleCheckpointReceived(
-    checkpointOperationsReceived: CheckpointOperation[],
+    checkpointOperationsReceived: OperationEvents[],
     trackedDurableOperations: DurableOperation<unknown>[]
   ): void {
     // Handle callback operations


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

### Description

Refactoring testing library local runner to support history events.

Before, I was storing the update associated with the operation to keep track of things and return data in helper methods. Now, I'm using the history events as the internal data store. This will make it much easier to support cloud testing since there aren't any operation updates when pulling history for cloud testing.

Currently, this just populates the internal data fields with the history events, and it's not accessible yet. I can expose the history events later.

### Demo/Screenshots

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests
Have unit tests been written for these changes? Yes

#### Integration Tests
Have integration tests been written for these changes? No

#### Examples
Has a new example been added for the change? (if applicable) N/A
