### PR TITLE
refactor(sdk): fix ESLint warnings and improve code quality

### DIFF
--- a/packages/aws-durable-execution-sdk-js/bundle-size-history.json
+++ b/packages/aws-durable-execution-sdk-js/bundle-size-history.json
@@ -1,10 +1,5 @@
 [
   {
-    "timestamp": "2025-06-27T16:38:03.394Z",
-    "size": 888765,
-    "gitCommit": "415861a578f98b671fdcdd598e56d7a001a95294"
-  },
-  {
     "timestamp": "2025-06-27T16:46:43.149Z",
     "size": 888765,
     "gitCommit": "6c98b2ec2c523a92309a7b8ee00e9c61f83392cf"
@@ -248,5 +243,10 @@
     "timestamp": "2025-09-27T19:52:39.277Z",
     "size": 361660,
     "gitCommit": "fed4cf7151607892268067a15ca3430c2f6abbbc"
+  },
+  {
+    "timestamp": "2025-09-29T03:15:18.425Z",
+    "size": 361568,
+    "gitCommit": "71b458e8159dfc4242c4e8c65820a6c21554e16c"
   }
 ]

--- a/packages/aws-durable-execution-sdk-js/eslint.config.js
+++ b/packages/aws-durable-execution-sdk-js/eslint.config.js
@@ -17,18 +17,42 @@ module.exports = [
     plugins: {
       "@typescript-eslint": typescriptEslint,
       "filename-convention": filenameConvention,
-      "tsdoc": tsdoc,
+      tsdoc: tsdoc,
     },
     rules: {
       ...typescriptEslint.configs.recommended.rules,
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/explicit-function-return-type": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
       "no-console": "warn",
       "no-debugger": "warn",
       "no-duplicate-imports": "error",
       "filename-convention/kebab-case": "error",
       "tsdoc/syntax": "warn",
+    },
+  },
+  {
+    files: ["src/**/*.test.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
   {

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -160,8 +160,8 @@ describe("Durable Context", () => {
     const input = { test: "data" };
     const config = {
       payloadSerdes: {
-        serialize: async () => "test",
-        deserialize: async () => ({}),
+        serialize: async (): Promise<string> => "test",
+        deserialize: async (): Promise<object> => ({}),
       },
     };
 

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
@@ -438,7 +438,7 @@ describe("initializeExecutionContext", () => {
     };
 
     // Execute
-    const result = await initializeExecutionContext(eventWithLocalRunner);
+    await initializeExecutionContext(eventWithLocalRunner);
 
     // Verify
     expect(ExecutionStateFactory.createExecutionState).toHaveBeenCalledWith(
@@ -509,7 +509,7 @@ describe("initializeExecutionContext", () => {
 
     // Test that it calls the utility function correctly
     // Since the step is stored with ID "step1", the getStepData should find it
-    const stepData = result.executionContext.getStepData(stepId);
+    result.executionContext.getStepData(stepId);
     // The actual behavior depends on the hash function, but we can verify the method exists and returns something
     expect(result.executionContext.getStepData).toBeDefined();
   });

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -78,7 +78,7 @@ export const initializeExecutionContext = async (
       isLocalMode,
       isVerbose,
       durableExecutionArn,
-      getStepData(stepId: string) {
+      getStepData(stepId: string): Operation | undefined {
         return getStepDataUtil(stepData, stepId);
       },
     },

--- a/packages/aws-durable-execution-sdk-js/src/errors/step-errors/step-errors.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/step-errors/step-errors.ts
@@ -3,7 +3,7 @@
  * before completion.
  */
 export class StepInterruptedError extends Error {
-  constructor(stepId: string, stepName?: string) {
+  constructor(_stepId: string, _stepName?: string) {
     super(
       `The step execution process was initiated but failed to reach completion due to an interruption.`,
     );

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
@@ -14,7 +14,7 @@ describe("Callback Handler Promise Interface", () => {
 
   beforeEach(() => {
     stepIdCounter = 0;
-    createStepId = () => `step-${++stepIdCounter}`;
+    createStepId = (): string => `step-${++stepIdCounter}`;
     mockHasRunningOperations = jest.fn().mockReturnValue(false);
 
     mockContext = createMockExecutionContext();
@@ -158,10 +158,10 @@ describe("Callback Handler Promise Interface", () => {
       const [promise] = await callbackHandler<string>("test-callback");
 
       // This should not throw a compilation error and should trigger termination
-      const asyncFunction = async () => {
+      const asyncFunction = async (): Promise<void> => {
         try {
           await promise; // This should trigger termination
-        } catch (error) {
+        } catch (_error) {
           // Handle error
         }
       };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -122,7 +122,7 @@ export class ConcurrencyController {
         return "FAILURE_TOLERANCE_EXCEEDED";
       };
 
-      const tryStartNext = () => {
+      const tryStartNext = (): void => {
         while (
           activeCount < maxConcurrency &&
           currentIndex < items.length &&
@@ -192,7 +192,7 @@ export class ConcurrencyController {
         }
       };
 
-      const onComplete = () => {
+      const onComplete = (): void => {
         activeCount--;
         completedCount++;
 
@@ -282,7 +282,7 @@ export const createConcurrentExecutionHandler = (
       );
     }
 
-    const executeOperation = async (executionContext: DurableContext) => {
+    const executeOperation = async (executionContext: DurableContext): Promise<BatchResult<TResult>> => {
       const concurrencyController = new ConcurrencyController(
         context.isVerbose,
         "concurrent-execution",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -357,8 +357,8 @@ describe("InvokeHandler", () => {
 
       const config = {
         payloadSerdes: {
-          serialize: async () => "custom",
-          deserialize: async () => ({}),
+          serialize: async (): Promise<string> => "custom",
+          deserialize: async (): Promise<object> => ({}),
         },
         timeoutSeconds: 30,
       };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -19,8 +19,16 @@ export const createInvokeHandler = (
   context: ExecutionContext,
   checkpoint: ReturnType<typeof createCheckpoint>,
   createStepId: () => string,
-  hasRunningOperations: () => boolean,
-) => {
+  _hasRunningOperations: () => boolean,
+): {
+  <I, O>(funcId: string, input: I, config?: InvokeConfig<I, O>): Promise<O>;
+  <I, O>(
+    name: string,
+    funcId: string,
+    input: I,
+    config?: InvokeConfig<I, O>,
+  ): Promise<O>;
+} => {
   function invokeHandler<I, O>(
     funcId: string,
     input: I,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
@@ -211,10 +211,8 @@ describe("Map Handler", () => {
         .mockResolvedValueOnce("result1")
         .mockResolvedValueOnce("result2");
 
-      let capturedExecutor: any;
       mockExecuteConcurrently.mockImplementation(async (...args: any[]) => {
         const [, executionItems, executor] = args;
-        capturedExecutor = executor;
 
         // Simulate calling the executor for each item
         const results = [];

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
@@ -5,7 +5,6 @@ import {
   ParallelFunc,
   BatchItemStatus,
 } from "../../types";
-import { TEST_CONSTANTS } from "../../testing/test-constants";
 import { MockBatchResult } from "../../testing/mock-batch-result";
 
 describe("Parallel Handler", () => {
@@ -184,7 +183,7 @@ describe("Parallel Handler", () => {
         nameOrItems: any,
         itemsOrExecutor?: any,
         executorOrConfig?: any,
-        maybeConfig?: any,
+        _maybeConfig?: any,
       ) => {
         // Handle the overloaded signature
         if (typeof nameOrItems === "string" || nameOrItems === undefined) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -7,7 +7,6 @@ import {
   OperationSubType,
   WaitForCallbackContext,
   StepContext,
-  Logger,
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 
@@ -51,7 +50,7 @@ export const createWaitForCallbackHandler = (
     });
 
     // Use runInChildContext to ensure proper ID generation and isolation
-    const childFunction = async (childCtx: DurableContext) => {
+    const childFunction = async (childCtx: DurableContext): Promise<T> => {
       // Convert WaitForCallbackConfig to CreateCallbackConfig
       const createCallbackConfig: CreateCallbackConfig | undefined = config
         ? {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -8,7 +8,6 @@ import {
   Logger,
 } from "../../types";
 import { terminate } from "../../utils/termination-helper";
-import { Context } from "aws-lambda";
 import {
   OperationAction,
   OperationStatus,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -17,7 +17,10 @@ export const createWaitHandler = (
   checkpoint: ReturnType<typeof createCheckpoint>,
   createStepId: () => string,
   hasRunningOperations: () => boolean,
-) => {
+): {
+  (name: string, millis: number): Promise<void>;
+  (millis: number): Promise<void>;
+} => {
   function waitHandler(name: string, millis: number): Promise<void>;
   function waitHandler(millis: number): Promise<void>;
   async function waitHandler(

--- a/packages/aws-durable-execution-sdk-js/src/mocks/execution-mock-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/mocks/execution-mock-handler.ts
@@ -36,7 +36,7 @@ export class ExecutionMockHandler {
 
   /**
    * Records an operation and returns a mock callback if one is registered
-   * Priority order: Index-based > Name-based > Name+Index-based
+   * Priority order: Index-based \> Name-based \> Name+Index-based
    */
   recordOperation(name?: string): MockCallback | undefined {
     const globalIndex = this.operationTracker.incrementGlobal();

--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
@@ -14,7 +14,7 @@ import { getCredentialsProvider } from "./credentials-provider";
 import { ExecutionState } from "./storage-provider";
 
 /**
- * Implementation of ExecutionState that uses the new @aws-sdk/client-lambda
+ * Implementation of ExecutionState that uses the new \@aws-sdk/client-lambda
  */
 export class ApiStorage implements ExecutionState {
   protected client: LambdaClient;
@@ -40,8 +40,8 @@ export class ApiStorage implements ExecutionState {
 
   /**
    * Gets step data from the durable execution
-   * @param checkpointToken The checkpoint token
-   * @param nextMarker The pagination token
+   * @param checkpointToken - The checkpoint token
+   * @param nextMarker - The pagination token
    * @returns Response with operations data
    */
   async getStepData(
@@ -63,8 +63,8 @@ export class ApiStorage implements ExecutionState {
 
   /**
    * Checkpoints the durable execution with operation updates
-   * @param checkpointToken The checkpoint token
-   * @param data The checkpoint data
+   * @param checkpointToken - The checkpoint token
+   * @param data - The checkpoint data
    * @returns Checkpoint response
    */
   async checkpoint(

--- a/packages/aws-durable-execution-sdk-js/src/storage/local-runner-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/local-runner-storage.test.ts
@@ -25,9 +25,6 @@ describe("PlaygroundLocalRunnerStorage", () => {
 
       new PlaygroundLocalRunnerStorage();
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Initializing local runner DAR client with endpoint: https://local-endpoint.com, region: us-west-2",
-      );
       expect(LambdaClient).toHaveBeenCalledWith({
         endpoint: "https://local-endpoint.com",
         region: "us-west-2",

--- a/packages/aws-durable-execution-sdk-js/src/storage/local-runner-storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/local-runner-storage.ts
@@ -32,7 +32,7 @@ class LocalRunnerSigV4Handler extends NodeHttpHandler {
 
   public async handle(
     request: HttpRequest,
-    handlerOptions?: HttpHandlerOptions | undefined,
+    _handlerOptions?: HttpHandlerOptions | undefined,
   ): Promise<{ response: HttpResponse }> {
     const signedRequest: HttpRequest = await this.signer.sign(request);
     // @ts-expect-error - The handle method signature doesn't match exactly but works correctly
@@ -45,9 +45,7 @@ export class PlaygroundLocalRunnerStorage extends ApiStorage {
     const endpoint = process.env.LOCAL_RUNNER_ENDPOINT;
     const region = process.env.LOCAL_RUNNER_REGION;
 
-    console.log(
-      `Initializing local runner DAR client with endpoint: ${endpoint}, region: ${region}`,
-    );
+    // Initializing local runner DAR client with endpoint and region
 
     const credentials = getCredentialsProvider();
     const client = new LambdaClient({

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
@@ -4,7 +4,7 @@ import { getStepData as getStepDataUtil } from "../utils/step-id-utils/step-id-u
 
 /**
  * Creates a mock ExecutionContext for testing purposes
- * @param overrides Optional overrides for specific properties
+ * @param overrides - Optional overrides for specific properties
  * @returns A mocked ExecutionContext
  */
 export const createMockExecutionContext = (

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -20,10 +20,7 @@ import type {
 } from "../handlers/concurrent-execution-handler/concurrent-execution-handler";
 
 // Import BatchResult types
-import type {
-  BatchResult,
-  BatchItem,
-} from "../handlers/concurrent-execution-handler/batch-result";
+import type { BatchResult } from "../handlers/concurrent-execution-handler/batch-result";
 
 export interface LambdaHandler<T> {
   (event: T, context: Context): Promise<DurableExecutionInvocationOutput>;
@@ -90,7 +87,7 @@ export interface DurableContext extends Context {
   _stepCounter: number;
   /**
    * Executes a function as a durable step with automatic retry and state persistence
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param fn - Function to execute as a durable step
    * @param config - Optional configuration for retry strategy, semantics, and serialization
    * @example
@@ -169,7 +166,7 @@ export interface DurableContext extends Context {
 
   /**
    * Runs a function in a child context with isolated state and execution tracking
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param fn - Function to execute in the child context
    * @param config - Optional configuration for serialization and sub-typing
    * @example
@@ -234,7 +231,7 @@ export interface DurableContext extends Context {
 
   /**
    * Waits for a condition to be met by periodically checking state
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param checkFunc - Function that checks the current state and returns updated state
    * @param config - Configuration for initial state, wait strategy, and serialization
    * @example
@@ -289,7 +286,7 @@ export interface DurableContext extends Context {
 
   /**
    * Creates a callback that external systems can complete
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param config - Optional configuration for timeout and serialization
    * @returns Tuple of [promise that resolves when callback is submitted, callback ID]
    * @example
@@ -329,7 +326,7 @@ export interface DurableContext extends Context {
   ): Promise<CreateCallbackResult<T>>;
   /**
    * Wait for an external system to complete a callback with the SendDurableExecutionCallbackSuccess or SendDurableExecutionCallbackFailure APIs.
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param submitter - Function that receives the callback ID and submits the callback
    * @param config - Optional configuration for timeout and retry behavior
    * @example
@@ -369,7 +366,7 @@ export interface DurableContext extends Context {
   ): Promise<T>;
   /**
    * Maps over an array of items with a function, executing in parallel with optional concurrency control
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param items - Array of items to process
    * @param mapFunc - Function to apply to each item (context, item, index, array) => Promise<T>
    * @param config - Optional configuration for concurrency and completion behavior
@@ -410,7 +407,7 @@ export interface DurableContext extends Context {
   ): Promise<BatchResult<T>>;
   /**
    * Executes multiple functions in parallel with optional concurrency control
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param branches - Array of functions to execute in parallel
    * @param config - Optional configuration for concurrency and completion behavior
    * @example
@@ -452,7 +449,7 @@ export interface DurableContext extends Context {
   promise: {
     /**
      * Waits for all promises to resolve and returns an array of all results
-     * @param name - Step name for tracking and debugging 
+     * @param name - Step name for tracking and debugging
      * @param promises - Array of promises to wait for
      * @example
      * ```typescript
@@ -483,7 +480,7 @@ export interface DurableContext extends Context {
 
     /**
      * Waits for all promises to settle (resolve or reject) and returns results with status
-     * @param name - Step name for tracking and debugging 
+     * @param name - Step name for tracking and debugging
      * @param promises - Array of promises to wait for
      * @example
      * ```typescript
@@ -525,7 +522,7 @@ export interface DurableContext extends Context {
 
     /**
      * Waits for the first promise to resolve successfully, ignoring rejections until all fail
-     * @param name - Step name for tracking and debugging 
+     * @param name - Step name for tracking and debugging
      * @param promises - Array of promises to race
      * @example
      * ```typescript
@@ -557,7 +554,7 @@ export interface DurableContext extends Context {
 
     /**
      * Returns the result of the first promise to settle (resolve or reject)
-     * @param name - Step name for tracking and debugging 
+     * @param name - Step name for tracking and debugging
      * @param promises - Array of promises to race
      * @example
      * ```typescript
@@ -589,7 +586,7 @@ export interface DurableContext extends Context {
 
   /**
    * Executes items concurrently with fine-grained control over execution strategy
-   * @param name - Step name for tracking and debugging 
+   * @param name - Step name for tracking and debugging
    * @param items - Array of items to execute concurrently
    * @param executor - Function that processes each item
    * @param config - Optional configuration for concurrency and completion behavior

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
@@ -17,7 +17,6 @@ describe("Checkpoint Integration Tests", () => {
   let mockState: any;
   let mockContext: ExecutionContext;
 
-  const mockTaskToken = TEST_CONSTANTS.CHECKPOINT_TOKEN;
   const mockNewTaskToken = "new-task-token";
 
   beforeEach(() => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
@@ -239,7 +239,7 @@ class CheckpointHandler {
   /**
    * Updates context.stepData with operations returned from checkpoint API
    * Operations from API already have hashed IDs, so we store them as-is
-   * @param operations Array of operations from checkpoint response
+   * @param operations - Array of operations from checkpoint response
    */
   private updateStepDataFromCheckpointResponse(operations: Operation[]): void {
     log(
@@ -286,7 +286,10 @@ let singletonCheckpointHandler: CheckpointHandler | null = null;
 export const createCheckpoint = (
   context: ExecutionContext,
   taskToken: string,
-) => {
+): {
+  (stepId: string, data: Partial<OperationUpdate>): Promise<void>;
+  force(): Promise<void>;
+} => {
   // Return existing handler if it exists, otherwise create new one
   if (!singletonCheckpointHandler) {
     singletonCheckpointHandler = new CheckpointHandler(context, taskToken);

--- a/packages/aws-durable-execution-sdk-js/src/utils/step-id-utils/step-id-utils.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/step-id-utils/step-id-utils.test.ts
@@ -1,5 +1,6 @@
 import { hashId, getStepData } from "./step-id-utils";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
+import { Operation } from "@aws-sdk/client-lambda";
 
 describe("Hash Utility", () => {
   describe("hashId", () => {
@@ -29,7 +30,10 @@ describe("Hash Utility", () => {
     it("should retrieve data using original stepId", () => {
       const stepId = TEST_CONSTANTS.STEP;
       const hashedId = hashId(stepId);
-      const mockData = { Status: "SUCCEEDED", Result: TEST_CONSTANTS.RESULT };
+      const mockData = {
+        Status: "SUCCEEDED",
+        Result: TEST_CONSTANTS.RESULT,
+      } as Operation;
 
       const stepData = {
         [hashedId]: mockData,
@@ -54,7 +58,7 @@ describe("Hash Utility", () => {
         StepDetails: {
           Result: "complex-result",
         },
-      };
+      } as Operation;
 
       const stepData = {
         [hashedId]: mockOperation,
@@ -62,7 +66,7 @@ describe("Hash Utility", () => {
 
       const result = getStepData(stepData, stepId);
       expect(result).toBe(mockOperation);
-      expect(result.StepDetails?.Result).toBe("complex-result");
+      expect(result?.StepDetails?.Result).toBe("complex-result");
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/step-id-utils/step-id-utils.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/step-id-utils/step-id-utils.ts
@@ -1,10 +1,11 @@
 import { createHash } from "crypto";
+import { Operation } from "@aws-sdk/client-lambda";
 
 const HASH_LENGTH = 16;
 
 /**
  * Creates an MD5 hash of the input string for better performance than SHA-256
- * @param input The string to hash
+ * @param input - The string to hash
  * @returns The truncated hexadecimal hash string
  */
 export const hashId = (input: string): string => {
@@ -17,11 +18,14 @@ export const hashId = (input: string): string => {
 /**
  * Helper function to get step data using the original stepId
  * This function handles the hashing internally so callers don't need to worry about it
- * @param stepData The stepData record from context
- * @param stepId The original stepId (will be hashed internally)
+ * @param stepData - The stepData record from context
+ * @param stepId - The original stepId (will be hashed internally)
  * @returns The operation data or undefined if not found
  */
-export const getStepData = (stepData: Record<string, any>, stepId: string) => {
+export const getStepData = (
+  stepData: Record<string, Operation>,
+  stepId: string,
+): Operation | undefined => {
   const hashedId = hashId(stepId);
   return stepData[hashedId];
 };

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
@@ -57,7 +57,7 @@ export async function waitBeforeContinue(
   const timers: NodeJS.Timeout[] = [];
 
   // Cleanup function to clear all timers
-  const cleanup = () => {
+  const cleanup = (): void => {
     timers.forEach((timer) => clearTimeout(timer));
   };
 
@@ -82,7 +82,7 @@ export async function waitBeforeContinue(
   if (checkHasRunningOperations) {
     const operationsPromise = new Promise<WaitBeforeContinueResult>(
       (resolve) => {
-        const checkOperations = () => {
+        const checkOperations = (): void => {
           if (!hasRunningOperations()) {
             resolve({ reason: "operations" });
           } else {
@@ -101,7 +101,7 @@ export async function waitBeforeContinue(
     const originalStatus = context.getStepData(stepId)?.Status;
     const stepStatusPromise = new Promise<WaitBeforeContinueResult>(
       (resolve) => {
-        const checkStepStatus = () => {
+        const checkStepStatus = (): void => {
           const currentStatus = context.getStepData(stepId)?.Status;
           if (originalStatus !== currentStatus) {
             resolve({ reason: "status" });


### PR DESCRIPTION
- Configure ESLint to ignore unused parameters prefixed with underscore
- Add test-specific ESLint config to disable explicit-any warnings for unit test files
- Prefix unused parameters with underscore across handlers and utilities
- Add proper TypeScript return type annotations
- Remove unused imports and variables
- Update TSDoc comments to use proper syntax
- Clean up console.log statements and test artifacts

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
