### PR TITLE
chore: Add workflow permissions unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ "main", "development", "add-workflow-permissions-unit-tests"]
+    branches: [ "main", "development"]
   pull_request:
     branches: [ "main", "development"]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* fix the following security alerts. Workflow does not contain permissions.

https://github.com/aws/aws-durable-functions-sdk-js/security/code-scanning/1
https://github.com/aws/aws-durable-functions-sdk-js/security/code-scanning/3

I tested by running the workflow with the updated permissions in the feature branch: https://github.com/aws/aws-durable-functions-sdk-js/actions/runs/17809031900/job/50627919794


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
