### PR TITLE
feat(testing-sdk): support running cloud tests asynchronously

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/examples-catalog.json
+++ b/packages/aws-durable-execution-sdk-js-examples/examples-catalog.json
@@ -188,9 +188,10 @@
       "handler": "wait-for-callback.handler",
       "durableConfig": {
         "RetentionPeriodInDays": 7,
-        "ExecutionTimeout": 300
+        "ExecutionTimeout": 60
       },
-      "path": "./src/examples/wait-for-callback.ts"
+      "path": "./src/examples/wait-for-callback.ts",
+      "integration": true
     },
     {
       "name": "Named Wait",

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/shared/test-helper.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/shared/test-helper.ts
@@ -4,6 +4,7 @@ import {
   DurableTestRunner,
   DurableOperation,
   LocalTestRunnerHandlerFunction,
+  InvocationType,
 } from "@aws/durable-execution-sdk-js-testing";
 
 export interface TestDefinition<ResultType> {
@@ -13,6 +14,7 @@ export interface TestDefinition<ResultType> {
   tests: (
     runner: DurableTestRunner<DurableOperation<unknown>, ResultType>
   ) => void;
+  invocationType?: InvocationType;
 }
 
 /**
@@ -36,9 +38,18 @@ export function createTests<ResultType>(testDef: TestDefinition<ResultType>) {
 
     const runner = new CloudDurableTestRunner<ResultType>({
       functionName,
-      config: {
+      clientConfig: {
         endpoint: process.env.LAMBDA_ENDPOINT,
       },
+      config: {
+        invocationType: testDef.invocationType,
+      },
+    });
+
+    beforeEach(() => {
+      // TODO: fix the testing library to allow the same runner to run multiple times on the same handler
+      // instead of needing to reset the operation storage
+      runner.reset();
     });
 
     describe(`${testDef.name} (cloud)`, () => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback.test.ts
@@ -1,44 +1,41 @@
-import {LocalDurableTestRunner, WaitingOperationStatus} from "@aws/durable-execution-sdk-js-testing";
-import {handler} from '../wait-for-callback';
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback";
+import { createTests } from "./shared/test-helper";
 
-beforeAll(() => LocalDurableTestRunner.setupTestEnvironment());
-afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
-
-let durableTestRunner: LocalDurableTestRunner<void>;
-
-beforeEach(async () => {
-    durableTestRunner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-    });
-})
-
-describe("wait-for-callback test", () => {
+createTests({
+  name: "wait-for-callback test",
+  functionName: "wait-for-callback",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
     it("function completes when callback succeeds - happy case", async () => {
-        const executionPromise = durableTestRunner.run();
+      const executionPromise = runner.run();
 
-        const waitForCallbackOp = durableTestRunner.getOperationByIndex(0);
-        await waitForCallbackOp.waitForData(WaitingOperationStatus.STARTED)
-        await waitForCallbackOp.sendCallbackSuccess("succeeded");
+      const waitForCallbackOp = runner.getOperationByIndex(0);
+      await waitForCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      await waitForCallbackOp.sendCallbackSuccess("succeeded");
 
-        const execution = await executionPromise;
+      const execution = await executionPromise;
 
-        expect(execution.getResult()).toBeDefined()
+      expect(execution.getResult()).toEqual("succeeded");
     });
 
     it("function completes when callback fails - happy case", async () => {
-        const executionPromise = durableTestRunner.run();
+      const executionPromise = runner.run();
 
-        const waitForCallbackOp = durableTestRunner.getOperationByIndex(0);
-        await waitForCallbackOp.waitForData(WaitingOperationStatus.STARTED)
-        await waitForCallbackOp.sendCallbackFailure({ErrorMessage: "ERROR"});
+      const waitForCallbackOp = runner.getOperationByIndex(0);
+      await waitForCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      await waitForCallbackOp.sendCallbackFailure({ ErrorMessage: "ERROR" });
 
-        const execution = await executionPromise;
+      const execution = await executionPromise;
 
-        expect(execution.getError()).toBeDefined()
+      expect(execution.getError()).toBeDefined();
     });
 
     it("function times out when callback is not called - failure case", async () => {
-        // TODO: add test when callback timeout is handled in TS SDK: https://tiny.amazon.com/1f5679y8l
     });
+  },
 });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback.ts
@@ -6,8 +6,10 @@ const mySubmitterFunction = async (callbackId: string): Promise<void> => {
 
 export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
     console.log("Hello world before callback!");
-    await context.waitForCallback("my callback function", mySubmitterFunction, {
+    const result = await context.waitForCallback("my callback function", mySubmitterFunction, {
         timeout: 10000,
     });
     console.log("Hello world after callback!");
+
+    return result
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/__tests__/cloud-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/__tests__/cloud-operation.test.ts
@@ -1,0 +1,55 @@
+import { InvocationType, OperationStatus } from "@aws-sdk/client-lambda";
+import { CloudOperation } from "../cloud-operation";
+import { OperationWaitManager } from "../../../local/operations/operation-wait-manager";
+import { IndexedOperations } from "../../../common/indexed-operations";
+import { DurableApiClient } from "../../../common/create-durable-api-client";
+import { WaitingOperationStatus } from "../../../durable-test-runner";
+
+describe("CloudOperation", () => {
+  const waitManager = new OperationWaitManager();
+  const mockIndexedOperations = new IndexedOperations([]);
+  const mockApiClient: jest.Mocked<DurableApiClient> = {
+    sendCallbackSuccess: jest.fn(),
+    sendCallbackFailure: jest.fn(),
+    sendCallbackHeartbeat: jest.fn(),
+  };
+
+  describe("waitForData", () => {
+    it("should delegate to parent and return CloudOperation when invocationType is Event", async () => {
+      const operation = new CloudOperation(
+        waitManager,
+        mockIndexedOperations,
+        mockApiClient,
+        InvocationType.Event
+      );
+
+      const checkpointData = {
+        operation: {
+          Id: "test-id",
+          Status: OperationStatus.SUCCEEDED,
+        },
+        events: [],
+      };
+
+      operation.populateData(checkpointData);
+
+      const result = await operation.waitForData(WaitingOperationStatus.COMPLETED);
+
+      expect(result).toBe(operation);
+      expect(result).toBeInstanceOf(CloudOperation);
+    });
+
+    it("should throw error when invocationType is not Event", async () => {
+      const operation = new CloudOperation(
+        waitManager,
+        mockIndexedOperations,
+        mockApiClient,
+        InvocationType.RequestResponse
+      );
+
+      await expect(operation.waitForData()).rejects.toThrow(
+        "InvocationType.RequestResponse cannot wait for operation data. Use InvocationType.Event to wait for operation data."
+      );
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/cloud-operation.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/cloud-operation.ts
@@ -1,0 +1,36 @@
+import { InvocationType } from "@aws-sdk/client-lambda";
+import { DurableApiClient } from "../../common/create-durable-api-client";
+import { IndexedOperations } from "../../common/indexed-operations";
+import {
+  OperationEvents,
+  OperationWithData,
+} from "../../common/operations/operation-with-data";
+import { WaitingOperationStatus } from "../../durable-test-runner";
+import { OperationWaitManager } from "../../local/operations/operation-wait-manager";
+
+export class CloudOperation<
+  OperationResultValue = unknown,
+> extends OperationWithData<OperationResultValue> {
+  constructor(
+    waitManager: OperationWaitManager,
+    operationIndex: IndexedOperations,
+    apiClient: DurableApiClient,
+    private readonly invocationType: InvocationType,
+    checkpointOperationData?: OperationEvents
+  ) {
+    super(waitManager, operationIndex, apiClient, checkpointOperationData);
+  }
+
+  async waitForData(
+    status?: WaitingOperationStatus
+  ): Promise<CloudOperation<OperationResultValue>> {
+    if (this.invocationType !== InvocationType.Event) {
+      throw new Error(
+        `InvocationType.${this.invocationType} cannot wait for operation data. Use InvocationType.Event to wait for operation data.`
+      );
+    }
+
+    await super.waitForData(status);
+    return this;
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/__tests__/history-poller.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/__tests__/history-poller.test.ts
@@ -1,0 +1,981 @@
+import {
+  Event,
+  EventType,
+  ExecutionStatus,
+  GetDurableExecutionCommandOutput,
+  GetDurableExecutionHistoryCommandOutput,
+} from "@aws-sdk/client-lambda";
+import {
+  HistoryPoller,
+  HistoryPollerParams,
+  HistoryApiClient,
+  ReceivedOperationEventsCallback,
+} from "../../../cloud/history-poller";
+import { TestExecutionState } from "../../../common/test-execution-state";
+
+// Test helper utilities
+interface CreateHistoryPollerOptions {
+  pollInterval?: number;
+  durableExecutionArn?: string;
+  historyResponses?: GetDurableExecutionHistoryCommandOutput[];
+  executionResponses?: GetDurableExecutionCommandOutput[];
+  historyError?: Error;
+  executionError?: Error;
+  onOperationEventsReceived?: ReceivedOperationEventsCallback;
+}
+
+function createMockEvent(overrides: Partial<Event> = {}): Event {
+  const eventType = overrides.EventType ?? EventType.ExecutionStarted;
+  const baseEvent: Event = {
+    EventTimestamp: new Date(),
+    EventType: eventType,
+    EventId: 1,
+    Id: "test-event-id",
+    ...overrides,
+  };
+
+  // Add required detail fields based on event type
+  if (eventType === EventType.ExecutionStarted) {
+    baseEvent.ExecutionStartedDetails = {};
+  } else if (eventType === EventType.StepStarted) {
+    baseEvent.StepStartedDetails = {
+      Name: "test-step",
+      Input: "{}",
+      ...(overrides.StepStartedDetails ?? {}),
+    };
+  } else if (eventType === EventType.StepSucceeded) {
+    baseEvent.StepSucceededDetails = {
+      Result: { Payload: '{"success": true}' },
+      ...(overrides.StepSucceededDetails ?? {}),
+    };
+  }
+
+  return baseEvent;
+}
+
+function createMockHistoryResponse(
+  overrides: Partial<GetDurableExecutionHistoryCommandOutput> = {}
+): GetDurableExecutionHistoryCommandOutput {
+  return {
+    Events: [createMockEvent()],
+    $metadata: {},
+    ...overrides,
+  };
+}
+
+function createMockExecutionResponse(
+  overrides: Partial<GetDurableExecutionCommandOutput> = {}
+): GetDurableExecutionCommandOutput {
+  const defaultResponse: GetDurableExecutionCommandOutput = {
+    Status: ExecutionStatus.SUCCEEDED,
+    $metadata: {},
+  };
+
+  if (overrides.Status !== ExecutionStatus.FAILED) {
+    defaultResponse.Result = '{"success": true}';
+  }
+
+  return {
+    ...defaultResponse,
+    ...overrides,
+  };
+}
+
+function createHistoryPoller(options: CreateHistoryPollerOptions = {}): {
+  poller: HistoryPoller;
+  mockApiClient: jest.Mocked<HistoryApiClient>;
+  testExecutionState: TestExecutionState;
+  onOperationEventsReceived: jest.MockedFunction<ReceivedOperationEventsCallback>;
+} {
+  const testExecutionState = new TestExecutionState();
+  const onOperationEventsReceived = jest.fn();
+
+  // Create simple Jest mocks for the API client
+  let historyCallCount = 0;
+  let executionCallCount = 0;
+
+  const mockApiClient: jest.Mocked<HistoryApiClient> = {
+    getHistory: jest.fn().mockImplementation(() => {
+      if (options.historyError) {
+        return Promise.reject(options.historyError);
+      }
+      const responses = options.historyResponses ?? [
+        createMockHistoryResponse(),
+      ];
+      const response =
+        responses[historyCallCount] ?? responses[responses.length - 1];
+      historyCallCount++;
+      return Promise.resolve(response);
+    }),
+    getExecution: jest.fn().mockImplementation(() => {
+      if (options.executionError) {
+        return Promise.reject(options.executionError);
+      }
+      const responses = options.executionResponses ?? [
+        createMockExecutionResponse(),
+      ];
+      const response =
+        responses[executionCallCount] ?? responses[responses.length - 1];
+      executionCallCount++;
+      return Promise.resolve(response);
+    }),
+  };
+
+  const params: HistoryPollerParams = {
+    pollInterval: options.pollInterval ?? 100,
+    durableExecutionArn: options.durableExecutionArn ?? "test-arn",
+    testExecutionState,
+    apiClient: mockApiClient,
+    onOperationEventsReceived:
+      options.onOperationEventsReceived ?? onOperationEventsReceived,
+  };
+
+  const poller = new HistoryPoller(params);
+
+  return {
+    poller,
+    mockApiClient,
+    testExecutionState,
+    onOperationEventsReceived,
+  };
+}
+
+async function waitForPollerCycles(
+  cycles: number,
+  pollInterval = 100
+): Promise<void> {
+  for (let i = 0; i < cycles; i++) {
+    await jest.advanceTimersByTimeAsync(pollInterval);
+  }
+}
+
+describe("HistoryPoller", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("startPolling", () => {
+    it("should start polling process", () => {
+      const { poller } = createHistoryPoller();
+
+      expect(() => {
+        poller.startPolling();
+      }).not.toThrow();
+    });
+
+    it("should throw error if already started", () => {
+      const { poller } = createHistoryPoller();
+
+      poller.startPolling();
+
+      expect(() => {
+        poller.startPolling();
+      }).toThrow("Poller already started");
+    });
+
+    it("should begin polling after pollInterval", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        pollInterval: 200,
+      });
+
+      poller.startPolling();
+
+      expect(mockApiClient.getHistory).not.toHaveBeenCalled();
+      expect(mockApiClient.getExecution).not.toHaveBeenCalled();
+
+      await waitForPollerCycles(1, 200);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalled();
+      expect(mockApiClient.getExecution).toHaveBeenCalled();
+    });
+  });
+
+  describe("stopPolling", () => {
+    it("should stop polling process", async () => {
+      const { poller, mockApiClient } = createHistoryPoller();
+
+      poller.startPolling();
+      await jest.advanceTimersByTimeAsync(100);
+
+      const initialHistoryCalls = mockApiClient.getHistory.mock.calls.length;
+
+      poller.stopPolling();
+      await jest.advanceTimersByTimeAsync(200);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(
+        initialHistoryCalls
+      );
+    });
+
+    it("should handle multiple stop calls gracefully", () => {
+      const { poller } = createHistoryPoller();
+
+      poller.startPolling();
+      poller.stopPolling();
+
+      expect(() => {
+        poller.stopPolling();
+      }).not.toThrow();
+    });
+
+    it("should handle stop call without start", () => {
+      const { poller } = createHistoryPoller();
+
+      expect(() => {
+        poller.stopPolling();
+      }).not.toThrow();
+    });
+  });
+
+  describe("getEvents", () => {
+    it("should return events after successful execution", async () => {
+      const testEvent = createMockEvent({ Id: "test-event" });
+      const { poller } = createHistoryPoller({
+        historyResponses: [createMockHistoryResponse({ Events: [testEvent] })],
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(poller.getEvents()).toContainEqual(testEvent);
+    });
+
+    it("should not add events for running executions", async () => {
+      const testEvent = createMockEvent({ Id: "test-event" });
+      const { poller } = createHistoryPoller({
+        historyResponses: [createMockHistoryResponse({ Events: [testEvent] })],
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(poller.getEvents()).toEqual([]);
+    });
+
+    it("should accumulate events across multiple successful polls", async () => {
+      const event1 = createMockEvent({ Id: "event-1" });
+      const event2 = createMockEvent({ Id: "event-2" });
+
+      const { poller } = createHistoryPoller({
+        historyResponses: [
+          createMockHistoryResponse({ Events: [event1] }),
+          createMockHistoryResponse({ Events: [event2] }),
+        ],
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(2);
+
+      const events = poller.getEvents();
+      expect(events).toContainEqual(event2);
+      expect(events).toHaveLength(1); // Only the last batch when execution completes
+    });
+  });
+
+  describe("Event processing", () => {
+    it("should call onOperationEventsReceived callback with processed events", async () => {
+      const testEvent = createMockEvent({ Id: "test-event" });
+      const { poller, onOperationEventsReceived } = createHistoryPoller({
+        historyResponses: [createMockHistoryResponse({ Events: [testEvent] })],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(onOperationEventsReceived).toHaveBeenCalledWith(expect.any(Array));
+      expect(onOperationEventsReceived).toHaveBeenCalledTimes(1);
+    });
+
+    it("should process empty events array", async () => {
+      const { poller, onOperationEventsReceived } = createHistoryPoller({
+        historyResponses: [createMockHistoryResponse({ Events: [] })],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(onOperationEventsReceived).toHaveBeenCalledWith(expect.any(Array));
+    });
+
+    it("should process undefined events array", async () => {
+      const { poller, onOperationEventsReceived } = createHistoryPoller({
+        historyResponses: [createMockHistoryResponse({ Events: undefined })],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(onOperationEventsReceived).toHaveBeenCalledWith(expect.any(Array));
+    });
+  });
+
+  describe("History pagination", () => {
+    it("should handle NextMarker pagination", async () => {
+      const event1 = createMockEvent({ Id: "event-1" });
+      const event2 = createMockEvent({ Id: "event-2" });
+
+      const { poller, mockApiClient } = createHistoryPoller({
+        pollInterval: 100,
+        historyResponses: [
+          createMockHistoryResponse({
+            Events: [event1],
+            NextMarker: "page-2-marker",
+          }),
+          createMockHistoryResponse({
+            Events: [event2],
+            NextMarker: undefined,
+          }),
+        ],
+      });
+
+      poller.startPolling();
+      // First cycle starts the polling
+      await jest.advanceTimersByTimeAsync(100);
+      // Wait for pagination delay between pages
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(2);
+    });
+
+    it("should process all events from paginated history", async () => {
+      const event1 = createMockEvent({
+        Id: "event-1",
+        EventType: EventType.StepStarted,
+      });
+      const event2 = createMockEvent({
+        Id: "event-2",
+        EventType: EventType.StepStarted,
+      });
+
+      const { poller, onOperationEventsReceived } = createHistoryPoller({
+        pollInterval: 100,
+        historyResponses: [
+          createMockHistoryResponse({
+            Events: [event1],
+            NextMarker: "marker",
+          }),
+          createMockHistoryResponse({
+            Events: [event2],
+            NextMarker: undefined,
+          }),
+        ],
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+      // Wait for initial polling delay
+      await jest.advanceTimersByTimeAsync(100);
+      // Wait for pagination delay
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(onOperationEventsReceived).toHaveBeenCalledWith(expect.any(Array));
+      const callArgs = onOperationEventsReceived.mock.calls[0][0];
+      expect(callArgs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Execution completion handling", () => {
+    it("should resolve test execution state on successful completion", async () => {
+      const { poller, testExecutionState } = createHistoryPoller({
+        executionResponses: [
+          createMockExecutionResponse({
+            Status: ExecutionStatus.SUCCEEDED,
+            Result: '{"result": "success"}',
+          }),
+        ],
+      });
+
+      const executionPromise = testExecutionState.createExecutionPromise();
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      const result = await executionPromise;
+      expect(result).toEqual({
+        status: ExecutionStatus.SUCCEEDED,
+        result: '{"result": "success"}',
+      });
+    });
+
+    it("should resolve test execution state on failed completion", async () => {
+      const mockError = {
+        ErrorMessage: "Execution failed",
+        ErrorType: "TestError",
+      };
+
+      const { poller, testExecutionState } = createHistoryPoller({
+        executionResponses: [
+          createMockExecutionResponse({
+            Status: ExecutionStatus.FAILED,
+            Error: mockError,
+          }),
+        ],
+      });
+
+      const executionPromise = testExecutionState.createExecutionPromise();
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      const result = await executionPromise;
+      expect(result).toEqual({
+        status: ExecutionStatus.FAILED,
+        error: mockError,
+      });
+    });
+
+    it("should stop polling after execution completion", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      const callsAfterCompletion = mockApiClient.getHistory.mock.calls.length;
+
+      await waitForPollerCycles(2);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(
+        callsAfterCompletion
+      );
+    });
+
+    it("should continue polling for running executions", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(3);
+
+      expect(mockApiClient.getExecution).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should reject test execution state on history API error", async () => {
+      const testError = new Error("History API failed");
+      const { poller, testExecutionState } = createHistoryPoller({
+        historyError: testError,
+      });
+
+      const executionPromise = testExecutionState.createExecutionPromise();
+
+      poller.startPolling();
+
+      jest.advanceTimersByTime(100);
+
+      await expect(executionPromise).rejects.toThrow("History API failed");
+    });
+
+    it("should reject test execution state on execution API error", async () => {
+      const testError = new Error("Execution API failed");
+      const { poller, testExecutionState } = createHistoryPoller({
+        executionError: testError,
+      });
+
+      const executionPromise = testExecutionState.createExecutionPromise();
+
+      poller.startPolling();
+
+      jest.advanceTimersByTime(100);
+
+      await expect(executionPromise).rejects.toThrow("Execution API failed");
+    });
+
+    it("should stop polling after error", async () => {
+      const testError = new Error("API failed");
+      const { poller, mockApiClient } = createHistoryPoller({
+        historyError: testError,
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      const callsAfterError = mockApiClient.getHistory.mock.calls.length;
+
+      await waitForPollerCycles(2);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(callsAfterError);
+    });
+  });
+
+  describe("API client parameter validation", () => {
+    it("should pass correct parameters to getHistory", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        durableExecutionArn: "test-execution-arn",
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledWith({
+        DurableExecutionArn: "test-execution-arn",
+        IncludeExecutionData: true,
+        MaxItems: 1000,
+        Marker: undefined,
+      });
+    });
+
+    it("should pass correct parameters to getExecution", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        durableExecutionArn: "test-execution-arn",
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      expect(mockApiClient.getExecution).toHaveBeenCalledWith({
+        DurableExecutionArn: "test-execution-arn",
+      });
+    });
+
+    it("should pass marker from previous history response", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        durableExecutionArn: "test-execution-arn",
+        pollInterval: 100,
+        historyResponses: [
+          createMockHistoryResponse({ NextMarker: "test-marker" }),
+          createMockHistoryResponse({ NextMarker: undefined }),
+        ],
+      });
+
+      poller.startPolling();
+      // Wait for initial polling delay
+      await jest.advanceTimersByTimeAsync(100);
+      // Wait for pagination delay
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(2);
+      expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          Marker: undefined,
+        })
+      );
+      expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          Marker: "test-marker",
+        })
+      );
+    });
+  });
+
+  describe("Polling behavior", () => {
+    it("should persist history marker across polling cycles for running executions", async () => {
+      const { poller, mockApiClient } = createHistoryPoller({
+        pollInterval: 100,
+        historyResponses: [
+          // First poll: return history with NextMarker but no pagination
+          createMockHistoryResponse({
+            Events: [createMockEvent({ Id: "event-1" })],
+            NextMarker: undefined, // No pagination in this poll
+          }),
+          // Second poll: should use marker from first poll
+          createMockHistoryResponse({
+            Events: [createMockEvent({ Id: "event-2" })],
+            NextMarker: undefined,
+          }),
+        ],
+        executionResponses: [
+          // First poll: execution still running
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          // Second poll: execution completes
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      // Override the first history response to return a NextMarker
+      // to simulate having more pages available but execution still running
+      let firstCall = true;
+      mockApiClient.getHistory.mockImplementation(() => {
+        if (firstCall) {
+          firstCall = false;
+          return Promise.resolve(
+            createMockHistoryResponse({
+              Events: [createMockEvent({ Id: "event-1" })],
+              NextMarker: "persistent-marker", // This should persist to next polling cycle
+            })
+          );
+        } else {
+          return Promise.resolve(
+            createMockHistoryResponse({
+              Events: [createMockEvent({ Id: "event-2" })],
+              NextMarker: undefined,
+            })
+          );
+        }
+      });
+
+      poller.startPolling();
+
+      // First polling cycle
+      await waitForPollerCycles(1, 100);
+
+      // Second polling cycle should use the marker from first cycle
+      await waitForPollerCycles(1, 100);
+
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(2);
+
+      // First call starts with no marker
+      expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ Marker: undefined })
+      );
+
+      // Second call should use the marker from first polling cycle
+      expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ Marker: "persistent-marker" })
+      );
+    });
+
+    it("should not overlap polling cycles when API calls are slow", async () => {
+      const getHistoryCallTimes: number[] = [];
+      const getExecutionCallTimes: number[] = [];
+
+      const { poller, mockApiClient } = createHistoryPoller({
+        pollInterval: 100, // Short poll interval
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      // Mock API calls to have delays longer than poll interval
+      mockApiClient.getHistory.mockImplementation(() => {
+        getHistoryCallTimes.push(Date.now());
+        // Simulate slow API call (300ms > 100ms poll interval)
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(createMockHistoryResponse());
+          }, 300);
+        });
+      });
+
+      mockApiClient.getExecution.mockImplementation(() => {
+        getExecutionCallTimes.push(Date.now());
+        const responses = [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ];
+        const response =
+          responses[getExecutionCallTimes.length - 1] ??
+          responses[responses.length - 1];
+        return Promise.resolve(response);
+      });
+
+      poller.startPolling();
+
+      // Advance through multiple polling cycles
+      // First poll starts at 100ms
+      await jest.advanceTimersByTimeAsync(100);
+      // API call takes 300ms, so it completes at 400ms
+      await jest.advanceTimersByTimeAsync(300);
+      // Next poll should only start after the previous completes
+      // Second poll starts at 400ms + poll interval = 500ms
+      await jest.advanceTimersByTimeAsync(100);
+      // Second poll completes, execution becomes SUCCEEDED, so polling stops
+      await jest.advanceTimersByTimeAsync(300);
+
+      // Verify calls happened sequentially, not overlapping
+      // Should be 2 calls since execution completes after second check
+      expect(mockApiClient.getHistory).toHaveBeenCalledTimes(2);
+      expect(mockApiClient.getExecution).toHaveBeenCalledTimes(2);
+
+      // Verify timing: second call should start after the first completes
+      // (300ms API delay + poll interval between calls)
+      expect(getHistoryCallTimes.length).toBe(2);
+      const timeBetweenCalls = getHistoryCallTimes[1] - getHistoryCallTimes[0];
+      expect(timeBetweenCalls).toBeGreaterThan(300); // Should wait for previous to complete
+    });
+  });
+
+  describe("Multi-page event handling", () => {
+    it("should immediately store all pages except last during running execution", async () => {
+      const page1Events = [
+        createMockEvent({
+          Id: "page1-event1",
+          EventType: EventType.StepStarted,
+        }),
+        createMockEvent({
+          Id: "page1-event2",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+      const page2Events = [
+        createMockEvent({
+          Id: "page2-event1",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+      const page3Events = [
+        createMockEvent({
+          Id: "page3-event1",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+
+      const { poller } = createHistoryPoller({
+        pollInterval: 100,
+        historyResponses: [
+          // First page
+          createMockHistoryResponse({
+            Events: page1Events,
+            NextMarker: "marker-page2",
+          }),
+          // Second page
+          createMockHistoryResponse({
+            Events: page2Events,
+            NextMarker: "marker-page3",
+          }),
+          // Last page
+          createMockHistoryResponse({
+            Events: page3Events,
+            NextMarker: undefined,
+          }),
+        ],
+        executionResponses: [
+          // Execution still running during first poll
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+        ],
+      });
+
+      poller.startPolling();
+      // Wait for first polling cycle with multiple pages
+      await jest.advanceTimersByTimeAsync(100); // Start poll
+      await jest.advanceTimersByTimeAsync(100); // Page 1->2 delay
+      await jest.advanceTimersByTimeAsync(100); // Page 2->3 delay
+
+      // Should have added pages 1-2 immediately, but NOT page 3 (last page)
+      const eventsAfterFirstPoll = poller.getEvents();
+      expect(eventsAfterFirstPoll).toEqual([...page1Events, ...page2Events]);
+      expect(eventsAfterFirstPoll).not.toContain(
+        expect.objectContaining({ Id: "page3-event1" })
+      );
+    });
+
+    it("should add last page when execution completes, including new events added to that page", async () => {
+      const page1Events = [
+        createMockEvent({
+          Id: "page1-event1",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+      const page2Events = [
+        createMockEvent({
+          Id: "page2-event1",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+      const page3OriginalEvents = [
+        createMockEvent({
+          Id: "page3-event1",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+      // Simulate new events being added to the last page while execution was running
+      const page3WithNewEvents = [
+        ...page3OriginalEvents,
+        createMockEvent({
+          Id: "page3-event2",
+          EventType: EventType.StepStarted,
+        }),
+        createMockEvent({
+          Id: "page3-event3",
+          EventType: EventType.StepSucceeded,
+        }),
+      ];
+
+      const { poller } = createHistoryPoller({
+        pollInterval: 100,
+        historyResponses: [
+          // First polling cycle - 3 pages, execution running
+          createMockHistoryResponse({
+            Events: page1Events,
+            NextMarker: "marker-page2",
+          }),
+          createMockHistoryResponse({
+            Events: page2Events,
+            NextMarker: "marker-page3",
+          }),
+          createMockHistoryResponse({
+            Events: page3OriginalEvents,
+            NextMarker: undefined,
+          }),
+          // Second polling cycle - re-fetch from marker-page3, now with additional events
+          createMockHistoryResponse({
+            Events: page3WithNewEvents,
+            NextMarker: undefined,
+          }),
+        ],
+        executionResponses: [
+          // First cycle: still running
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+          // Second cycle: execution completes
+          createMockExecutionResponse({ Status: ExecutionStatus.SUCCEEDED }),
+        ],
+      });
+
+      poller.startPolling();
+
+      // First polling cycle - multiple pages, execution running
+      await jest.advanceTimersByTimeAsync(100); // Start poll
+      await jest.advanceTimersByTimeAsync(100); // Page 1->2 delay
+      await jest.advanceTimersByTimeAsync(100); // Page 2->3 delay
+
+      // After first cycle: should have pages 1-2 but NOT page 3 (last page is held back)
+      const eventsAfterFirstPoll = poller.getEvents();
+      expect(eventsAfterFirstPoll).toEqual([...page1Events, ...page2Events]);
+      expect(eventsAfterFirstPoll).not.toContainEqual(
+        expect.objectContaining({ Id: "page3-event1" })
+      );
+
+      // Second polling cycle - execution completes, re-fetches the last page with new events
+      await jest.advanceTimersByTimeAsync(100); // Next poll starts
+
+      // After completion: should have early pages + the re-fetched last page with new events
+      const finalEvents = poller.getEvents();
+
+      expect(finalEvents).toEqual([
+        ...page1Events,
+        ...page2Events,
+        ...page3WithNewEvents, // Re-fetched last page now includes original + new events
+      ]);
+
+      // Verify we have both original and new events from the last page
+      expect(finalEvents).toContainEqual(
+        expect.objectContaining({ Id: "page3-event1" })
+      ); // Original
+      expect(finalEvents).toContainEqual(
+        expect.objectContaining({ Id: "page3-event2" })
+      ); // New
+      expect(finalEvents).toContainEqual(
+        expect.objectContaining({ Id: "page3-event3" })
+      ); // New
+
+      // Total: 2 from early pages + 3 from re-fetched last page = 5 events
+      expect(finalEvents).toHaveLength(5);
+    });
+
+    it("should handle single page correctly during running execution", async () => {
+      const singlePageEvents = [
+        createMockEvent({
+          Id: "single-event",
+          EventType: EventType.StepStarted,
+        }),
+      ];
+
+      const { poller } = createHistoryPoller({
+        historyResponses: [
+          createMockHistoryResponse({
+            Events: singlePageEvents,
+            NextMarker: undefined,
+          }),
+        ],
+        executionResponses: [
+          createMockExecutionResponse({ Status: ExecutionStatus.RUNNING }),
+        ],
+      });
+
+      poller.startPolling();
+      await waitForPollerCycles(1);
+
+      // With single page during running execution, no events should be stored yet
+      // (since the single page is the "last page")
+      expect(poller.getEvents()).toEqual([]);
+    });
+  });
+
+  describe("Integration scenarios", () => {
+    it("should handle complete polling lifecycle", async () => {
+      const events = [
+        createMockEvent({
+          Id: "event-1",
+          EventType: EventType.ExecutionStarted,
+        }),
+        createMockEvent({ Id: "event-2", EventType: EventType.StepStarted }),
+        createMockEvent({ Id: "event-3", EventType: EventType.StepSucceeded }),
+      ];
+
+      const { poller, testExecutionState, onOperationEventsReceived } =
+        createHistoryPoller({
+          pollInterval: 50,
+          historyResponses: [createMockHistoryResponse({ Events: events })],
+          executionResponses: [
+            createMockExecutionResponse({
+              Status: ExecutionStatus.SUCCEEDED,
+              Result: '{"completed": true}',
+            }),
+          ],
+        });
+
+      const executionPromise = testExecutionState.createExecutionPromise();
+
+      poller.startPolling();
+      await waitForPollerCycles(1, 50);
+
+      // Verify events were processed
+      expect(onOperationEventsReceived).toHaveBeenCalledWith(expect.any(Array));
+
+      // Verify execution completed
+      const result = await executionPromise;
+      expect(result.status).toBe(ExecutionStatus.SUCCEEDED);
+      expect(result.result).toBe('{"completed": true}');
+
+      // Verify events were stored
+      expect(poller.getEvents()).toEqual(events);
+    });
+
+    it("should handle restart after stop", () => {
+      const { poller } = createHistoryPoller();
+
+      poller.startPolling();
+      poller.stopPolling();
+
+      expect(() => {
+        poller.startPolling();
+      }).not.toThrow();
+    });
+
+    it("should handle multiple rapid start/stop cycles", () => {
+      const { poller } = createHistoryPoller();
+
+      for (let i = 0; i < 5; i++) {
+        poller.startPolling();
+        poller.stopPolling();
+      }
+
+      expect(() => {
+        poller.startPolling();
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/utils.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
-import { tryJsonParse } from "../utils";
+import { ExecutionStatus } from "@aws-sdk/client-lambda";
+import { tryJsonParse, isClosedExecution } from "../utils";
 
 describe("tryJsonParse", () => {
   describe("valid JSON parsing", () => {
@@ -274,5 +275,19 @@ describe("tryJsonParse", () => {
         expect(result).toBe(pattern);
       });
     });
+  });
+});
+
+describe("isClosedExecution", () => {
+  it.each([
+    [ExecutionStatus.RUNNING, false],
+    [ExecutionStatus.FAILED, true],
+    [ExecutionStatus.STOPPED, true],
+    [ExecutionStatus.SUCCEEDED, true],
+    [ExecutionStatus.TIMED_OUT, true],
+    [undefined, true],
+  ])("should return %s when status is %p", (status, expected) => {
+    const result = isClosedExecution(status);
+    expect(result).toBe(expected);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
@@ -74,21 +74,11 @@ export class OperationWithData<OperationResultValue = unknown>
     if (
       doesStatusMatch(this.checkpointOperationData?.operation.Status, status)
     ) {
-      return new OperationWithData(
-        this.waitManager,
-        this.operationIndex,
-        this.apiClient,
-        this.checkpointOperationData
-      );
+      return this;
     }
 
     await this.waitManager.waitForOperation(this, status);
-    return new OperationWithData(
-      this.waitManager,
-      this.operationIndex,
-      this.apiClient,
-      this.checkpointOperationData
-    );
+    return this;
   }
 
   getContextDetails():

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/utils.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/utils.ts
@@ -1,4 +1,5 @@
-// Intentionally casting the result for better DX
+import { ExecutionStatus } from "@aws-sdk/client-lambda";
+
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function tryJsonParse<ResultType>(
   obj: string | undefined
@@ -14,4 +15,8 @@ export function tryJsonParse<ResultType>(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     return obj as ResultType;
   }
+}
+
+export function isClosedExecution(status: ExecutionStatus | undefined): boolean {
+  return status !== ExecutionStatus.RUNNING;
 }


### PR DESCRIPTION
*Issue #, if available:*
DAR-SDK-305

*Description of changes:*

Adding support for running cloud tests with `InvocationType.Event` (async invoke).

The implementation uses a HistoryPoller class which will poll the execution history to get all events. Customers will be able to specify if they want to use async or sync executions using the `invocationType` parameter. By default, the runner will use sync executions only and `waitFor` will throw an error unless they use `InvocationType.Event`.

Additionally:
- Enabling wait-for-callback.test.ts to run on both cloud and local runners
- Adjust integration-test.js script to allow running specific tests

TODO:
- Stop the execution and polling if the test fails. Currently it will run forever if the test fails.
- Add a test that has many events (this will take time to run since it needs to generate a lot of events -> maybe run this only on push?)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
