### PR TITLE
feat(testing-sdk): add history to local runner result

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager.test.ts
@@ -1413,6 +1413,56 @@ describe("CheckpointManager", () => {
   });
 
   describe("updateOperation", () => {
+    it("should update operation for WAIT and update history", () => {
+      const initialOperation = storage.initialize();
+
+      const newOperationData = {
+        Type: OperationType.WAIT,
+        Status: OperationStatus.SUCCEEDED,
+        EndTimestamp: new Date(),
+      };
+
+      const result = storage.updateOperation(
+        initialOperation.Id,
+        newOperationData
+      );
+
+      // Should return the updated CheckpointOperation
+      expect(result.operation.Id).toBe(initialOperation.Id);
+      expect(result.operation.Status).toBe(OperationStatus.SUCCEEDED); // Updated status
+      expect(result.operation.EndTimestamp).toEqual(
+        newOperationData.EndTimestamp
+      );
+
+      expect(result.events).toEqual([
+        {
+          EventType: "ExecutionStarted",
+          SubType: undefined,
+          EventId: 1,
+          Id: "mocked-uuid",
+          Name: undefined,
+          EventTimestamp: expect.any(Date),
+          ParentId: undefined,
+          ExecutionStartedDetails: {
+            Input: {
+              Payload: "{}",
+            },
+            ExecutionTimeout: undefined,
+          },
+        },
+        {
+          EventType: "WaitSucceeded",
+          SubType: undefined,
+          EventId: 2,
+          Id: "mocked-uuid",
+          Name: undefined,
+          EventTimestamp: expect.any(Date),
+          ParentId: undefined,
+          WaitSucceededDetails: { Duration: undefined },
+        },
+      ]);
+    });
+
     it("should update existing operation and return the updated CheckpointOperation", () => {
       const initialOperation = storage.initialize();
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/callback-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/callback-manager.ts
@@ -13,17 +13,12 @@ import {
 import { decodeCallbackId, encodeCallbackId } from "../utils/callback-id";
 import { CheckpointManager } from "./checkpoint-manager";
 import { OperationEvents } from "../../test-runner/common/operations/operation-with-data";
+import { OperationHistoryEventDetails } from "./types";
 
 export enum CompleteCallbackStatus {
   SUCCEEDED = "SUCCEEDED",
   FAILED = "FAILED",
   TIMED_OUT = "TIMED_OUT",
-}
-
-interface OperationHistoryEventDetails<T extends keyof Event> {
-  eventType: EventType;
-  detailPlace: T;
-  getDetails: (operation: Operation) => Event[T];
 }
 
 export const callbackHistoryDetails = {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/types.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/types.ts
@@ -1,0 +1,7 @@
+import { EventType, Operation, Event } from "@aws-sdk/client-lambda";
+
+export interface OperationHistoryEventDetails<T extends keyof Event> {
+  eventType: EventType;
+  detailPlace: T;
+  getDetails?: (operation: Operation) => Event[T];
+}

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/wait-details.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/wait-details.ts
@@ -1,0 +1,26 @@
+import {
+  EventType,
+  OperationStatus,
+  Event,
+} from "@aws-sdk/client-lambda";
+import { OperationHistoryEventDetails } from "./types";
+
+export const waitHistoryDetails = {
+  [OperationStatus.CANCELLED]: {
+    eventType: EventType.WaitCancelled,
+    detailPlace: "WaitCancelledDetails",
+  },
+  [OperationStatus.SUCCEEDED]: {
+    eventType: EventType.WaitSucceeded,
+    detailPlace: "WaitSucceededDetails",
+  },
+  [OperationStatus.FAILED]: undefined,
+  [OperationStatus.PENDING]: undefined,
+  [OperationStatus.READY]: undefined,
+  [OperationStatus.STARTED]: undefined,
+  [OperationStatus.STOPPED]: undefined,
+  [OperationStatus.TIMED_OUT]: undefined,
+} satisfies Record<
+  OperationStatus,
+  OperationHistoryEventDetails<keyof Event> | undefined
+>;

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
@@ -57,6 +57,7 @@ describe("CloudDurableTestRunner", () => {
         getInvocations: jest.fn().mockReturnValue([]),
         getResult: jest.fn().mockReturnValue({ data: { success: true } }),
         getError: jest.fn(),
+        getHistoryEvents: jest.fn(),
       }),
     } as unknown as jest.Mocked<ResultFormatter<{ success: boolean }>>;
 
@@ -213,6 +214,7 @@ describe("CloudDurableTestRunner", () => {
           result: JSON.stringify({ success: true }),
           error: undefined,
         },
+        mockHistoryResult.Events,
         mockOperationStorage,
         []
       );
@@ -313,6 +315,7 @@ describe("CloudDurableTestRunner", () => {
             errorType: "RuntimeError",
           },
         },
+        mockHistoryResult.Events,
         mockOperationStorage,
         []
       );
@@ -364,40 +367,6 @@ describe("CloudDurableTestRunner", () => {
       await runner.run();
 
       expect(historyEventsToOperationEvents).toHaveBeenCalledWith([]);
-    });
-  });
-
-  describe("getHistory", () => {
-    it("should return undefined before run is called", () => {
-      const runner = new CloudDurableTestRunner<{ success: boolean }>({
-        functionName: mockFunctionArn,
-      });
-
-      expect(runner.getHistory()).toBeUndefined();
-    });
-
-    it("should return history after successful run", async () => {
-      const runner = new CloudDurableTestRunner<{ success: boolean }>({
-        functionName: mockFunctionArn,
-      });
-
-      const mockHistoryResult: GetDurableExecutionHistoryResponse = {
-        Events: [
-          {
-            EventType: EventType.ExecutionStarted,
-            EventTimestamp: new Date(),
-          },
-        ],
-      };
-
-      (mockLambdaClient.send as jest.Mock)
-        .mockResolvedValueOnce({ DurableExecutionArn: mockExecutionArn })
-        .mockResolvedValueOnce({ Status: "SUCCEEDED", Result: "{}" })
-        .mockResolvedValueOnce(mockHistoryResult);
-
-      await runner.run();
-
-      expect(runner.getHistory()).toBe(mockHistoryResult);
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/cloud-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/cloud-durable-test-runner.ts
@@ -70,10 +70,9 @@ export class CloudDurableTestRunner<ResultType>
     );
 
     this.history = history;
+    const events = this.history.Events ?? [];
 
-    const operationEvents = historyEventsToOperationEvents(
-      this.history.Events ?? []
-    );
+    const operationEvents = historyEventsToOperationEvents(events);
     this.operationStorage.populateOperations(operationEvents);
 
     const lambdaResponse = {
@@ -84,14 +83,12 @@ export class CloudDurableTestRunner<ResultType>
 
     return this.formatter.formatTestResult(
       lambdaResponse,
+      events,
       this.operationStorage,
       []
     );
   }
 
-  getHistory() {
-    return this.history;
-  }
   getOperation<T>(name: string): OperationWithData<T> {
     return this.getOperationByNameAndIndex(name, 0);
   }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
@@ -10,7 +10,11 @@ describe("IndexedOperations", () => {
         Name: "operation1",
         Status: OperationStatus.SUCCEEDED,
       },
-      events: [],
+      events: [
+        {
+          EventId: 1,
+        },
+      ],
     },
     {
       operation: {
@@ -18,7 +22,11 @@ describe("IndexedOperations", () => {
         Name: "operation2",
         Status: OperationStatus.SUCCEEDED,
       },
-      events: [],
+      events: [
+        {
+          EventId: 2,
+        },
+      ],
     },
     {
       operation: {
@@ -26,7 +34,11 @@ describe("IndexedOperations", () => {
         Name: "operation1", // Same name as first operation
         Status: OperationStatus.FAILED,
       },
-      events: [],
+      events: [
+        {
+          EventId: 3,
+        },
+      ],
     },
   ];
 
@@ -306,6 +318,22 @@ describe("IndexedOperations", () => {
 
       expect(indexed.getOperations()).toHaveLength(1);
       expect(indexed.getByNameAndIndex("", 0)).toBe(operationWithEmptyName);
+    });
+  });
+
+  describe("getHistoryEvents", () => {
+    it("should return history events", () => {
+      const indexed = new IndexedOperations(sampleOperations);
+      const historyEvents = indexed.getHistoryEvents();
+
+      expect(historyEvents).toHaveLength(3);
+    });
+
+    it("should return empty list if no operations exist", () => {
+      const indexed = new IndexedOperations([]);
+      const historyEvents = indexed.getHistoryEvents();
+
+      expect(historyEvents).toHaveLength(0);
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/indexed-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/indexed-operations.ts
@@ -1,4 +1,5 @@
 import { OperationEvents } from "./operations/operation-with-data";
+import { Event } from "@aws-sdk/client-lambda";
 
 /**
  * Optimized way of retrieving operations by id and name/index.
@@ -18,6 +19,10 @@ export class IndexedOperations {
 
   constructor(operations: OperationEvents[]) {
     this.addOperations(operations);
+  }
+
+  getHistoryEvents(): Event[] {
+    return this.getOperations().flatMap((op) => op.events);
   }
 
   getOperations(): OperationEvents[] {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
@@ -283,10 +283,26 @@ export class OperationWithData<OperationResultValue = unknown>
   }
 
   getStartTimestamp(): Date | undefined {
+    // TODO: remove this when the local runner converts to Date correctly
+    if (
+      typeof this.checkpointOperationData?.operation.StartTimestamp === "number"
+    ) {
+      return new Date(
+        this.checkpointOperationData.operation.StartTimestamp * 1000
+      );
+    }
     return this.checkpointOperationData?.operation.StartTimestamp;
   }
 
   getEndTimestamp(): Date | undefined {
+    // TODO: remove this when the local runner converts to Date correctly
+    if (
+      typeof this.checkpointOperationData?.operation.EndTimestamp === "number"
+    ) {
+      return new Date(
+        this.checkpointOperationData.operation.EndTimestamp * 1000
+      );
+    }
     return this.checkpointOperationData?.operation.EndTimestamp;
   }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/durable-test-runner.ts
@@ -7,6 +7,7 @@ import {
   SendDurableExecutionCallbackFailureCommandOutput,
   SendDurableExecutionCallbackHeartbeatCommandOutput,
   SendDurableExecutionCallbackSuccessCommandOutput,
+  Event,
 } from "@aws-sdk/client-lambda";
 import { OperationWithData } from "./common/operations/operation-with-data";
 
@@ -90,6 +91,11 @@ export interface TestResult<T> {
    * @throws An error if the execution succeeded.
    */
   getError(): TestResultError;
+
+  /**
+   * Returns the history events for the execution.
+   */
+  getHistoryEvents(): Event[]
 
   /**
    * Prints a table of all operations to the console with their details.

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -525,6 +525,79 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(invocationOperations[1]).toEqual([stepOpId, secondWaitId]);
     // - Invocation 2: no checkpoints performed
     expect(invocationOperations[2]).toEqual([]);
+
+    // Assert history events
+    // TODO: update timestamps to Date objects
+    expect(result.getHistoryEvents()).toEqual([
+      {
+        EventType: "WaitStarted",
+        SubType: "Wait",
+        EventId: 2,
+        Id: "c4ca4238a0b92382",
+        Name: "wait-invocation-1",
+        EventTimestamp: expect.any(Number),
+        WaitStartedDetails: {
+          Duration: 1,
+          ScheduledEndTimestamp: expect.any(Number),
+        },
+      },
+      {
+        EventType: "WaitSucceeded",
+        SubType: "Wait",
+        EventId: 3,
+        Id: "c4ca4238a0b92382",
+        Name: "wait-invocation-1",
+        EventTimestamp: expect.any(Number),
+        WaitSucceededDetails: { Duration: 1 },
+      },
+      {
+        EventType: "StepStarted",
+        SubType: "Step",
+        EventId: 4,
+        Id: "c81e728d9d4c2f63",
+        Name: "process-data-step",
+        EventTimestamp: expect.any(Number),
+        StepStartedDetails: {},
+      },
+      {
+        EventType: "StepSucceeded",
+        SubType: "Step",
+        EventId: 5,
+        Id: "c81e728d9d4c2f63",
+        Name: "process-data-step",
+        EventTimestamp: expect.any(Number),
+        StepSucceededDetails: {
+          Result: {
+            Payload: JSON.stringify({
+              processed: true,
+              timestamp: resultData.result.timestamp,
+            }),
+          },
+          RetryDetails: {},
+        },
+      },
+      {
+        EventType: "WaitStarted",
+        SubType: "Wait",
+        EventId: 6,
+        Id: "eccbc87e4b5ce2fe",
+        Name: "wait-invocation-2",
+        EventTimestamp: expect.any(Number),
+        WaitStartedDetails: {
+          Duration: 1,
+          ScheduledEndTimestamp: expect.any(Number),
+        },
+      },
+      {
+        EventType: "WaitSucceeded",
+        SubType: "Wait",
+        EventId: 7,
+        Id: "eccbc87e4b5ce2fe",
+        Name: "wait-invocation-2",
+        EventTimestamp: expect.any(Number),
+        WaitSucceededDetails: { Duration: 1 },
+      },
+    ]);
   });
 
   // enable when language SDK supports concurrent waits

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -938,7 +938,7 @@ describe("WaitForCallback Operations Integration", () => {
       const completedOperations = result.getOperations({
         status: OperationStatus.SUCCEEDED,
       });
-      expect(completedOperations.length).toBe(7);
+      expect(completedOperations.length).toBe(8);
     });
 
     it("should handle multiple invocations tracking with waitForCallback operations", async () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
@@ -55,6 +55,7 @@ describe("LocalDurableTestRunner", () => {
     mockOperationStorage = {
       registerOperation: jest.fn(),
       populateOperations: jest.fn(),
+      getHistoryEvents: jest.fn().mockReturnValue([]),
     };
 
     mockOrchestrator = {
@@ -70,6 +71,7 @@ describe("LocalDurableTestRunner", () => {
         getOperations: jest.fn().mockReturnValue([]),
         getInvocations: jest.fn().mockReturnValue([]),
         getResult: jest.fn().mockReturnValue({ data: { success: true } }),
+        getHistoryEvents: jest.fn(),
       }),
     } as unknown as jest.Mocked<ResultFormatter<{ success: boolean }>>;
 
@@ -141,6 +143,7 @@ describe("LocalDurableTestRunner", () => {
           Status: InvocationStatus.SUCCEEDED,
           Result: JSON.stringify({ success: true }),
         }),
+        [],
         mockOperationStorage,
         []
       );

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/result-formatter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/result-formatter.test.ts
@@ -1,7 +1,7 @@
 import { ResultFormatter } from "../result-formatter";
 import { LocalOperationStorage } from "../operations/local-operation-storage";
 import { OperationWaitManager } from "../operations/operation-wait-manager";
-import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
+import { OperationStatus, OperationType, Event } from "@aws-sdk/client-lambda";
 import { OperationWithData } from "../../common/operations/operation-with-data";
 import { IndexedOperations } from "../../common/indexed-operations";
 import { TestExecutionResult } from "../test-execution-state";
@@ -55,6 +55,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         mockInvocations
       );
@@ -106,6 +107,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -150,6 +152,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         mockInvocations
       );
@@ -172,6 +175,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -189,6 +193,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -206,6 +211,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -253,6 +259,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -281,6 +288,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -296,6 +304,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -311,6 +320,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -339,6 +349,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -356,6 +367,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -373,6 +385,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -390,6 +403,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -413,6 +427,7 @@ describe("ResultFormatter", () => {
 
       const testResult = resultFormatter.formatTestResult(
         lambdaResponse,
+        [],
         mockOperationStorage,
         []
       );
@@ -423,6 +438,57 @@ describe("ResultFormatter", () => {
         errorType: "my-error-type",
         stackTrace: ["my-stack-trace"],
       });
+    });
+  });
+
+  describe("getHistoryEvents", () => {
+    it("should return events passed to formatTestResult", () => {
+      mockOperationStorage.getOperations.mockReturnValue([]);
+
+      const mockEvents: Event[] = [
+        {
+          Id: "event-1",
+          Name: "TestEvent1",
+          EventTimestamp: new Date("2023-01-01T00:00:00Z"),
+        },
+        {
+          Id: "event-2",
+          Name: "TestEvent2",
+          EventTimestamp: new Date("2023-01-01T00:01:00Z"),
+        },
+      ];
+
+      const lambdaResponse: TestExecutionResult = {
+        status: OperationStatus.SUCCEEDED,
+        result: JSON.stringify({ success: true }),
+      };
+
+      const testResult = resultFormatter.formatTestResult(
+        lambdaResponse,
+        mockEvents,
+        mockOperationStorage,
+        []
+      );
+
+      expect(testResult.getHistoryEvents()).toEqual(mockEvents);
+    });
+
+    it("should return empty array when no events provided", () => {
+      mockOperationStorage.getOperations.mockReturnValue([]);
+
+      const lambdaResponse: TestExecutionResult = {
+        status: OperationStatus.SUCCEEDED,
+        result: JSON.stringify({ success: true }),
+      };
+
+      const testResult = resultFormatter.formatTestResult(
+        lambdaResponse,
+        [],
+        mockOperationStorage,
+        []
+      );
+
+      expect(testResult.getHistoryEvents()).toEqual([]);
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
@@ -99,6 +99,7 @@ export class LocalDurableTestRunner<ResultType>
       const lambdaResponse = await orchestrator.executeHandler(params);
       return this.resultFormatter.formatTestResult(
         lambdaResponse,
+        this.operationStorage.getHistoryEvents(),
         this.operationStorage,
         orchestrator.getInvocations()
       );

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/result-formatter.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/result-formatter.ts
@@ -5,7 +5,7 @@ import {
 } from "../durable-test-runner";
 import { tryJsonParse } from "../common/utils";
 import { TestExecutionResult } from "./test-execution-state";
-import { OperationStatus } from "@aws-sdk/client-lambda";
+import { OperationStatus, Event } from "@aws-sdk/client-lambda";
 import { OperationStorage } from "../common/operation-storage";
 
 /**
@@ -23,6 +23,7 @@ export class ResultFormatter<ResultType> {
    */
   formatTestResult(
     lambdaResponse: TestExecutionResult,
+    events: Event[],
     operationStorage: OperationStorage,
     invocations: Invocation[]
   ): TestResult<ResultType> {
@@ -37,6 +38,9 @@ export class ResultFormatter<ResultType> {
       },
       getInvocations() {
         return invocations;
+      },
+      getHistoryEvents() {
+        return events;
       },
       getResult: () => {
         if (lambdaResponse.status === OperationStatus.FAILED) {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
@@ -251,7 +251,11 @@ export class TestExecutionOrchestrator {
     operation: Operation,
     executionId: ExecutionId
   ): void {
-    const waitSeconds = update?.WaitOptions?.WaitSeconds;
+    if (update?.Action !== OperationAction.START) {
+      return;
+    }
+
+    const waitSeconds = update.WaitOptions?.WaitSeconds;
 
     if (!waitSeconds) {
       throw new Error("Wait operation is missing waitSeconds");


### PR DESCRIPTION
*Issue #, if available:*

DAR-SDK-255

*Description of changes:*

Following up from https://github.com/aws/aws-durable-functions-sdk-js/pull/36

Adding history events to test lib local runner result.

Also fixing the history events/operation updates for WaitSucceeded. Before, it was not adding the wait succeed operation to the operation storage, but now it is.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
