### PR TITLE
ci: add GitHub action to clean log groups created by integration tests

### DIFF
--- a/.github/workflows/cleanup-pr-logs.yml
+++ b/.github/workflows/cleanup-pr-logs.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - development
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   cleanup-logs:
     if: github.event.pull_request.merged == true
@@ -15,9 +19,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: "${{ secrets.ACTIONS_WEBHOOK_ROLE_ARN }}"
+          role-session-name: "GitHub-PR-${{ github.event.pull_request.number }}-Cleanup"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Cleanup PR log group
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,11 @@ on:
 env:
   AWS_REGION: us-west-2
 
+# permission can be added at job level or workflow level
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -44,8 +49,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+        role-session-name: githubIntegrationTest
         aws-region: ${{ env.AWS_REGION }}
     
     - name: Install custom Lambda model

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ "main", "development"]
 
+# permission can be added at job level or workflow level
+permissions:
+  contents: read    # This is required for actions/checkout
+
 # Cancel old jobs when a pull request is updated.
 concurrency:
     group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a new GH action that will clean the log groups that get created by running integration tests against each PR.

I'm not 100% sure this will work but I think so based on https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges. We'll know for sure when I merge it and it hits the webhook!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
