### PR TITLE
feat(sdk): improve termination handling with status checking and operation coordination

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -252,6 +252,7 @@ describe("Durable Context", () => {
       mockExecutionContext,
       mockCheckpointHandler,
       expect.any(Function),
+      expect.any(Function), // hasRunningOperations
     );
     expect(mockCallbackHandler).toHaveBeenCalledWith(
       callbackName,
@@ -272,6 +273,7 @@ describe("Durable Context", () => {
       mockExecutionContext,
       mockCheckpointHandler,
       expect.any(Function),
+      expect.any(Function), // hasRunningOperations
     );
     expect(mockCallbackHandler).toHaveBeenCalledWith(callbackConfig, undefined);
   });

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -136,6 +136,7 @@ export const createDurableContext = (
       executionContext,
       checkpoint,
       createStepId,
+      hasRunningOperations,
     );
     return callbackFactory(nameOrConfig, maybeConfig);
   };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
@@ -10,10 +10,12 @@ describe("Callback Handler Promise Interface", () => {
   let mockCheckpoint: ReturnType<typeof createCheckpoint>;
   let createStepId: () => string;
   let stepIdCounter: number;
+  let mockHasRunningOperations: jest.Mock;
 
   beforeEach(() => {
     stepIdCounter = 0;
     createStepId = () => `step-${++stepIdCounter}`;
+    mockHasRunningOperations = jest.fn().mockReturnValue(false);
 
     mockContext = createMockExecutionContext();
 
@@ -39,6 +41,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -52,6 +55,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -77,6 +81,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -102,6 +107,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -127,6 +133,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -145,6 +152,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -196,6 +204,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       // Force the step ID to be "step-1" to match our mock
@@ -210,6 +219,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       stepIdCounter = 0;
@@ -226,6 +236,7 @@ describe("Callback Handler Promise Interface", () => {
         mockContext,
         mockCheckpoint,
         createStepId,
+        mockHasRunningOperations,
       );
 
       stepIdCounter = 0;


### PR DESCRIPTION
- Implement smart termination that waits for operations before checking status
- Use 1000ms polling with waitBeforeContinue for status checking
- Add unit test coverage

**1000ms is temporary**

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
