### PR TITLE
ci: fail fast on build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test --workspaces --if-present",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/eslint-plugin-durable-functions",
     "test:integration": "act -W .github/workflows/integration-tests.yml --secret-file .secrets --artifact-server-path /tmp/artifacts --container-architecture linux/amd64",
-    "build": "npm run build -w packages/aws-durable-execution-sdk-js -w packages/aws-durable-execution-sdk-js-testing -w packages/aws-durable-execution-sdk-js-examples -w packages/eslint-plugin-durable-functions",
+    "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/eslint-plugin-durable-functions",
     "postpublish": "git restore .",
     "clean": "rm -rf node_modules && npm run clean --workspaces --if-present",
     "prepare": "husky install"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Builds continue when previous builds fail. NPM has an active discussion and PR to fix it https://github.com/npm/cli/pull/8323, but it's not merged yet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
