### PR TITLE
ci: run jest integration tests instead of history tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,15 +4,18 @@ on:
   push:
     branches: [ "main", "development" ]
     paths:
-      - 'packages/aws-durable-execution-sdk-js/**'
-      - 'packages/aws-durable-execution-sdk-js-examples/**'
+      - 'packages/aws-durable-execution-**'
+      - 'packages/client-lambda/**'
       - '.github/workflows/integration-tests.yml'
+      - '.github/workflows/scripts/integration-test/**'
+      - '.github/model/**'
   pull_request:
     branches: [ "main", "development"]
     paths:
-      - 'packages/aws-durable-execution-sdk-js/**'
-      - 'packages/aws-durable-execution-sdk-js-examples/**'
+      - 'packages/aws-durable-execution-**'
+      - 'packages/client-lambda/**'
       - '.github/workflows/integration-tests.yml'
+      - '.github/workflows/scripts/integration-test/**'
       - '.github/model/**'
   workflow_dispatch:
 
@@ -28,7 +31,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      examples: ${{ steps.get-examples.outputs.examples }}
+      function-name-map: ${{ steps.deploy-functions.outputs.function-name-map }}
     steps:
     - uses: actions/checkout@v4
     
@@ -37,65 +40,51 @@ jobs:
       with:
         node-version: '22.x'
         cache: 'npm'
-    
-    - name: Install AWS CLI (for local act runs)
-      run: |
-        if ! command -v aws &> /dev/null; then
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
-        fi
-    
-    - name: Configure AWS credentials
+
+    - name: Configure AWS credentials (OIDC for main workflow)
+      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
         role-session-name: githubIntegrationTest
         aws-region: ${{ env.AWS_REGION }}
-    
+
     - name: Install custom Lambda model
       run: |
         aws configure add-model --service-model file://.github/model/lambda.json --service-name lambda
-    
+
     - name: Install dependencies
-      run: npm run install-all
-    
+      run:
+        npm run install-all
+
     - name: Build project
-      run: npm run build
-    
-    - name: Verify SDK build
-      run: |
-        if [ ! -f "packages/aws-durable-execution-sdk-js/dist/index.js" ]; then
-          echo "ERROR: SDK index.js not found"
-          exit 1
-        fi
-        if [ ! -f "packages/aws-durable-execution-sdk-js-examples/dist/hello-world.js" ]; then
-          echo "ERROR: Examples hello-world.js not found"
-          exit 1
-        fi
-    
+      run:
+        npm run build
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: built-examples
+        name: built-artifacts
         path: |
