### PR TITLE
feat(sdk): add logger property to DurableContext with execution mode filtering

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/logger-example.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/logger-example.test.ts
@@ -1,0 +1,25 @@
+import { loggerExample } from "../logger-example";
+import { withDurableFunctions } from "@aws/durable-execution-sdk-js";
+import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
+
+const handler = withDurableFunctions(loggerExample);
+
+describe("logger-example test (local)", () => {
+  beforeAll(() => LocalDurableTestRunner.setupTestEnvironment());
+  afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
+
+  const runner = new LocalDurableTestRunner({
+    handlerFunction: handler,
+    skipTime: true,
+  });
+
+  beforeEach(() => {
+    runner.reset();
+  });
+
+  it("should execute successfully with logger", async () => {
+    const execution = await runner.run();
+
+    expect(execution.getResult()).toEqual("processed-child-processed");
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-example.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-example.ts
@@ -1,0 +1,70 @@
+/**
+ * Example demonstrating logger usage in DurableContext
+ *
+ * This example shows:
+ * 1. How to access the logger from DurableContext
+ * 2. How child contexts inherit the parent's logger
+ * 3. How step contexts get enriched loggers
+ * 4. Logger only logs in ExecutionMode (not during replay)
+ * 5. Context logger enrichment with execution ARN and step ID
+ *
+ * Logger Enrichment:
+ * - Top-level DurableContext: Enriched with execution_arn (no step_id)
+ * - Child context: Enriched with execution_arn, step_id="<child-id>"
+ * - Step context: Enriched with execution_arn, step_id="<step-id>", attempt
+ *
+ * Note: The DurableContext logger automatically checks the execution mode
+ * and only logs when in ExecutionMode. During replay (ReplayMode or
+ * ReplaySucceededContext), logging is suppressed to avoid duplicate logs.
+ */
+
+import { DurableContext } from "@aws/durable-execution-sdk-js";
+
+export async function loggerExample(
+  event: any,
+  context: DurableContext,
+): Promise<string> {
+  // Top-level context logger: no step_id field
+  context.logger.info("Starting workflow", { eventId: event.id });
+  // Logs: { execution_arn: "...", level: "info", message: "Starting workflow", data: { eventId: ... }, timestamp: "..." }
+
+  // Logger in steps - gets enriched with step ID and attempt number
+  const result1 = await context.step("process-data", async (stepCtx) => {
+    // Step context has an enriched logger with step ID and attempt number
+    stepCtx.logger.info("Processing data in step");
+    // Logs: { execution_arn: "...", step_id: "1", attempt: 0, level: "info", message: "Processing data in step", timestamp: "..." }
+    return "processed";
+  });
+
+  context.logger.info("Step 1 completed", { result: result1 });
+
+  // Child contexts inherit the parent's logger and have their own step ID
+  const result2 = await context.runInChildContext(
+    "child-workflow",
+    async (childCtx) => {
+      // Child context logger has step_id populated with child context ID
+      childCtx.logger.info("Running in child context");
+      // Logs: { execution_arn: "...", step_id: "2", level: "info", message: "Running in child context", timestamp: "..." }
+
+      const childResult = await childCtx.step("child-step", async (stepCtx) => {
+        // Step in child context has nested step ID
+        stepCtx.logger.info("Processing in child step");
+        // Logs: { execution_arn: "...", step_id: "2-1", attempt: 0, level: "info", message: "Processing in child step", timestamp: "..." }
+        return "child-processed";
+      });
+
+      childCtx.logger.info("Child workflow completed", {
+        result: childResult,
+      });
+
+      return childResult;
+    },
+  );
+
+  context.logger.info("Workflow completed", {
+    result1,
+    result2,
+  });
+
+  return `${result1}-${result2}`;
+}

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -197,6 +197,7 @@ describe("Durable Context", () => {
       mockCheckpointHandler,
       mockParentContext,
       expect.any(Function),
+      expect.any(Function),
     );
     expect(mockRunInChildContextHandler).toHaveBeenCalledWith(
       "test-block",

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/logger-property.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/logger-property.test.ts
@@ -1,0 +1,188 @@
+import { createDurableContext } from "./durable-context";
+import { ExecutionContext, Logger, DurableExecutionMode } from "../../types";
+import { Context } from "aws-lambda";
+
+describe("DurableContext Logger Property", () => {
+  let mockExecutionContext: ExecutionContext;
+  let mockParentContext: Context;
+  let customLogger: Logger;
+
+  beforeEach(() => {
+    customLogger = {
+      log: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockExecutionContext = {
+      _stepData: {},
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
+      durableExecutionArn: "test-arn",
+      executionContextId: "test-id",
+      customerHandlerEvent: {},
+      isVerbose: false,
+      terminationManager: {
+        terminate: jest.fn(),
+        getTerminationPromise: jest.fn().mockResolvedValue({ reason: "test" }),
+      },
+      getStepData: jest.fn(),
+      state: {
+        getStepData: jest.fn(),
+        checkpoint: jest.fn(),
+      },
+    } as any;
+
+    mockParentContext = {
+      awsRequestId: "test-request-id",
+      getRemainingTimeInMillis: () => 30000,
+    } as any;
+  });
+
+  test("DurableContext should have logger property", () => {
+    const context = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+
+    expect(context.logger).toBeDefined();
+    expect(typeof context.logger.info).toBe("function");
+    expect(typeof context.logger.error).toBe("function");
+    expect(typeof context.logger.warn).toBe("function");
+    expect(typeof context.logger.debug).toBe("function");
+  });
+
+  test("DurableContext logger should be customizable via setCustomLogger", () => {
+    const context = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+
+    // Set custom logger
+    context.setCustomLogger(customLogger);
+
+    // Verify it works by calling a method
+    context.logger.info("test message", { data: "test" });
+
+    // Logger is enriched with execution context (no step_id at top level)
+    expect(customLogger.info).toHaveBeenCalledWith(
+      "test message",
+      expect.objectContaining({
+        execution_arn: "test-arn",
+        level: "info",
+        message: "test message",
+        data: { data: "test" },
+      }),
+    );
+
+    // Verify step_id is NOT present
+    const callArgs = (customLogger.info as jest.Mock).mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty("step_id");
+  });
+
+  test("Logger property should be a live reference (getter)", () => {
+    const context = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+
+    // Call logger before setting custom logger
+    context.logger.info("message1");
+
+    // Set custom logger
+    context.setCustomLogger(customLogger);
+
+    // Call logger after setting custom logger
+    context.logger.info("message2");
+
+    // Custom logger should only be called for the second message
+    expect(customLogger.info).toHaveBeenCalledTimes(1);
+    expect(customLogger.info).toHaveBeenCalledWith(
+      "message2",
+      expect.objectContaining({
+        execution_arn: "test-arn",
+      }),
+    );
+
+    // Verify step_id is NOT present
+    const callArgs = (customLogger.info as jest.Mock).mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty("step_id");
+  });
+
+  test("Logger should only log in ExecutionMode", () => {
+    // Test in ExecutionMode
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ExecutionMode;
+    const contextExecution = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+    contextExecution.setCustomLogger(customLogger);
+
+    contextExecution.logger.info("execution mode message");
+    expect(customLogger.info).toHaveBeenCalledWith(
+      "execution mode message",
+      expect.objectContaining({
+        execution_arn: "test-arn",
+      }),
+    );
+
+    // Verify step_id is NOT present
+    const callArgs = (customLogger.info as jest.Mock).mock.calls[0][1];
+    expect(callArgs).not.toHaveProperty("step_id");
+
+    // Reset mock
+    jest.clearAllMocks();
+
+    // Test in ReplayMode - should NOT log
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ReplayMode;
+    const contextReplay = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+    contextReplay.setCustomLogger(customLogger);
+
+    contextReplay.logger.info("replay mode message");
+    expect(customLogger.info).not.toHaveBeenCalled();
+
+    // Reset mock
+    jest.clearAllMocks();
+
+    // Test in ReplaySucceededContext - should NOT log
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ReplaySucceededContext;
+    const contextReplaySucceeded = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+    );
+    contextReplaySucceeded.setCustomLogger(customLogger);
+
+    contextReplaySucceeded.logger.info("replay succeeded message");
+    expect(customLogger.info).not.toHaveBeenCalled();
+  });
+
+  test("Logger in child context should have step ID", () => {
+    // Create a child context with a step prefix
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ExecutionMode;
+    const childContext = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+      "1", // stepPrefix for child context
+    );
+    childContext.setCustomLogger(customLogger);
+
+    childContext.logger.info("child message");
+
+    // Child context logger should have step_id populated with the prefix
+    expect(customLogger.info).toHaveBeenCalledWith(
+      "child message",
+      expect.objectContaining({
+        execution_arn: "test-arn",
+        step_id: "1", // Should match the stepPrefix
+      }),
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -57,11 +57,19 @@ describe("Run In Child Context Handler", () => {
     mockCheckpoint = createMockCheckpoint();
     mockParentContext = { awsRequestId: "mock-request-id" };
     createStepId = jest.fn().mockReturnValue(TEST_CONSTANTS.CHILD_CONTEXT_ID);
+    const mockGetLogger = jest.fn().mockReturnValue({
+      log: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    });
     runInChildContextHandler = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       createStepId,
+      mockGetLogger,
     );
   });
 
@@ -492,12 +500,20 @@ describe("runInChildContext with custom serdes", () => {
     mockCheckpoint = createMockCheckpoint();
     mockParentContext = { getRemainingTimeInMillis: () => 30000 };
     mockCreateStepId = jest.fn().mockReturnValue("test-step-id");
+    const mockGetLogger = jest.fn().mockReturnValue({
+      log: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    });
 
     runInChildContext = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       mockCreateStepId,
+      mockGetLogger,
     );
   });
 
@@ -590,11 +606,19 @@ describe("Mock Integration", () => {
     mockCheckpoint = createMockCheckpoint();
     mockParentContext = { awsRequestId: "mock-request-id" };
     createStepId = jest.fn().mockReturnValue(TEST_CONSTANTS.CHILD_CONTEXT_ID);
+    const mockGetLogger = jest.fn().mockReturnValue({
+      log: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    });
     runInChildContextHandler = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       createStepId,
+      mockGetLogger,
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -4,6 +4,7 @@ import {
   ChildConfig,
   OperationSubType,
   DurableExecutionMode,
+  Logger,
 } from "../../types";
 import { Context } from "aws-lambda";
 import {
@@ -57,6 +58,7 @@ export const createRunInChildContextHandler = (
   checkpoint: ReturnType<typeof createCheckpoint>,
   parentContext: Context,
   createStepId: () => string,
+  getParentLogger: () => Logger,
 ) => {
   return async <T>(
     nameOrFn: string | undefined | ChildFunc<T>,
@@ -92,6 +94,7 @@ export const createRunInChildContextHandler = (
         name,
         fn,
         options,
+        getParentLogger,
       );
     }
 
@@ -103,6 +106,7 @@ export const createRunInChildContextHandler = (
       name,
       fn,
       options,
+      getParentLogger,
     );
   };
 };
@@ -113,7 +117,8 @@ export const handleCompletedChildContext = async <T>(
   entityId: string,
   stepName: string | undefined,
   fn: ChildFunc<T>,
-  options?: ChildConfig<T>,
+  options: ChildConfig<T> | undefined,
+  getParentLogger: () => Logger,
 ): Promise<T> => {
   const serdes = options?.serdes || defaultSerdes;
   const stepData = context.getStepData(entityId);
@@ -137,6 +142,8 @@ export const handleCompletedChildContext = async <T>(
       },
       parentContext,
       entityId,
+      undefined,
+      getParentLogger(),
     );
 
     return await OperationInterceptor.forExecution(
@@ -169,7 +176,8 @@ export const executeChildContext = async <T>(
   entityId: string,
   name: string | undefined,
   fn: ChildFunc<T>,
-  options?: ChildConfig<T>,
+  options: ChildConfig<T> | undefined,
+  getParentLogger: () => Logger,
 ): Promise<T> => {
   const serdes = options?.serdes || defaultSerdes;
 
@@ -195,6 +203,8 @@ export const executeChildContext = async <T>(
     },
     parentContext,
     entityId,
+    undefined,
+    getParentLogger(),
   );
 
   try {

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -94,6 +94,10 @@ export interface DurableContext extends Context {
   _stepCounter: number;
   _durableExecutionMode: DurableExecutionMode;
   /**
+   * Logger instance for this context, enriched with execution context information
+   */
+  logger: Logger;
+  /**
    * Executes a function as a durable step with automatic retry and state persistence
    * @param name - Step name for tracking and debugging
    * @param fn - Function to execute as a durable step

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
@@ -16,10 +16,10 @@ export const createContextLoggerFactory = (
       const entry: Record<string, unknown> = {
         timestamp: new Date().toISOString(),
         execution_arn: executionContext.durableExecutionArn,
-        step_id: stepId,
         level,
       };
 
+      if (stepId) entry.step_id = stepId;
       if (attempt !== undefined) entry.attempt = attempt;
       if (message) entry.message = message;
       if (data) entry.data = data;

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.test.ts
@@ -1,0 +1,148 @@
+import { createModeAwareLogger } from "./mode-aware-logger";
+import { ExecutionContext, Logger, DurableExecutionMode } from "../../types";
+
+describe("Mode-Aware Logger", () => {
+  let mockExecutionContext: ExecutionContext;
+  let mockEnrichedLogger: Logger;
+  let mockCreateContextLogger: jest.Mock;
+
+  beforeEach(() => {
+    mockEnrichedLogger = {
+      log: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockCreateContextLogger = jest.fn().mockReturnValue(mockEnrichedLogger);
+
+    mockExecutionContext = {
+      _stepData: {},
+      _durableExecutionMode: DurableExecutionMode.ExecutionMode,
+      durableExecutionArn: "test-arn",
+      executionContextId: "test-id",
+      customerHandlerEvent: {},
+      isVerbose: false,
+      terminationManager: {
+        terminate: jest.fn(),
+        getTerminationPromise: jest.fn().mockResolvedValue({ reason: "test" }),
+      },
+      getStepData: jest.fn(),
+      state: {
+        getStepData: jest.fn(),
+        checkpoint: jest.fn(),
+      },
+    } as any;
+  });
+
+  test("should log in ExecutionMode", () => {
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ExecutionMode;
+    const logger = createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+    );
+
+    logger.info("test message");
+
+    expect(mockEnrichedLogger.info).toHaveBeenCalledWith(
+      "test message",
+      undefined,
+    );
+  });
+
+  test("should not log in ReplayMode", () => {
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ReplayMode;
+    const logger = createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+    );
+
+    logger.info("test message");
+
+    expect(mockEnrichedLogger.info).not.toHaveBeenCalled();
+  });
+
+  test("should not log in ReplaySucceededContext", () => {
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ReplaySucceededContext;
+    const logger = createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+    );
+
+    logger.info("test message");
+
+    expect(mockEnrichedLogger.info).not.toHaveBeenCalled();
+  });
+
+  test("should pass stepPrefix to createContextLogger", () => {
+    const stepPrefix = "1-2";
+    createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+      stepPrefix,
+    );
+
+    expect(mockCreateContextLogger).toHaveBeenCalledWith(stepPrefix, undefined);
+  });
+
+  test("should pass empty string when no stepPrefix", () => {
+    createModeAwareLogger(mockExecutionContext, mockCreateContextLogger);
+
+    expect(mockCreateContextLogger).toHaveBeenCalledWith("", undefined);
+  });
+
+  test("should call all logger methods in ExecutionMode", () => {
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ExecutionMode;
+    const logger = createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+    );
+
+    logger.log("custom", "log message", { data: "test" }, new Error("test"));
+    logger.error("error message", new Error("test"), { data: "test" });
+    logger.warn("warn message", { data: "test" });
+    logger.debug("debug message", { data: "test" });
+
+    expect(mockEnrichedLogger.log).toHaveBeenCalledWith(
+      "custom",
+      "log message",
+      { data: "test" },
+      expect.any(Error),
+    );
+    expect(mockEnrichedLogger.error).toHaveBeenCalledWith(
+      "error message",
+      expect.any(Error),
+      { data: "test" },
+    );
+    expect(mockEnrichedLogger.warn).toHaveBeenCalledWith("warn message", {
+      data: "test",
+    });
+    expect(mockEnrichedLogger.debug).toHaveBeenCalledWith("debug message", {
+      data: "test",
+    });
+  });
+
+  test("should not call any logger methods in ReplayMode", () => {
+    mockExecutionContext._durableExecutionMode =
+      DurableExecutionMode.ReplayMode;
+    const logger = createModeAwareLogger(
+      mockExecutionContext,
+      mockCreateContextLogger,
+    );
+
+    logger.log("custom", "log message");
+    logger.error("error message", new Error("test"));
+    logger.warn("warn message");
+    logger.debug("debug message");
+
+    expect(mockEnrichedLogger.log).not.toHaveBeenCalled();
+    expect(mockEnrichedLogger.error).not.toHaveBeenCalled();
+    expect(mockEnrichedLogger.warn).not.toHaveBeenCalled();
+    expect(mockEnrichedLogger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.ts
@@ -1,0 +1,38 @@
+import { Logger, ExecutionContext, DurableExecutionMode } from "../../types";
+
+export const createModeAwareLogger = (
+  executionContext: ExecutionContext,
+  createContextLogger: (stepId: string, attempt?: number) => Logger,
+  stepPrefix?: string,
+): Logger => {
+  // Use context logger factory with stepPrefix as step ID (or undefined for top level)
+  const enrichedLogger = createContextLogger(stepPrefix || "", undefined);
+
+  // Only log if in ExecutionMode
+  const shouldLog = () =>
+    executionContext._durableExecutionMode ===
+    DurableExecutionMode.ExecutionMode;
+
+  return {
+    log: (
+      level: string,
+      message?: string,
+      data?: unknown,
+      error?: Error,
+    ): void => {
+      if (shouldLog()) enrichedLogger.log(level, message, data, error);
+    },
+    info: (message?: string, data?: unknown): void => {
+      if (shouldLog()) enrichedLogger.info(message, data);
+    },
+    error: (message?: string, error?: Error, data?: unknown): void => {
+      if (shouldLog()) enrichedLogger.error(message, error, data);
+    },
+    warn: (message?: string, data?: unknown): void => {
+      if (shouldLog()) enrichedLogger.warn(message, data);
+    },
+    debug: (message?: string, data?: unknown): void => {
+      if (shouldLog()) enrichedLogger.debug(message, data);
+    },
+  };
+};


### PR DESCRIPTION
*Description of changes:*
    Add logger property to DurableContext that provides enriched logging with
    execution context information and automatic execution mode filtering.

    - Add logger property to DurableContext interface with execution ARN enrichment
    - Logger includes step_id for child contexts and steps (omitted at top level)
    - Automatic filtering: only logs in ExecutionMode, suppresses in replay modes
    - Child contexts inherit parent's custom logger via getParentLogger
    - Add logger-example.ts with test in examples package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
