### PR TITLE
feat(sdk): implement waitForContinuation with concurrent operations support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 .secrets
 .env
 .env.local
+
+# Node version
+.nvmrc

--- a/docs/step-handler-flowchart.md
+++ b/docs/step-handler-flowchart.md
@@ -1,0 +1,131 @@
+# Step Handler Flowchart
+
+```mermaid
+---
+title: Step Handler Flow
+---
+flowchart TD
+    subgraph Main["Main Step Handler Flow"]
+        direction TB
+        A[Step Handler Called] --> B[Parse Parameters]
+        B --> C[Generate Step ID]
+        C --> D[Start Main Loop]
+        
+        D --> E{Step Status?}
+        
+        E -->|SUCCEEDED| F[Return Cached Result]
+        E -->|FAILED| G[Throw Error]
+        E -->|PENDING| H[waitForContinuation]
+        E -->|STARTED| I{Semantics Check}
+        E -->|READY/undefined| J[executeStep]
+        
+        I -->|AtMostOncePerRetry| K[Handle Interrupted Step]
+        I -->|AtLeastOncePerRetry| L[executeStep]
+        
+        K --> M{Should Retry?}
+        M -->|No| N[Checkpoint FAIL & Throw Error]
+        M -->|Yes| O[Checkpoint RETRY]
+        O --> P[waitForContinuation]
+        P --> Q[Continue Loop]
+        Q --> E
+        
+        H --> R[Continue Loop]
+        R --> E
+        
+        J --> S{executeStep Result}
+        S -->|Success| T[Return Result]
+        S -->|Continue Signal| U[Continue Loop]
+        U --> E
+        
+        L --> V{executeStep Result}
+        V -->|Success| W[Return Result]
+        V -->|Continue Signal| X[Continue Loop]
+        X --> E
+    end
+    
+    subgraph Timer["waitForContinuation Subprocess"]
+        direction TB
+        Y[waitForContinuation Called] --> Z{Has Running Operations?}
+        
+        Z -->|No| AA[Terminate with RETRY_SCHEDULED]
+        Z -->|Yes| BB[Start waitBeforeContinue]
+        
+        BB --> CC[Setup Promise Race]
+        CC --> DD[Monitor 3 Conditions Simultaneously]
+        
+        DD --> EE{Which Condition Resolves First?}
+        
+        EE -->|Timer Expired| FF[Timer Condition Met]
+        EE -->|No Running Operations| GG[Operations Condition Met]  
+        EE -->|Step Status Changed| HH[Status Change Condition Met]
+        
+        FF --> II[Force Checkpoint Refresh]
+        II --> JJ[Return to Main Loop]
+        
+        GG --> JJ
+        HH --> JJ
+    end
+    
+    subgraph Execute["executeStep Subprocess"]
+        direction TB
+        KK[executeStep Called] --> LL{Already Started?}
+        LL -->|No| MM[Checkpoint START]
+        LL -->|Yes| NN[Skip Checkpoint]
+        
+        MM --> OO[Execute Function]
+        NN --> OO
+        
+        OO --> PP{Execution Result}
+        
+        PP -->|Success| QQ[Serialize & Checkpoint SUCCEED]
+        QQ --> RR[Return Result]
+        
+        PP -->|Error| SS{Unrecoverable Error?}
+        SS -->|Yes| TT[Terminate for Unrecoverable Error]
+        SS -->|No| UU[Apply Retry Strategy]
+        
+        UU --> VV{Should Retry?}
+        VV -->|No| WW[Checkpoint FAIL & Throw Error]
+        VV -->|Yes| XX[Checkpoint RETRY]
+        XX --> YY[waitForContinuation]
+        YY --> ZZ[Return Continue Signal]
+    end
+    
+    style F fill:#90EE90
+    style G fill:#FFB6C1
+    style N fill:#FFB6C1
+    style Q fill:#87CEEB
+    style R fill:#87CEEB
+    style T fill:#90EE90
+    style U fill:#87CEEB
+    style W fill:#90EE90
+    style X fill:#87CEEB
+    style AA fill:#FFE4B5
+    style JJ fill:#87CEEB
+    style RR fill:#90EE90
+    style TT fill:#FF6B6B
+    style WW fill:#FFB6C1
+    style ZZ fill:#87CEEB
+```
+
+## waitForContinuation Detailed Logic
+
+The expanded waitForContinuation subprocess now shows:
+
+**1. Initial Check**: `Has Running Operations?`
+- If no operations → immediate termination
+- If operations exist → proceed to sophisticated waiting
+
+**2. Promise Race Setup**: `Setup Promise Race`
+- Creates multiple promises to monitor different conditions
+- Uses `Promise.race()` to wait for first condition to resolve
+
+**3. Three Monitoring Conditions**:
+- **Timer Promise**: Waits for `NextAttemptTimestamp` to expire
+- **Operations Promise**: Polls `hasRunningOperations()` every 100ms
+- **Status Promise**: Polls step status changes every 100ms
+
+**4. Condition Resolution**:
+- **Timer Expired**: Forces checkpoint refresh to get latest data
+- **No Running Operations**: Can safely return to main loop
+- **Status Changed**: Step was updated externally, re-evaluate immediately

