### PR TITLE
fix(sdk): enhance invoke handler to wait for running operations

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -14,12 +14,13 @@ import {
   safeDeserialize,
 } from "../../errors/serdes-errors/serdes-errors";
 import { OperationInterceptor } from "../../mocks/operation-interceptor";
+import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 
 export const createInvokeHandler = (
   context: ExecutionContext,
   checkpoint: ReturnType<typeof createCheckpoint>,
   createStepId: () => string,
-  _hasRunningOperations: () => boolean,
+  hasRunningOperations: () => boolean,
 ): {
   <I, O>(funcId: string, input: I, config?: InvokeConfig<I, O>): Promise<O>;
   <I, O>(
@@ -58,88 +59,105 @@ export const createInvokeHandler = (
 
     log(context.isVerbose, "🔗", `Invoke ${name || funcId} (${stepId})`);
 
-    // Check if we have existing step data
-    const stepData = context.getStepData(stepId);
+    // Main invoke logic - can be re-executed if step status changes
+    while (true) {
+      // Check if we have existing step data
+      const stepData = context.getStepData(stepId);
 
-    if (stepData?.Status === OperationStatus.SUCCEEDED) {
-      // Return cached result - no need to check for errors in successful operations
-      const invokeDetails = stepData.InvokeDetails;
-      return await safeDeserialize(
-        config?.resultSerdes || defaultSerdes,
-        invokeDetails?.Result,
-        stepId,
-        name,
-        context.terminationManager,
-        context.isVerbose,
+      if (stepData?.Status === OperationStatus.SUCCEEDED) {
+        // Return cached result - no need to check for errors in successful operations
+        const invokeDetails = stepData.InvokeDetails;
+        return await safeDeserialize(
+          config?.resultSerdes || defaultSerdes,
+          invokeDetails?.Result,
+          stepId,
+          name,
+          context.terminationManager,
+          context.isVerbose,
+          context.durableExecutionArn,
+        );
+      }
+
+      if (stepData?.Status === OperationStatus.FAILED) {
+        // Operation failed, throw error
+        const invokeDetails = stepData.InvokeDetails;
+        const error = new Error(
+          invokeDetails?.Error?.ErrorMessage || "Invoke failed",
+        );
+        error.name = invokeDetails?.Error?.ErrorType || "InvokeError";
+        throw error;
+      }
+
+      if (stepData?.Status === OperationStatus.STARTED) {
+        // Operation is still running, check for other operations before terminating
+        if (hasRunningOperations()) {
+          log(
+            context.isVerbose,
+            "⏳",
+            `Invoke ${name || funcId} still in progress, waiting for other operations`,
+          );
+          await waitBeforeContinue({
+            checkHasRunningOperations: true,
+            checkStepStatus: true,
+            checkTimer: false,
+            stepId,
+            context,
+            hasRunningOperations,
+          });
+          continue; // Re-evaluate status after waiting
+        }
+        
+        // No other operations running, safe to terminate
+        log(
+          context.isVerbose,
+          "⏳",
+          `Invoke ${name || funcId} still in progress, terminating`,
+        );
+        return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
+      }
+
+      // Execute with potential interception (testing)
+      await OperationInterceptor.forExecution(
         context.durableExecutionArn,
-      );
-    }
+      ).execute(name, async (): Promise<void> => {
+        // Serialize the input payload
+        const serializedPayload = await safeSerialize(
+          config?.payloadSerdes || defaultSerdes,
+          input,
+          stepId,
+          name,
+          context.terminationManager,
+          context.isVerbose,
+          context.durableExecutionArn,
+        );
 
-    if (stepData?.Status === OperationStatus.FAILED) {
-      // Operation failed, throw error
-      const invokeDetails = stepData.InvokeDetails;
-      const error = new Error(
-        invokeDetails?.Error?.ErrorMessage || "Invoke failed",
-      );
-      error.name = invokeDetails?.Error?.ErrorType || "InvokeError";
-      throw error;
-    }
+        // Create checkpoint for the invoke operation
+        await checkpoint(stepId, {
+          Id: stepId,
+          ParentId: context.parentId,
+          Action: OperationAction.START,
+          SubType: OperationSubType.INVOKE,
+          Type: OperationType.INVOKE,
+          Name: name,
+          Payload: serializedPayload,
+          InvokeOptions: {
+            FunctionName: funcId,
+            ...(config?.timeoutSeconds && {
+              TimeoutSeconds: config.timeoutSeconds,
+            }),
+          },
+        });
 
-    if (stepData?.Status === OperationStatus.STARTED) {
-      // Operation is still running, terminate and wait for completion
-      // It's a temporary solution until we implement more sopesticated solution
-      log(
-        context.isVerbose,
-        "⏳",
-        `Invoke ${name || funcId} still in progress, terminating`,
-      );
-      return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
-    }
-
-    // Execute with potential interception (testing)
-    const result = await OperationInterceptor.forExecution(
-      context.durableExecutionArn,
-    ).execute(name, async (): Promise<O> => {
-      // Serialize the input payload
-      const serializedPayload = await safeSerialize(
-        config?.payloadSerdes || defaultSerdes,
-        input,
-        stepId,
-        name,
-        context.terminationManager,
-        context.isVerbose,
-        context.durableExecutionArn,
-      );
-
-      // Create checkpoint for the invoke operation
-      await checkpoint(stepId, {
-        Id: stepId,
-        ParentId: context.parentId,
-        Action: OperationAction.START,
-        SubType: OperationSubType.INVOKE,
-        Type: OperationType.INVOKE,
-        Name: name,
-        Payload: serializedPayload,
-        InvokeOptions: {
-          FunctionName: funcId,
-          ...(config?.timeoutSeconds && {
-            TimeoutSeconds: config.timeoutSeconds,
-          }),
-        },
+        log(
+          context.isVerbose,
+          "🚀",
+          `Invoke ${name || funcId} started, re-checking status`,
+        );
       });
 
-      log(
-        context.isVerbose,
-        "🚀",
-        `Invoke ${name || funcId} started, terminating for async execution`,
-      );
-
-      // Terminate to allow the invoke to execute asynchronously
-      // It's a temporary solution until we implement more sopesticated solution
-      return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
-    });
-
-    return result;
+      // Continue the loop to re-evaluate status (will hit STARTED case)
+      continue;
+    }
   }
 
   return invokeHandler;


### PR DESCRIPTION
fix(sdk): enhance invoke handler to wait for running operations before terminating

- Wrap invoke logic in while loop to allow re-evaluation of step status
- Check for running operations before terminating STARTED invokes
- Use waitBeforeContinue utility when other operations are running
- Update unit tests to cover new waiting behavior and while loop logic
- Add test for scenario where invoke waits for other operations
- Remove outdated intercepted execution test that didn't fit new pattern

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
