### PR TITLE
ci: Use short term credentials for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
         fi
     
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
         role-session-name: githubIntegrationTest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use short term credentials (OIDC provider) instead of long term credentials (IAM user) for integration tests

See successful Action run using short term credentials: https://github.com/aws/aws-durable-functions-sdk-js/actions/runs/17806757780/job/50620422696

https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
