### PR TITLE
feat(checkpoint): add 750KB payload size limit to checkpoint batching

### DIFF
--- a/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
@@ -90,7 +90,9 @@ describe("Run In Child Context Integration Tests", () => {
     // The fire-and-forget optimization means we may only see the START checkpoint
     // in the test environment, but the functionality should work correctly
     expect(checkpointCalls.length).toBeGreaterThanOrEqual(1);
-    expect(checkpointCalls[0].data.Updates[0].Action).toBe(OperationAction.START);
+    expect(checkpointCalls[0].data.Updates[0].Action).toBe(
+      OperationAction.START,
+    );
     expect(checkpointCalls[0].data.Updates[0].Id).toBe(hashId("1"));
     expect(checkpointCalls[0].data.Updates[0].Type).toBe(OperationType.CONTEXT);
     expect(checkpointCalls[0].data.Updates[0].Name).toBe("test-child-context");
@@ -139,7 +141,9 @@ describe("Run In Child Context Integration Tests", () => {
 
     // Child context should create at least START checkpoint (fire-and-forget optimization)
     expect(checkpointCalls.length).toBeGreaterThanOrEqual(1);
-    expect(checkpointCalls[0].data.Updates[0].Action).toBe(OperationAction.START);
+    expect(checkpointCalls[0].data.Updates[0].Action).toBe(
+      OperationAction.START,
+    );
   });
 
   test("should support nested child contexts with deterministic IDs", async () => {
@@ -232,7 +236,9 @@ describe("Run In Child Context Integration Tests", () => {
     expect(checkpointCalls.length).toBeGreaterThanOrEqual(2);
 
     // First checkpoint should be child context START
-    expect(checkpointCalls[0].data.Updates[0].Action).toBe(OperationAction.START);
+    expect(checkpointCalls[0].data.Updates[0].Action).toBe(
+      OperationAction.START,
+    );
     expect(checkpointCalls[0].data.Updates[0].Id).toBe(hashId("1"));
 
     // If we have more than 2 checkpoints, check for child step
@@ -245,7 +251,9 @@ describe("Run In Child Context Integration Tests", () => {
     // Last checkpoint should be child context SUCCEED
     const lastCheckpoint = checkpointCalls[checkpointCalls.length - 1];
     expect(lastCheckpoint.data.Updates[0].Action).toBe(OperationAction.SUCCEED);
-    expect(lastCheckpoint.data.Updates[0].ParentId).toBe(hashId("original-parent-123"));
+    expect(lastCheckpoint.data.Updates[0].ParentId).toBe(
+      hashId("original-parent-123"),
+    );
     expect(lastCheckpoint.data.Updates[0].Name).toBe("test-child-context");
   });
 

--- a/packages/lambda-durable-functions-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -1029,4 +1029,86 @@ describe("createCheckpointHandler", () => {
     expect(calls[0][1].Updates[0].Id).toBe(hashId("step-1"));
     expect(calls[0][1].Updates[1].Id).toBe(hashId("step-2"));
   });
+
+  it("should split large payloads into multiple API calls when exceeding 750KB limit", async () => {
+    deleteCheckpoint();
+    const checkpoint = createCheckpoint(mockContext, TEST_CONSTANTS.CHECKPOINT_TOKEN);
+    
+    // Create large payload data that will exceed 750KB when combined
+    const largeData = "x".repeat(400000); // 400KB per item
+    
+    // Queue two large items that together exceed 750KB
+    const promises = [
+      checkpoint("large-step-1", { Action: OperationAction.START, Payload: largeData }),
+      checkpoint("large-step-2", { Action: OperationAction.START, Payload: largeData }),
+    ];
+
+    await Promise.all(promises);
+
+    // Should make multiple API calls due to size limit
+    expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
+    
+    // First call should have one item
+    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    // Second call should have the remaining item
+    expect(mockState.checkpoint.mock.calls[1][1].Updates).toHaveLength(1);
+  });
+
+  it("should process remaining items in queue after size limit is reached", async () => {
+    deleteCheckpoint();
+    const checkpoint = createCheckpoint(mockContext, TEST_CONSTANTS.CHECKPOINT_TOKEN);
+    
+    // Create items where first is large enough to trigger size limit
+    const largeData = "x".repeat(400000); // 400KB
+    
+    // Add first large item
+    const promise1 = checkpoint("large-step", { Action: OperationAction.START, Payload: largeData });
+    
+    // Wait a bit then add more items
+    await new Promise(resolve => setTimeout(resolve, 10));
+    
+    const promise2 = checkpoint("small-step-1", { Action: OperationAction.START, Payload: largeData });
+    const promise3 = checkpoint("small-step-2", { Action: OperationAction.START });
+
+    await Promise.all([promise1, promise2, promise3]);
+
+    // Should make multiple calls due to size limits
+    expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
+    
+    // Verify all items were processed
+    const allUpdates = mockState.checkpoint.mock.calls.flatMap((call: any) => call[1].Updates);
+    expect(allUpdates).toHaveLength(3);
+    expect(allUpdates.map((u: any) => u.Id)).toEqual([
+      hashId("large-step"),
+      hashId("small-step-1"), 
+      hashId("small-step-2")
+    ]);
+  });
+
+  it("should update stepData from checkpoint response operations", async () => {
+    deleteCheckpoint();
+    const checkpoint = createCheckpoint(mockContext, TEST_CONSTANTS.CHECKPOINT_TOKEN);
+    
+    // Mock checkpoint response with operations
+    const mockOperations = [
+      {
+        Id: hashId("test-step"),
+        Type: OperationType.STEP,
+        Action: OperationAction.START,
+        Payload: "test-result"
+      }
+    ];
+    
+    mockState.checkpoint.mockResolvedValue({
+      CheckpointToken: "new-task-token",
+      NewExecutionState: {
+        Operations: mockOperations
+      }
+    });
+
+    await checkpoint("test-step", { Action: OperationAction.START });
+
+    // Verify stepData was updated with operations from response
+    expect(mockContext._stepData[hashId("test-step")]).toEqual(mockOperations[0]);
+  });
 });


### PR DESCRIPTION
- Implement payload size checking to prevent API failures
- Split large checkpoint batches into multiple API calls when exceeding 750KB
- Automatically process remaining queue items after size limit reached
- Add tests for payload size functionality

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
