### PR TITLE
feat(sdk): Add summary generators for map and parallel operations

### DIFF
--- a/packages/aws-durable-execution-sdk-js/bundle-size-history.json
+++ b/packages/aws-durable-execution-sdk-js/bundle-size-history.json
@@ -1,15 +1,5 @@
 [
   {
-    "timestamp": "2025-06-27T16:47:20.156Z",
-    "size": 888765,
-    "gitCommit": "6c98b2ec2c523a92309a7b8ee00e9c61f83392cf"
-  },
-  {
-    "timestamp": "2025-07-09T20:06:07.839Z",
-    "size": 891952,
-    "gitCommit": "bf7ad0b2cbd6aa0a0bf265e67a013bdf1dec4854"
-  },
-  {
     "timestamp": "2025-07-10T01:35:30.375Z",
     "size": 891887,
     "gitCommit": "ee000fbc8653964a49a894906b8741272288490f"
@@ -248,5 +238,15 @@
     "timestamp": "2025-09-29T21:53:05.018Z",
     "size": 361581,
     "gitCommit": "1eba8c6d9f097275746307697346a5f2caf27c23"
+  },
+  {
+    "timestamp": "2025-10-02T19:08:08.763Z",
+    "size": 357086,
+    "gitCommit": "77e3ad5a04f502ab227318b89b47b5ac8b63630f"
+  },
+  {
+    "timestamp": "2025-10-02T19:56:14.710Z",
+    "size": 357050,
+    "gitCommit": "7934b1ddf1b32907d5a20f1995a49bfa22845821"
   }
 ]

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -18,6 +18,7 @@ export interface ConcurrencyConfig {
   maxConcurrency?: number;
   topLevelSubType?: string;
   iterationSubType?: string;
+  summaryGenerator?: (result: any) => string;
   completionConfig?: {
     minSuccessful?: number;
     toleratedFailureCount?: number;
@@ -300,6 +301,7 @@ export const createConcurrentExecutionHandler = (
 
     return await runInChildContext(name, executeOperation, {
       subType: config?.topLevelSubType,
+      summaryGenerator: config?.summaryGenerator,
     });
   };
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -268,9 +268,13 @@ describe("InvokeHandler", () => {
     });
 
     it("should wait when operation is in progress and other operations are running", async () => {
-      const mockGetStepData = jest.fn()
+      const mockGetStepData = jest
+        .fn()
         .mockReturnValueOnce({ Status: OperationStatus.STARTED })
-        .mockReturnValueOnce({ Status: OperationStatus.SUCCEEDED, InvokeDetails: { Result: '{"result":"success"}' } });
+        .mockReturnValueOnce({
+          Status: OperationStatus.SUCCEEDED,
+          InvokeDetails: { Result: '{"result":"success"}' },
+        });
 
       mockContext.getStepData = mockGetStepData;
       mockHasRunningOperations.mockReturnValue(true); // Other operations running
@@ -303,7 +307,8 @@ describe("InvokeHandler", () => {
     });
 
     it("should create checkpoint and terminate for new invoke without name", async () => {
-      const mockGetStepData = jest.fn()
+      const mockGetStepData = jest
+        .fn()
         .mockReturnValueOnce(undefined) // First call - no step data
         .mockReturnValueOnce({ Status: OperationStatus.STARTED }); // After checkpoint
 
@@ -358,7 +363,8 @@ describe("InvokeHandler", () => {
     });
 
     it("should create checkpoint and terminate for new invoke with name", async () => {
-      const mockGetStepData = jest.fn()
+      const mockGetStepData = jest
+        .fn()
         .mockReturnValueOnce(undefined) // First call - no step data
         .mockReturnValueOnce({ Status: OperationStatus.STARTED }); // After checkpoint
 
@@ -397,7 +403,8 @@ describe("InvokeHandler", () => {
     });
 
     it("should handle invoke with options", async () => {
-      const mockGetStepData = jest.fn()
+      const mockGetStepData = jest
+        .fn()
         .mockReturnValueOnce(undefined) // First call - no step data
         .mockReturnValueOnce({ Status: OperationStatus.STARTED }); // After checkpoint
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -106,14 +106,18 @@ export const createInvokeHandler = (
           });
           continue; // Re-evaluate status after waiting
         }
-        
+
         // No other operations running, safe to terminate
         log(
           context.isVerbose,
           "⏳",
           `Invoke ${name || funcId} still in progress, terminating`,
         );
-        return terminate(context, TerminationReason.OPERATION_TERMINATED, stepId);
+        return terminate(
+          context,
+          TerminationReason.OPERATION_TERMINATED,
+          stepId,
+        );
       }
 
       // Execute with potential interception (testing)

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
@@ -47,7 +47,15 @@ describe("Map Handler", () => {
           { id: "map-item-1", data: "item2", index: 1 },
         ],
         expect.any(Function),
-        TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        {
+          ...{
+            ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+            summaryGenerator: expect.any(Function),
+            completionConfig: undefined,
+          },
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
       );
     });
 
@@ -70,7 +78,11 @@ describe("Map Handler", () => {
           { id: "map-item-1", data: "item2", index: 1 },
         ],
         expect.any(Function),
-        TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        {
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
       );
     });
 
@@ -89,7 +101,11 @@ describe("Map Handler", () => {
         undefined,
         [{ id: "map-item-0", data: "item", index: 0 }],
         expect.any(Function),
-        TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        {
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
       );
     });
 
@@ -97,7 +113,11 @@ describe("Map Handler", () => {
       const items = ["item1", "item2"];
       const mapFunc: MapFunc<string> = jest.fn().mockResolvedValue("result");
       const config = {
-        ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        ...{
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
         maxConcurrency: 2,
       };
 
@@ -116,7 +136,14 @@ describe("Map Handler", () => {
           { id: "map-item-1", data: "item2", index: 1 },
         ],
         expect.any(Function),
-        { ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG, maxConcurrency: 2 },
+        {
+          ...{
+            ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+            summaryGenerator: expect.any(Function),
+            completionConfig: undefined,
+          },
+          maxConcurrency: 2,
+        },
       );
     });
   });
@@ -154,7 +181,11 @@ describe("Map Handler", () => {
         undefined,
         [],
         expect.any(Function),
-        TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        {
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
       );
     });
 
@@ -179,7 +210,11 @@ describe("Map Handler", () => {
           { id: "map-item-2", data: "item3", index: 2 },
         ],
         expect.any(Function),
-        TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        {
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
       );
     });
 
@@ -251,7 +286,11 @@ describe("Map Handler", () => {
       const items = ["item1", "item2"];
       const mapFunc: MapFunc<string> = jest.fn().mockResolvedValue("result");
       const config = {
-        ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+        ...{
+          ...TEST_CONSTANTS.DEFAULT_MAP_CONFIG,
+          summaryGenerator: expect.any(Function),
+          completionConfig: undefined,
+        },
         maxConcurrency: 5,
       };
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
@@ -9,6 +9,7 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { BatchResult } from "../concurrent-execution-handler/batch-result";
+import { createMapSummaryGenerator } from "../../utils/summary-generators";
 
 export const createMapHandler = (
   context: ExecutionContext,
@@ -74,6 +75,7 @@ export const createMapHandler = (
       maxConcurrency: config?.maxConcurrency,
       topLevelSubType: OperationSubType.MAP,
       iterationSubType: OperationSubType.MAP_ITERATION,
+      summaryGenerator: createMapSummaryGenerator(),
       completionConfig: config?.completionConfig,
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
@@ -63,6 +63,7 @@ describe("Parallel Handler", () => {
           completionConfig: undefined,
           iterationSubType: "ParallelBranch",
           maxConcurrency: undefined,
+          summaryGenerator: expect.any(Function),
           topLevelSubType: "Parallel",
         },
       );
@@ -91,6 +92,7 @@ describe("Parallel Handler", () => {
           completionConfig: undefined,
           iterationSubType: "ParallelBranch",
           maxConcurrency: 2,
+          summaryGenerator: expect.any(Function),
           topLevelSubType: "Parallel",
         },
       );
@@ -119,6 +121,7 @@ describe("Parallel Handler", () => {
           completionConfig: undefined,
           iterationSubType: "ParallelBranch",
           maxConcurrency: 3,
+          summaryGenerator: expect.any(Function),
           topLevelSubType: "Parallel",
         },
       );

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
@@ -9,6 +9,7 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { BatchResult } from "../concurrent-execution-handler/batch-result";
+import { createParallelSummaryGenerator } from "../../utils/summary-generators";
 
 export const createParallelHandler = (
   context: ExecutionContext,
@@ -84,6 +85,7 @@ export const createParallelHandler = (
       maxConcurrency: config?.maxConcurrency,
       topLevelSubType: OperationSubType.PARALLEL,
       iterationSubType: OperationSubType.PARALLEL_BRANCH,
+      summaryGenerator: createParallelSummaryGenerator(),
       completionConfig: config?.completionConfig,
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators.test.ts
@@ -1,0 +1,158 @@
+import { createParallelSummaryGenerator, createMapSummaryGenerator } from "./summary-generators";
+import { BatchResultImpl } from "../handlers/concurrent-execution-handler/batch-result";
+import { BatchItemStatus } from "../types";
+
+describe("Summary Generators", () => {
+  describe("createParallelSummaryGenerator", () => {
+    it("should generate summary for successful parallel result", () => {
+      const batchResult = new BatchResultImpl([
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
+      ], "ALL_COMPLETED");
+
+      const summaryGenerator = createParallelSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "ParallelResult",
+        totalCount: 2,
+        successCount: 2,
+        failureCount: 0,
+        startedCount: 0,
+        completionReason: "ALL_COMPLETED",
+        status: BatchItemStatus.SUCCEEDED,
+      });
+    });
+
+    it("should generate summary for failed parallel result", () => {
+      const error = new Error("Test error");
+      const batchResult = new BatchResultImpl([
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, error, status: BatchItemStatus.FAILED },
+      ], "ALL_COMPLETED");
+
+      const summaryGenerator = createParallelSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "ParallelResult",
+        totalCount: 2,
+        successCount: 1,
+        failureCount: 1,
+        startedCount: 0,
+        completionReason: "ALL_COMPLETED",
+        status: BatchItemStatus.FAILED,
+      });
+    });
+
+    it("should generate summary for early completion", () => {
+      const batchResult = new BatchResultImpl([
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, status: BatchItemStatus.STARTED },
+      ], "MIN_SUCCESSFUL_REACHED");
+
+      const summaryGenerator = createParallelSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "ParallelResult",
+        totalCount: 2,
+        successCount: 1,
+        failureCount: 0,
+        startedCount: 1,
+        completionReason: "MIN_SUCCESSFUL_REACHED",
+        status: BatchItemStatus.SUCCEEDED,
+      });
+    });
+  });
+
+  describe("createMapSummaryGenerator", () => {
+    it("should generate summary for successful map result", () => {
+      const batchResult = new BatchResultImpl([
+        { index: 0, result: "mapped1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, result: "mapped2", status: BatchItemStatus.SUCCEEDED },
+        { index: 2, result: "mapped3", status: BatchItemStatus.SUCCEEDED },
+      ], "ALL_COMPLETED");
+
+      const summaryGenerator = createMapSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "MapResult",
+        totalCount: 3,
+        successCount: 3,
+        failureCount: 0,
+        completionReason: "ALL_COMPLETED",
+        status: BatchItemStatus.SUCCEEDED,
+      });
+    });
+
+    it("should generate summary for failed map result", () => {
+      const error = new Error("Mapping failed");
+      const batchResult = new BatchResultImpl([
+        { index: 0, result: "mapped1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, error, status: BatchItemStatus.FAILED },
+        { index: 2, result: "mapped3", status: BatchItemStatus.SUCCEEDED },
+      ], "ALL_COMPLETED");
+
+      const summaryGenerator = createMapSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "MapResult",
+        totalCount: 3,
+        successCount: 2,
+        failureCount: 1,
+        completionReason: "ALL_COMPLETED",
+        status: BatchItemStatus.FAILED,
+      });
+    });
+
+    it("should generate summary for failure tolerance exceeded", () => {
+      const error1 = new Error("Error 1");
+      const error2 = new Error("Error 2");
+      const batchResult = new BatchResultImpl([
+        { index: 0, error: error1, status: BatchItemStatus.FAILED },
+        { index: 1, error: error2, status: BatchItemStatus.FAILED },
+      ], "FAILURE_TOLERANCE_EXCEEDED");
+
+      const summaryGenerator = createMapSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      const parsed = JSON.parse(summary);
+
+      expect(parsed).toEqual({
+        type: "MapResult",
+        totalCount: 2,
+        successCount: 0,
+        failureCount: 2,
+        completionReason: "FAILURE_TOLERANCE_EXCEEDED",
+        status: BatchItemStatus.FAILED,
+      });
+    });
+  });
+
+  describe("summary generator return types", () => {
+    it("should return string from parallel summary generator", () => {
+      const batchResult = new BatchResultImpl([], "ALL_COMPLETED");
+      const summaryGenerator = createParallelSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      
+      expect(typeof summary).toBe("string");
+      expect(() => JSON.parse(summary)).not.toThrow();
+    });
+
+    it("should return string from map summary generator", () => {
+      const batchResult = new BatchResultImpl([], "ALL_COMPLETED");
+      const summaryGenerator = createMapSummaryGenerator();
+      const summary = summaryGenerator(batchResult);
+      
+      expect(typeof summary).toBe("string");
+      expect(() => JSON.parse(summary)).not.toThrow();
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators.ts
@@ -1,0 +1,31 @@
+import { BatchResult } from "../handlers/concurrent-execution-handler/batch-result";
+
+/**
+ * Creates a predefined summary generator for parallel operations
+ */
+export const createParallelSummaryGenerator =
+  () => (result: BatchResult<any>) => {
+    return JSON.stringify({
+      type: "ParallelResult",
+      totalCount: result.totalCount,
+      successCount: result.successCount,
+      failureCount: result.failureCount,
+      startedCount: result.startedCount,
+      completionReason: result.completionReason,
+      status: result.status,
+    });
+  };
+
+/**
+ * Creates a predefined summary generator for map operations
+ */
+export const createMapSummaryGenerator = () => (result: BatchResult<any>) => {
+  return JSON.stringify({
+    type: "MapResult",
+    totalCount: result.totalCount,
+    successCount: result.successCount,
+    failureCount: result.failureCount,
+    completionReason: result.completionReason,
+    status: result.status,
+  });
+};

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-functions.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-functions.test.ts
@@ -2,9 +2,9 @@ import { withDurableFunctions } from "./with-durable-functions";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { createDurableContext } from "./context/durable-context/durable-context";
 import { CheckpointFailedError } from "./errors/checkpoint-errors/checkpoint-errors";
-import { 
-  UnrecoverableInvocationError, 
-  UnrecoverableExecutionError 
+import {
+  UnrecoverableInvocationError,
+  UnrecoverableExecutionError,
 } from "./errors/unrecoverable-error/unrecoverable-error";
 import { SerializationFailedError } from "./errors/serdes-errors/serdes-errors";
 import { TerminationReason } from "./termination-manager/types";
@@ -415,7 +415,7 @@ describe("withDurableFunctions", () => {
         super(message);
       }
     }
-    
+
     const customError = new CustomInvocationError("Custom invocation error");
     const mockHandler = jest.fn().mockRejectedValue(customError);
     mockTerminationManager.getTerminationPromise.mockReturnValue(
@@ -441,7 +441,7 @@ describe("withDurableFunctions", () => {
         super(message);
       }
     }
-    
+
     const executionError = new CustomExecutionError("Custom execution error");
     const mockHandler = jest.fn().mockRejectedValue(executionError);
     mockTerminationManager.getTerminationPromise.mockReturnValue(


### PR DESCRIPTION
*Description of changes:*

- Add summaryGenerator field to ConcurrencyConfig interface
- Create predefined summary generators for map and parallel operations
- Update ConcurrencyController to pass summaryGenerator to top-level runInChildContext only
- Update map and parallel handlers to use predefined summary generators
- Update tests to expect new configuration fields

This enables summaries for large BatchResult payloads in map and parallel operations.

*Issue #, if available:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
