### PR TITLE
feat(sdk): implement deterministic durable execution mode with replay functionality

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -2,7 +2,11 @@ import { Operation } from "@aws-sdk/client-lambda";
 import { randomUUID } from "crypto";
 import { ExecutionStateFactory } from "../../storage/storage-factory";
 import { TerminationManager } from "../../termination-manager/termination-manager";
-import { DurableExecutionInvocationInput, ExecutionContext } from "../../types";
+import {
+  DurableExecutionInvocationInput,
+  ExecutionContext,
+  DurableExecutionMode,
+} from "../../types";
 import { log } from "../../utils/logger/logger";
 import { getStepData as getStepDataUtil } from "../../utils/step-id-utils/step-id-utils";
 
@@ -48,6 +52,12 @@ export const initializeExecutionContext = async (
     initialExecutionEvent.ExecutionDetails?.InputPayload ?? "{}",
   );
 
+  // Determine replay mode based on operations array length
+  const durableExecutionMode =
+    operationsArray.length > 1
+      ? DurableExecutionMode.ReplayMode
+      : DurableExecutionMode.ExecutionMode;
+
   log(isVerbose, "📝", "Operations:", operationsArray);
 
   const stepData: Record<string, Operation> = operationsArray.reduce(
@@ -69,6 +79,7 @@ export const initializeExecutionContext = async (
       customerHandlerEvent,
       state,
       _stepData: stepData,
+      _durableExecutionMode: durableExecutionMode,
       terminationManager: new TerminationManager(),
       isVerbose,
       durableExecutionArn,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
@@ -1,5 +1,9 @@
 import { createDurableContext } from "../../context/durable-context/durable-context";
-import { ExecutionContext, DurableContext } from "../../types";
+import {
+  ExecutionContext,
+  DurableContext,
+  DurableExecutionMode,
+} from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import {
   OperationType,
@@ -54,6 +58,7 @@ describe("Run In Child Context Integration Tests", () => {
           ),
       },
       _stepData: {},
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
       terminationManager: mockTerminationManager,
       isVerbose: false,
       customerHandlerEvent: {},

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from "../types";
+import { ExecutionContext, DurableExecutionMode } from "../types";
 import { TerminationManager } from "../termination-manager/termination-manager";
 import { getStepData as getStepDataUtil } from "../utils/step-id-utils/step-id-utils";
 
@@ -23,6 +23,7 @@ export const createMockExecutionContext = (
       checkpoint: jest.fn(),
     },
     _stepData: {},
+    _durableExecutionMode: DurableExecutionMode.ExecutionMode,
     terminationManager: mockTerminationManager,
     isVerbose: false,
     durableExecutionArn: "test-arn",

--- a/packages/aws-durable-execution-sdk-js/src/testing/test-constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/test-constants.ts
@@ -19,6 +19,7 @@ export const TEST_CONSTANTS = {
 
   // Child context constants
   CHILD_CONTEXT_ID: "test-child-context-id",
+  CHILD_CONTEXT_STEP_ID: "test-child-context-step-id",
   CHILD_CONTEXT_NAME: "test-child-context",
   CHILD_CONTEXT_RESULT: "child-context-result",
 

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -12,6 +12,13 @@ export enum BatchItemStatus {
   STARTED = "STARTED",
 }
 
+// Define DurableExecutionMode enum
+export enum DurableExecutionMode {
+  ExecutionMode = "ExecutionMode",
+  ReplayMode = "ReplayMode",
+  ReplaySucceededContext = "ReplaySucceededContext",
+}
+
 // Import types for concurrent execution
 import type {
   ConcurrentExecutionItem,
@@ -85,6 +92,7 @@ export type DurableExecutionInvocationOutput =
 export interface DurableContext extends Context {
   _stepPrefix?: string;
   _stepCounter: number;
+  _durableExecutionMode: DurableExecutionMode;
   /**
    * Executes a function as a durable step with automatic retry and state persistence
    * @param name - Step name for tracking and debugging
@@ -204,30 +212,28 @@ export interface DurableContext extends Context {
    */
   runInChildContext<T>(fn: ChildFunc<T>, config?: ChildConfig<T>): Promise<T>;
 
-  wait: {
-    /**
-     * Pauses execution for the specified duration
-     * @param name - Step name for tracking and debugging
-     * @param millis - Duration to wait in milliseconds
-     * @example
-     * ```typescript
-     * // Wait 5 seconds before retrying
-     * await context.wait("retry-delay", 5000);
-     * ```
-     */
-    (name: string, millis: number): Promise<void>;
+  /**
+   * Pauses execution for the specified duration
+   * @param name - Step name for tracking and debugging
+   * @param millis - Duration to wait in milliseconds
+   * @example
+   * ```typescript
+   * // Wait 5 seconds before retrying
+   * await context.wait("retry-delay", 5000);
+   * ```
+   */
+  wait(name: string, millis: number): Promise<void>;
 
-    /**
-     * Pauses execution for the specified duration
-     * @param millis - Duration to wait in milliseconds
-     * @example
-     * ```typescript
-     * // Wait 30 seconds for rate limiting
-     * await context.wait(30000);
-     * ```
-     */
-    (millis: number): Promise<void>;
-  };
+  /**
+   * Pauses execution for the specified duration
+   * @param millis - Duration to wait in milliseconds
+   * @example
+   * ```typescript
+   * // Wait 30 seconds for rate limiting
+   * await context.wait(30000);
+   * ```
+   */
+  wait(millis: number): Promise<void>;
 
   /**
    * Waits for a condition to be met by periodically checking state
@@ -668,6 +674,7 @@ export interface ExecutionContext {
   customerHandlerEvent: any;
   state: ExecutionState;
   _stepData: Record<string, Operation>; // Private, use getStepData() instead
+  _durableExecutionMode: DurableExecutionMode;
   terminationManager: TerminationManager;
   isVerbose: boolean;
   durableExecutionArn: string;

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
@@ -1,5 +1,9 @@
 import { CheckpointHandler } from "./checkpoint";
-import { ExecutionContext, OperationSubType } from "../../types";
+import {
+  ExecutionContext,
+  OperationSubType,
+  DurableExecutionMode,
+} from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import {
   CheckpointDurableExecutionResponse,
@@ -34,6 +38,7 @@ describe("CheckpointHandler - StepData Update", () => {
       customerHandlerEvent: {},
       state: mockState,
       _stepData: stepData,
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
       terminationManager: new TerminationManager(),
       durableExecutionArn:
         "arn:aws:durable-execution:us-east-1:123456789012:execution/test-execution",

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -6,7 +6,11 @@ import {
 import { CheckpointFailedError } from "../../errors/checkpoint-errors/checkpoint-errors";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
-import { OperationSubType, ExecutionContext } from "../../types";
+import {
+  OperationSubType,
+  ExecutionContext,
+  DurableExecutionMode,
+} from "../../types";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
 import {
   CheckpointHandler,
@@ -47,6 +51,7 @@ describe("CheckpointHandler", () => {
       durableExecutionArn: "test-durable-execution-arn",
       state: mockState,
       _stepData: stepData,
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
       terminationManager: mockTerminationManager,
       isVerbose: false,
       customerHandlerEvent: {},
@@ -593,6 +598,7 @@ describe("deleteCheckpointHandler", () => {
       _stepData: stepData1,
       terminationManager: mockTerminationManager,
       isVerbose: false,
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
       customerHandlerEvent: {},
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData1, stepId);
@@ -611,6 +617,7 @@ describe("deleteCheckpointHandler", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData2, stepId);
       }),
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
     } satisfies ExecutionContext;
   });
 
@@ -834,6 +841,7 @@ describe("createCheckpointHandler", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData, stepId);
       }),
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
     } satisfies ExecutionContext;
   });
 


### PR DESCRIPTION
*Description of changes:*

    - Add DurableExecutionMode enum (ExecutionMode, ReplayMode, ReplaySucceededContext)
    - Implement _durableExecutionMode property for each context object
    - Add replay mode determination logic based on operations array length and step data status
    - Implement checkAndUpdateReplayMode() to transition from replay to execution mode
    - Add checkForNonResolvingPromise() to prevent non-deterministic re-execution
    - Apply replay mode checks to all step-creating methods (step, invoke, runInChildContext, etc.)
    - Return non-resolving promises in ReplaySucceededContext mode for unfinished operations
    - Refactor wait method interface from object-style to function overloads
    - Add unit test coverage including determinism edge cases

    This ensures deterministic workflow execution by preventing incomplete operations
    from being re-executed and potentially changing outcomes on retry. DurableExecutionMode also will bring used in Not do logging more than once in ctx.logger in top level or inside runInChildContext

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