--- a/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -60,10 +60,10 @@ describe("Durable Context", () => {
       memoryLimitInMB: "128",
       logGroupName: "/aws/lambda/mock-function",
       logStreamName: "2023/01/01/[$LATEST]abcdef123456",
-      getRemainingTimeInMillis: () => 30000,
-      done: () => {},
-      fail: () => {},
-      succeed: () => {},
+      getRemainingTimeInMillis: (): number => 30000,
+      done: (): void => {},
+      fail: (): void => {},
+      succeed: (): void => {},
     };
 
     // Setup mocks
@@ -140,6 +140,7 @@ describe("Durable Context", () => {
       expect.any(Function), // createContextLogger
       expect.any(Function), // addRunningOperation
       expect.any(Function), // removeRunningOperation
+      expect.any(Function), // hasRunningOperations
     );
     expect(mockStepHandler).toHaveBeenCalledWith("test-step", stepFn, options);
   });

--- a/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/context/durable-context/durable-context.ts
@@ -87,6 +87,7 @@ export const createDurableContext = (
       createContextLogger,
       addRunningOperation,
       removeRunningOperation,
+      hasRunningOperations,
     );
     return stepHandler(nameOrFn, fnOrOptions, maybeOptions);
   };

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -85,6 +85,7 @@ describe("Step Handler", () => {
       createMockEnrichedLogger,
       jest.fn(), // addRunningOperation
       jest.fn(), // removeRunningOperation
+      jest.fn(() => false), // hasRunningOperations
     );
 
     // Reset the mock for retryPresets.default

--- a/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
+++ b/packages/lambda-durable-functions-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
@@ -1,0 +1,232 @@
+import {
+  createMockCheckpoint,
+  CheckpointFunction,
+} from "../../testing/mock-checkpoint";
+import { createStepHandler } from "./step-handler";
+import { ExecutionContext, StepSemantics } from "../../types";
+import { TerminationManager } from "../../termination-manager/termination-manager";
+import { TerminationReason } from "../../termination-manager/types";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+import { hashId } from "../../utils/step-id-utils/step-id-utils";
+
+describe("Step Handler Timing Tests", () => {
+  let mockExecutionContext: jest.Mocked<ExecutionContext>;
+  let mockCheckpoint: jest.MockedFunction<CheckpointFunction>;
+  let mockParentContext: any;
+  let createStepId: jest.Mock;
+  let stepHandler: ReturnType<typeof createStepHandler>;
+  let mockTerminationManager: jest.Mocked<TerminationManager>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockTerminationManager = {
+      terminate: jest.fn(),
+      getTerminationPromise: jest.fn(),
+    } as unknown as jest.Mocked<TerminationManager>;
+
+    mockExecutionContext = {
+      durableExecutionArn: "test-arn",
+      parentId: "test-parent-id",
+      isVerbose: false,
+      terminationManager: mockTerminationManager,
+      getStepData: jest.fn().mockReturnValue(undefined),
+      _stepData: {},
+    } as unknown as jest.Mocked<ExecutionContext>;
+
+    mockCheckpoint = createMockCheckpoint();
+    mockParentContext = { getRemainingTimeInMillis: () => 30000 };
+    createStepId = jest.fn().mockReturnValue("test-step-id");
+
+    stepHandler = createStepHandler(
+      mockExecutionContext,
+      mockCheckpoint,
+      mockParentContext,
+      createStepId,
+      jest.fn().mockReturnValue({ log: jest.fn() }),
+      jest.fn(),
+      jest.fn(),
+      jest.fn().mockReturnValue(false),
+    );
+  });
+
+  describe("Step Handler Timing and Concurrency Tests", () => {
+    test("should terminate when retry is scheduled", async () => {
+      const stepFn = jest.fn().mockRejectedValue(new Error("Test error"));
+      const mockRetryStrategy = jest
+        .fn()
+        .mockReturnValue({ shouldRetry: true, delaySeconds: 1 });
+
+      const mockHasRunningOperations = jest.fn().mockReturnValue(false);
+
+      const stepHandlerWithMocks = createStepHandler(
+        mockExecutionContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        jest.fn().mockReturnValue({ log: jest.fn() }),
+        jest.fn(),
+        jest.fn(),
+        mockHasRunningOperations,
+      );
+
+      const stepPromise = stepHandlerWithMocks("test-step", stepFn, {
+        retryStrategy: mockRetryStrategy,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
+        reason: TerminationReason.RETRY_SCHEDULED,
+        message: expect.stringContaining("test-step"),
+      });
+    });
+
+    test("should wait for pending step and continue execution", async () => {
+      const stepId = "test-step-id";
+      const hashedStepId = hashId(stepId);
+
+      // Create a step handler that will definitely hit the PENDING path
+      const mockGetStepData = jest
+        .fn()
+        .mockReturnValueOnce({
+          Id: hashedStepId,
+          Status: OperationStatus.PENDING,
+          StepDetails: { Attempt: 1 },
+        })
+        .mockReturnValueOnce(undefined); // After continue, return undefined to proceed
+
+      mockExecutionContext.getStepData = mockGetStepData;
+
+      const stepFn = jest.fn().mockResolvedValue("test-result");
+
+      // Mock hasRunningOperations to return true initially (to trigger waitForContinuation)
+      // then false to allow normal execution
+      const mockHasRunningOperations = jest
+        .fn()
+        .mockReturnValueOnce(true)
+        .mockReturnValue(false);
+
+      const stepHandlerWithMocks = createStepHandler(
+        mockExecutionContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        jest.fn().mockReturnValue({ log: jest.fn() }),
+        jest.fn(),
+        jest.fn(),
+        mockHasRunningOperations,
+      );
+
+      const result = await stepHandlerWithMocks("test-step", stepFn);
+
+      // Verify the continue statement was executed by checking the result
+      expect(result).toBe("test-result");
+      expect(mockGetStepData).toHaveBeenCalled();
+    });
+
+    test("should retry interrupted AtMostOncePerRetry step and continue main loop", async () => {
+      const stepId = "test-step-id";
+      const hashedStepId = hashId(stepId);
+
+      // Set up step data with STARTED status (interrupted) for AtMostOncePerRetry
+      mockExecutionContext._stepData = {
+        [hashedStepId]: {
+          Id: hashedStepId,
+          Status: OperationStatus.STARTED,
+          StepDetails: { Attempt: 1 },
+        },
+      } as any;
+
+      mockExecutionContext.getStepData = jest
+        .fn()
+        .mockReturnValueOnce({
+          Id: hashedStepId,
+          Status: OperationStatus.STARTED,
+          StepDetails: { Attempt: 1 },
+        })
+        .mockReturnValue(undefined); // After continue, return undefined to proceed
+
+      const stepFn = jest.fn().mockResolvedValue("retry-result");
+
+      // Mock retry strategy that decides to retry the interrupted step
+      const mockRetryStrategy = jest.fn().mockReturnValue({
+        shouldRetry: true,
+        delaySeconds: 2,
+      });
+
+      // Mock hasRunningOperations to trigger waitForContinuation, then allow execution
+      const mockHasRunningOperations = jest
+        .fn()
+        .mockReturnValueOnce(true) // Trigger waitForContinuation in retry path (line 207)
+        .mockReturnValue(false); // Allow execution after continue
+
+      const stepHandlerWithMocks = createStepHandler(
+        mockExecutionContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        jest.fn().mockReturnValue({ log: jest.fn() }),
+        jest.fn(),
+        jest.fn(),
+        mockHasRunningOperations,
+      );
+
+      const result = await stepHandlerWithMocks("test-step", stepFn, {
+        semantics: StepSemantics.AtMostOncePerRetry, // This is key for line 207
+        retryStrategy: mockRetryStrategy,
+      });
+
+      expect(result).toBe("retry-result");
+      expect(mockRetryStrategy).toHaveBeenCalled();
+      expect(mockHasRunningOperations).toHaveBeenCalled();
+    });
+
+    test("should retry step with scheduled delay", async () => {
+      const stepId = "test-step-id";
+      const hashedStepId = hashId(stepId);
+
+      mockExecutionContext._stepData = {
+        [hashedStepId]: {
+          Id: hashedStepId,
+          Status: OperationStatus.STARTED,
+          StepDetails: {
+            Attempt: 1,
+            NextAttemptTimestamp: new Date(Date.now() + 1000),
+          },
+        },
+      } as any;
+
+      const stepFn = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("Test error"))
+        .mockResolvedValue("result");
+
+      const mockRetryStrategy = jest
+        .fn()
+        .mockReturnValue({ shouldRetry: true, delaySeconds: 1 });
+
+      const mockHasRunningOperations = jest
+        .fn()
+        .mockReturnValueOnce(true) // Trigger waitForContinuation in executeStep
+        .mockReturnValue(false); // Allow execution after continue
+
+      const stepHandlerWithMocks = createStepHandler(
+        mockExecutionContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        jest.fn().mockReturnValue({ log: jest.fn() }),
+        jest.fn(),
+        jest.fn(),
+        mockHasRunningOperations,
+      );
+
+      const result = await stepHandlerWithMocks("test-step", stepFn, {
+        retryStrategy: mockRetryStrategy,
+      });
+
+      expect(result).toBe("result");
+    });
+  });
+});


