### PR TITLE
refactor(sdk): add separate serdes to InvokeConfig

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -159,7 +159,7 @@ describe("Durable Context", () => {
     const funcId = "arn:aws:lambda:us-east-1:123456789012:function:test";
     const input = { test: "data" };
     const config = {
-      serdes: { serialize: async () => "test", deserialize: async () => ({}) },
+      payloadSerdes: { serialize: async () => "test", deserialize: async () => ({}) },
     };
 
     durableContext.invoke("test-invoke", funcId, input, config);

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -97,8 +97,8 @@ export const createDurableContext = (
   const invoke: DurableContext["invoke"] = <I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
-    inputOrConfig?: I | InvokeConfig,
-    maybeConfig?: InvokeConfig,
+    inputOrConfig?: I | InvokeConfig<I, O>,
+    maybeConfig?: InvokeConfig<I, O>,
   ) => {
     const invokeHandler = createInvokeHandler(
       executionContext,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -356,11 +356,11 @@ describe("InvokeHandler", () => {
       );
 
       const config = {
-        serdes: {
+        payloadSerdes: {
           serialize: async () => "custom",
           deserialize: async () => ({}),
         },
-        TimeoutSeconds: 30,
+        timeoutSeconds: 30,
       };
 
       await expect(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -24,25 +24,25 @@ export const createInvokeHandler = (
   function invokeHandler<I, O>(
     funcId: string,
     input: I,
-    config?: InvokeConfig,
+    config?: InvokeConfig<I, O>,
   ): Promise<O>;
   function invokeHandler<I, O>(
     name: string,
     funcId: string,
     input: I,
-    config?: InvokeConfig,
+    config?: InvokeConfig<I, O>,
   ): Promise<O>;
   async function invokeHandler<I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
-    inputOrConfig?: I | InvokeConfig,
-    maybeConfig?: InvokeConfig,
+    inputOrConfig?: I | InvokeConfig<I, O>,
+    maybeConfig?: InvokeConfig<I, O>,
   ): Promise<O> {
     const isNameFirst = typeof funcIdOrInput === "string";
     const name = isNameFirst ? nameOrFuncId : undefined;
     const funcId = isNameFirst ? (funcIdOrInput as string) : nameOrFuncId;
     const input = isNameFirst ? (inputOrConfig as I) : (funcIdOrInput as I);
-    const config = isNameFirst ? maybeConfig : (inputOrConfig as InvokeConfig);
+    const config = isNameFirst ? maybeConfig : (inputOrConfig as InvokeConfig<I, O>);
 
     const stepId = createStepId();
 
@@ -55,7 +55,7 @@ export const createInvokeHandler = (
       // Return cached result - no need to check for errors in successful operations
       const invokeDetails = stepData.InvokeDetails;
       return await safeDeserialize(
-        config?.serdes || defaultSerdes,
+        config?.resultSerdes || defaultSerdes,
         invokeDetails?.Result,
         stepId,
         name,
@@ -92,7 +92,7 @@ export const createInvokeHandler = (
     ).execute(name, async (): Promise<O> => {
       // Serialize the input payload
       const serializedPayload = await safeSerialize(
-        config?.serdes || defaultSerdes,
+        config?.payloadSerdes || defaultSerdes,
         input,
         stepId,
         name,
@@ -112,7 +112,7 @@ export const createInvokeHandler = (
         Payload: serializedPayload,
         InvokeOptions: {
           FunctionName: funcId,
-          ...(config?.TimeoutSeconds && { TimeoutSeconds: config.TimeoutSeconds }),
+          ...(config?.timeoutSeconds && { TimeoutSeconds: config.timeoutSeconds }),
         },
       });
 

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -96,8 +96,8 @@ export interface DurableContext extends Context {
   invoke: <I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
-    inputOrConfig?: I | InvokeConfig,
-    maybeConfig?: InvokeConfig,
+    inputOrConfig?: I | InvokeConfig<I, O>,
+    maybeConfig?: InvokeConfig<I, O>,
   ) => Promise<O>;
   runInChildContext: <T>(
     nameOrFn: string | undefined | ChildFunc<T>,
@@ -211,9 +211,10 @@ export interface WaitForCallbackConfig {
   serdes?: Serdes<any>;
 }
 
-export interface InvokeConfig {
-  serdes?: Serdes<any>;
-  TimeoutSeconds?: number | undefined;
+export interface InvokeConfig<I = any, O = any> {
+  payloadSerdes?: Serdes<I>;
+  resultSerdes?: Serdes<O>;
+  timeoutSeconds?: number | undefined;
 }
 
 export type CreateCallbackResult<T> = [Promise<T>, string]; // [promise, callbackId]


### PR DESCRIPTION
- Replace single serdes with payloadSerdes and resultSerdes for type safety
- Change TimeoutSeconds to timeoutSeconds for naming consistency
- Update InvokeConfig to be generic InvokeConfig<I, O>
- Use payloadSerdes (Serdes<I>) for input serialization
- Use resultSerdes (Serdes<O>) for output deserialization

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
