### PR TITLE
refactor(sdk): fix InvokeConfig to follow other Config pattern

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -158,9 +158,9 @@ describe("Durable Context", () => {
     );
     const funcId = "arn:aws:lambda:us-east-1:123456789012:function:test";
     const input = { test: "data" };
-    const options = { FunctionQualifier: "LATEST" };
+    const config = { serdes: { serialize: async () => "test", deserialize: async () => ({}) } };
 
-    durableContext.invoke("test-invoke", funcId, input, options);
+    durableContext.invoke("test-invoke", funcId, input, config);
 
     expect(createInvokeHandler).toHaveBeenCalledWith(
       mockExecutionContext,
@@ -172,7 +172,7 @@ describe("Durable Context", () => {
       "test-invoke",
       funcId,
       input,
-      options,
+      config,
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -16,7 +16,7 @@ import {
   ConcurrentExecutor,
   ConcurrencyConfig,
   Logger,
-  InvokeOptions,
+  InvokeConfig,
 } from "../../types";
 import { Context } from "aws-lambda";
 import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
@@ -97,8 +97,8 @@ export const createDurableContext = (
   const invoke: DurableContext["invoke"] = <I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
-    inputOrOptions?: I | InvokeOptions,
-    maybeOptions?: InvokeOptions,
+    inputOrConfig?: I | InvokeConfig,
+    maybeConfig?: InvokeConfig,
   ) => {
     const invokeHandler = createInvokeHandler(
       executionContext,
@@ -109,8 +109,8 @@ export const createDurableContext = (
     return invokeHandler<I, O>(
       nameOrFuncId,
       funcIdOrInput as any,
-      inputOrOptions as any,
-      maybeOptions,
+      inputOrConfig as any,
+      maybeConfig,
     );
   };
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -290,7 +290,9 @@ describe("InvokeHandler", () => {
         Type: OperationType.INVOKE,
         Name: undefined,
         Payload: '{"serialized":"data"}',
-        InvokeOptions: {},
+        InvokeOptions: {
+          FunctionName: "test-function",
+        },
       });
 
       expect(mockLog).toHaveBeenCalledWith(
@@ -326,7 +328,9 @@ describe("InvokeHandler", () => {
         Type: OperationType.INVOKE,
         Name: "my-invoke",
         Payload: '{"serialized":"data"}',
-        InvokeOptions: {},
+        InvokeOptions: {
+          FunctionName: "test-function",
+        },
       });
     });
 
@@ -344,10 +348,10 @@ describe("InvokeHandler", () => {
         mockHasRunningOperations,
       );
 
-      const options = { FunctionQualifier: "LATEST" };
+      const config = { serdes: { serialize: async () => "custom", deserialize: async () => ({}) } };
 
       await expect(
-        invokeHandler("test-function", { test: "data" }, options),
+        invokeHandler("test-function", { test: "data" }, config),
       ).rejects.toThrow("Execution terminated");
 
       expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
@@ -358,7 +362,9 @@ describe("InvokeHandler", () => {
         Type: OperationType.INVOKE,
         Name: undefined,
         Payload: '{"serialized":"data"}',
-        InvokeOptions: options,
+        InvokeOptions: {
+          FunctionName: "test-function",
+        },
       });
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -20,7 +20,7 @@ export {
   WaitForConditionWaitStrategyFunc,
   Logger,
   LambdaHandler,
-  InvokeOptions,
+  InvokeConfig,
 } from "./types";
 export { StepInterruptedError } from "./errors/step-errors/step-errors";
 export {

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -96,8 +96,8 @@ export interface DurableContext extends Context {
   invoke: <I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
-    inputOrOptions?: I | InvokeOptions,
-    maybeOptions?: InvokeOptions,
+    inputOrConfig?: I | InvokeConfig,
+    maybeConfig?: InvokeConfig,
   ) => Promise<O>;
   runInChildContext: <T>(
     nameOrFn: string | undefined | ChildFunc<T>,
@@ -211,10 +211,8 @@ export interface WaitForCallbackConfig {
   serdes?: Serdes<any>;
 }
 
-export interface InvokeOptions {
-  FunctionName?: string | undefined;
-  FunctionQualifier?: string | undefined;
-  DurableExecutionName?: string | undefined;
+export interface InvokeConfig {
+  serdes?: Serdes<any>;
 }
 
 export type CreateCallbackResult<T> = [Promise<T>, string]; // [promise, callbackId]


### PR DESCRIPTION
Fixed InvokeConfig interface to properly separate configuration from function data:

- Renamed InvokeOptions → InvokeConfig: to match naming convention (StepConfig, ChildConfig) 
- Add serdes to InvokeConfig: to use single serdes?: Serdes<any> like other config interfaces
- Moved function data out of config: funcId now passed as parameter, not in config 
- Fixed serialization/deserialization: to use config's serdes for both input and output
- Updated tests: to expect proper checkpoint format and use correct config structure

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
