### PR TITLE
feat(sdk): restore BatchResult methods after deserialization

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
@@ -1,20 +1,29 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
+export const handler = withDurableFunctions(
+  async (event: any, context: DurableContext) => {
     const items = [1, 2, 3, 4, 5];
-    
+
     const results = await context.map(
-        "map",
-        items,
-        async (context: DurableContext, item: number, index: number) => {
-            return await context.step(async () => {
-                return item * 2;
-            });
-        },
-        {
-            maxConcurrency: 2
-        }
+      "map",
+      items,
+      async (context: DurableContext, item: number, index: number) => {
+        return await context.step(async () => {
+          return item * 2;
+        });
+      },
+      {
+        maxConcurrency: 2,
+      },
     );
-    
+
+    // context.wait() terminates the current execution and restarts it later,
+    // ensuring getResults() functions correctly during workflow replay
+    await context.wait(1000);
+
     return results.getResults();
-});
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -1,6 +1,11 @@
 import { ExecutionContext, DurableContext, BatchItemStatus } from "../../types";
 import { log } from "../../utils/logger/logger";
-import { BatchResult, BatchItem, BatchResultImpl } from "./batch-result";
+import {
+  BatchResult,
+  BatchItem,
+  BatchResultImpl,
+  restoreBatchResult,
+} from "./batch-result";
 
 /**
  * Represents an item to be executed with metadata for deterministic replay
@@ -306,6 +311,12 @@ export const createConcurrentExecutionHandler = (
     return await runInChildContext(name, executeOperation, {
       subType: config?.topLevelSubType,
       summaryGenerator: config?.summaryGenerator,
+    }).then((result) => {
+      // Restore BatchResult methods if the result came from deserialized data
+      if (result && typeof result === "object" && Array.isArray(result.all)) {
+        return restoreBatchResult(result);
+      }
+      return result;
     });
   };
 };


### PR DESCRIPTION
*Description of changes:*

Fix issue where BatchResult objects lose their methods (getResults, getErrors, etc.)
when restored from checkpointed data. The concurrent execution handler now automatically
detects and restores BatchResult methods using the existing restoreBatchResult function.

This ensures that operations like context.map() work correctly even when followed by
checkpoint-triggering operations like context.wait().

- Add automatic BatchResult method restoration in concurrent execution handler
- Add regression test to prevent future removal of restoration logic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
