### PR TITLE
ci: bundle examples with rollup instead of manually copying node_modules

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,7 +69,7 @@ jobs:
           echo "ERROR: SDK index.js not found"
           exit 1
         fi
-        if [ ! -f "packages/examples/dist/examples/hello-world.js" ]; then
+        if [ ! -f "packages/examples/dist/hello-world.js" ]; then
           echo "ERROR: Examples hello-world.js not found"
           exit 1
         fi
@@ -79,20 +79,8 @@ jobs:
       with:
         name: built-examples
         path: |
-          packages/examples/dist/
-          packages/examples/node_modules/
-          packages/lambda-durable-functions-sdk-js/dist/
-          packages/lambda-durable-functions-sdk-js/package.json
-          packages/dex-internal-sdk/dist-cjs/
-          packages/dex-internal-sdk/package.json
-          node_modules/@amzn/
-          node_modules/tslib/
-          node_modules/@smithy/
-          node_modules/@aws-sdk/
-          node_modules/uuid/
-          node_modules/fast-xml-parser/
-          node_modules/@aws-crypto/
-          node_modules/bowser/
+          packages/examples/dist
+          package.json
     
     - name: Get examples from catalog
       id: get-examples
@@ -126,7 +114,7 @@ jobs:
     
     - name: Verify downloaded artifacts
       run: |
-        if [ ! -f "packages/examples/dist/examples/hello-world.js" ]; then
+        if [ ! -f "packages/examples/dist/hello-world.js" ]; then
           echo "ERROR: Examples not found in artifacts"
           exit 1
         fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -3060,6 +3060,33 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
+      "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -5971,6 +5998,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -7886,6 +7920,24 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8730,6 +8782,16 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -10041,6 +10103,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -13160,6 +13232,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.23.0",
+        "@rollup/plugin-commonjs": "^28.0.6",
         "@tsconfig/node22": "^22.0.1",
         "@types/aws-lambda": "^8.10.145",
         "@types/jest": "^29.5.14",

--- a/packages/examples/examples-catalog.json
+++ b/packages/examples/examples-catalog.json
@@ -9,7 +9,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 14,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/block-example.ts"
     },
     {
       "name": "Comprehensive Operations",
@@ -19,7 +20,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 14,
         "ExecutionTimeout": 900
-      }
+      },
+      "path": "./src/examples/comprehensive-operations.ts"
     },
     {
       "name": "Create Callback",
@@ -28,7 +30,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/create-callback.ts"
     },
     {
       "name": "Hello World",
@@ -38,7 +41,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/hello-world.ts"
     },
     {
       "name": "Basic Map",
@@ -48,7 +52,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/map-basic.ts"
     },
     {
       "name": "Basic Parallel",
@@ -58,7 +63,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/parallel-basic.ts"
     },
     {
       "name": "Promise All",
@@ -68,7 +74,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/promise-all.ts"
     },
     {
       "name": "Promise All Settled",
@@ -77,7 +84,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/promise-all-settled.ts"
     },
     {
       "name": "Promise Any",
@@ -86,7 +94,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/promise-any.ts"
     },
     {
       "name": "Promise Combinators",
@@ -95,7 +104,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/promise-combinators.ts"
     },
     {
       "name": "Promise Race",
@@ -105,7 +115,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/promise-race.ts"
     },
     {
       "name": "Run in Child Context",
@@ -115,7 +126,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/run-in-child-context.ts"
     },
     {
       "name": "Basic Step",
@@ -125,7 +137,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/step-basic.ts"
     },
     {
       "name": "Named Step",
@@ -135,7 +148,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/step-named.ts"
     },
     {
       "name": "Step with Retry",
@@ -144,7 +158,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 14,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/step-with-retry.ts"
     },
     {
       "name": "Steps With Retry",
@@ -153,7 +168,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 14,
         "ExecutionTimeout": 600
-      }
+      },
+      "path": "./src/examples/steps-with-retry.ts"
     },
     {
       "name": "Wait State",
@@ -163,7 +179,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/wait.ts"
     },
     {
       "name": "Wait for Callback",
@@ -172,7 +189,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/wait-for-callback.ts"
     },
     {
       "name": "Named Wait",
@@ -182,7 +200,8 @@
       "durableConfig": {
         "RetentionPeriodInDays": 7,
         "ExecutionTimeout": 300
-      }
+      },
+      "path": "./src/examples/wait-named.ts"
     }
   ]
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -21,8 +21,8 @@
     "clean": "rm -rf build/ build coverage node_modules/ dist/",
     "release": "npm run build && mkdir -p build/durable-executions-typescript-sdk-examples && npm run copy-files",
     "prebuild": "rm -rf build/durable-executions-typescript-sdk-examples",