-          packages/aws-durable-execution-sdk-js-examples/dist
+          packages/**/dist/*
+          packages/**/dist-cjs/*
           package.json
     
-    - name: Get examples from catalog
-      id: get-examples
-      working-directory: ./packages/aws-durable-execution-sdk-js-examples
-      run: |
-        echo "examples=$(jq -c '.examples | map(select(.integration == true))' examples-catalog.json)" >> $GITHUB_OUTPUT
+    - name: Deploy functions
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+        INVOKE_ACCOUNT_ID: ${{ secrets.INVOKE_ACCOUNT_ID }}
+        KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+      run:
+        node .github/workflows/scripts/integration-test/integration-test.js --deploy-only
 
-  integration-test:
+  jest-integration-test:
     needs: setup
     runs-on: ubuntu-latest
-    name: ${{ matrix.example.name }}
-    strategy:
-      matrix:
-        example: ${{ fromJson(needs.setup.outputs.examples) }}
-      fail-fast: false
+    name: Jest Integration Tests
     
     steps:
     - uses: actions/checkout@v4
@@ -106,129 +95,70 @@ jobs:
         node-version: '22.x'
         cache: 'npm'
     
+    - name: Configure AWS credentials (OIDC for main workflow)
+      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+        role-session-name: githubIntegrationTest
+        aws-region: ${{ env.AWS_REGION }}
+
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:
-        name: built-examples
+        name: built-artifacts
         path: .
-    
-    - name: Verify downloaded artifacts
+
+    - name: Install dependencies
       run: |
-        if [ ! -f "packages/aws-durable-execution-sdk-js-examples/dist/hello-world.js" ]; then
-          echo "ERROR: Examples not found in artifacts"
-          exit 1
-        fi
+        npm run install-all
     
-    - name: Install AWS CLI (for local act runs)
+    - name: Run Jest integration tests
+      env:
+        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+        FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
       run: |
-        if ! command -v aws &> /dev/null; then
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
-        fi
+         node .github/workflows/scripts/integration-test/integration-test.js --test-only
+
+  cleanup:
+    needs: [setup, jest-integration-test]
+    runs-on: ubuntu-latest
+    if: always()
     
-    - name: Configure AWS credentials
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+        cache: 'npm'
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: built-artifacts
+        path: .
+
+    - name: Install dependencies
+      run: |
+        npm run install-all
+    
+    - name: Configure AWS credentials (OIDC for main workflow)
+      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+        role-session-name: githubIntegrationTest
         aws-region: ${{ env.AWS_REGION }}
-    
-    - name: Install custom Lambda model
-      run: |
-        aws configure add-model --service-model file://.github/model/lambda.json --service-name lambda
 
-    - name: Package Lambda function - ${{ matrix.example.name }}
-      working-directory: ./packages/aws-durable-execution-sdk-js-examples
-      run: |
-        # Extract handler file name from catalog
-        HANDLER_FILE=$(echo "${{ matrix.example.handler }}" | sed 's/\.handler$//')
-        npm run package -- "$HANDLER_FILE"
-
-    - name: Deploy Lambda function - ${{ matrix.example.name }}
-      working-directory: ./packages/aws-durable-execution-sdk-js-examples
-      env:
-        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-        INVOKE_ACCOUNT_ID: ${{ secrets.INVOKE_ACCOUNT_ID }}
-        KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
-      run: |
-        # Build function name for GitHub Actions
-        BASE_NAME=$(echo "${{ matrix.example.name }}" | sed 's/ //g')-TypeScript
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          FUNCTION_NAME="${BASE_NAME}-PR-${{ github.event.number }}"
-        else
-          FUNCTION_NAME="${BASE_NAME}"
-        fi
-        
-        # Extract handler file name from catalog
-        HANDLER_FILE=$(echo "${{ matrix.example.handler }}" | sed 's/\.handler$//')
-        
-        # Deploy using npm script
-        npm run deploy -- "$HANDLER_FILE" "$FUNCTION_NAME"
-    
-    - name: Invoke Lambda function - ${{ matrix.example.name }}
+    - name: Cleanup Lambda functions
       env:
         LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+        FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
       run: |
-        echo "Testing function: $FUNCTION_NAME"
-        aws lambda invoke \
-          --function-name "$FUNCTION_NAME" \
-          --cli-binary-format raw-in-base64-out \
-          --payload '{"name": "World"}' \
-          --region "${{ env.AWS_REGION }}" \
-          --endpoint-url "$LAMBDA_ENDPOINT" \
-          /tmp/response.json
-        echo "Response:"
-        cat /tmp/response.json
-    
-    - name: Find Durable Execution - ${{ matrix.example.name }}
-      env:
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-      run: |
-        echo "Listing durable executions for function: $FUNCTION_NAME"
-        aws lambda list-durable-executions \
-          --function-name "$FUNCTION_NAME" \
-          --region "${{ env.AWS_REGION }}" \
-          --endpoint-url "$LAMBDA_ENDPOINT" \
-          --cli-binary-format raw-in-base64-out \
-          --status-filter SUCCEEDED \
-          > /tmp/executions.json
-        echo "Durable Executions:"
-        cat /tmp/executions.json
-        
-        # Extract the first execution ARN for history retrieval
-        EXECUTION_ARN=$(jq -r '.DurableExecutions[0].DurableExecutionArn // empty' /tmp/executions.json)
-        echo "EXECUTION_ARN=$EXECUTION_ARN" >> $GITHUB_ENV
-    
-    - name: Get Durable Execution History - ${{ matrix.example.name }}
-      if: env.EXECUTION_ARN != ''
-      env:
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-      run: |
-        echo "Getting execution history for: $EXECUTION_ARN"
-        aws lambda get-durable-execution-history \
-          --durable-execution-arn "$EXECUTION_ARN" \
-          --region "${{ env.AWS_REGION }}" \
-          --endpoint-url "$LAMBDA_ENDPOINT" \
-          --cli-binary-format raw-in-base64-out \
-          > /tmp/history.json
-        echo "Execution History:"
-        cat /tmp/history.json
-    
-    - name: Assert History - ${{ matrix.example.name }}
-      if: env.EXECUTION_ARN != ''
-      working-directory: ./packages/aws-durable-execution-sdk-js-examples
-      run: |
-        node scripts/assert-history.js "${{ matrix.example.handler }}" "/tmp/history.json"
-    
-    - name: Cleanup Lambda function
-      if: always()
-      env:
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-      run: |
-        echo "Deleting function: $FUNCTION_NAME"
-        aws lambda delete-function \
-          --function-name "$FUNCTION_NAME" \
-          --endpoint-url "$LAMBDA_ENDPOINT" \
-          --region "${{ env.AWS_REGION }}" || echo "Function already deleted or doesn't exist"
+        node .github/workflows/scripts/integration-test/integration-test.js --cleanup-only

--- a/.github/workflows/scripts/integration-test/integration-test.js
+++ b/.github/workflows/scripts/integration-test/integration-test.js
@@ -1,0 +1,374 @@
+// @ts-check
+
+import { execSync } from "child_process";
+import { appendFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+import examplesCatalog from "../../../../packages/aws-durable-execution-sdk-js-examples/examples-catalog.json" with { type: "json" };
+import { LambdaClient, DeleteFunctionCommand } from "@aws-sdk/client-lambda";
+
+// Colors for output
+const COLORS = {
+  RED: "\x1b[0;31m",
+  GREEN: "\x1b[0;32m",
+  YELLOW: "\x1b[1;33m",
+  BLUE: "\x1b[0;34m",
+  NC: "\x1b[0m", // No Color
+};
+
+const log = {
+  info: (/** @type {string} */ msg) =>
+    console.log(`${COLORS.BLUE}[INFO]${COLORS.NC} ${msg}`),
+  success: (/** @type {string} */ msg) =>
+    console.log(`${COLORS.GREEN}[SUCCESS]${COLORS.NC} ${msg}`),
+  warning: (/** @type {string} */ msg) =>
+    console.log(`${COLORS.YELLOW}[WARNING]${COLORS.NC} ${msg}`),
+  error: (/** @type {string} */ msg) =>
+    console.error(`${COLORS.RED}[ERROR]${COLORS.NC} ${msg}`),
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Configuration
+const CONFIG = {
+  AWS_REGION: process.env.AWS_REGION || "us-west-2",
+  LAMBDA_ENDPOINT:
+    process.env.LAMBDA_ENDPOINT ||
+    "https://durable.durable-functions.devo.us-west-2.lambda.aws.a2z.com",
+  PROJECT_ROOT: join(__dirname, "../../../.."),
+  // Package directory paths
+  SDK_PACKAGE_PATH: join(
+    __dirname,
+    "../../../../packages/aws-durable-execution-sdk-js"
+  ),
+  EXAMPLES_PACKAGE_PATH: join(
+    __dirname,
+    "../../../../packages/aws-durable-execution-sdk-js-examples"
+  ),
+};
+
+class IntegrationTestRunner {
+  /**
+   * @param {Object} options
+   * @param {boolean} [options.cleanupOnExit]
+   */
+  constructor(options = {}) {
+    this.cleanupOnExit = options.cleanupOnExit !== false;
+    this.isGitHubActions = !!process.env.GITHUB_ACTIONS;
+    /** @type {Record<string, string> | undefined} */
+    this.functionNameMap = undefined;
+    /** @type {import('@aws-sdk/client-lambda').LambdaClient | null} */
+    this.lambdaClient = null;
+
+    // Set up cleanup handler
+    if (this.cleanupOnExit) {
+      process.on("exit", () => this.cleanup());
+      process.on("SIGINT", () => {
+        this.cleanup();
+        process.exit(130);
+      });
+      process.on("SIGTERM", () => {
+        this.cleanup();
+        process.exit(143);
+      });
+    }
+  }
+
+  initializeLambdaClient() {
+    if (!this.lambdaClient) {
+      /** @type {import('@aws-sdk/client-lambda').LambdaClientConfig} */
+      const clientConfig = {
+        region: CONFIG.AWS_REGION,
+      };
+
+      // Add custom endpoint if specified
+      if (CONFIG.LAMBDA_ENDPOINT) {
+        clientConfig.endpoint = CONFIG.LAMBDA_ENDPOINT;
+      }
+
+      this.lambdaClient = new LambdaClient(clientConfig);
+      log.info(`Lambda client initialized for region: ${CONFIG.AWS_REGION}`);
+      if (CONFIG.LAMBDA_ENDPOINT) {
+        log.info(`Using custom endpoint: ${CONFIG.LAMBDA_ENDPOINT}`);
+      }
+    }
+    return this.lambdaClient;
+  }
+
+  /**
+   * @param {string} command
+   * @param {Object} options
+   * @param {boolean} [options.silent]
+   * @param {string} [options.cwd]
+   * @param {Object} [options.env]
+   */
+  execCommand(command, options = {}) {
+    /** @type {import('child_process').ExecSyncOptions} */
+    const execOptions = {
+      encoding: "utf8",
+      stdio: options.silent ? "pipe" : "inherit",
+      cwd: options.cwd || CONFIG.PROJECT_ROOT,
+    };
+
+    if (options.env) {
+      /** @type {NodeJS.ProcessEnv} */
+      const envVars = {};
+      Object.assign(envVars, process.env, options.env);
+      execOptions.env = envVars;
+    }
+
+    const result = execSync(command, execOptions);
+    return { output: result };
+  }
+
+  // Get integration examples from catalog
+  getIntegrationExamples() {
+    log.info("Getting integration examples...");
+
+    const integrationExamples = examplesCatalog.examples.filter(
+      (example) => example.integration === true
+    );
+    return integrationExamples;
+  }
+
+  getFunctionNameMap() {
+    if (this.functionNameMap) {
+      return this.functionNameMap;
+    }
+
+    const examples = this.getIntegrationExamples();
+    /** @type {Record<string, string>} */
+    const functionNameMap = {};
+
+    for (const example of examples) {
+      const exampleName = example.name;
+      const exampleHandler = example.handler;
+
+      // Build function name
+      let functionName;
+      if (this.isGitHubActions) {
+        const baseName = exampleName.replace(/\s/g, "") + "-TypeScript";
+        if (process.env.GITHUB_EVENT_NAME === "pull_request") {
+          if (!process.env.GITHUB_EVENT_NUMBER) {
+            throw new Error(
+              "Could not find GITHUB_EVENT_NUMBER environment variable"
+            );
+          }
+          functionName = `${baseName}-PR-${process.env.GITHUB_EVENT_NUMBER}`;
+        } else {
+          functionName = baseName;
+        }
+      } else {
+        functionName = exampleName.replace(/\s/g, "") + "-TypeScript-Local";
+      }
+
+      const handlerFile = exampleHandler.replace(/\.handler$/, "");
+      functionNameMap[handlerFile] = functionName;
+    }
+
+    this.functionNameMap = functionNameMap;
+    return functionNameMap;
+  }
+
+  // Deploy Lambda functions
+  async deployFunctions() {
+    log.info("Deploying Lambda functions...");
+
+    const examples = this.getIntegrationExamples();
+    const examplesDir = CONFIG.EXAMPLES_PACKAGE_PATH;
+
+    const functionNameMap = this.getFunctionNameMap();
+
+    for (const example of examples) {
+      const exampleHandler = example.handler;
+
+      // Extract handler file name from catalog
+      const handlerFile = exampleHandler.replace(/\.handler$/, "");
+      const functionName = functionNameMap[handlerFile];
+
+      log.info(`Deploying function: ${functionName} (handler: ${handlerFile})`);
+
+      // Package the function
+      this.execCommand(`npm run package -- "${handlerFile}"`, {
+        cwd: examplesDir,
+      });
+
+      // Deploy using npm script
+      this.execCommand(`npm run deploy -- "${handlerFile}" "${functionName}"`, {
+        cwd: examplesDir,
+      });
+      log.success(`Deployed function: ${functionName}`);
+    }
+
+    log.info("Function name map:");
+    console.log(JSON.stringify(functionNameMap, null, 2));
+
+    if (this.isGitHubActions) {
+      if (!process.env.GITHUB_OUTPUT) {
+        throw new Error("Could not find GITHUB_OUTPUT environment variable");
+      }
+      appendFileSync(
+        process.env.GITHUB_OUTPUT,
+        `function-name-map=${JSON.stringify(functionNameMap)}`
+      );
+    }
+
+    log.success("Function deployment completed");
+  }
+
+  // Run Jest integration tests
+  async runJestTests() {
+    log.info("Running Jest integration tests...");
+
+    const examplesDir = CONFIG.EXAMPLES_PACKAGE_PATH;
+
+    // Set environment variables
+    const env = {
+      ...process.env,
+      FUNCTION_NAME_MAP: JSON.stringify(this.getFunctionNameMap()),
+      LAMBDA_ENDPOINT: CONFIG.LAMBDA_ENDPOINT,
+    };
+
+    log.info("Running Jest integration tests with function map:");
+    console.log(JSON.stringify(this.getFunctionNameMap(), null, 2));
+    log.info(`Lambda Endpoint: ${CONFIG.LAMBDA_ENDPOINT}`);
+
+    this.execCommand("npm run test:integration", {
+      cwd: examplesDir,
+      env,
+    });
+    log.success("Jest integration tests passed");
+  }
+
+  // Cleanup deployed functions
+  async cleanup() {
+    const functionNameMap = this.getFunctionNameMap();
+
+    if (Object.keys(functionNameMap).length === 0) {
+      log.warning("No functions to clean up");
+      return;
+    }
+
+    log.info("Cleaning up deployed functions...");
+
+    // Initialize Lambda client for cleanup
+    const lambdaClient = this.initializeLambdaClient();
+
+    for (const functionName of Object.values(functionNameMap)) {
+      log.info(`Deleting function: ${functionName}`);
+
+      const deleteCommand = new DeleteFunctionCommand({
+        FunctionName: functionName,
+      });
+
+      await lambdaClient.send(deleteCommand);
+      log.success(`Deleted function: ${functionName}`);
+    }
+  }
+
+  /**
+   * @param {Object} options
+   * @param {boolean} [options.deployOnly]
+   * @param {boolean} [options.testOnly]
+   * @param {boolean} [options.cleanupOnly]
+   */
+  async run(options = {}) {
+    const {
+      deployOnly = false,
+      testOnly = false,
+      cleanupOnly = false,
+    } = options;
+
+    log.info("Starting integration test...");
+    log.info(`AWS Region: ${CONFIG.AWS_REGION}`);
+    if (CONFIG.LAMBDA_ENDPOINT) {
+      log.info(`Lambda Endpoint: ${CONFIG.LAMBDA_ENDPOINT}`);
+    }
+
+    if (cleanupOnly) {
+      await this.cleanup();
+      return;
+    }
+
+    if (!testOnly) {
+      await this.deployFunctions();
+    }
+
+    if (!deployOnly) {
+      await this.runJestTests();
+    }
+
+    log.success("Integration test completed successfully!");
+
+    if (!this.cleanupOnExit) {
+      log.warning(
+        "Functions were not cleaned up. Use --cleanup-only to clean them up later."
+      );
+    }
+  }
+}
+
+// CLI interface
+function showUsage() {
+  console.log("Usage: node integration-test.js [OPTIONS]");
+  console.log("");
+  console.log("Options:");
+  console.log("  --deploy-only   Only deploy functions, don't run tests");
+  console.log(
+    "  --test-only     Only run tests (assumes functions are already deployed)"
+  );
+  console.log("  --cleanup-only  Only cleanup existing functions");
+  console.log("  --help          Show this help message");
+  console.log("");
+  console.log("Environment Variables:");
+  console.log("  AWS_REGION      AWS region (default: us-west-2)");
+  console.log("  LAMBDA_ENDPOINT Custom Lambda endpoint URL");
+  console.log("");
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse command line arguments
+  const options = {
+    cleanupOnExit: true,
+    deployOnly: false,
+    testOnly: false,
+    cleanupOnly: false,
+  };
+
+  for (const arg of args) {
+    switch (arg) {
+      case "--deploy-only":
+        options.deployOnly = true;
+        options.cleanupOnExit = false;
+        break;
+      case "--test-only":
+        options.testOnly = true;
+        options.cleanupOnExit = false;
+        break;
+      case "--cleanup-only":
+        options.cleanupOnly = true;
+        break;
+      case "--help":
+        showUsage();
+        process.exit(0);
+      default:
+        log.error(`Unknown option: ${arg}`);
+        showUsage();
+        process.exit(1);
+    }
+  }
+
+  const runner = new IntegrationTestRunner(options);
+
+  await runner.run(options);
+}
+
+// Run if this file is executed directly
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.sh
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.sh
@@ -70,13 +70,6 @@ fi
 
 ROLE_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/DurableFunctionsIntegrationTestRole"
 
