### PR TITLE
fix(testing-sdk): stop throwing error for missing Id field in InvocationCompleted event

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/process-history-events.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/process-history-events.test.ts
@@ -26,7 +26,7 @@ describe("historyEventsToOperationEvents", () => {
 
     expect(() => {
       historyEventsToOperationEvents(events);
-    }).toThrow("Missing required fields in event");
+    }).toThrow("Missing required 'EventType' field in event");
   });
 
   it("should throw error when Id is missing", () => {
@@ -39,7 +39,18 @@ describe("historyEventsToOperationEvents", () => {
 
     expect(() => {
       historyEventsToOperationEvents(events);
-    }).toThrow("Missing required fields in event");
+    }).toThrow("Missing required 'Id' field in event");
+  });
+
+  it("should not throw error when Id is missing for InvocationCompleted event", () => {
+    const events: Event[] = [
+      {
+        EventType: EventType.InvocationCompleted,
+        EventTimestamp: new Date("2023-01-01T12:00:00Z"),
+      },
+    ];
+
+    expect(historyEventsToOperationEvents(events)).toEqual([]);
   });
 
   it("should skip EXECUTION operation types", () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Integration tests are failing since the `Id` field is expected but not found in the new `InvocationCompleted` event. This event isn't associated with an operation so it won't have this field. For now I'm skipping this event, but will be processing it later.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