-    "build": "tsc",
     "package": "node scripts/package.js",
+    "build": "rollup --config rollup.config.mjs",
     "deploy": "bash scripts/deploy-lambda.sh",
     "prerelease": "npm run generate-template",
     "copy-files": "npm run copy-lambda && npm run copy-examples && npm run copy-source && npm run copy-catalog",
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
+    "@rollup/plugin-commonjs": "^28.0.6",
     "@tsconfig/node22": "^22.0.1",
     "@types/aws-lambda": "^8.10.145",
     "@types/jest": "^29.5.14",

--- a/packages/examples/rollup.config.mjs
+++ b/packages/examples/rollup.config.mjs
@@ -1,0 +1,33 @@
+// @ts-check
+
+import { defineConfig } from "rollup";
+import examplesCatalog from "./examples-catalog.json" with { type: "json" };
+import typescript from "@rollup/plugin-typescript";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import json from "@rollup/plugin-json";
+import commonJs from "@rollup/plugin-commonjs";
+
+const config = defineConfig(
+  examplesCatalog.examples.map((example) =>
+    defineConfig({
+      input: example.path,
+      output: {
+        file: `dist/${example.handler.replace(".handler", ".js")}`,
+        format: "cjs",
+        inlineDynamicImports: true,
+        sourcemap: true,
+        sourcemapExcludeSources: true,
+      },
+      plugins: [
+        typescript(),
+        nodeResolve({
+          preferBuiltins: true,
+        }),
+        json(),
+        commonJs(),
+      ],
+    })
+  )
+);
+
+export default config;

--- a/packages/examples/scripts/package.js
+++ b/packages/examples/scripts/package.js
@@ -25,42 +25,17 @@ fs.mkdirSync(tempDir);
 
 // Copy JS file
 fs.copyFileSync(
-    path.join('dist/examples', fileName + '.js'), 
+    path.join('dist', fileName + '.js'), 
     path.join(tempDir, fileName + '.js')
 );
 
 // Copy source map if exists
 try {
     fs.copyFileSync(
-        path.join('dist/examples', fileName + '.js.map'), 
+        path.join('dist', fileName + '.js.map'), 
         path.join(tempDir, fileName + '.js.map')
     );
 } catch {}
-
-// Copy required dependencies from root node_modules
-console.log('Copying required dependencies...');
-fs.mkdirSync(path.join(tempDir, 'node_modules'), { recursive: true });
-
-const requiredDeps = [
-    '@amzn',
-    'tslib',
-    '@smithy',
-    '@aws-sdk',
-    'uuid',
-    'fast-xml-parser',
-    '@aws-crypto',
-    'bowser'
-];
-
-for (const dep of requiredDeps) {
-    const srcPath = path.join('../../node_modules', dep);
-    const destPath = path.join(tempDir, 'node_modules', dep);
-    
-    if (fs.existsSync(srcPath)) {
-        console.log(`Copying ${dep}...`);
-        execSync(`cp -r "${srcPath}" "${path.dirname(destPath)}"`);
-    }
-}
 
 // Create zip file with quiet mode to avoid buffer overflow
 const zipFile = `${handlerFile}.zip`;

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -1,13 +1,18 @@
 {
-  "extends": ["@tsconfig/node22", "../../tsconfig.json"],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "lib": ["ES2022"],
     "declaration": true,
+    "emitDeclarationOnly": true,
     "outDir": "./dist",
-    "sourceMap": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": false,
-    "module": "node16",
-    "moduleResolution": "node16"
-},
+    "rootDir": "./src",
+    "strict": true,
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
   "include": ["src"]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Instead of manually bundling node modules, this change bundles the language SDK, AWS SDK, other dependencies, etc into one JS file for each example using rollup. This makes it easier to use the examples directly since they'll just be one file.

For more comprehensive testing of the language SDK, we should have more types of examples as projects such as ESM projects with node modules, CJS projects with node modules, projects using dependencies in a layer, etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
