### PR TITLE
feat(testing-sdk): add cloud test runner

### DIFF
--- a/packages/examples/jest.config.integration.js
+++ b/packages/examples/jest.config.integration.js
@@ -1,0 +1,11 @@
+const { createDefaultPreset } = require("ts-jest");
+
+const defaultPreset = createDefaultPreset();
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  ...defaultPreset,
+  testMatch: ["**/__tests__/integration/**.test.ts"],
+  coverageReporters: ["cobertura", "html", "text"],
+  testTimeout: 30000,
+};

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -32,6 +32,7 @@
     "copy-catalog": "cp examples-catalog.json build/durable-executions-typescript-sdk-examples/",
     "generate-template": "node scripts/generate-template.js",
     "test": "npm run unit-test",
+    "test:integration": "jest --config jest.config.integration.js",
     "unit-test": "jest --collectCoverage",
     "unit-test-watch": "jest --watch",
     "prettier": "prettier --write './src/**/*.*' && prettier --write './test/**/*.*'"

--- a/packages/examples/src/examples/__tests__/integration/step-basic.test.ts
+++ b/packages/examples/src/examples/__tests__/integration/step-basic.test.ts
@@ -1,0 +1,26 @@
+import { CloudDurableTestRunner } from "@amzn/durable-executions-type-script-testing-library";
+
+if (!process.env.FUNCTION_NAME_MAP) {
+  throw new Error("FUNCTION_NAME_MAP is not set");
+}
+
+const functionNames = JSON.parse(process.env.FUNCTION_NAME_MAP!);
+
+describe("step-basic test", () => {
+  const durableTestRunner = new CloudDurableTestRunner({
+    functionName: functionNames["step-basic"],
+    config: {
+      endpoint: process.env.LAMBDA_ENDPOINT,
+    },
+  });
+
+  it("should execute step and return correct result", async () => {
+    const execution = await durableTestRunner.run();
+
+    expect(execution.getOperations()).toHaveLength(1);
+    expect(durableTestRunner.getOperationByIndex(0).getStepDetails()).toEqual({
+      result: "step completed",
+    });
+    expect(execution.getResult()).toStrictEqual("step completed");
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/__tests__/index.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import * as indexExports from "../index";
 import * as localExports from "../local";
+import * as cloudExports from "../cloud";
 import * as durableTestRunnerExports from "../durable-test-runner";
 
 describe("test-runner/index.ts exports", () => {
@@ -12,6 +13,19 @@ describe("test-runner/index.ts exports", () => {
       expect(Object.keys(indexExports)).toContain(key);
       expect((indexExports as Record<string, unknown>)[key]).toBe(
         (localExports as Record<string, unknown>)[key]
+      );
+    }
+  });
+
+  it("should correctly re-export all exports from cloud", () => {
+    // Get all exported keys from cloud
+    const cloudKeys = Object.keys(cloudExports);
+
+    // Check that all keys from cloud are in index exports
+    for (const key of cloudKeys) {
+      expect(Object.keys(indexExports)).toContain(key);
+      expect((indexExports as Record<string, unknown>)[key]).toBe(
+        (cloudExports as Record<string, unknown>)[key]
       );
     }
   });
@@ -34,15 +48,19 @@ describe("test-runner/index.ts exports", () => {
     const indexKeys = Object.keys(indexExports);
     const localKeys = Object.keys(localExports);
     const durableKeys = Object.keys(durableTestRunnerExports);
+    const cloudKeys = Object.keys(cloudExports);
 
     // The total count of exports should match the sum of the individual modules
-    expect(indexKeys.length).toBe(localKeys.length + durableKeys.length);
+    expect(indexKeys.length).toBe(
+      localKeys.length + durableKeys.length + cloudKeys.length
+    );
 
     // Every key in indexExports should be in either localExports or durableTestRunnerExports
     for (const key of indexKeys) {
       const isInLocal = localKeys.includes(key);
       const isInDurable = durableKeys.includes(key);
-      expect(isInLocal || isInDurable).toBe(true);
+      const isInCloud = cloudKeys.includes(key);
+      expect(isInLocal || isInDurable || isInCloud).toBe(true);
     }
   });
 });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
@@ -1,0 +1,626 @@
+import {
+  LambdaClient,
+  Invoke20150331Command,
+  GetDurableExecutionCommand,
+  GetDurableExecutionHistoryCommand,
+  GetDurableExecutionHistoryResponse,
+  LambdaClientConfig,
+  EventType,
+} from "@amzn/dex-internal-sdk";
+import { CloudDurableTestRunner } from "../cloud-durable-test-runner";
+import {
+  OperationWithData,
+  OperationEvents,
+} from "../../common/operations/operation-with-data";
+import { IndexedOperations } from "../../common/indexed-operations";
+import { OperationStorage } from "../../common/operation-storage";
+import { OperationWaitManager } from "../../local/operations/operation-wait-manager";
+import { ResultFormatter } from "../../local/result-formatter";
+import { historyEventsToOperationEvents } from "../utils/process-history-events/process-history-events";
+
+// Mock all dependencies
+jest.mock("@amzn/dex-internal-sdk");
+jest.mock("../../common/indexed-operations");
+jest.mock("../../common/operation-storage");
+jest.mock("../../local/operations/operation-wait-manager");
+jest.mock("../../local/result-formatter");
+jest.mock("../../common/operations/operation-with-data");
+jest.mock("../utils/process-history-events/process-history-events");
+
+describe("CloudDurableTestRunner", () => {
+  let mockLambdaClient: jest.Mocked<LambdaClient>;
+  let mockResultFormatter: jest.Mocked<ResultFormatter<{ success: boolean }>>;
+  let mockWaitManager: jest.Mocked<OperationWaitManager>;
+  let mockIndexedOperations: jest.Mocked<IndexedOperations>;
+  let mockOperationStorage: jest.Mocked<OperationStorage>;
+  let mockOperationWithData: jest.Mocked<OperationWithData>;
+
+  const mockFunctionArn =
+    "arn:aws:lambda:us-east-1:123456789012:function:test-function";
+  const mockExecutionArn =
+    "arn:aws:lambda:us-east-1:123456789012:execution:test-execution";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    // Mock LambdaClient
+    mockLambdaClient = {
+      send: jest.fn(),
+    } as unknown as jest.Mocked<LambdaClient>;
+
+    (LambdaClient as jest.Mock).mockImplementation(() => mockLambdaClient);
+
+    // Mock ResultFormatter
+    mockResultFormatter = {
+      formatTestResult: jest.fn().mockReturnValue({
+        getOperations: jest.fn().mockReturnValue([]),
+        getInvocations: jest.fn().mockReturnValue([]),
+        getResult: jest.fn().mockReturnValue({ data: { success: true } }),
+        getError: jest.fn(),
+      }),
+    } as unknown as jest.Mocked<ResultFormatter<{ success: boolean }>>;
+
+    (ResultFormatter as jest.Mock).mockImplementation(
+      () => mockResultFormatter
+    );
+
+    // Mock OperationWaitManager
+    mockWaitManager = {
+      waitForOperation: jest.fn(),
+      clearWaitingOperations: jest.fn(),
+      handleCheckpointReceived: jest.fn(),
+    } as unknown as jest.Mocked<OperationWaitManager>;
+
+    (OperationWaitManager as jest.Mock).mockImplementation(
+      () => mockWaitManager
+    );
+
+    // Mock IndexedOperations
+    mockIndexedOperations = {
+      getByIndex: jest.fn(),
+      getByNameAndIndex: jest.fn(),
+      getById: jest.fn(),
+    } as unknown as jest.Mocked<IndexedOperations>;
+
+    (IndexedOperations as jest.Mock).mockImplementation(
+      () => mockIndexedOperations
+    );
+
+    // Mock OperationStorage
+    mockOperationStorage = {
+      populateOperations: jest.fn(),
+      registerOperation: jest.fn(),
+    } as unknown as jest.Mocked<OperationStorage>;
+
+    (OperationStorage as jest.Mock).mockImplementation(
+      () => mockOperationStorage
+    );
+
+    // Mock OperationWithData
+    mockOperationWithData = {
+      getData: jest.fn(),
+      getStatus: jest.fn(),
+    } as unknown as jest.Mocked<OperationWithData>;
+
+    (OperationWithData as jest.Mock).mockImplementation(
+      () => mockOperationWithData
+    );
+
+    // Mock historyEventsToOperationEvents
+    (historyEventsToOperationEvents as jest.Mock).mockReturnValue([]);
+  });
+
+  describe("constructor", () => {
+    it("should initialize with required parameters", () => {
+      const runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+
+      expect(runner).toBeDefined();
+      expect(LambdaClient).toHaveBeenCalledWith({});
+    });
+
+    it("should initialize with custom Lambda client config", () => {
+      const customConfig: LambdaClientConfig = {
+        region: "us-west-2",
+        credentials: {
+          accessKeyId: "test-key",
+          secretAccessKey: "test-secret",
+        },
+      };
+
+      const runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+        config: customConfig,
+      });
+
+      expect(runner).toBeDefined();
+      expect(LambdaClient).toHaveBeenCalledWith(customConfig);
+    });
+
+    it("should initialize all internal dependencies", () => {
+      new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+
+      expect(ResultFormatter).toHaveBeenCalled();
+      expect(OperationWaitManager).toHaveBeenCalled();
+      expect(IndexedOperations).toHaveBeenCalledWith([]);
+      expect(OperationStorage).toHaveBeenCalledWith(
+        mockWaitManager,
+        mockIndexedOperations
+      );
+    });
+  });
+
+  describe("run", () => {
+    let runner: CloudDurableTestRunner<{ success: boolean }>;
+
+    beforeEach(() => {
+      runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+    });
+
+    it("should successfully execute a durable function without parameters", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "SUCCEEDED",
+        Result: JSON.stringify({ success: true }),
+        Error: undefined,
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [
+          {
+            EventType: EventType.ExecutionStarted,
+            EventTimestamp: new Date(),
+          },
+        ],
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult) // Invoke20150331Command
+        .mockResolvedValueOnce(mockExecutionResult) // GetDurableExecutionCommand
+        .mockResolvedValueOnce(mockHistoryResult); // GetDurableExecutionHistoryCommand
+
+      const result = await runner.run();
+
+      expect(mockLambdaClient.send).toHaveBeenCalledTimes(3);
+      expect(mockLambdaClient.send).toHaveBeenNthCalledWith(
+        1,
+        expect.any(Invoke20150331Command)
+      );
+      expect(mockLambdaClient.send).toHaveBeenNthCalledWith(
+        2,
+        expect.any(GetDurableExecutionCommand)
+      );
+      expect(mockLambdaClient.send).toHaveBeenNthCalledWith(
+        3,
+        expect.any(GetDurableExecutionHistoryCommand)
+      );
+
+      expect(historyEventsToOperationEvents).toHaveBeenCalledWith(
+        mockHistoryResult.Events
+      );
+      expect(mockOperationStorage.populateOperations).toHaveBeenCalled();
+      expect(mockResultFormatter.formatTestResult).toHaveBeenCalledWith(
+        {
+          status: "SUCCEEDED",
+          result: JSON.stringify({ success: true }),
+          error: undefined,
+        },
+        mockOperationStorage,
+        []
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it("should execute with payload parameters", async () => {
+      const testPayload = { input: "test-data", count: 42 };
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "SUCCEEDED",
+        Result: JSON.stringify({ success: true }),
+        Error: undefined,
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [],
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult)
+        .mockResolvedValueOnce(mockExecutionResult)
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      await runner.run({ payload: testPayload });
+
+      // Verify that Invoke20150331Command was called with correct parameters
+      expect(Invoke20150331Command).toHaveBeenCalledWith({
+        FunctionName: mockFunctionArn,
+        Payload: JSON.stringify(testPayload),
+      });
+    });
+
+    it("should handle execution without payload", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "SUCCEEDED",
+        Result: JSON.stringify({ success: true }),
+        Error: undefined,
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [],
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult)
+        .mockResolvedValueOnce(mockExecutionResult)
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      await runner.run();
+
+      // Verify that Invoke20150331Command was called with correct parameters
+      expect(Invoke20150331Command).toHaveBeenCalledWith({
+        FunctionName: mockFunctionArn,
+        Payload: undefined,
+      });
+    });
+
+    it("should handle failed execution", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "FAILED",
+        Result: undefined,
+        Error: {
+          errorMessage: "Execution failed",
+          errorType: "RuntimeError",
+        },
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [],
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult)
+        .mockResolvedValueOnce(mockExecutionResult)
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      const result = await runner.run();
+
+      expect(mockResultFormatter.formatTestResult).toHaveBeenCalledWith(
+        {
+          status: "FAILED",
+          result: undefined,
+          error: {
+            errorMessage: "Execution failed",
+            errorType: "RuntimeError",
+          },
+        },
+        mockOperationStorage,
+        []
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it("should propagate Lambda client errors", async () => {
+      const mockError = new Error("Lambda invocation failed");
+      (mockLambdaClient.send as jest.Mock).mockRejectedValue(mockError);
+
+      await expect(runner.run()).rejects.toThrow("Lambda invocation failed");
+    });
+
+    it("should handle missing execution ARN", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: undefined,
+      };
+
+      (mockLambdaClient.send as jest.Mock).mockResolvedValueOnce(
+        mockInvokeResult
+      );
+
+      // The code should handle undefined execution ARN by attempting to use it
+      // This will likely cause an error when trying to use undefined in subsequent calls
+      await expect(runner.run()).rejects.toThrow();
+    });
+
+    it("should handle empty history events", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "SUCCEEDED",
+        Result: JSON.stringify({ success: true }),
+        Error: undefined,
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: undefined,
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult)
+        .mockResolvedValueOnce(mockExecutionResult)
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      await runner.run();
+
+      expect(historyEventsToOperationEvents).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe("getHistory", () => {
+    it("should return undefined before run is called", () => {
+      const runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+
+      expect(runner.getHistory()).toBeUndefined();
+    });
+
+    it("should return history after successful run", async () => {
+      const runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [
+          {
+            EventType: EventType.ExecutionStarted,
+            EventTimestamp: new Date(),
+          },
+        ],
+      };
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce({ DurableExecutionArn: mockExecutionArn })
+        .mockResolvedValueOnce({ Status: "SUCCEEDED", Result: "{}" })
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      await runner.run();
+
+      expect(runner.getHistory()).toBe(mockHistoryResult);
+    });
+  });
+
+  describe("operation retrieval methods", () => {
+    let runner: CloudDurableTestRunner<{ success: boolean }>;
+
+    beforeEach(() => {
+      runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+    });
+
+    describe("getOperation", () => {
+      it("should delegate to getOperationByNameAndIndex with index 0", () => {
+        const mockOperation: OperationEvents = {
+          operation: { Id: "test-id", Name: "testOp" },
+          events: [],
+        };
+        mockIndexedOperations.getByNameAndIndex.mockReturnValue(mockOperation);
+
+        const result = runner.getOperation("testOp");
+
+        expect(mockIndexedOperations.getByNameAndIndex).toHaveBeenCalledWith(
+          "testOp",
+          0
+        );
+        expect(OperationWithData).toHaveBeenCalledWith(
+          mockWaitManager,
+          mockIndexedOperations,
+          mockOperation
+        );
+        expect(result).toBe(mockOperationWithData);
+      });
+    });
+
+    describe("getOperationByIndex", () => {
+      it("should retrieve operation by index", () => {
+        const mockOperation: OperationEvents = {
+          operation: { Id: "test-id-2" },
+          events: [],
+        };
+        mockIndexedOperations.getByIndex.mockReturnValue(mockOperation);
+
+        const result = runner.getOperationByIndex(2);
+
+        expect(mockIndexedOperations.getByIndex).toHaveBeenCalledWith(2);
+        expect(OperationWithData).toHaveBeenCalledWith(
+          mockWaitManager,
+          mockIndexedOperations,
+          mockOperation
+        );
+        expect(result).toBe(mockOperationWithData);
+      });
+    });
+
+    describe("getOperationByNameAndIndex", () => {
+      it("should retrieve operation by name and index", () => {
+        const mockOperation: OperationEvents = {
+          operation: { Id: "test-id-3", Name: "testOp" },
+          events: [],
+        };
+        mockIndexedOperations.getByNameAndIndex.mockReturnValue(mockOperation);
+
+        const result = runner.getOperationByNameAndIndex("testOp", 1);
+
+        expect(mockIndexedOperations.getByNameAndIndex).toHaveBeenCalledWith(
+          "testOp",
+          1
+        );
+        expect(OperationWithData).toHaveBeenCalledWith(
+          mockWaitManager,
+          mockIndexedOperations,
+          mockOperation
+        );
+        expect(result).toBe(mockOperationWithData);
+      });
+    });
+
+    describe("getOperationById", () => {
+      it("should retrieve operation by ID", () => {
+        const mockOperation: OperationEvents = {
+          operation: { Id: "op-123" },
+          events: [],
+        };
+        mockIndexedOperations.getById.mockReturnValue(mockOperation);
+
+        const result = runner.getOperationById("op-123");
+
+        expect(mockIndexedOperations.getById).toHaveBeenCalledWith("op-123");
+        expect(OperationWithData).toHaveBeenCalledWith(
+          mockWaitManager,
+          mockIndexedOperations,
+          mockOperation
+        );
+        expect(result).toBe(mockOperationWithData);
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    let runner: CloudDurableTestRunner<{ success: boolean }>;
+
+    beforeEach(() => {
+      runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+    });
+
+    it("should handle invoke command failure", async () => {
+      const invokeError = new Error("Failed to invoke function");
+      (mockLambdaClient.send as jest.Mock).mockRejectedValue(invokeError);
+
+      await expect(runner.run()).rejects.toThrow("Failed to invoke function");
+    });
+
+    it("should handle get execution command failure", async () => {
+      const executionError = new Error("Failed to get execution");
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce({ DurableExecutionArn: mockExecutionArn })
+        .mockRejectedValue(executionError);
+
+      await expect(runner.run()).rejects.toThrow("Failed to get execution");
+    });
+
+    it("should handle get history command failure", async () => {
+      const historyError = new Error("Failed to get history");
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce({ DurableExecutionArn: mockExecutionArn })
+        .mockResolvedValueOnce({ Status: "SUCCEEDED", Result: "{}" })
+        .mockRejectedValue(historyError);
+
+      await expect(runner.run()).rejects.toThrow("Failed to get history");
+    });
+
+    it("should handle operation retrieval errors gracefully", () => {
+      const retrievalError = new Error("Operation not found");
+      mockIndexedOperations.getById.mockImplementation(() => {
+        throw retrievalError;
+      });
+
+      expect(() => runner.getOperationById("non-existent")).toThrow(
+        "Operation not found"
+      );
+    });
+  });
+
+  describe("integration scenarios", () => {
+    let runner: CloudDurableTestRunner<{ success: boolean }>;
+
+    beforeEach(() => {
+      runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+    });
+
+    it("should handle complex execution with multiple operations", async () => {
+      const mockInvokeResult = {
+        DurableExecutionArn: mockExecutionArn,
+      };
+
+      const mockExecutionResult = {
+        Status: "SUCCEEDED",
+        Result: JSON.stringify({ success: true, operationCount: 3 }),
+        Error: undefined,
+      };
+
+      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
+        Events: [
+          {
+            EventType: EventType.ExecutionStarted,
+            EventTimestamp: new Date(),
+          },
+          {
+            EventType: EventType.StepStarted,
+            EventTimestamp: new Date(),
+          },
+          {
+            EventType: EventType.StepSucceeded,
+            EventTimestamp: new Date(),
+          },
+        ],
+      };
+
+      const mockOperationEvents: OperationEvents[] = [
+        { operation: { Id: "op1" }, events: [] },
+        { operation: { Id: "op2" }, events: [] },
+        { operation: { Id: "op3" }, events: [] },
+      ];
+
+      (historyEventsToOperationEvents as jest.Mock).mockReturnValue(
+        mockOperationEvents
+      );
+
+      (mockLambdaClient.send as jest.Mock)
+        .mockResolvedValueOnce(mockInvokeResult)
+        .mockResolvedValueOnce(mockExecutionResult)
+        .mockResolvedValueOnce(mockHistoryResult);
+
+      const result = await runner.run({ payload: { test: "data" } });
+
+      expect(historyEventsToOperationEvents).toHaveBeenCalledWith(
+        mockHistoryResult.Events
+      );
+      expect(mockOperationStorage.populateOperations).toHaveBeenCalledWith(
+        mockOperationEvents
+      );
+      expect(result).toBeDefined();
+    });
+
+    it("should maintain state between multiple operation retrievals", () => {
+      const mockOp1: OperationEvents = { operation: { Id: "op1" }, events: [] };
+      const mockOp2: OperationEvents = { operation: { Id: "op2" }, events: [] };
+
+      mockIndexedOperations.getById
+        .mockReturnValueOnce(mockOp1)
+        .mockReturnValueOnce(mockOp2);
+
+      const operation1 = runner.getOperationById("op1");
+      const operation2 = runner.getOperationById("op2");
+
+      expect(operation1).toBe(mockOperationWithData);
+      expect(operation2).toBe(mockOperationWithData);
+      expect(OperationWithData).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/__tests__/process-history-events.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/__tests__/process-history-events.test.ts
@@ -1,0 +1,457 @@
+import {
+  Event,
+  EventType,
+  OperationType,
+  OperationStatus,
+  ErrorObject,
+} from "@amzn/dex-internal-sdk";
+import { historyEventsToOperationEvents } from "../utils/process-history-events/process-history-events";
+
+describe("historyEventsToOperationEvents", () => {
+  const mockTimestamp = new Date("2023-01-01T00:00:00.000Z");
+  const mockError: ErrorObject = {
+    ErrorMessage: "Test error",
+    ErrorType: "TestError",
+    ErrorData: "test-data",
+    StackTrace: ["line1", "line2"],
+  };
+
+  describe("basic functionality", () => {
+    it("should handle empty events array", () => {
+      const result = historyEventsToOperationEvents([]);
+      expect(result).toEqual([]);
+    });
+
+    it("should throw error for events missing required fields", () => {
+      const invalidEvent = {} as Event;
+      expect(() => historyEventsToOperationEvents([invalidEvent])).toThrow(
+        "Missing required fields in event"
+      );
+    });
+
+    it("should throw error for events missing EventType", () => {
+      const invalidEvent = {
+        Id: "test-id",
+        EventTimestamp: mockTimestamp,
+      } as Event;
+      expect(() => historyEventsToOperationEvents([invalidEvent])).toThrow(
+        "Missing required fields in event"
+      );
+    });
+  });
+
+  it.each([
+    EventType.ExecutionStarted,
+    EventType.ExecutionFailed,
+    EventType.ExecutionStopped,
+    EventType.ExecutionSucceeded,
+    EventType.ExecutionTimedOut,
+  ])("should not process %s event", (eventType) => {
+    const event: Event = {
+      EventType: eventType,
+      Id: "execution-1",
+      Name: "test-execution",
+      EventTimestamp: mockTimestamp,
+      ExecutionFailedDetails: {
+        Error: {
+          Payload: mockError,
+        },
+      },
+    };
+
+    const result = historyEventsToOperationEvents([event]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  describe("CallbackStarted events", () => {
+    it("should process CallbackStarted event correctly", () => {
+      const event: Event = {
+        EventType: EventType.CallbackStarted,
+        Id: "callback-1",
+        Name: "test-callback",
+        EventTimestamp: mockTimestamp,
+        CallbackStartedDetails: {
+          CallbackId: "callback-123",
+          Input: {
+            Payload: '{"input": "data"}',
+          },
+          HeartbeatTimeout: 60,
+          Timeout: 300,
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "callback-1",
+        ParentId: undefined,
+        Name: "test-callback",
+        Type: OperationType.CALLBACK,
+        SubType: undefined,
+        Status: OperationStatus.STARTED,
+        StartTimestamp: mockTimestamp,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+        },
+      });
+    });
+  });
+
+  describe("CallbackSucceeded events", () => {
+    it("should process CallbackSucceeded event correctly", () => {
+      const event: Event = {
+        EventType: EventType.CallbackSucceeded,
+        Id: "callback-1",
+        Name: "test-callback",
+        EventTimestamp: mockTimestamp,
+        CallbackSucceededDetails: {
+          Result: {
+            Payload: '{"result": "callback-success"}',
+          },
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "callback-1",
+        ParentId: undefined,
+        Name: "test-callback",
+        Type: OperationType.CALLBACK,
+        SubType: undefined,
+        Status: OperationStatus.SUCCEEDED,
+        EndTimestamp: mockTimestamp,
+        CallbackDetails: {
+          Result: '{"result": "callback-success"}',
+        },
+      });
+    });
+  });
+
+  describe("CallbackFailed events", () => {
+    it("should process CallbackFailed event correctly", () => {
+      const event: Event = {
+        EventType: EventType.CallbackFailed,
+        Id: "callback-1",
+        Name: "test-callback",
+        EventTimestamp: mockTimestamp,
+        CallbackFailedDetails: {
+          Error: {
+            Payload: mockError,
+          },
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "callback-1",
+        ParentId: undefined,
+        Name: "test-callback",
+        Type: OperationType.CALLBACK,
+        SubType: undefined,
+        Status: OperationStatus.FAILED,
+        EndTimestamp: mockTimestamp,
+        CallbackDetails: {
+          Error: mockError,
+        },
+      });
+    });
+  });
+
+  describe("ContextStarted events", () => {
+    it("should process ContextStarted event correctly", () => {
+      const event: Event = {
+        EventType: EventType.ContextStarted,
+        Id: "context-1",
+        Name: "test-context",
+        EventTimestamp: mockTimestamp,
+        ContextStartedDetails: {},
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "context-1",
+        ParentId: undefined,
+        Name: "test-context",
+        Type: OperationType.CONTEXT,
+        SubType: undefined,
+        Status: OperationStatus.STARTED,
+        StartTimestamp: mockTimestamp,
+      });
+    });
+  });
+
+  describe("ContextSucceeded events", () => {
+    it("should process ContextSucceeded event correctly", () => {
+      const event: Event = {
+        EventType: EventType.ContextSucceeded,
+        Id: "context-1",
+        Name: "test-context",
+        EventTimestamp: mockTimestamp,
+        ContextSucceededDetails: {
+          Result: {
+            Payload: '{"context": "result"}',
+          },
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "context-1",
+        ParentId: undefined,
+        Name: "test-context",
+        Type: OperationType.CONTEXT,
+        SubType: undefined,
+        Status: OperationStatus.SUCCEEDED,
+        EndTimestamp: mockTimestamp,
+        CallbackDetails: {
+          Result: '{"context": "result"}',
+        },
+      });
+    });
+  });
+
+  describe("StepStarted events", () => {
+    it("should process StepStarted event correctly", () => {
+      const event: Event = {
+        EventType: EventType.StepStarted,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: mockTimestamp,
+        StepStartedDetails: {},
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "step-1",
+        ParentId: undefined,
+        Name: "test-step",
+        Type: OperationType.STEP,
+        SubType: undefined,
+        Status: OperationStatus.STARTED,
+        StartTimestamp: mockTimestamp,
+      });
+    });
+  });
+
+  describe("StepFailed events", () => {
+    it("should process StepFailed event with retry details correctly", () => {
+      const event: Event = {
+        EventType: EventType.StepFailed,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: mockTimestamp,
+        StepFailedDetails: {
+          Error: {
+            Payload: mockError,
+          },
+          RetryDetails: {
+            CurrentAttempt: 2,
+            NextAttemptDelaySeconds: 30,
+          },
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "step-1",
+        ParentId: undefined,
+        Name: "test-step",
+        Type: OperationType.STEP,
+        SubType: undefined,
+        Status: OperationStatus.FAILED,
+        EndTimestamp: mockTimestamp,
+        StepDetails: {
+          Attempt: 2,
+          NextAttemptTimestamp: new Date("2023-01-01T00:00:30.000Z"),
+          Error: mockError,
+        },
+      });
+    });
+  });
+
+  describe("WaitStarted events", () => {
+    it("should process WaitStarted event correctly", () => {
+      const scheduledEndTime = new Date("2023-01-01T00:05:00.000Z");
+      const event: Event = {
+        EventType: EventType.WaitStarted,
+        Id: "wait-1",
+        Name: "test-wait",
+        EventTimestamp: mockTimestamp,
+        WaitStartedDetails: {
+          Duration: 300,
+          ScheduledEndTimestamp: scheduledEndTime,
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "wait-1",
+        ParentId: undefined,
+        Name: "test-wait",
+        Type: OperationType.WAIT,
+        SubType: undefined,
+        Status: OperationStatus.STARTED,
+        StartTimestamp: mockTimestamp,
+        WaitDetails: {
+          ScheduledTimestamp: scheduledEndTime,
+        },
+      });
+    });
+  });
+
+  describe("InvokeStarted events", () => {
+    it("should process InvokeStarted event correctly", () => {
+      const event: Event = {
+        EventType: EventType.InvokeStarted,
+        Id: "invoke-1",
+        Name: "test-invoke",
+        EventTimestamp: mockTimestamp,
+        InvokeStartedDetails: {
+          Input: {
+            Payload: '{"invoke": "input"}',
+          },
+          FunctionArn: "arn:aws:lambda:us-east-1:123456789012:function:test",
+          DurableExecutionArn:
+            "arn:aws:lambda:us-east-1:123456789012:durable-execution:test",
+        },
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "invoke-1",
+        ParentId: undefined,
+        Name: "test-invoke",
+        Type: OperationType.INVOKE,
+        SubType: undefined,
+        Status: OperationStatus.STARTED,
+        StartTimestamp: mockTimestamp,
+      });
+    });
+  });
+
+  describe("multiple events for same operation", () => {
+    it("should merge events for the same operation ID", () => {
+      const startEvent: Event = {
+        EventType: EventType.StepStarted,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: mockTimestamp,
+        StepStartedDetails: {},
+      };
+
+      const endEvent: Event = {
+        EventType: EventType.StepSucceeded,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: new Date("2023-01-01T00:01:00.000Z"),
+        StepSucceededDetails: {
+          Result: {
+            Payload: '{"step": "result"}',
+          },
+        },
+      };
+
+      const result = historyEventsToOperationEvents([startEvent, endEvent]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation).toEqual({
+        Id: "step-1",
+        ParentId: undefined,
+        Name: "test-step",
+        Type: OperationType.STEP,
+        SubType: undefined,
+        Status: OperationStatus.SUCCEEDED,
+        StartTimestamp: mockTimestamp,
+        EndTimestamp: new Date("2023-01-01T00:01:00.000Z"),
+        StepDetails: {
+          Result: '{"step": "result"}',
+        },
+      });
+      expect(result[0].events).toEqual([startEvent, endEvent]);
+    });
+  });
+
+  describe("multiple different operations", () => {
+    it("should handle multiple different operations", () => {
+      const executionEvent: Event = {
+        EventType: EventType.ExecutionStarted,
+        Id: "execution-1",
+        Name: "test-execution",
+        EventTimestamp: mockTimestamp,
+        ExecutionStartedDetails: {
+          Input: {
+            Payload: '{"test": "data"}',
+          },
+        },
+      };
+
+      const stepEvent: Event = {
+        EventType: EventType.StepStarted,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: mockTimestamp,
+        ParentId: "execution-1",
+        StepStartedDetails: {},
+      };
+
+      const result = historyEventsToOperationEvents([
+        executionEvent,
+        stepEvent,
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation.Id).toBe("step-1");
+      expect(result[0].operation.ParentId).toBe("execution-1");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle events with no detail place", () => {
+      const event: Event = {
+        EventType: EventType.StepStarted,
+        Id: "execution-1",
+        Name: "test-execution",
+        EventTimestamp: mockTimestamp,
+        StepStartedDetails: {},
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation.Status).toBe(OperationStatus.STARTED);
+    });
+
+    it("should handle events with undefined detail fields", () => {
+      const event: Event = {
+        EventType: EventType.StepSucceeded,
+        Id: "step-1",
+        Name: "test-step",
+        EventTimestamp: mockTimestamp,
+        StepSucceededDetails: undefined,
+      };
+
+      const result = historyEventsToOperationEvents([event]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].operation.Status).toBe(OperationStatus.SUCCEEDED);
+    });
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/cloud-durable-test-runner.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/cloud-durable-test-runner.ts
@@ -1,0 +1,119 @@
+import {
+  Invoke20150331Command,
+  LambdaClientConfig,
+  LambdaClient,
+  GetDurableExecutionCommand,
+  GetDurableExecutionHistoryCommand,
+  GetDurableExecutionHistoryResponse,
+} from "@amzn/dex-internal-sdk";
+import { IndexedOperations } from "../common/indexed-operations";
+import { OperationStorage } from "../common/operation-storage";
+import { OperationWithData } from "../common/operations/operation-with-data";
+import {
+  DurableTestRunner,
+  InvokeRequest,
+  TestResult,
+} from "../durable-test-runner";
+import { OperationWaitManager } from "../local/operations/operation-wait-manager";
+import { ResultFormatter } from "../local/result-formatter";
+import { historyEventsToOperationEvents } from "./utils/process-history-events/process-history-events";
+
+export interface CloudDurableTestRunnerParameters {
+  functionName: string;
+  config?: LambdaClientConfig;
+}
+
+export class CloudDurableTestRunner<ResultType>
+  implements DurableTestRunner<OperationWithData, ResultType>
+{
+  private readonly functionArn: string;
+  private readonly client: LambdaClient;
+  private readonly formatter = new ResultFormatter<ResultType>();
+  private readonly waitManager = new OperationWaitManager();
+  private readonly indexedOperations = new IndexedOperations([]);
+  private readonly operationStorage = new OperationStorage(
+    this.waitManager,
+    this.indexedOperations
+  );
+  private history: GetDurableExecutionHistoryResponse | undefined = undefined;
+
+  constructor({ functionName: functionArn, config }: CloudDurableTestRunnerParameters) {
+    this.client = new LambdaClient(config ?? {});
+    this.functionArn = functionArn;
+  }
+
+  async run(params?: InvokeRequest): Promise<TestResult<ResultType>> {
+    const invokeResult = await this.client.send(
+      new Invoke20150331Command({
+        FunctionName: this.functionArn,
+        Payload: params?.payload ? JSON.stringify(params.payload) : undefined,
+      })
+    );
+
+    const executionArn = invokeResult.DurableExecutionArn;
+
+    const result = await this.client.send(
+      new GetDurableExecutionCommand({
+        DurableExecutionArn: executionArn,
+      })
+    );
+
+    // TODO: poll for history instead of waiting for invoke to complete
+    const history = await this.client.send(
+      new GetDurableExecutionHistoryCommand({
+        DurableExecutionArn: executionArn,
+        IncludeExecutionData: true,
+      })
+    );
+
+    this.history = history;
+
+    const operationEvents = historyEventsToOperationEvents(
+      this.history.Events ?? []
+    );
+    this.operationStorage.populateOperations(operationEvents);
+
+    const lambdaResponse = {
+      status: result.Status,
+      result: result.Result,
+      error: result.Error,
+    };
+
+    return this.formatter.formatTestResult(
+      lambdaResponse,
+      this.operationStorage,
+      []
+    );
+  }
+
+  getHistory() {
+    return this.history;
+  }
+  getOperation<T>(name: string): OperationWithData<T> {
+    return this.getOperationByNameAndIndex(name, 0);
+  }
+  getOperationByIndex<T>(index: number): OperationWithData<T> {
+    return new OperationWithData(
+      this.waitManager,
+      this.indexedOperations,
+      this.indexedOperations.getByIndex(index)
+    );
+  }
+  getOperationByNameAndIndex<T>(
+    name: string,
+    index: number
+  ): OperationWithData<T> {
+    return new OperationWithData(
+      this.waitManager,
+      this.indexedOperations,
+      this.indexedOperations.getByNameAndIndex(name, index)
+    );
+  }
+  getOperationById<T>(id: string): OperationWithData<T> {
+    return new OperationWithData(
+      this.waitManager,
+      this.indexedOperations,
+      this.indexedOperations.getById(id)
+    );
+  }
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/index.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/index.ts
@@ -1,0 +1,1 @@
+export * from "./cloud-durable-test-runner";

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/event-data-extractors.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/event-data-extractors.ts
@@ -1,0 +1,54 @@
+import { ErrorObject, Event } from "@amzn/dex-internal-sdk";
+import { HistoryEventTypes } from "./operation-types";
+
+/**
+ * Extracts error information from an event's detail section.
+ * Looks for error payload data in the specified detail place of the event.
+ *
+ * @param event - The event object to extract error information from
+ * @param detailPlace - The property name where event details are stored
+ * @returns The error object if found, undefined otherwise
+ */
+export function getErrorFromEvent(
+  event: Event,
+  detailPlace: HistoryEventTypes["detailPlace"]
+): ErrorObject | undefined {
+  const details = event[detailPlace];
+  if (!details) {
+    return undefined;
+  }
+
+  if ("Error" in details) {
+    return details.Error?.Payload;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts payload data from an event's detail section.
+ * Looks for either input or result payload data in the specified detail place of the event.
+ *
+ * @param event - The event object to extract payload information from
+ * @param detailPlace - The property name where event details are stored
+ * @returns The payload string if found (either from Input or Result), undefined otherwise
+ */
+export function getPayloadFromEvent(
+  event: Event,
+  detailPlace: HistoryEventTypes["detailPlace"]
+): string | undefined {
+  const details = event[detailPlace];
+  if (!details) {
+    return undefined;
+  }
+
+  if ("Input" in details) {
+    return details.Input?.Payload;
+  }
+
+  if ("Result" in details) {
+    return details.Result?.Payload;
+  }
+
+  return undefined;
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/history-event-types.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/history-event-types.ts
@@ -1,0 +1,242 @@
+import {
+  OperationType,
+  OperationStatus,
+  EventType,
+  Event,
+  Operation,
+} from "@amzn/dex-internal-sdk";
+
+/**
+ * Mapping of event types to their corresponding history event type configurations.
+ * This constant defines how each event type should be processed
+ * and what properties it contains.
+ */
+export const historyEventTypes = {
+  ExecutionStarted: {
+    operationType: OperationType.EXECUTION,
+    operationStatus: OperationStatus.STARTED,
+    operationDetailPlace: "ExecutionDetails",
+    detailPlace: "ExecutionStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    hasResult: false,
+  },
+  ExecutionFailed: {
+    operationType: OperationType.EXECUTION,
+    operationStatus: OperationStatus.FAILED,
+    detailPlace: "ExecutionFailedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: false,
+  },
+  ExecutionStopped: {
+    operationType: OperationType.EXECUTION,
+    operationStatus: OperationStatus.STOPPED,
+    detailPlace: "ExecutionStoppedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: false,
+  },
+  ExecutionSucceeded: {
+    operationType: OperationType.EXECUTION,
+    operationStatus: OperationStatus.SUCCEEDED,
+    detailPlace: "ExecutionSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: false,
+  },
+  ExecutionTimedOut: {
+    operationType: OperationType.EXECUTION,
+    operationStatus: OperationStatus.TIMED_OUT,
+    detailPlace: "ExecutionTimedOutDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: false,
+  },
+  CallbackStarted: {
+    operationType: OperationType.CALLBACK,
+    operationStatus: OperationStatus.STARTED,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "CallbackStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    hasResult: false,
+  },
+  CallbackFailed: {
+    operationType: OperationType.CALLBACK,
+    operationStatus: OperationStatus.FAILED,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "CallbackFailedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  CallbackSucceeded: {
+    operationType: OperationType.CALLBACK,
+    operationStatus: OperationStatus.SUCCEEDED,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "CallbackSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  CallbackTimedOut: {
+    operationType: OperationType.CALLBACK,
+    operationStatus: OperationStatus.TIMED_OUT,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "CallbackTimedOutDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  ContextStarted: {
+    operationType: OperationType.CONTEXT,
+    operationStatus: OperationStatus.STARTED,
+    detailPlace: "ContextStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    operationDetailPlace: undefined,
+    hasResult: false,
+  },
+  ContextFailed: {
+    operationType: OperationType.CONTEXT,
+    operationStatus: OperationStatus.FAILED,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "ContextFailedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  ContextSucceeded: {
+    operationType: OperationType.CONTEXT,
+    operationStatus: OperationStatus.SUCCEEDED,
+    operationDetailPlace: "CallbackDetails",
+    detailPlace: "ContextSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  InvokeStarted: {
+    operationType: OperationType.INVOKE,
+    operationStatus: OperationStatus.STARTED,
+    operationDetailPlace: "InvokeDetails",
+    detailPlace: "InvokeStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    hasResult: false,
+  },
+  InvokeFailed: {
+    operationType: OperationType.INVOKE,
+    operationStatus: OperationStatus.FAILED,
+    detailPlace: "InvokeFailedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+  InvokeSucceeded: {
+    operationType: OperationType.INVOKE,
+    operationStatus: OperationStatus.SUCCEEDED,
+    detailPlace: "InvokeSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+  InvokeTimedOut: {
+    operationType: OperationType.INVOKE,
+    operationStatus: OperationStatus.TIMED_OUT,
+    detailPlace: "InvokeTimedOutDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+  InvokeCancelled: {
+    operationType: OperationType.INVOKE,
+    operationStatus: OperationStatus.CANCELLED,
+    detailPlace: "InvokeCancelledDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+  StepStarted: {
+    operationType: OperationType.STEP,
+    operationStatus: OperationStatus.STARTED,
+    operationDetailPlace: "StepDetails",
+    detailPlace: "StepStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    hasResult: false,
+  },
+  StepFailed: {
+    operationType: OperationType.STEP,
+    operationStatus: OperationStatus.FAILED,
+    operationDetailPlace: "StepDetails",
+    detailPlace: "StepFailedDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  StepSucceeded: {
+    operationType: OperationType.STEP,
+    operationStatus: OperationStatus.SUCCEEDED,
+    operationDetailPlace: "StepDetails",
+    detailPlace: "StepSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    hasResult: true,
+  },
+  WaitStarted: {
+    operationType: OperationType.WAIT,
+    operationStatus: OperationStatus.STARTED,
+    operationDetailPlace: "WaitDetails",
+    detailPlace: "WaitStartedDetails",
+    isStartEvent: true,
+    isEndEvent: false,
+    hasResult: true,
+  },
+  WaitSucceeded: {
+    operationType: OperationType.WAIT,
+    operationStatus: OperationStatus.SUCCEEDED,
+    detailPlace: "WaitSucceededDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+  WaitCancelled: {
+    operationType: OperationType.WAIT,
+    operationStatus: OperationStatus.CANCELLED,
+    detailPlace: "WaitCancelledDetails",
+    isStartEvent: false,
+    isEndEvent: true,
+    operationDetailPlace: undefined,
+    hasResult: true,
+  },
+} as const satisfies Record<EventType, HistoryEventType>; /**
+ * Defines the structure and properties of a history event type.
+ * This interface maps event types to their corresponding operation characteristics.
+ */
+
+export interface HistoryEventType {
+  /** The type of operation this event represents */
+  operationType: OperationType;
+  /** The status of the operation (started, succeeded, failed, etc.) */
+  operationStatus: OperationStatus;
+  /** The property name in the Event object where event details are stored */
+  detailPlace: keyof Event | null;
+  /** The property name in the Operation object where operation details are stored */
+  operationDetailPlace: keyof Operation | undefined;
+  /** Whether this event type contains result data */
+  hasResult: boolean;
+  /** Whether this event marks the start of an operation */
+  isStartEvent: boolean;
+  /** Whether this event marks the end of an operation */
+  isEndEvent: boolean;
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-details.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-details.ts
@@ -1,0 +1,37 @@
+import { Operation } from "@amzn/dex-internal-sdk";
+import { OperationDetailFields, PropertyValueMap, Entries } from "./operation-types";
+
+/**
+ * Adds operation details to an operation object by merging property values.
+ * This function safely updates the operation's detail fields with new values,
+ * preserving existing properties and only adding defined values.
+ *
+ * @template DetailsField - The type of the operation detail field being updated
+ * @param operation - The operation object to update
+ * @param detailsField - The specific detail field to update on the operation
+ * @param propertyValueMap - Map of property names to values to add to the detail field
+ */
+export function addOperationDetails<DetailsField extends OperationDetailFields>(
+  operation: Operation,
+  detailsField: DetailsField | undefined,
+  propertyValueMap: PropertyValueMap<DetailsField>
+) {
+  if (!detailsField) {
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const entries = Object.entries(propertyValueMap) as Entries<
+    typeof propertyValueMap
+  >;
+  for (const [key, value] of entries) {
+    if (value === undefined) {
+      continue;
+    }
+
+    operation[detailsField] = {
+      ...operation[detailsField],
+      [key]: value,
+    };
+  }
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-factory.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-factory.ts
@@ -1,0 +1,110 @@
+import { Operation, Event } from "@amzn/dex-internal-sdk";
+import { OperationEvents } from "../../../common/operations/operation-with-data";
+import { HistoryEventType } from "./history-event-types";
+import { HistoryEventTypes } from "./operation-types";
+import { addOperationDetails } from "./operation-details";
+import { getErrorFromEvent, getPayloadFromEvent } from "./event-data-extractors";
+
+/**
+ * Creates an Operation object from an event and its history event type configuration.
+ * This function builds the base operation structure, merging with any previous operation data
+ * and setting appropriate timestamps based on whether the event marks the start or end of an operation.
+ *
+ * @param previousOperationEvents - Previously processed operation events for the same operation ID, if any
+ * @param event - The current event being processed
+ * @param historyEventType - Configuration object defining how this event type should be processed
+ * @returns A new Operation object with basic properties populated
+ */
+export function createOperation(
+  previousOperationEvents: OperationEvents | undefined,
+  event: Event,
+  historyEventType: HistoryEventType
+): Operation {
+  const operation: Operation = {
+    ...previousOperationEvents?.operation,
+    Id: event.Id,
+    ParentId: event.ParentId,
+    Name: event.Name,
+    Type: historyEventType.operationType,
+    SubType: event.SubType,
+    Status: historyEventType.operationStatus,
+  };
+
+  if (historyEventType.isStartEvent) {
+    operation.StartTimestamp = event.EventTimestamp;
+  }
+
+  if (historyEventType.isEndEvent) {
+    operation.EndTimestamp = event.EventTimestamp;
+  }
+
+  return operation;
+}
+
+/**
+ * Populates operation-specific details based on the event type and extracted data.
+ * This function handles the complex logic of extracting payloads, errors, and operation-specific
+ * information from events and adding them to the appropriate operation detail fields.
+ *
+ * The function processes different operation types with their specific requirements:
+ * - EXECUTION: Adds input payload information
+ * - CALLBACK: Adds callback ID from callback events
+ * - STEP: Adds retry attempt information and next attempt timestamps
+ * - WAIT: Adds scheduled timestamp information
+ *
+ * @param event - The event containing the data to extract
+ * @param historyEventType - Configuration defining how to process this event type
+ * @param operation - The operation object to populate with details (modified in place)
+ * @throws {Error} When EventTimestamp is missing from the event
+ *
+ */
+export function populateOperationDetails(
+  event: Event,
+  historyEventType: HistoryEventTypes,
+  operation: Operation
+) {
+  if (!event.EventTimestamp) {
+    throw new Error("Missing required fields in event");
+  }
+
+  const payload = getPayloadFromEvent(event, historyEventType.detailPlace);
+  const error = getErrorFromEvent(event, historyEventType.detailPlace);
+
+  if (historyEventType.hasResult) {
+    addOperationDetails(operation, historyEventType.operationDetailPlace, {
+      Result: payload,
+      Error: error,
+    });
+  }
+
+  switch (historyEventType.operationType) {
+    case "CALLBACK":
+      addOperationDetails(operation, historyEventType.operationDetailPlace, {
+        CallbackId: event.CallbackStartedDetails?.CallbackId,
+      });
+      break;
+    case "STEP":
+      addOperationDetails(operation, historyEventType.operationDetailPlace, {
+        Attempt: event.StepFailedDetails?.RetryDetails?.CurrentAttempt,
+        NextAttemptTimestamp:
+          event.StepFailedDetails?.RetryDetails?.NextAttemptDelaySeconds !==
+          undefined
+            ? new Date(
+                event.EventTimestamp.getTime() +
+                  event.StepFailedDetails.RetryDetails.NextAttemptDelaySeconds *
+                    1000
+              )
+            : undefined,
+      });
+      break;
+    case "WAIT":
+      addOperationDetails(operation, historyEventType.operationDetailPlace, {
+        ScheduledTimestamp: event.WaitStartedDetails?.ScheduledEndTimestamp,
+      });
+      break;
+    case "EXECUTION":
+      throw new Error("Cannot populate EXECUTION event");
+    default:
+      break;
+  }
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-types.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/operation-types.ts
@@ -1,0 +1,39 @@
+import { Operation } from "@amzn/dex-internal-sdk";
+import { historyEventTypes } from "./history-event-types";
+
+/**
+ * Union type representing the valid operation detail field names.
+ * These are the specific properties on the Operation object that contain detailed information
+ * about different types of operations (execution, context, step, wait, callback, invoke).
+ */
+export type OperationDetailFields = Extract<
+  keyof Operation,
+  | "ExecutionDetails"
+  | "ContextDetails"
+  | "StepDetails"
+  | "WaitDetails"
+  | "CallbackDetails"
+  | "InvokeDetails"
+>;
+
+/**
+ * Union type representing all possible history event type configurations.
+ */
+export type HistoryEventTypes =
+  (typeof historyEventTypes)[keyof typeof historyEventTypes];
+
+/**
+ * Maps operation detail fields to their non-nullable property value types.
+ * @template DetailsField - The operation detail field type
+ */
+export type PropertyValueMap<DetailsField extends OperationDetailFields> = NonNullable<
+  Operation[DetailsField]
+>;
+
+/**
+ * Utility type that converts an object type to an array of key-value pair tuples.
+ * @template T - The object type to convert
+ */
+export type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/process-history-events.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events/process-history-events.ts
@@ -1,0 +1,52 @@
+import { Event, OperationType } from "@amzn/dex-internal-sdk";
+import { OperationEvents } from "../../../common/operations/operation-with-data";
+import { historyEventTypes } from "./history-event-types";
+import { createOperation, populateOperationDetails } from "./operation-factory";
+
+/**
+ * Converts an array of history events into structured operation events.
+ * This function processes raw history events and groups them by operation ID, creating
+ * comprehensive operation objects with associated events and detailed information.
+ *
+ * The function handles various event types (execution, callback, context, invoke, step, wait)
+ * and their different statuses (started, succeeded, failed, timed out, etc.), extracting
+ * relevant data such as payloads, errors, timestamps, and operation-specific details.
+ *
+ * @param events - Array of history events to process
+ * @returns Array of operation events, each containing an operation object and its associated events
+ * @throws {Error} When required fields (EventType, Id, EventTimestamp) are missing from an event
+ */
+export function historyEventsToOperationEvents(
+  events: Event[]
+): OperationEvents[] {
+  const operationEvents = new Map<string, OperationEvents>();
+  for (const event of events) {
+    if (!event.EventType || !event.Id) {
+      throw new Error("Missing required fields in event");
+    }
+
+    const historyEventType = historyEventTypes[event.EventType];
+
+    if (historyEventType.operationType === OperationType.EXECUTION) {
+      // Skip populating the EXECUTION operation type
+      continue;
+    }
+
+    const previousOperationEvents = operationEvents.get(event.Id);
+
+    const operation = createOperation(
+      previousOperationEvents,
+      event,
+      historyEventType
+    );
+
+    populateOperationDetails(event, historyEventType, operation);
+
+    operationEvents.set(event.Id, {
+      operation,
+      events: [...(previousOperationEvents?.events ?? []), event],
+    });
+  }
+
+  return Array.from(operationEvents.values());
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/__tests__/operation-storage.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/__tests__/operation-storage.test.ts
@@ -1,0 +1,112 @@
+import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
+import { OperationStorage } from "../operation-storage";
+import { OperationWaitManager } from "../../local/operations/operation-wait-manager";
+import { IndexedOperations } from "../indexed-operations";
+import { OperationEvents } from "../operations/operation-with-data";
+
+// Mock the OperationWaitManager
+jest.mock("../../local/operations/operation-wait-manager");
+
+describe("OperationStorage", () => {
+  let mockWaitManager: OperationWaitManager;
+  let mockIndexedOperations: IndexedOperations;
+
+  // Sample operations for testing
+  const sampleOperations: OperationEvents[] = [
+    {
+      operation: {
+        Id: "op1",
+        Name: "operation1",
+        Type: OperationType.STEP,
+        Status: OperationStatus.SUCCEEDED,
+      },
+      events: [],
+    },
+    {
+      operation: {
+        Id: "op2",
+        Name: "operation2",
+        Type: OperationType.WAIT,
+        Status: OperationStatus.SUCCEEDED,
+      },
+      events: [],
+    },
+    {
+      operation: {
+        Id: "op3",
+        Name: "operation1", // Same name as first operation
+        Type: OperationType.CALLBACK,
+        Status: OperationStatus.FAILED,
+      },
+      events: [],
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWaitManager = new OperationWaitManager();
+    mockIndexedOperations = new IndexedOperations([]);
+  });
+
+  describe("constructor", () => {
+    it("should initialize with empty operations", () => {
+      const storage = new OperationStorage(
+        mockWaitManager,
+        mockIndexedOperations
+      );
+
+      expect(storage.getOperations()).toEqual([]);
+    });
+  });
+
+  describe("getOperations", () => {
+    it("should return all operations after they have been populated", () => {
+      const storage = new OperationStorage(
+        mockWaitManager,
+        mockIndexedOperations
+      );
+
+      storage.populateOperations(sampleOperations);
+
+      expect(storage.getOperations()).toHaveLength(
+        sampleOperations.length
+      );
+    });
+
+    it("should not return execution operations", () => {
+      const storage = new OperationStorage(
+        mockWaitManager,
+        mockIndexedOperations
+      );
+
+      storage.populateOperations(
+        sampleOperations.concat({
+          operation: {
+            Id: "Execution-operation-id",
+            Type: OperationType.EXECUTION,
+          },
+          events: [],
+        })
+      );
+
+      expect(storage.getOperations()).toHaveLength(
+        sampleOperations.length
+      );
+    });
+  });
+
+  describe("populateOperations", () => {
+    it("should add operations to storage", () => {
+      const storage = new OperationStorage(
+        mockWaitManager,
+        mockIndexedOperations
+      );
+
+      storage.populateOperations(sampleOperations);
+
+      expect(storage.getOperations()).toHaveLength(
+        sampleOperations.length
+      );
+    });
+  });
+});

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/operation-storage.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/common/operation-storage.ts
@@ -1,0 +1,35 @@
+import { OperationType } from "@amzn/dex-internal-sdk";
+import { IndexedOperations } from "./indexed-operations";
+import {
+  OperationEvents,
+  OperationWithData,
+} from "./operations/operation-with-data";
+import { OperationWaitManager } from "../local/operations/operation-wait-manager";
+
+export class OperationStorage {
+  constructor(
+    private readonly waitManager: OperationWaitManager,
+    protected readonly indexedOperations: IndexedOperations
+  ) {}
+
+  getOperations(): OperationWithData[] {
+    return (
+      this.indexedOperations
+        .getOperations()
+        .map((data) => {
+          const operation = new OperationWithData(
+            this.waitManager,
+            this.indexedOperations
+          );
+          operation.populateData(data);
+          return operation;
+        })
+        // TODO: should we even add execution operations to the storage?
+        .filter((operation) => operation.getType() !== OperationType.EXECUTION)
+    );
+  }
+
+  populateOperations(newCheckpointOperations: OperationEvents[]): void {
+    this.indexedOperations.addOperations(newCheckpointOperations);
+  }
+}

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/index.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/index.ts
@@ -1,2 +1,3 @@
 export * from "./local";
+export * from "./cloud";
 export * from "./durable-test-runner";

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
@@ -2,7 +2,7 @@ import { LocalDurableTestRunner } from "../local-durable-test-runner";
 import { MockOperation } from "../operations/mock-operation";
 import { TestExecutionOrchestrator } from "../test-execution-orchestrator";
 import { ResultFormatter } from "../result-formatter";
-import { OperationStorage } from "../operations/operation-storage";
+import { LocalOperationStorage } from "../operations/local-operation-storage";
 import { OperationWaitManager } from "../operations/operation-wait-manager";
 import { InvocationStatus } from "@amzn/durable-executions-language-sdk";
 import { CheckpointServerWorkerManager } from "../checkpoint-server-worker-manager";
@@ -11,7 +11,7 @@ import { CheckpointApiClient } from "../api-client/checkpoint-api-client";
 
 jest.mock("../test-execution-orchestrator");
 jest.mock("../result-formatter");
-jest.mock("../operations/operation-storage");
+jest.mock("../operations/local-operation-storage");
 jest.mock("../operations/operation-wait-manager");
 jest.mock("../checkpoint-server-worker-manager");
 
@@ -19,7 +19,7 @@ describe("LocalDurableTestRunner", () => {
   const mockHandlerFunction = jest.fn();
   let mockOrchestrator: jest.Mocked<TestExecutionOrchestrator>;
   let mockResultFormatter: jest.Mocked<ResultFormatter<{ success: boolean }>>;
-  let mockOperationStorage: Partial<jest.Mocked<OperationStorage>>;
+  let mockOperationStorage: Partial<jest.Mocked<LocalOperationStorage>>;
   let mockWaitManager: Partial<jest.Mocked<OperationWaitManager>>;
   let mockCheckpointServerWorkerManager: jest.Mocked<CheckpointServerWorkerManager>;
 
@@ -77,7 +77,7 @@ describe("LocalDurableTestRunner", () => {
     (OperationWaitManager as jest.Mock).mockImplementation(
       () => mockWaitManager
     );
-    (OperationStorage as jest.Mock).mockImplementation(
+    (LocalOperationStorage as jest.Mock).mockImplementation(
       () => mockOperationStorage
     );
     (TestExecutionOrchestrator as unknown as jest.Mock).mockImplementation(
@@ -96,7 +96,7 @@ describe("LocalDurableTestRunner", () => {
 
       expect(runner).toBeDefined();
       expect(OperationWaitManager).toHaveBeenCalledWith();
-      expect(OperationStorage).toHaveBeenCalledWith(
+      expect(LocalOperationStorage).toHaveBeenCalledWith(
         mockWaitManager,
         expect.any(Object),
         expect.any(Function)

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/result-formatter.test.ts
@@ -1,5 +1,5 @@
 import { ResultFormatter } from "../result-formatter";
-import { OperationStorage } from "../operations/operation-storage";
+import { LocalOperationStorage } from "../operations/local-operation-storage";
 import { OperationWaitManager } from "../operations/operation-wait-manager";
 import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
 import { OperationWithData } from "../../common/operations/operation-with-data";
@@ -7,21 +7,21 @@ import { IndexedOperations } from "../../common/indexed-operations";
 import { TestExecutionResult } from "../test-execution-state";
 
 // Mock OperationStorage
-jest.mock("../operations/operation-storage");
+jest.mock("../operations/local-operation-storage");
 
 describe("ResultFormatter", () => {
   let resultFormatter: ResultFormatter<{ success: boolean }>;
-  let mockOperationStorage: jest.Mocked<OperationStorage>;
+  let mockOperationStorage: jest.Mocked<LocalOperationStorage>;
   let mockWaitManager: OperationWaitManager;
   let mockOperationIndex: IndexedOperations;
 
   beforeEach(() => {
     mockOperationIndex = new IndexedOperations([]);
-    mockOperationStorage = new OperationStorage(
+    mockOperationStorage = new LocalOperationStorage(
       new OperationWaitManager(),
       mockOperationIndex,
       jest.fn()
-    ) as jest.Mocked<OperationStorage>;
+    ) as jest.Mocked<LocalOperationStorage>;
     resultFormatter = new ResultFormatter<{ success: boolean }>();
     mockWaitManager = new OperationWaitManager();
   });

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { TestExecutionOrchestrator } from "../test-execution-orchestrator";
-import { OperationStorage } from "../operations/operation-storage";
+import { LocalOperationStorage } from "../operations/local-operation-storage";
 import {
   createCheckpointToken,
   createExecutionId,
@@ -24,7 +24,7 @@ import { Scheduler } from "../orchestration/scheduler";
 import { CheckpointOperation } from "../../../checkpoint-server/storage/checkpoint-manager";
 
 // Mock dependencies
-jest.mock("../operations/operation-storage");
+jest.mock("../operations/local-operation-storage");
 
 const mockInvoke = jest.fn();
 
@@ -40,7 +40,7 @@ describe("TestExecutionOrchestrator", () => {
   const mockCheckpointToken = createCheckpointToken("test-checkpoint-token");
 
   let orchestrator: TestExecutionOrchestrator;
-  let mockOperationStorage: jest.Mocked<OperationStorage>;
+  let mockOperationStorage: jest.Mocked<LocalOperationStorage>;
   let checkpointApi: CheckpointApiClient;
   let mockScheduler: Scheduler;
 
@@ -54,11 +54,11 @@ describe("TestExecutionOrchestrator", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Mock OperationStorage
-    mockOperationStorage = new OperationStorage(
+    mockOperationStorage = new LocalOperationStorage(
       new OperationWaitManager(),
       new IndexedOperations([]),
       jest.fn()
-    ) as jest.Mocked<OperationStorage>;
+    ) as jest.Mocked<LocalOperationStorage>;
     mockOperationStorage.populateOperations = jest.fn();
 
     checkpointApi = new CheckpointApiClient("http://127.0.0.1:1234");

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/local-durable-test-runner.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/local-durable-test-runner.ts
@@ -4,7 +4,7 @@ import {
   DurableTestRunner,
 } from "../durable-test-runner";
 import { withDurableFunctions } from "@amzn/durable-executions-language-sdk";
-import { OperationStorage } from "./operations/operation-storage";
+import { LocalOperationStorage } from "./operations/local-operation-storage";
 import { OperationWaitManager } from "./operations/operation-wait-manager";
 import { MockOperation } from "./operations/mock-operation";
 import { TestExecutionOrchestrator } from "./test-execution-orchestrator";
@@ -39,7 +39,7 @@ export interface LocalDurableTestRunnerParameters {
 export class LocalDurableTestRunner<ResultType>
   implements DurableTestRunner<MockOperation, ResultType>
 {
-  private readonly operationStorage: OperationStorage;
+  private readonly operationStorage: LocalOperationStorage;
   private readonly waitManager: OperationWaitManager;
   private readonly resultFormatter: ResultFormatter<ResultType>;
   private readonly operationIndex: IndexedOperations;
@@ -59,7 +59,7 @@ export class LocalDurableTestRunner<ResultType>
   }: LocalDurableTestRunnerParameters) {
     this.waitManager = new OperationWaitManager();
     this.operationIndex = new IndexedOperations([]);
-    this.operationStorage = new OperationStorage(
+    this.operationStorage = new LocalOperationStorage(
       this.waitManager,
       this.operationIndex,
       this.waitManager.handleCheckpointReceived.bind(this.waitManager)

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/invocation-tracker.test.ts
@@ -1,6 +1,6 @@
 import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
 import { InvocationTracker } from "../invocation-tracker";
-import { OperationStorage } from "../operation-storage";
+import { LocalOperationStorage } from "../local-operation-storage";
 import { createInvocationId } from "../../../../checkpoint-server/utils/tagged-strings";
 import { OperationWaitManager } from "../operation-wait-manager";
 import { IndexedOperations } from "../../../common/indexed-operations";
@@ -10,7 +10,7 @@ import { OperationEvents } from "../../../common/operations/operation-with-data"
 describe("InvocationTracker", () => {
   let waitManager: OperationWaitManager;
   let indexedOperations: IndexedOperations;
-  let operationStorage: OperationStorage;
+  let operationStorage: LocalOperationStorage;
   let invocationTracker: InvocationTracker;
 
   // Helper function to create test operations
@@ -35,7 +35,7 @@ describe("InvocationTracker", () => {
   beforeEach(() => {
     waitManager = new OperationWaitManager();
     indexedOperations = new IndexedOperations([]);
-    operationStorage = new OperationStorage(
+    operationStorage = new LocalOperationStorage(
       waitManager,
       indexedOperations,
       jest.fn()

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
@@ -1,5 +1,5 @@
 import { OperationStatus, OperationType } from "@amzn/dex-internal-sdk";
-import { OperationStorage } from "../operation-storage";
+import { LocalOperationStorage } from "../local-operation-storage";
 import { OperationWaitManager } from "../operation-wait-manager";
 import { MockOperation } from "../mock-operation";
 import { createExecutionId } from "../../../../checkpoint-server/utils/tagged-strings";
@@ -9,7 +9,7 @@ import { OperationEvents } from "../../../common/operations/operation-with-data"
 // Mock the OperationWaitManager
 jest.mock("../operation-wait-manager");
 
-describe("OperationStorage", () => {
+describe("LocalOperationStorage", () => {
   let mockWaitManager: OperationWaitManager;
   let mockIndexedOperations: IndexedOperations;
   let mockCallback: jest.Mock;
@@ -52,73 +52,10 @@ describe("OperationStorage", () => {
     mockCallback = jest.fn();
   });
 
-  describe("constructor", () => {
-    it("should initialize with empty operations", () => {
-      const storage = new OperationStorage(
-        mockWaitManager,
-        mockIndexedOperations,
-        mockCallback
-      );
-
-      expect(storage.getOperations()).toEqual([]);
-    });
-  });
-
-  describe("getOperations", () => {
-    it("should return all operations after they have been populated", () => {
-      const storage = new OperationStorage(
-        mockWaitManager,
-        mockIndexedOperations,
-        mockCallback
-      );
-
-      storage.populateOperations(sampleOperations);
-
-      expect(storage.getOperations()).toHaveLength(
-        sampleOperations.length
-      );
-    });
-
-    it("should not return execution operations", () => {
-      const storage = new OperationStorage(
-        mockWaitManager,
-        mockIndexedOperations,
-        mockCallback
-      );
-
-      storage.populateOperations(
-        sampleOperations.concat({
-          operation: {
-            Id: "Execution-operation-id",
-            Type: OperationType.EXECUTION,
-          },
-          events: [],
-        })
-      );
-
-      expect(storage.getOperations()).toHaveLength(
-        sampleOperations.length
-      );
-    });
-  });
-
   describe("populateOperations", () => {
-    it("should add operations to storage", () => {
-      const storage = new OperationStorage(
-        mockWaitManager,
-        mockIndexedOperations,
-        mockCallback
-      );
-
-      storage.populateOperations(sampleOperations);
-
-      expect(storage.getOperations()).toHaveLength(
-        sampleOperations.length
-      );
-    });
 
     it("should update registered mock operations with matching ID", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -145,7 +82,7 @@ describe("OperationStorage", () => {
     });
 
     it("should update registered mock operations with matching name and index", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -172,7 +109,7 @@ describe("OperationStorage", () => {
     });
 
     it("should update registered mock operations with matching index only", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -199,7 +136,7 @@ describe("OperationStorage", () => {
     });
 
     it("should not throw for mock operations without matching operation data", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -224,7 +161,7 @@ describe("OperationStorage", () => {
 
     it("should notify wait manager when operations are populated", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -249,7 +186,7 @@ describe("OperationStorage", () => {
 
     it("should notify wait manager for multiple populated operations", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -282,7 +219,7 @@ describe("OperationStorage", () => {
 
   describe("registerOperation", () => {
     it("should register a mock operation", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -318,7 +255,7 @@ describe("OperationStorage", () => {
     });
 
     it("should populate mock operation data if matching operation exists", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -342,7 +279,7 @@ describe("OperationStorage", () => {
     });
 
     it("should handle mock operations with empty string id", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -378,7 +315,7 @@ describe("OperationStorage", () => {
     });
 
     it("should handle mock operations with empty string name", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -414,7 +351,7 @@ describe("OperationStorage", () => {
     });
 
     it("should handle mock operations with index 0", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -460,7 +397,7 @@ describe("OperationStorage", () => {
 
     it("should notify wait manager when registering operations with existing data", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -486,7 +423,7 @@ describe("OperationStorage", () => {
 
   describe("registerMocks", () => {
     it("should call registerMocks on all registered mock operations", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -532,7 +469,7 @@ describe("OperationStorage", () => {
     });
 
     it("should not throw when no mock operations are registered", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -547,7 +484,7 @@ describe("OperationStorage", () => {
     });
 
     it("should handle mixed types of mock operations", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -590,7 +527,7 @@ describe("OperationStorage", () => {
     });
 
     it("should call registerMocks even if mock operations are not populated with data", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -621,7 +558,7 @@ describe("OperationStorage", () => {
 
   describe("Callback functionality edge cases", () => {
     it("should always call callback since it is required", () => {
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -642,7 +579,7 @@ describe("OperationStorage", () => {
 
     it("should call callback with empty populated operations when no operations are populated", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -662,7 +599,7 @@ describe("OperationStorage", () => {
 
     it("should call callback with empty arrays when no operations provided", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -677,7 +614,7 @@ describe("OperationStorage", () => {
 
     it("should call callback only for operations that actually got populated", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback
@@ -706,7 +643,7 @@ describe("OperationStorage", () => {
 
     it("should call callback when registering operation with existing data", () => {
       const mockCallback = jest.fn();
-      const storage = new OperationStorage(
+      const storage = new LocalOperationStorage(
         mockWaitManager,
         mockIndexedOperations,
         mockCallback

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/invocation-tracker.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/operations/invocation-tracker.ts
@@ -1,5 +1,5 @@
 import { OperationStatus } from "@amzn/dex-internal-sdk";
-import { OperationStorage } from "./operation-storage";
+import { LocalOperationStorage } from "./local-operation-storage";
 import { Invocation } from "../../durable-test-runner";
 import { OperationWithData } from "../../common/operations/operation-with-data";
 import { InvocationId } from "../../../checkpoint-server/utils/tagged-strings";
@@ -13,7 +13,7 @@ export class InvocationTracker {
   private invocationOperationsMap = new Map<InvocationId, Set<string>>(); // invocationId -> Set of operationIds
   private completedInvocations = new Set<InvocationId>();
 
-  constructor(private operationStorage: OperationStorage) {}
+  constructor(private operationStorage: LocalOperationStorage) {}
 
   /**
    * Reset all invocation tracking data.

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/result-formatter.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/result-formatter.ts
@@ -3,10 +3,10 @@ import {
   TestResultError,
   Invocation,
 } from "../durable-test-runner";
-import { OperationStorage } from "./operations/operation-storage";
 import { tryJsonParse } from "../common/utils";
 import { TestExecutionResult } from "./test-execution-state";
 import { OperationStatus } from "@amzn/dex-internal-sdk";
+import { OperationStorage } from "../common/operation-storage";
 
 /**
  * Handles formatting and processing of execution results for LocalDurableTestRunner.

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/test-execution-orchestrator.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/test-execution-orchestrator.ts
@@ -1,4 +1,8 @@
-import { Operation, OperationStatus } from "@amzn/dex-internal-sdk";
+import {
+  ExecutionStatus,
+  Operation,
+  OperationStatus,
+} from "@amzn/dex-internal-sdk";
 import {
   withDurableFunctions,
   InvocationStatus,
@@ -10,7 +14,7 @@ import {
   InvocationId,
 } from "../../checkpoint-server/utils/tagged-strings";
 import { InvokeHandler } from "./invoke-handler";
-import { OperationStorage } from "./operations/operation-storage";
+import { LocalOperationStorage } from "./operations/local-operation-storage";
 import { InvocationTracker } from "./operations/invocation-tracker";
 import {
   TestExecutionResult,
@@ -40,7 +44,7 @@ export class TestExecutionOrchestrator {
 
   constructor(
     private handlerFunction: ReturnType<typeof withDurableFunctions>,
-    private operationStorage: OperationStorage,
+    private operationStorage: LocalOperationStorage,
     private readonly checkpointApi: CheckpointApiClient,
     private readonly scheduler: Scheduler,
     private skipTime = false
@@ -368,7 +372,10 @@ export class TestExecutionOrchestrator {
     this.executionState.resolveWith({
       result: update.Payload,
       error: update.Error,
-      status: operation.Status,
+      status:
+        update.Action === OperationAction.SUCCEED
+          ? ExecutionStatus.SUCCEEDED
+          : ExecutionStatus.FAILED,
     });
   }
 

--- a/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/test-execution-state.ts
+++ b/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/local/test-execution-state.ts
@@ -1,7 +1,7 @@
-import { ErrorObject, OperationStatus } from "@amzn/dex-internal-sdk";
+import { ErrorObject, ExecutionStatus } from "@amzn/dex-internal-sdk";
 
 export interface TestExecutionResult {
-  status: OperationStatus;
+  status: ExecutionStatus | undefined;
   result?: string;
   error?: ErrorObject;
 }


### PR DESCRIPTION
*Issue #, if available:*

DAR-SDK-202

*Description of changes:*

Adding cloud test runner. Main files to review:
- [CloudDurableTestRunner](https://github.com/aws/aws-durable-functions-sdk-js/pull/54/files#diff-36b8a09cffc406ff8d1ba4c6a4db48d81dad8bfc82237094340a1d194682bc09)
- code inside `cloud/utils/process-history-events`: https://github.com/aws/aws-durable-functions-sdk-js/tree/73a8466f4dc087530b44b1763865838e3b8f33e6/packages/lambda-durable-functions-testing-sdk-js/src/test-runner/cloud/utils/process-history-events, primarily the main [processHistoryEvents function](https://github.com/aws/aws-durable-functions-sdk-js/pull/54/files#diff-35df72e580bcedce73c9a1b3969a75769772b73b1df62c5a9ca38b139b4d5b6e)

Currently, the cloud test runner will invoke the function synchronously, wait for completion, then pull the history. Then, it will transform the history to a testing library interface.

TODO:
- Use NextToken to fetch more history events
- Invoke the durable function asynchronously and poll for history events. This will allow for completing callbacks.
- Add the Github workflow that runs the tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
