### PR TITLE
fix(sdk): handle flakiness with callback concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12440,7 +12440,7 @@
         "typescript-eslint": "^8.29.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/aws-durable-execution-sdk-js-examples/node_modules/@jest/console": {

--- a/packages/aws-durable-execution-sdk-js/bundle-size-history.json
+++ b/packages/aws-durable-execution-sdk-js/bundle-size-history.json
@@ -1,25 +1,5 @@
 [
   {
-    "timestamp": "2025-07-21T21:51:01.611Z",
-    "size": 1349420,
-    "gitCommit": "e9513fc546f97089ee7d5f0d8039c07cddc99c0f"
-  },
-  {
-    "timestamp": "2025-07-21T22:11:08.534Z",
-    "size": 1350280,
-    "gitCommit": "e9513fc546f97089ee7d5f0d8039c07cddc99c0f"
-  },
-  {
-    "timestamp": "2025-07-21T22:21:10.382Z",
-    "size": 1349932,
-    "gitCommit": "e9513fc546f97089ee7d5f0d8039c07cddc99c0f"
-  },
-  {
-    "timestamp": "2025-07-23T20:25:44.950Z",
-    "size": 20536,
-    "gitCommit": "bab7e2191489706d82120a3d73299f56f1b4fdf3"
-  },
-  {
     "timestamp": "2025-07-29T02:58:40.637Z",
     "size": 59973,
     "gitCommit": "174518553e1eb133ebf4793c26dfc5d0e11ed623"
@@ -248,5 +228,10 @@
     "timestamp": "2025-10-07T18:02:14.254Z",
     "size": 99063,
     "gitCommit": "f46bcfb8ad05f0862a0330e4b4ed37f77e385caf"
+  },
+  {
+    "timestamp": "2025-10-07T20:06:03.996Z",
+    "size": 98667,
+    "gitCommit": "526292dee1a9001b46b36b1c1b998a4239514977"
   }
 ]

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
@@ -4,6 +4,8 @@ import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
 import { TerminationReason } from "../../termination-manager/types";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
 import { createMockExecutionContext } from "../../testing/mock-context";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+import { createErrorObjectFromError } from "../../utils/error-object/error-object";
 
 describe("Callback Handler Promise Interface", () => {
   let mockContext: ExecutionContext;
@@ -36,7 +38,7 @@ describe("Callback Handler Promise Interface", () => {
   });
 
   describe("Promise Interface Compliance", () => {
-    it("should support instanceof Promise check", async () => {
+    it("should not support instanceof Promise check", async () => {
       const callbackHandler = createCallback(
         mockContext,
         mockCheckpoint,
@@ -46,8 +48,7 @@ describe("Callback Handler Promise Interface", () => {
 
       const [promise] = await callbackHandler<string>("test-callback");
 
-      // This should return true now
-      expect(promise instanceof Promise).toBe(true);
+      expect(promise instanceof Promise).toBe(false);
     });
 
     it("should support .catch() method and terminate when called", async () => {
@@ -72,7 +73,6 @@ describe("Callback Handler Promise Interface", () => {
           "Callback test-callback created and pending external completion",
       });
 
-      // Should return a promise
       expect(catchPromise instanceof Promise).toBe(true);
     });
 
@@ -181,9 +181,256 @@ describe("Callback Handler Promise Interface", () => {
           "Callback test-callback created and pending external completion",
       });
 
-      // Clean up the hanging promise
       asyncPromise.catch(() => {}); // Prevent unhandled promise rejection
-    }, 1000); // Set a reasonable timeout
+    }, 1000);
+  });
+
+  describe("await with completed vs pending callbacks", () => {
+    it("should resolve normally with await when callback result exists", async () => {
+      // Mock a completed callback with result
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+      const expectedResult = "callback-result";
+
+      mockContext._stepData[hashedStepId] = {
+        Status: OperationStatus.SUCCEEDED,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+          Result: expectedResult,
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      stepIdCounter = 0; // Reset to ensure we get step-1
+      const [promise] = await callbackHandler<string>("test-callback");
+
+      const asyncFunction = async (): Promise<string> => {
+        try {
+          const result = await promise; // This should resolve immediately
+          return result;
+        } catch {
+          return "error caught";
+        }
+      };
+
+      const result = await asyncFunction();
+
+      // Should resolve with the actual result, not terminate
+      expect(result).toBe(expectedResult);
+      expect(mockContext.terminationManager.terminate).not.toHaveBeenCalled();
+    });
+
+    it("should reject normally when callback failed", async () => {
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+      const errorMessage = "Callback failed";
+
+      mockContext._stepData[hashedStepId] = {
+        Status: OperationStatus.FAILED,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+          Error: createErrorObjectFromError(new Error(errorMessage)),
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      stepIdCounter = 0;
+      const [promise] = await callbackHandler<string>("test-callback");
+
+      const asyncFunction = async (): Promise<string> => {
+        try {
+          await promise;
+          return "try: success";
+        } catch (error) {
+          return `catch: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      };
+
+      const result = await asyncFunction();
+
+      expect(result).toBe(`catch: ${errorMessage}`);
+      expect(mockContext.terminationManager.terminate).not.toHaveBeenCalled();
+    });
+
+    it("should handle mixed pending and completed callbacks correctly", async () => {
+      // Setup one completed callback
+      const completedStepId = "step-1";
+      const completedHashedStepId = hashId(completedStepId);
+      mockContext._stepData[completedHashedStepId] = {
+        Status: OperationStatus.SUCCEEDED,
+        CallbackDetails: {
+          CallbackId: "callback-completed",
+          Result: "completed-result",
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      // Create completed callback (step-1)
+      stepIdCounter = 0;
+      const [completedPromise] =
+        await callbackHandler<string>("completed-callback");
+
+      // Create pending callback (step-2)
+      const [pendingPromise] =
+        await callbackHandler<string>("pending-callback");
+
+      const asyncFunction = async (): Promise<string> => {
+        try {
+          // First await should resolve immediately
+          const completedResult = await completedPromise;
+
+          // Second await should terminate (never reached)
+          const pendingResult = await pendingPromise;
+          return `${completedResult},${pendingResult}`;
+        } catch {
+          return "error";
+        }
+      };
+
+      const asyncPromise = asyncFunction();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should have terminated on the second await (pending callback)
+      expect(mockContext.terminationManager.terminate).toHaveBeenCalledWith({
+        reason: TerminationReason.CALLBACK_PENDING,
+        message:
+          "Callback pending-callback created and pending external completion",
+      });
+
+      asyncPromise.catch(() => {}); // Prevent unhandled promise rejection
+    });
+
+    it("should handle failed callback with .then() and only success handler", async () => {
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+      const errorMessage = "Callback failed";
+
+      mockContext._stepData[hashedStepId] = {
+        Status: OperationStatus.FAILED,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+          Error: createErrorObjectFromError(new Error(errorMessage)),
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      stepIdCounter = 0;
+      const [promise] = await callbackHandler<string>("test-callback");
+
+      // Call .then() with only success handler (no rejection handler)
+      const thenPromise = promise.then((result) => `Success: ${result}`);
+
+      // Should reject with CallbackError, not resolve with success message
+      await expect(thenPromise).rejects.toThrow("Callback failed");
+      expect(mockContext.terminationManager.terminate).not.toHaveBeenCalled();
+    });
+
+    it("should handle failed callback with .then() and both handlers", async () => {
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+      const errorMessage = "Callback failed";
+
+      mockContext._stepData[hashedStepId] = {
+        Status: OperationStatus.FAILED,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+          Error: createErrorObjectFromError(new Error(errorMessage)),
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      stepIdCounter = 0;
+      const [promise] = await callbackHandler<string>("test-callback");
+
+      // Call .then() with both success and rejection handlers
+      const thenPromise = promise.then(
+        (result) => `Success: ${result}`,
+        (error) => `Handled error: ${error.message}`,
+      );
+
+      // Should call rejection handler and resolve with handled error message
+      const result = await thenPromise;
+      expect(result).toBe(`Handled error: ${errorMessage}`);
+      expect(mockContext.terminationManager.terminate).not.toHaveBeenCalled();
+    });
+
+    it("should not cause unhandled promise rejections for failed callbacks", async () => {
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+      const errorMessage = "Callback failed";
+
+      mockContext._stepData[hashedStepId] = {
+        Status: OperationStatus.FAILED,
+        CallbackDetails: {
+          CallbackId: "callback-123",
+          Error: createErrorObjectFromError(new Error(errorMessage)),
+        },
+      };
+
+      const callbackHandler = createCallback(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        mockHasRunningOperations,
+      );
+
+      stepIdCounter = 0;
+      const [promise] = await callbackHandler<string>("test-callback");
+
+      // Track unhandled rejections
+      const unhandledRejections: any[] = [];
+      const testHandler = (reason: any): void => {
+        unhandledRejections.push(reason);
+      };
+
+      process.on("unhandledRejection", testHandler);
+
+      try {
+        // These operations should not cause unhandled rejections
+        promise.then(() => {}).catch(() => {}); // Handled
+        promise.catch(() => {}); // Handled
+        promise.finally(() => {}).catch(() => {}); // Handled
+
+        // Wait a bit to see if any unhandled rejections occur
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Should not have any unhandled rejections
+        expect(unhandledRejections).toHaveLength(0);
+      } finally {
+        // Clean up the test handler
+        process.removeListener("unhandledRejection", testHandler);
+      }
+    });
   });
 
   describe("Started Callback Promise Interface", () => {
@@ -199,7 +446,7 @@ describe("Callback Handler Promise Interface", () => {
       };
     });
 
-    it("should support instanceof Promise for started callbacks", async () => {
+    it("should not support instanceof Promise for started callbacks", async () => {
       const callbackHandler = createCallback(
         mockContext,
         mockCheckpoint,
@@ -211,7 +458,8 @@ describe("Callback Handler Promise Interface", () => {
       stepIdCounter = 0;
       const [promise] = await callbackHandler<string>("test-callback");
 
-      expect(promise instanceof Promise).toBe(true);
+      expect(promise instanceof Promise).toBe(false);
+      expect(String(promise)).toBe("[object TerminatingPromise]");
     });
 
     it("should support .catch() for started callbacks", async () => {


### PR DESCRIPTION
*Issue #, if available:*
DAR-SDK-319

*Description of changes:*

The tests were failing due to callback concurrency not working properly in some cases. The history was:
1. Callback created
2. Callback succeeded (no re-invocation)
3. Step succeeded
4. Callback not checked again properly, invocation terminates but execution not completed.

I've updated some tests to have longer delays so that it will fail every time if it breaks.

The TerminatingPromise class had issues where it was not resolving properly. I updated the class to no longer extend from Promise, and just implement it. This means `instanceof Promise` will no longer be true, but it fixes the logic. All the methods and promise logic should work now as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