-# Verify role exists
-echo "Verifying IAM role exists..."
-if ! aws iam get-role --role-name DurableFunctionsIntegrationTestRole >/dev/null 2>&1; then
-    echo "Error: IAM role 'DurableFunctionsIntegrationTestRole' does not exist in account ${AWS_ACCOUNT_ID}"
-    exit 1
-fi
-
 echo "Checking if function exists..."
 
 if aws lambda get-function --function-name "$FUNCTION_NAME" --endpoint-url "$LAMBDA_ENDPOINT" --region "$AWS_REGION" >/dev/null 2>&1; then

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/comprehensive-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/comprehensive-operations.test.ts
@@ -37,31 +37,16 @@ createTests({
       expect(
         result.summary.fruitsSelected.all.map((item: any) => item.result)
       ).toEqual(["apple", "banana", "orange"]);
-    });
 
-    it("should execute step1 operation correctly", async () => {
       const step1Op = runner.getOperation("step1");
-
-      await runner.run();
 
       expect(step1Op).toBeDefined();
       expect(step1Op.getStepDetails()?.result).toBe(
         "Step 1 completed successfully"
       );
-    });
-
-    it("should execute wait operation for 5 seconds", async () => {
       const waitOp = runner.getOperationByIndex(1); // Wait should be the second operation
 
-      await runner.run();
-
       expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(5);
-    });
-
-    it("should execute map operation with detailed steps", async () => {
-      const execution = await runner.run();
-      const result = execution.getResult() as any;
-
       // Verify map results - now BatchResult object
       expect(result.mapResults.all).toHaveLength(5);
       expect(result.mapResults.all.map((item: any) => item.result)).toEqual([
@@ -74,11 +59,6 @@ createTests({
         expect(mapStepOp).toBeDefined();
         expect(mapStepOp.getStepDetails()?.result).toBe(i + 1);
       }
-    });
-
-    it("should execute parallel operations with fruit names", async () => {
-      const execution = await runner.run();
-      const result = execution.getResult() as any;
 
       // Verify parallel results - now BatchResult object
       expect(result.parallelResults.all).toHaveLength(3);
@@ -98,11 +78,6 @@ createTests({
       expect(fruitStep1Op.getStepDetails()?.result).toBe("apple");
       expect(fruitStep2Op.getStepDetails()?.result).toBe("banana");
       expect(fruitStep3Op.getStepDetails()?.result).toBe("orange");
-    });
-
-    it("should create comprehensive summary object", async () => {
-      const execution = await runner.run();
-      const result = execution.getResult() as any;
 
       // Verify summary structure - now using BatchResult objects
       expect(result.summary).toBeDefined();
@@ -114,10 +89,6 @@ createTests({
       expect(
         result.summary.fruitsSelected.all.map((item: any) => item.result)
       ).toEqual(["apple", "banana", "orange"]);
-    });
-
-    it("should complete execution without errors", async () => {
-      const execution = await runner.run();
 
       // Verify execution completed successfully
       expect(execution.getResult()).toBeDefined();

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait.test.ts
@@ -7,10 +7,10 @@ createTests({
   handler,
   tests: (runner) => {
     it("should call wait for 10 seconds", async () => {
-      const waitStep = runner.getOperationByIndex(0);
-
+      
       const execution = await runner.run();
-
+      
+      const waitStep = runner.getOperationByIndex(0);
       expect(execution.getResult()).toBe("Function Completed");
       expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(10);
     });


### PR DESCRIPTION
*Issue #, if available:*

DAR-SDK-277

*Description of changes:*

Running jest integration tests as the integration test workflow instead of the history tests. Currently, I removed the history tests, but I'll add them back as part of the testing lib later.

Also included in this change:
- Refactors our integration test workflow to run a JS script instead of inline bash scripts (which makes it easier to debug locally).
- Stops using the hardcoded credentials and use the OIDC role instead

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
