### PR TITLE
fix(sdk): add missing WaitCancelledDetails shape in lambda.json model

### DIFF
--- a/.github/model/lambda.json
+++ b/.github/model/lambda.json
@@ -4859,6 +4859,12 @@
         "Error":{"shape":"EventError"}
       }
     },
+    "WaitCancelledDetails":{
+      "type":"structure",
+      "members":{
+        "Error":{"shape":"EventError"}
+      }
+    },
     "InvokeStartedDetails":{
       "type":"structure",
       "members":{}
@@ -4885,6 +4891,19 @@
       "type":"structure",
       "members":{
         "Error":{"shape":"EventError"}
+      }
+    },
+    "ExecutionDetails":{
+      "type":"structure",
+      "members":{
+        "InputPayload":{"shape":"InputPayload"}
+      }
+    },
+    "ContextDetails":{
+      "type":"structure",
+      "members":{
+        "Result":{"shape":"OperationPayload"},
+        "Error":{"shape":"ErrorObject"}
       }
     },
     "Origin":{


### PR DESCRIPTION
The WaitCancelledDetails shape was referenced in the Event structure but not defined in the shapes section, causing AWS CLI to fail with exit code 255 when parsing responses containing WaitCancelledDetails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

