### PR TITLE
fix(sdk): comprehensive ESLint and TSDoc compliance improvements

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -17,7 +17,7 @@ describe("WaitForCallback Operations Integration", () => {
   it("should handle basic waitForCallback with anonymous submitter", async () => {
     let receivedCallbackId: string | undefined;
 
-    const handler = withDurableFunctions(
+    const handler = withDurableFunctions<unknown, unknown>(
       async (_event: unknown, context: DurableContext) => {
         const result = await context.waitForCallback<{ data: string }>(
           async (callbackId) => {
@@ -67,7 +67,7 @@ describe("WaitForCallback Operations Integration", () => {
 
   it("should handle basic waitForCallback with named submitter", async () => {
     let receivedCallbackId: string | undefined; // simulates a side-effect since it's outside the handler
-    const handler = withDurableFunctions(
+    const handler = withDurableFunctions<unknown, unknown>(
       async (_event: unknown, context: DurableContext) => {
         const result = await context.waitForCallback<{ data: string }>(
           async (callbackId) => {
@@ -116,7 +116,7 @@ describe("WaitForCallback Operations Integration", () => {
   // Error Handling & Submitter Function Variants Category
   describe("Error Handling & Submitter Function Variants", () => {
     it("should handle waitForCallback with submitter function synchronous errors", async () => {
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -160,7 +160,7 @@ describe("WaitForCallback Operations Integration", () => {
     });
 
     it("should handle waitForCallback with submitter function returning rejected promises", async () => {
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -206,7 +206,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with callback failure scenarios", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -271,7 +271,7 @@ describe("WaitForCallback Operations Integration", () => {
       let scenario2CallbackId: string | undefined;
 
       // Test scenario where submitter fails but callback would have succeeded
-      const handler1 = withDurableFunctions(
+      const handler1 = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -310,7 +310,7 @@ describe("WaitForCallback Operations Integration", () => {
 
       // Test scenario where submitter succeeds but callback fails (covered in previous test)
       // This test demonstrates the contrast between the two scenarios
-      const handler2 = withDurableFunctions(
+      const handler2 = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             (callbackId) => {
@@ -361,7 +361,7 @@ describe("WaitForCallback Operations Integration", () => {
       let callbackId: string | undefined;
       let sideEffectCounter = 0;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -439,7 +439,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with heartbeat timeout configuration", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             async (callbackId) => {
@@ -508,7 +508,7 @@ describe("WaitForCallback Operations Integration", () => {
       let submitterStartTime: number;
       let submitterEndTime: number;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ processed: number }>(
             async (callbackId) => {
@@ -586,7 +586,7 @@ describe("WaitForCallback Operations Integration", () => {
 
     // Skip timeout scenarios until SDK properly supports them (similar to callback-operations.integration.test.ts)
     it.skip("should handle waitForCallback timeout scenarios", async () => {
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -636,7 +636,7 @@ describe("WaitForCallback Operations Integration", () => {
       let callback2Id: string | undefined;
       let callback3Id: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           // Start multiple waitForCallback operations concurrently
           const [result1, result2, result3] = await Promise.all([
@@ -756,7 +756,7 @@ describe("WaitForCallback Operations Integration", () => {
     it.skip("should handle waitForCallback mixed with steps, waits, and other operations", async () => {
       let callbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           // Mix waitForCallback with other operation types
           await context.wait("initial-wait", 50);
@@ -843,7 +843,7 @@ describe("WaitForCallback Operations Integration", () => {
       let parentCallbackId: string | undefined;
       let childCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const parentResult = await context.waitForCallback<{
             parentData: string;
@@ -945,7 +945,7 @@ describe("WaitForCallback Operations Integration", () => {
       let firstCallbackId: string | undefined;
       let secondCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           await context.wait("wait-invocation-1", 1000);
 
@@ -1048,7 +1048,7 @@ describe("WaitForCallback Operations Integration", () => {
       let innerCallbackId: string | undefined;
       let nestedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const outerResult = await context.waitForCallback<{ level: string }>(
             "outer-callback-op",
@@ -1192,7 +1192,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with custom timeout settings", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             "custom-timeout-callback",
@@ -1307,7 +1307,7 @@ describe("WaitForCallback Operations Integration", () => {
       let receivedCallbackId: string | undefined;
       let submitterData: CustomData | undefined;
 
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<CustomData>(
             "custom-serdes-callback",
@@ -1396,7 +1396,7 @@ describe("WaitForCallback Operations Integration", () => {
 
   describe("Mocking Tests", () => {
     it("should handle basic waitForCallback mocking functionality", async () => {
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result1 = await context.waitForCallback<{ data: string }>(
             "mock-callback-1",
@@ -1460,7 +1460,7 @@ describe("WaitForCallback Operations Integration", () => {
     });
 
     it("should handle waitForCallback error mocking", async () => {
-      const handler = withDurableFunctions(
+      const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(

--- a/packages/aws-durable-execution-sdk-js/bundle-size-history.json
+++ b/packages/aws-durable-execution-sdk-js/bundle-size-history.json
@@ -1,10 +1,5 @@
 [
   {
-    "timestamp": "2025-06-27T16:46:43.149Z",
-    "size": 888765,
-    "gitCommit": "6c98b2ec2c523a92309a7b8ee00e9c61f83392cf"
-  },
-  {
     "timestamp": "2025-06-27T16:47:20.156Z",
     "size": 888765,
     "gitCommit": "6c98b2ec2c523a92309a7b8ee00e9c61f83392cf"
@@ -248,5 +243,10 @@
     "timestamp": "2025-09-29T03:15:18.425Z",
     "size": 361568,
     "gitCommit": "71b458e8159dfc4242c4e8c65820a6c21554e16c"
+  },
+  {
+    "timestamp": "2025-09-29T21:53:05.018Z",
+    "size": 361581,
+    "gitCommit": "1eba8c6d9f097275746307697346a5f2caf27c23"
   }
 ]

--- a/packages/aws-durable-execution-sdk-js/src/errors/serdes-errors/serdes-errors.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/serdes-errors/serdes-errors.test.ts
@@ -248,7 +248,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -276,7 +276,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -304,7 +304,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -331,7 +331,7 @@ describe("Serdes Errors", () => {
       mockSerdes.serialize.mockRejectedValue(originalError);
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -357,7 +357,7 @@ describe("Serdes Errors", () => {
       mockSerdes.serialize.mockRejectedValue("Async string error");
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -383,7 +383,7 @@ describe("Serdes Errors", () => {
       mockSerdes.serialize.mockRejectedValue("Async string error");
 
       // Call safeSerialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeSerialize(
+      safeSerialize(
         mockSerdes,
         value,
         TEST_CONSTANTS.STEP_ID_1,
@@ -469,7 +469,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,
@@ -497,7 +497,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,
@@ -525,7 +525,7 @@ describe("Serdes Errors", () => {
       });
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,
@@ -552,7 +552,7 @@ describe("Serdes Errors", () => {
       mockSerdes.deserialize.mockRejectedValue(originalError);
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,
@@ -578,7 +578,7 @@ describe("Serdes Errors", () => {
       mockSerdes.deserialize.mockRejectedValue("Async string error");
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,
@@ -604,7 +604,7 @@ describe("Serdes Errors", () => {
       mockSerdes.deserialize.mockRejectedValue("Async string error");
 
       // Call safeDeserialize but don't await it (it will never resolve due to termination)
-      const resultPromise = safeDeserialize(
+      safeDeserialize(
         mockSerdes,
         data,
         TEST_CONSTANTS.STEP_ID_1,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -437,8 +437,7 @@ describe("Callback Handler", () => {
       };
 
       // Call callbackHandler but don't await the returned promise
-      const [promise, callbackId] =
-        await callbackHandler<string>("started-callback");
+      const [, callbackId] = await callbackHandler<string>("started-callback");
 
       // Verify the callback ID is returned immediately
       expect(callbackId).toBe("started-callback-123");
@@ -467,7 +466,7 @@ describe("Callback Handler", () => {
       const [promise] = await callbackHandler<string>();
 
       // Await the promise to trigger termination
-      const promiseResult = promise.then(() => "should-never-resolve");
+      promise.then(() => "should-never-resolve");
 
       // Verify terminate was called with stepId in message
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
@@ -544,7 +543,7 @@ describe("Callback Handler", () => {
   describe("New Callback Creation Scenarios", () => {
     test("should create new callback and return never-resolving promise", async () => {
       // Mock the checkpoint to simulate callback creation
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         // Simulate the API updating stepData with callback ID after checkpoint
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
@@ -579,7 +578,7 @@ describe("Callback Handler", () => {
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
 
       // Now await the promise, which should trigger termination
-      const promiseResult = promise.then(() => "should-never-resolve");
+      promise.then(() => "should-never-resolve");
 
       // Verify terminate was called when the promise was awaited
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
@@ -590,7 +589,7 @@ describe("Callback Handler", () => {
     });
 
     test("should create new callback with timeout configuration", async () => {
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -606,7 +605,7 @@ describe("Callback Handler", () => {
         heartbeatTimeout: 60,
       };
 
-      const [promise, callbackId] = await callbackHandler<string>(
+      const [, callbackId] = await callbackHandler<string>(
         "timeout-callback",
         config,
       );
@@ -627,7 +626,7 @@ describe("Callback Handler", () => {
     });
 
     test("should create new callback without name", async () => {
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -658,7 +657,7 @@ describe("Callback Handler", () => {
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
 
       // Now await the promise, which should trigger termination
-      const promiseResult = promise.then(() => "should-never-resolve");
+      promise.then(() => "should-never-resolve");
 
       // Verify termination message uses stepId when name is undefined
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
@@ -680,7 +679,7 @@ describe("Callback Handler", () => {
     });
 
     test("should throw error if CallbackDetails missing after checkpoint", async () => {
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -699,7 +698,7 @@ describe("Callback Handler", () => {
 
   describe("Configuration Parameter Handling", () => {
     test("should handle string name as first parameter", async () => {
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -714,7 +713,7 @@ describe("Callback Handler", () => {
         timeout: 120,
       };
 
-      const [promise, callbackId] = await callbackHandler<string>(
+      const [, callbackId] = await callbackHandler<string>(
         "string-name",
         config,
       );
@@ -735,7 +734,7 @@ describe("Callback Handler", () => {
     });
 
     test("should handle config object as first parameter", async () => {
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -751,7 +750,7 @@ describe("Callback Handler", () => {
         heartbeatTimeout: 30,
       };
 
-      const [promise, callbackId] = await callbackHandler<string>(config);
+      const [, callbackId] = await callbackHandler<string>(config);
 
       expect(mockCheckpoint).toHaveBeenCalledWith(TEST_CONSTANTS.CALLBACK_ID, {
         Id: TEST_CONSTANTS.CALLBACK_ID,
@@ -774,7 +773,7 @@ describe("Callback Handler", () => {
       mockExecutionContext._stepData = {};
 
       // Mock the checkpoint to simulate callback creation
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -854,7 +853,7 @@ describe("Callback Handler", () => {
     test("should include ParentId in checkpoint when creating new callback with defined parentId", async () => {
       mockExecutionContext.parentId = "parent-step-123";
 
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -884,7 +883,7 @@ describe("Callback Handler", () => {
     test("should include ParentId as undefined in checkpoint when creating new callback with undefined parentId", async () => {
       mockExecutionContext.parentId = undefined;
 
-      mockCheckpoint.mockImplementation(async (stepId, operation) => {
+      mockCheckpoint.mockImplementation(async (stepId, _operation) => {
         const hashedStepId = hashId(stepId);
         mockExecutionContext._stepData[hashedStepId] = {
           Id: hashedStepId,
@@ -1328,9 +1327,9 @@ describe("Callback Handler", () => {
           // Manually execute the success callback (lines 89-91)
           if (onFulfilled) {
             try {
-              const result = onFulfilled("test-value");
+              onFulfilled("test-value");
               // This should call _onfinally?.() and return value
-            } catch (e) {
+            } catch (_e) {
               // Ignore errors for this test
             }
           }
@@ -1340,7 +1339,7 @@ describe("Callback Handler", () => {
             try {
               onRejected(new Error("test-error"));
               // This should call _onfinally?.() and throw reason
-            } catch (e) {
+            } catch (_e) {
               // Expected to throw
             }
           }

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -272,7 +272,7 @@ describe("Concurrent Execution Handler", () => {
       // Mock the executeOperation function to capture the actual execution
       let capturedExecuteOperation: any;
       mockRunInChildContext.mockImplementation(
-        (nameOrFn: any, fnOrConfig?: any, maybeConfig?: any) => {
+        (nameOrFn: any, fnOrConfig?: any, _maybeConfig?: any) => {
           // Handle the overloaded signature
           if (typeof nameOrFn === "string" || nameOrFn === undefined) {
             capturedExecuteOperation = fnOrConfig;
@@ -302,7 +302,7 @@ describe("Concurrent Execution Handler", () => {
       // Create a real execution context that will execute the actual path
       let actualExecuteOperation: any;
       mockRunInChildContext.mockImplementation(
-        async (nameOrFn: any, fnOrConfig?: any, maybeConfig?: any) => {
+        async (nameOrFn: any, fnOrConfig?: any, _maybeConfig?: any) => {
           // Handle the overloaded signature
           let actualFn;
           if (typeof nameOrFn === "string" || nameOrFn === undefined) {
@@ -336,7 +336,7 @@ describe("Concurrent Execution Handler", () => {
       // Test with undefined config to cover the config || {} branch
       let actualExecuteOperation: any;
       mockRunInChildContext.mockImplementation(
-        async (nameOrFn: any, fnOrConfig?: any, maybeConfig?: any) => {
+        async (nameOrFn: any, fnOrConfig?: any, _maybeConfig?: any) => {
           // Handle the overloaded signature
           let actualFn;
           if (typeof nameOrFn === "string" || nameOrFn === undefined) {
@@ -632,12 +632,7 @@ describe("ConcurrencyController", () => {
       // For empty arrays, the promise should resolve immediately
       // but the current implementation has a bug where it doesn't
       // Let's test what actually happens
-      const promise = controller.executeItems(
-        [],
-        jest.fn(),
-        mockParentContext,
-        {},
-      );
+      controller.executeItems([], jest.fn(), mockParentContext, {});
 
       // Since the implementation has a bug with empty arrays, let's skip this test for now
       // and focus on the coverage we've achieved

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -282,7 +282,9 @@ export const createConcurrentExecutionHandler = (
       );
     }
 
-    const executeOperation = async (executionContext: DurableContext): Promise<BatchResult<TResult>> => {
+    const executeOperation = async (
+      executionContext: DurableContext,
+    ): Promise<BatchResult<TResult>> => {
       const concurrencyController = new ConcurrencyController(
         context.isVerbose,
         "concurrent-execution",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
@@ -16,9 +16,11 @@ import { hashId } from "../../utils/step-id-utils/step-id-utils";
 describe("WaitForCondition Handler Timing Tests", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
   let mockCheckpoint: jest.MockedFunction<CheckpointFunction>;
-  let mockParentContext: any;
+  let _mockParentContext: any;
   let createStepId: jest.Mock;
-  let waitForConditionHandler: ReturnType<typeof createWaitForConditionHandler>;
+  let _waitForConditionHandler: ReturnType<
+    typeof createWaitForConditionHandler
+  >;
   let mockTerminationManager: jest.Mocked<TerminationManager>;
 
   beforeEach(() => {
@@ -39,10 +41,10 @@ describe("WaitForCondition Handler Timing Tests", () => {
     } as unknown as jest.Mocked<ExecutionContext>;
 
     mockCheckpoint = createMockCheckpoint();
-    mockParentContext = { getRemainingTimeInMillis: () => 30000 };
+    _mockParentContext = { getRemainingTimeInMillis: (): number => 30000 };
     createStepId = jest.fn().mockReturnValue("test-step-id");
 
-    waitForConditionHandler = createWaitForConditionHandler(
+    _waitForConditionHandler = createWaitForConditionHandler(
       mockExecutionContext,
       mockCheckpoint,
       createStepId,
@@ -76,11 +78,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         mockHasRunningOperations,
       );
 
-      const waitPromise = waitForConditionHandlerWithMocks(
-        "test-wait",
-        checkFn,
-        config,
-      );
+      waitForConditionHandlerWithMocks("test-wait", checkFn, config);
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -158,7 +156,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
 
       const config: WaitForConditionConfig<{ count: number }> = {
         initialState: { count: 0 },
-        waitStrategy: (state, attempt) => ({
+        waitStrategy: (state, _attempt) => ({
           shouldContinue: state.count < 2, // Continue until count reaches 2
           delaySeconds: 1,
         }),
@@ -230,7 +228,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
 
       const config: WaitForConditionConfig<{ progress: number }> = {
         initialState: { progress: 0 },
-        waitStrategy: (state, attempt) => ({
+        waitStrategy: (state, _attempt) => ({
           shouldContinue: state.progress < 100,
           delaySeconds: 2,
         }),

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -368,7 +368,7 @@ export interface DurableContext extends Context {
    * Maps over an array of items with a function, executing in parallel with optional concurrency control
    * @param name - Step name for tracking and debugging
    * @param items - Array of items to process
-   * @param mapFunc - Function to apply to each item (context, item, index, array) => Promise<T>
+   * @param mapFunc - Function to apply to each item (context, item, index, array) =\> Promise<T>
    * @param config - Optional configuration for concurrency and completion behavior
    * @example
    * ```typescript
@@ -390,7 +390,7 @@ export interface DurableContext extends Context {
   /**
    * Maps over an array of items with a function, executing in parallel with optional concurrency control
    * @param items - Array of items to process
-   * @param mapFunc - Function to apply to each item (context, item, index, array) => Promise<T>
+   * @param mapFunc - Function to apply to each item (context, item, index, array) =\> Promise<T>
    * @param config - Optional configuration for concurrency and completion behavior
    * @example
    * ```typescript
@@ -763,11 +763,11 @@ export type WaitForCallbackSubmitterFunc = (
  */
 export interface Logger {
   /** Generic log method with configurable level */
-  log(level: string, message?: string, data?: any, error?: Error): void;
+  log(level: string, message?: string, data?: unknown, error?: Error): void;
   /** Log error messages with optional error object and additional data */
-  error(message?: string, error?: Error, data?: any): void;
+  error(message?: string, error?: Error, data?: unknown): void;
   /** Log warning messages with optional additional data */
-  warn(message?: string, data?: any): void;
+  warn(message?: string, data?: unknown): void;
   /** Log informational messages with optional additional data */
   info(message?: string, data?: any): void;
   /** Log debug messages with optional additional data */

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -27,7 +27,6 @@ describe("CheckpointHandler", () => {
   let mockContext: ExecutionContext;
   let checkpointHandler: CheckpointHandler;
 
-  const mockTaskToken = TEST_CONSTANTS.CHECKPOINT_TOKEN;
   const mockNewTaskToken = "new-task-token";
 
   beforeEach(() => {
@@ -72,7 +71,7 @@ describe("CheckpointHandler", () => {
         Type: OperationType.STEP,
       };
 
-      const result = await checkpointHandler.checkpoint(stepId, data);
+      await checkpointHandler.checkpoint(stepId, data);
 
       // Should be processed immediately
       expect(checkpointHandler.getQueueStatus().queueLength).toBe(0);
@@ -805,7 +804,6 @@ describe("deleteCheckpointHandler", () => {
 describe("createCheckpointHandler", () => {
   // Setup common test variables
   const mockStepId = "test-step-id";
-  const mockTaskToken = TEST_CONSTANTS.CHECKPOINT_TOKEN;
 
   const mockCheckpointResponse = {
     CheckpointToken: "new-task-token",
@@ -856,7 +854,7 @@ describe("createCheckpointHandler", () => {
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
     );
-    const result = await checkpoint(mockStepId, checkpointData);
+    await checkpoint(mockStepId, checkpointData);
 
     // Verify
     expect(mockState.checkpoint).toHaveBeenCalledWith(

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.test.ts
@@ -146,19 +146,24 @@ describe("Context Logger", () => {
     // Create a default logger that mimics the one in durable-context
     const createDefaultLogger = (): Logger => ({
       log: (level: string, message?: string, data?: any, error?: Error) =>
+        // eslint-disable-next-line no-console
         console.log(level, message, data, error),
       info: (message?: string, data?: any) =>
+        // eslint-disable-next-line no-console
         console.log("info", message, data),
       error: (message?: string, error?: Error, data?: any) =>
+        // eslint-disable-next-line no-console
         console.log("error", message, error, data),
       warn: (message?: string, data?: any) =>
+        // eslint-disable-next-line no-console
         console.log("warn", message, data),
       debug: (message?: string, data?: any) =>
+        // eslint-disable-next-line no-console
         console.log("debug", message, data),
     });
 
     const defaultLogger = createDefaultLogger();
-    const getDefaultLogger = () => defaultLogger;
+    const getDefaultLogger = (): Logger => defaultLogger;
 
     const factory = createContextLoggerFactory(
       mockExecutionContext,

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
@@ -10,23 +10,37 @@ export const createContextLoggerFactory = (
     const createLogEntry = (
       level: string,
       message?: string,
-      data?: any,
+      data?: unknown,
       error?: Error,
-    ) => ({
-      timestamp: new Date().toISOString(),
-      execution_arn: executionContext.durableExecutionArn,
-      step_id: stepId,
-      ...(attempt !== undefined && { attempt }),
-      level,
-      ...(message && { message }),
-      ...(data && { data }),
-      ...(error && {
-        error: { name: error.name, message: error.message, stack: error.stack },
-      }),
-    });
+    ): Record<string, unknown> => {
+      const entry: Record<string, unknown> = {
+        timestamp: new Date().toISOString(),
+        execution_arn: executionContext.durableExecutionArn,
+        step_id: stepId,
+        level,
+      };
+
+      if (attempt !== undefined) entry.attempt = attempt;
+      if (message) entry.message = message;
+      if (data) entry.data = data;
+      if (error) {
+        entry.error = {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+        };
+      }
+
+      return entry;
+    };
 
     return {
-      log: (level: string, message?: string, data?: any, error?: Error) => {
+      log: (
+        level: string,
+        message?: string,
+        data?: unknown,
+        error?: Error,
+      ): void => {
         baseLogger.log(
           level,
           message,
@@ -34,20 +48,20 @@ export const createContextLoggerFactory = (
           error,
         );
       },
-      info: (message?: string, data?: any) => {
+      info: (message?: string, data?: unknown): void => {
         baseLogger.info(message, createLogEntry("info", message, data));
       },
-      error: (message?: string, error?: Error, data?: any) => {
+      error: (message?: string, error?: Error, data?: unknown): void => {
         baseLogger.error(
           message,
           error,
           createLogEntry("error", message, data, error),
         );
       },
-      warn: (message?: string, data?: any) => {
+      warn: (message?: string, data?: unknown): void => {
         baseLogger.warn(message, createLogEntry("warn", message, data));
       },
-      debug: (message?: string, data?: any) => {
+      debug: (message?: string, data?: unknown): void => {
         baseLogger.debug(message, createLogEntry("debug", message, data));
       },
     };

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
@@ -4,12 +4,17 @@ import { Logger } from "../../types";
  * Creates a default logger that outputs to console.
  * Used as fallback when no custom logger is provided.
  */
+/* eslint-disable no-console */
 export const createDefaultLogger = (): Logger => ({
-  log: (level: string, message?: string, data?: any, error?: Error) =>
+  log: (level: string, message?: string, data?: unknown, error?: Error) =>
     console.log(level, message, data, error),
-  info: (message?: string, data?: any) => console.log("info", message, data),
-  error: (message?: string, error?: Error, data?: any) =>
+  info: (message?: string, data?: unknown) =>
+    console.log("info", message, data),
+  error: (message?: string, error?: Error, data?: unknown) =>
     console.log("error", message, error, data),
-  warn: (message?: string, data?: any) => console.log("warn", message, data),
-  debug: (message?: string, data?: any) => console.log("debug", message, data),
+  warn: (message?: string, data?: unknown) =>
+    console.log("warn", message, data),
+  debug: (message?: string, data?: unknown) =>
+    console.log("debug", message, data),
 });
+/* eslint-enable no-console */

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/structured-logger-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/structured-logger-integration.test.ts
@@ -1,5 +1,3 @@
-import { createDurableContext } from "../../context/durable-context/durable-context";
-import { createMockExecutionContext } from "../../testing/mock-context";
 import { Context } from "aws-lambda";
 import { hashId } from "../step-id-utils/step-id-utils";
 
@@ -15,11 +13,7 @@ describe("Structured Logger Integration", () => {
   });
 
   it("should use correct stepId for step logger", async () => {
-    const mockExecutionContext = createMockExecutionContext({
-      durableExecutionArn: "test-execution-arn",
-    });
-
-    const mockLambdaContext = {
+    const _mockLambdaContext = {
       callbackWaitsForEmptyEventLoop: false,
       functionName: "test-function",
       functionVersion: "1",
@@ -37,7 +31,7 @@ describe("Structured Logger Integration", () => {
     // Simulate step execution with stepUtil
     const stepUtil = {
       logger: {
-        info: (message: string) => {
+        info: (message: string): void => {
           const logEntry = {
             timestamp: new Date().toISOString(),
             level: "info",
@@ -46,6 +40,7 @@ describe("Structured Logger Integration", () => {
             stepId: hashId("test-step"),
             attempt: 0,
           };
+          // eslint-disable-next-line no-console
           console.log(JSON.stringify(logEntry));
         },
       },

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.test.ts
@@ -81,7 +81,7 @@ describe("Serdes", () => {
         if (value !== undefined) this.value = value;
       }
 
-      getFullName() {
+      getFullName(): string {
         return `${this.name}-${this.value}`;
       }
     }
@@ -136,7 +136,7 @@ describe("Serdes", () => {
           this.createdAt = new Date();
         }
 
-        getAge() {
+        getAge(): number {
           return Date.now() - this.createdAt.getTime();
         }
       }
@@ -175,11 +175,11 @@ describe("Serdes", () => {
         this.createdAt = new Date();
       }
 
-      getAge() {
+      getAge(): number {
         return Date.now() - this.createdAt.getTime();
       }
 
-      update() {
+      update(): void {
         this.updatedAt = new Date();
       }
     }

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
@@ -19,8 +19,8 @@ export interface SerdesContext {
 export interface Serdes<T> {
   /**
    * Serializes a value to a string representation
-   * @param value The value to serialize
-   * @param context Context information for external storage (entityId, durableExecutionArn)
+   * @param value - The value to serialize
+   * @param context - Context information for external storage (entityId, durableExecutionArn)
    * @returns A Promise that resolves to a string representation of the value or pointer
    */
   serialize: (
@@ -30,8 +30,8 @@ export interface Serdes<T> {
 
   /**
    * Deserializes a string back to the original value
-   * @param data The string to deserialize (could be actual data or a pointer)
-   * @param context Context information for external storage (entityId, durableExecutionArn)
+   * @param data - The string to deserialize (could be actual data or a pointer)
+   * @param context - Context information for external storage (entityId, durableExecutionArn)
    * @returns A Promise that resolves to the deserialized value
    */
   deserialize: (
@@ -59,7 +59,7 @@ export const defaultSerdes: Serdes<any> = {
 
 /**
  * Creates a Serdes for a specific class that preserves the class type
- * @param cls The class constructor
+ * @param cls - The class constructor
  * @returns A Serdes that maintains the class type during serialization/deserialization
  *
  * Note: This basic implementation doesn't handle special types like Date objects.
@@ -87,8 +87,8 @@ export function createClassSerdes<T extends object>(
 
 /**
  * Creates a custom Serdes for a class with special handling for Date properties
- * @param cls The class constructor
- * @param dateProps Array of property names that should be converted to Date objects
+ * @param cls - The class constructor
+ * @param dateProps - Array of property names that should be converted to Date objects
  * @returns A Serdes that maintains the class type and converts specified properties to Date objects
  */
 export function createClassSerdesWithDates<T extends object>(


### PR DESCRIPTION
- Remove 'any' type defaults from withDurableFunctions generic parameters
- Replace 'any' with 'unknown' in logger interfaces for better type safety
- Add missing return type annotations across test files and utility functions
- Remove unused variable assignments and rename unused parameters with underscore prefix
- Fix destructuring assignments to only capture needed variables
- Add eslint-disable comments for legitimate console.log usage in tests and loggers
- Escape greater-than characters in TSDoc comments to prevent HTML tag confusion
- Fix TSDoc parameter documentation with proper hyphen formatting

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