### PR DESCRIPTION
Implement waitForContinuation with concurrent operations support

- Add waitForContinuation function to handle concurrent operations during step retries
- Implement main loop in step handler to re-evaluate step status after waiting
- Add hasRunningOperations parameter to step handler for concurrency control
- Create CONTINUE_MAIN_LOOP symbol for flow control between executeStep and main loop
- Add comprehensive timing tests covering waitForContinuation
- Add step handler flowchart documentation for visual flow understanding
- Update .gitignore to exclude .nvmrc files

This change enables the step handler to properly wait for ongoing operations before terminating, preventing race conditions in concurrent execution scenarios. The main loop allows re-evaluation of step status after waitForContinuation completes, ensuring correct behavior for PENDING and retry scenarios.

# New Step Handler Flowchart

```mermaid
---
title: Step Handler Flow
---
flowchart TD
    subgraph Main["Main Step Handler Flow"]
        direction TB
        A[Step Handler Called] --> B[Parse Parameters]
        B --> C[Generate Step ID]
        C --> D[Start Main Loop]
        
        D --> E{Step Status?}
        
        E -->|SUCCEEDED| F[Return Cached Result]
        E -->|FAILED| G[Throw Error]
        E -->|PENDING| H[waitForContinuation]
        E -->|STARTED| I{Semantics Check}
        E -->|READY/undefined| J[executeStep]
        
        I -->|AtMostOncePerRetry| K[Handle Interrupted Step]
        I -->|AtLeastOncePerRetry| L[executeStep]
        
        K --> M{Should Retry?}
        M -->|No| N[Checkpoint FAIL & Throw Error]
        M -->|Yes| O[Checkpoint RETRY]
        O --> P[waitForContinuation]
        P --> Q[Continue Loop]
        Q --> E
        
        H --> R[Continue Loop]
        R --> E
        
        J --> S{executeStep Result}
        S -->|Success| T[Return Result]
        S -->|Continue Signal| U[Continue Loop]
        U --> E
        
        L --> V{executeStep Result}
        V -->|Success| W[Return Result]
        V -->|Continue Signal| X[Continue Loop]
        X --> E
    end
    
    subgraph Timer["waitForContinuation Subprocess"]
        direction TB
        Y[waitForContinuation Called] --> Z{Has Running Operations?}
        
        Z -->|No| AA[Terminate with RETRY_SCHEDULED]
        Z -->|Yes| BB[Start waitBeforeContinue]
        
        BB --> CC[Setup Promise Race]
        CC --> DD[Monitor 3 Conditions Simultaneously]
        
        DD --> EE{Which Condition Resolves First?}
        
        EE -->|Timer Expired| FF[Timer Condition Met]
        EE -->|No Running Operations| GG[Operations Condition Met]  
        EE -->|Step Status Changed| HH[Status Change Condition Met]
        
        FF --> II[Force Checkpoint Refresh]
        II --> JJ[Return to Main Loop]
        
        GG --> JJ
        HH --> JJ
    end
    
    subgraph Execute["executeStep Subprocess"]
        direction TB
        KK[executeStep Called] --> LL{Already Started?}
        LL -->|No| MM[Checkpoint START]
        LL -->|Yes| NN[Skip Checkpoint]
        
        MM --> OO[Execute Function]
        NN --> OO
        
        OO --> PP{Execution Result}
        
        PP -->|Success| QQ[Serialize & Checkpoint SUCCEED]
        QQ --> RR[Return Result]
        
        PP -->|Error| SS{Unrecoverable Error?}
        SS -->|Yes| TT[Terminate for Unrecoverable Error]
        SS -->|No| UU[Apply Retry Strategy]
        
        UU --> VV{Should Retry?}
        VV -->|No| WW[Checkpoint FAIL & Throw Error]
        VV -->|Yes| XX[Checkpoint RETRY]
        XX --> YY[waitForContinuation]
        YY --> ZZ[Return Continue Signal]
    end
    
    style F fill:#90EE90
    style G fill:#FFB6C1
    style N fill:#FFB6C1
    style Q fill:#87CEEB
    style R fill:#87CEEB
    style T fill:#90EE90
    style U fill:#87CEEB
    style W fill:#90EE90
    style X fill:#87CEEB
    style AA fill:#FFE4B5
    style JJ fill:#87CEEB
    style RR fill:#90EE90
    style TT fill:#FF6B6B
    style WW fill:#FFB6C1
    style ZZ fill:#87CEEB
```

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
