### PR TITLE
feat(sdk): implement ctx.invoke for chaining Lambda functions durably

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -1,0 +1,388 @@
+import { createInvokeHandler } from "./invoke-handler";
+import { ExecutionContext, OperationSubType } from "../../types";
+import {
+  OperationStatus,
+  OperationType,
+  OperationAction,
+} from "@aws-sdk/client-lambda";
+import { TerminationReason } from "../../termination-manager/types";
+import { OperationInterceptor } from "../../mocks/operation-interceptor";
+
+// Mock dependencies
+jest.mock("../../utils/checkpoint/checkpoint");
+jest.mock("../../utils/termination-helper");
+jest.mock("../../mocks/operation-interceptor");
+jest.mock("../../utils/logger/logger");
+jest.mock("../../errors/serdes-errors/serdes-errors");
+
+import { terminate } from "../../utils/termination-helper";
+import { log } from "../../utils/logger/logger";
+import { safeSerialize, safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
+
+const mockTerminate = terminate as jest.MockedFunction<typeof terminate>;
+const mockLog = log as jest.MockedFunction<typeof log>;
+const mockSafeSerialize = safeSerialize as jest.MockedFunction<typeof safeSerialize>;
+const mockSafeDeserialize = safeDeserialize as jest.MockedFunction<typeof safeDeserialize>;
+
+describe("InvokeHandler", () => {
+  let mockContext: ExecutionContext;
+  let mockCreateStepId: jest.Mock;
+  let mockHasRunningOperations: jest.Mock;
+  let mockCheckpointFn: any;
+  let mockOperationInterceptor: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCreateStepId = jest.fn().mockReturnValue("test-step-1");
+    mockHasRunningOperations = jest.fn().mockReturnValue(false);
+
+    // Create a proper checkpoint mock with force method
+    mockCheckpointFn = jest.fn().mockResolvedValue(undefined);
+    mockCheckpointFn.force = jest.fn().mockResolvedValue(undefined);
+
+    mockContext = {
+      executionContextId: "test-context",
+      customerHandlerEvent: {},
+      state: {
+        operations: [],
+        nextMarker: "1",
+        getStepData: jest.fn(),
+        checkpoint: jest.fn(),
+      },
+      _stepData: {},
+      terminationManager: {
+        terminate: jest.fn(),
+      },
+      isLocalMode: false,
+      isVerbose: true,
+      durableExecutionArn: "test-arn",
+      parentId: "parent-123",
+      getStepData: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    // Mock OperationInterceptor
+    mockOperationInterceptor = {
+      execute: jest.fn(),
+    };
+    (OperationInterceptor.forExecution as jest.Mock).mockReturnValue(
+      mockOperationInterceptor,
+    );
+
+    // Mock serdes functions
+    mockSafeSerialize.mockResolvedValue('{"serialized":"data"}');
+    mockSafeDeserialize.mockResolvedValue({ deserialized: "data" });
+
+    // Mock terminate to throw (simulating termination)
+    mockTerminate.mockImplementation(() => {
+      throw new Error("Execution terminated");
+    });
+  });
+
+  describe("invoke", () => {
+    it("should return cached result for completed invoke", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.SUCCEEDED,
+        InvokeDetails: {
+          Result: '{"result":"success"}',
+        },
+      });
+
+      mockContext.getStepData = mockGetStepData;
+      mockSafeDeserialize.mockResolvedValue({ result: "success" });
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      const result = await invokeHandler("test-function", { test: "data" });
+
+      expect(result).toEqual({ result: "success" });
+      expect(mockCheckpointFn).not.toHaveBeenCalled();
+      expect(mockSafeDeserialize).toHaveBeenCalledWith(
+        expect.anything(),
+        '{"result":"success"}',
+        "test-step-1",
+        undefined,
+        mockContext.terminationManager,
+        true,
+        "test-arn",
+      );
+    });
+
+    it("should handle invoke with name parameter", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.SUCCEEDED,
+        InvokeDetails: {
+          Result: '{"result":"named"}',
+        },
+      });
+
+      mockContext.getStepData = mockGetStepData;
+      mockSafeDeserialize.mockResolvedValue({ result: "named" });
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      const result = await invokeHandler("test-invoke", "test-function", {
+        test: "data",
+      });
+
+      expect(result).toEqual({ result: "named" });
+      expect(mockSafeDeserialize).toHaveBeenCalledWith(
+        expect.anything(),
+        '{"result":"named"}',
+        "test-step-1",
+        "test-invoke",
+        mockContext.terminationManager,
+        true,
+        "test-arn",
+      );
+    });
+
+    it("should handle undefined result for void functions", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.SUCCEEDED,
+        InvokeDetails: {
+          Result: undefined,
+        },
+      });
+
+      mockContext.getStepData = mockGetStepData;
+      mockSafeDeserialize.mockResolvedValue(undefined);
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      const result = await invokeHandler("test-function", { test: "data" });
+
+      expect(result).toBeUndefined();
+      expect(mockSafeDeserialize).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        "test-step-1",
+        undefined,
+        mockContext.terminationManager,
+        true,
+        "test-arn",
+      );
+    });
+
+    it("should throw error when operation status is FAILED", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.FAILED,
+        InvokeDetails: {
+          Error: {
+            ErrorMessage: "Lambda function execution failed",
+            ErrorType: "ExecutionError",
+          },
+        },
+      });
+
+      mockContext.getStepData = mockGetStepData;
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      await expect(
+        invokeHandler("test-function", { test: "data" }),
+      ).rejects.toThrow("Lambda function execution failed");
+    });
+
+    it("should throw error with default message when FAILED status has no error details", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.FAILED,
+        InvokeDetails: {},
+      });
+
+      mockContext.getStepData = mockGetStepData;
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      await expect(
+        invokeHandler("test-function", { test: "data" }),
+      ).rejects.toThrow("Invoke failed");
+    });
+
+    it("should terminate when operation is still in progress", async () => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: OperationStatus.STARTED,
+      });
+
+      mockContext.getStepData = mockGetStepData;
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      await expect(
+        invokeHandler("test-function", { test: "data" }),
+      ).rejects.toThrow("Execution terminated");
+
+      expect(mockLog).toHaveBeenCalledWith(
+        true,
+        "⏳",
+        "Invoke test-function still in progress, terminating",
+      );
+      expect(mockTerminate).toHaveBeenCalledWith(
+        mockContext,
+        TerminationReason.OPERATION_TERMINATED,
+        "test-step-1",
+      );
+    });
+
+    it("should create checkpoint and terminate for new invoke without name", async () => {
+      mockOperationInterceptor.execute.mockImplementation(
+        async (name: any, fn: any) => {
+          return await fn();
+        },
+      );
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      await expect(
+        invokeHandler("test-function", { test: "data" }),
+      ).rejects.toThrow("Execution terminated");
+
+      expect(mockSafeSerialize).toHaveBeenCalledWith(
+        expect.anything(),
+        { test: "data" },
+        "test-step-1",
+        undefined,
+        mockContext.terminationManager,
+        true,
+        "test-arn",
+      );
+
+      expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
+        Id: "test-step-1",
+        ParentId: "parent-123",
+        Action: OperationAction.START,
+        SubType: OperationSubType.INVOKE,
+        Type: OperationType.INVOKE,
+        Name: undefined,
+        Payload: '{"serialized":"data"}',
+        InvokeOptions: {},
+      });
+
+      expect(mockLog).toHaveBeenCalledWith(
+        true,
+        "🚀",
+        "Invoke test-function started, terminating for async execution",
+      );
+    });
+
+    it("should create checkpoint and terminate for new invoke with name", async () => {
+      mockOperationInterceptor.execute.mockImplementation(
+        async (name: any, fn: any) => {
+          return await fn();
+        },
+      );
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      await expect(
+        invokeHandler("my-invoke", "test-function", { test: "data" }),
+      ).rejects.toThrow("Execution terminated");
+
+      expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
+        Id: "test-step-1",
+        ParentId: "parent-123",
+        Action: OperationAction.START,
+        SubType: OperationSubType.INVOKE,
+        Type: OperationType.INVOKE,
+        Name: "my-invoke",
+        Payload: '{"serialized":"data"}',
+        InvokeOptions: {},
+      });
+    });
+
+    it("should handle invoke with options", async () => {
+      mockOperationInterceptor.execute.mockImplementation(
+        async (name: any, fn: any) => {
+          return await fn();
+        },
+      );
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      const options = { FunctionQualifier: "LATEST" };
+
+      await expect(
+        invokeHandler("test-function", { test: "data" }, options),
+      ).rejects.toThrow("Execution terminated");
+
+      expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
+        Id: "test-step-1",
+        ParentId: "parent-123",
+        Action: OperationAction.START,
+        SubType: OperationSubType.INVOKE,
+        Type: OperationType.INVOKE,
+        Name: undefined,
+        Payload: '{"serialized":"data"}',
+        InvokeOptions: options,
+      });
+    });
+
+    it("should handle intercepted execution", async () => {
+      const interceptedResult = { intercepted: true };
+      mockOperationInterceptor.execute.mockResolvedValue(interceptedResult);
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
+
+      const result = await invokeHandler("test-function", { test: "data" });
+
+      expect(result).toBe(interceptedResult);
+      expect(OperationInterceptor.forExecution).toHaveBeenCalledWith(
+        "test-arn",
+      );
+      expect(mockOperationInterceptor.execute).toHaveBeenCalledWith(
+        undefined,
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -1,0 +1,133 @@
+import { ExecutionContext, InvokeOptions, OperationSubType } from "../../types";
+import { terminate } from "../../utils/termination-helper";
+import {
+  OperationAction,
+  OperationStatus,
+  OperationType,
+} from "@aws-sdk/client-lambda";
+import { log } from "../../utils/logger/logger";
+import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
+import { TerminationReason } from "../../termination-manager/types";
+import { defaultSerdes } from "../../utils/serdes/serdes";
+import {
+  safeSerialize,
+  safeDeserialize,
+} from "../../errors/serdes-errors/serdes-errors";
+import { OperationInterceptor } from "../../mocks/operation-interceptor";
+
+export const createInvokeHandler = (
+  context: ExecutionContext,
+  checkpoint: ReturnType<typeof createCheckpoint>,
+  createStepId: () => string,
+  hasRunningOperations: () => boolean,
+) => {
+  function invokeHandler<I, O>(
+    funcId: string,
+    input: I,
+    options?: InvokeOptions,
+  ): Promise<O>;
+  function invokeHandler<I, O>(
+    name: string,
+    funcId: string,
+    input: I,
+    options?: InvokeOptions,
+  ): Promise<O>;
+  async function invokeHandler<I, O>(
+    nameOrFuncId: string,
+    funcIdOrInput?: string | I,
+    inputOrOptions?: I | InvokeOptions,
+    maybeOptions?: InvokeOptions,
+  ): Promise<O> {
+    const isNameFirst = typeof funcIdOrInput === "string";
+    const name = isNameFirst ? nameOrFuncId : undefined;
+    const funcId = isNameFirst ? (funcIdOrInput as string) : nameOrFuncId;
+    const input = isNameFirst ? (inputOrOptions as I) : (funcIdOrInput as I);
+    const options = isNameFirst
+      ? maybeOptions
+      : (inputOrOptions as InvokeOptions);
+
+    const stepId = createStepId();
+
+    log(context.isVerbose, "🔗", `Invoke ${name || funcId} (${stepId})`);
+
+    // Check if we have existing step data
+    const stepData = context.getStepData(stepId);
+
+    if (stepData?.Status === OperationStatus.SUCCEEDED) {
+      // Return cached result - no need to check for errors in successful operations
+      const invokeDetails = stepData.InvokeDetails;
+      return await safeDeserialize(
+        defaultSerdes,
+        invokeDetails?.Result,
+        stepId,
+        name,
+        context.terminationManager,
+        context.isVerbose,
+        context.durableExecutionArn,
+      );
+    }
+
+    if (stepData?.Status === OperationStatus.FAILED) {
+      // Operation failed, throw error
+      const invokeDetails = stepData.InvokeDetails;
+      const error = new Error(
+        invokeDetails?.Error?.ErrorMessage || "Invoke failed",
+      );
+      error.name = invokeDetails?.Error?.ErrorType || "InvokeError";
+      throw error;
+    }
+
+    if (stepData?.Status === OperationStatus.STARTED) {
+      // Operation is still running, terminate and wait for completion
+      // It's a temporary solution until we implement more sopesticated solution
+      log(
+        context.isVerbose,
+        "⏳",
+        `Invoke ${name || funcId} still in progress, terminating`,
+      );
+      return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
+    }
+
+    // Execute with potential interception (testing)
+    const result = await OperationInterceptor.forExecution(
+      context.durableExecutionArn,
+    ).execute(name, async (): Promise<O> => {
+      // Serialize the input payload
+      const serializedPayload = await safeSerialize(
+        defaultSerdes,
+        input,
+        stepId,
+        name,
+        context.terminationManager,
+        context.isVerbose,
+        context.durableExecutionArn,
+      );
+
+      // Create checkpoint for the invoke operation
+      await checkpoint(stepId, {
+        Id: stepId,
+        ParentId: context.parentId,
+        Action: OperationAction.START,
+        SubType: OperationSubType.INVOKE,
+        Type: OperationType.INVOKE,
+        Name: name,
+        Payload: serializedPayload,
+        InvokeOptions: options || {},
+      });
+
+      log(
+        context.isVerbose,
+        "🚀",
+        `Invoke ${name || funcId} started, terminating for async execution`,
+      );
+
+      // Terminate to allow the invoke to execute asynchronously
+      // It's a temporary solution until we implement more sopesticated solution
+      return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
+    });
+
+    return result;
+  }
+
+  return invokeHandler;
+};

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
@@ -3,7 +3,11 @@ import {
   CheckpointFunction,
 } from "../../testing/mock-checkpoint";
 import { createWaitForConditionHandler } from "./wait-for-condition-handler";
-import { ExecutionContext, WaitForConditionCheckFunc, WaitForConditionConfig } from "../../types";
+import {
+  ExecutionContext,
+  WaitForConditionCheckFunc,
+  WaitForConditionConfig,
+} from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
@@ -54,7 +58,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
       const checkFn: WaitForConditionCheckFunc<{ complete: boolean }> = jest
         .fn()
         .mockReturnValue({ complete: false });
-      
+
       const config: WaitForConditionConfig<{ complete: boolean }> = {
         initialState: { complete: false },
         waitStrategy: () => ({ shouldContinue: true, delaySeconds: 1 }),
@@ -109,7 +113,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
       const checkFn: WaitForConditionCheckFunc<{ complete: boolean }> = jest
         .fn()
         .mockReturnValue({ complete: true });
-      
+
       const config: WaitForConditionConfig<{ complete: boolean }> = {
         initialState: { complete: false },
         waitStrategy: () => ({ shouldContinue: false, delaySeconds: 0 }),
@@ -167,7 +171,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         .mockReturnValueOnce({
           Id: hashedStepId,
           Status: OperationStatus.PENDING,
-          StepDetails: { 
+          StepDetails: {
             Attempt: 1,
             Result: JSON.stringify({ count: 1 }),
           },
@@ -277,10 +281,6 @@ describe("WaitForCondition Handler Timing Tests", () => {
       expect(checkFn).toHaveBeenCalledTimes(2);
     });
 
-
-
-
-
     test("should handle concurrent operations during retry with main loop", async () => {
       const stepId = "test-step-id";
       const hashedStepId = hashId(stepId);
@@ -353,7 +353,5 @@ describe("WaitForCondition Handler Timing Tests", () => {
       expect(mockHasRunningOperations).toHaveBeenCalled();
       expect(checkFn).toHaveBeenCalledTimes(3); // Check function called 3 times
     });
-
-
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -20,6 +20,7 @@ export {
   WaitForConditionWaitStrategyFunc,
   Logger,
   LambdaHandler,
+  InvokeOptions,
 } from "./types";
 export { StepInterruptedError } from "./errors/step-errors/step-errors";
 export {

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -63,6 +63,7 @@ export enum OperationSubType {
   PARALLEL_BRANCH = "ParallelBranch",
   WAIT_FOR_CALLBACK = "WaitForCallback",
   WAIT_FOR_CONDITION = "WaitForCondition",
+  INVOKE = "Invoke",
 }
 
 interface DurableExecutionInvocationOutputFailed {
@@ -92,6 +93,12 @@ export interface DurableContext extends Context {
     fnOrOptions?: StepFunc<T> | StepConfig<T>,
     maybeOptions?: StepConfig<T>,
   ) => Promise<T>;
+  invoke: <I, O>(
+    nameOrFuncId: string,
+    funcIdOrInput?: string | I,
+    inputOrOptions?: I | InvokeOptions,
+    maybeOptions?: InvokeOptions,
+  ) => Promise<O>;
   runInChildContext: <T>(
     nameOrFn: string | undefined | ChildFunc<T>,
     fnOrOptions?: ChildFunc<T> | ChildConfig<T>,
@@ -202,6 +209,12 @@ export interface WaitForCallbackConfig {
   heartbeatTimeout?: number; // seconds
   retryStrategy?: (error: Error, attemptCount: number) => RetryDecision;
   serdes?: Serdes<any>;
+}
+
+export interface InvokeOptions {
+  FunctionName?: string | undefined;
+  FunctionQualifier?: string | undefined;
+  DurableExecutionName?: string | undefined;
 }
 
 export type CreateCallbackResult<T> = [Promise<T>, string]; // [promise, callbackId]


### PR DESCRIPTION
- Add invoke handler with checkpoint/recovery support
- Support both named and unnamed invocations with InvokeOptions
- Handle SUCCEEDED/FAILED operation statuses appropriately
- Integrate with OperationInterceptor for testing support
- Add unit tests (coverage 100%)

Enables durable function chaining with automatic state persistence, retry handling, and recovery capabilities for complex workflows.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
