### PR TITLE
fix(testing-sdk): add execution events to local runner history

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/steps-with-retry.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/steps-with-retry.test.ts
@@ -109,7 +109,7 @@ describe("steps-with-retry", () => {
       errorMessage: "Persistent failure",
       errorType: "Error",
       stackTrace: expect.any(Array),
-    }
+    };
 
     const result = await durableTestRunner.run();
     const error = result.getError();
@@ -119,7 +119,7 @@ describe("steps-with-retry", () => {
     // Verify that step operations were attempted
     const stepOp = durableTestRunner.getOperationByIndex(0);
     expect(stepOp.getStepDetails()?.result).toBeUndefined();
-    expect(stepOp.getStepDetails()?.error).toEqual(expectedErrorObject)
+    expect(stepOp.getStepDetails()?.error).toEqual(expectedErrorObject);
   });
 
   it("should fail when item is not found after maximum polls", async () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-details.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-details.ts
@@ -1,0 +1,31 @@
+import { EventType, OperationStatus, Event } from "@aws-sdk/client-lambda";
+import { OperationHistoryEventDetails } from "./types";
+
+export const executionDetails = {
+  [OperationStatus.STOPPED]: {
+    eventType: EventType.ExecutionStopped,
+    detailPlace: "ExecutionStoppedDetails",
+  },
+  [OperationStatus.FAILED]: {
+    eventType: EventType.ExecutionFailed,
+    detailPlace: "ExecutionFailedDetails",
+  },
+  [OperationStatus.STARTED]: {
+    eventType: EventType.ExecutionStarted,
+    detailPlace: "ExecutionStartedDetails",
+  },
+  [OperationStatus.SUCCEEDED]: {
+    eventType: EventType.ExecutionSucceeded,
+    detailPlace: "ExecutionSucceededDetails",
+  },
+  [OperationStatus.TIMED_OUT]: {
+    eventType: EventType.ExecutionTimedOut,
+    detailPlace: "ExecutionTimedOutDetails",
+  },
+  [OperationStatus.READY]: undefined,
+  [OperationStatus.CANCELLED]: undefined,
+  [OperationStatus.PENDING]: undefined,
+} satisfies Record<
+  OperationStatus,
+  OperationHistoryEventDetails<keyof Event> | undefined
+>;

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-manager.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { CheckpointManager } from "./checkpoint-manager";
-import { Operation } from "@aws-sdk/client-lambda";
 import {
   encodeCheckpointToken,
   decodeCheckpointToken,
@@ -13,12 +12,13 @@ import {
   createInvocationId,
 } from "../utils/tagged-strings";
 import { decodeCallbackId } from "../utils/callback-id";
+import { OperationEvents } from "../../test-runner/common/operations/operation-with-data";
 
 export interface InvocationResult {
   checkpointToken: CheckpointToken;
   executionId: ExecutionId;
   invocationId: InvocationId;
-  operations: Operation[];
+  operationEvents: OperationEvents[];
 }
 
 export interface StartExecutionParams {
@@ -57,7 +57,7 @@ export class ExecutionManager {
       checkpointToken,
       executionId,
       invocationId,
-      operations: [initialOperation],
+      operationEvents: [initialOperation],
     };
   }
 
@@ -84,9 +84,7 @@ export class ExecutionManager {
       checkpointToken,
       executionId,
       invocationId,
-      operations: Array.from(checkpointStorage.operationDataMap.values()).map(
-        (operationData) => operationData.operation
-      ),
+      operationEvents: Array.from(checkpointStorage.operationDataMap.values()),
     };
   }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/history-poller.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/history-poller.ts
@@ -11,7 +11,7 @@ import { TestExecutionState } from "../common/test-execution-state";
 import { isClosedExecution } from "../common/utils";
 
 export type ReceivedOperationEventsCallback = (
-  operationEvents: OperationEvents[]
+  operationEvents: OperationEvents[],
 ) => void;
 
 export interface HistoryPollerParams {
@@ -26,10 +26,10 @@ export interface HistoryPollerParams {
 
 export interface HistoryApiClient {
   getHistory: (
-    request: GetDurableExecutionHistoryRequest
+    request: GetDurableExecutionHistoryRequest,
   ) => Promise<GetDurableExecutionHistoryCommandOutput>;
   getExecution: (
-    request: GetDurableExecutionRequest
+    request: GetDurableExecutionRequest,
   ) => Promise<GetDurableExecutionCommandOutput>;
 }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/__tests__/history-poller.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/__tests__/history-poller.test.ts
@@ -54,7 +54,7 @@ function createMockEvent(overrides: Partial<Event> = {}): Event {
 }
 
 function createMockHistoryResponse(
-  overrides: Partial<GetDurableExecutionHistoryCommandOutput> = {}
+  overrides: Partial<GetDurableExecutionHistoryCommandOutput> = {},
 ): GetDurableExecutionHistoryCommandOutput {
   return {
     Events: [createMockEvent()],
@@ -64,7 +64,7 @@ function createMockHistoryResponse(
 }
 
 function createMockExecutionResponse(
-  overrides: Partial<GetDurableExecutionCommandOutput> = {}
+  overrides: Partial<GetDurableExecutionCommandOutput> = {},
 ): GetDurableExecutionCommandOutput {
   const defaultResponse: GetDurableExecutionCommandOutput = {
     Status: ExecutionStatus.SUCCEEDED,
@@ -142,7 +142,7 @@ function createHistoryPoller(options: CreateHistoryPollerOptions = {}): {
 
 async function waitForPollerCycles(
   cycles: number,
-  pollInterval = 100
+  pollInterval = 100,
 ): Promise<void> {
   for (let i = 0; i < cycles; i++) {
     await jest.advanceTimersByTimeAsync(pollInterval);
@@ -208,7 +208,7 @@ describe("HistoryPoller", () => {
       await jest.advanceTimersByTimeAsync(200);
 
       expect(mockApiClient.getHistory).toHaveBeenCalledTimes(
-        initialHistoryCalls
+        initialHistoryCalls,
       );
     });
 
@@ -456,7 +456,7 @@ describe("HistoryPoller", () => {
       await waitForPollerCycles(2);
 
       expect(mockApiClient.getHistory).toHaveBeenCalledTimes(
-        callsAfterCompletion
+        callsAfterCompletion,
       );
     });
 
@@ -575,13 +575,13 @@ describe("HistoryPoller", () => {
         1,
         expect.objectContaining({
           Marker: undefined,
-        })
+        }),
       );
       expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
           Marker: "test-marker",
-        })
+        }),
       );
     });
   });
@@ -620,14 +620,14 @@ describe("HistoryPoller", () => {
             createMockHistoryResponse({
               Events: [createMockEvent({ Id: "event-1" })],
               NextMarker: "persistent-marker", // This should persist to next polling cycle
-            })
+            }),
           );
         } else {
           return Promise.resolve(
             createMockHistoryResponse({
               Events: [createMockEvent({ Id: "event-2" })],
               NextMarker: undefined,
-            })
+            }),
           );
         }
       });
@@ -645,13 +645,13 @@ describe("HistoryPoller", () => {
       // First call starts with no marker
       expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ Marker: undefined })
+        expect.objectContaining({ Marker: undefined }),
       );
 
       // Second call should use the marker from first polling cycle
       expect(mockApiClient.getHistory).toHaveBeenNthCalledWith(
         2,
-        expect.objectContaining({ Marker: "persistent-marker" })
+        expect.objectContaining({ Marker: "persistent-marker" }),
       );
     });
 
@@ -778,7 +778,7 @@ describe("HistoryPoller", () => {
       const eventsAfterFirstPoll = poller.getEvents();
       expect(eventsAfterFirstPoll).toEqual([...page1Events, ...page2Events]);
       expect(eventsAfterFirstPoll).not.toContain(
-        expect.objectContaining({ Id: "page3-event1" })
+        expect.objectContaining({ Id: "page3-event1" }),
       );
     });
 
@@ -855,7 +855,7 @@ describe("HistoryPoller", () => {
       const eventsAfterFirstPoll = poller.getEvents();
       expect(eventsAfterFirstPoll).toEqual([...page1Events, ...page2Events]);
       expect(eventsAfterFirstPoll).not.toContainEqual(
-        expect.objectContaining({ Id: "page3-event1" })
+        expect.objectContaining({ Id: "page3-event1" }),
       );
 
       // Second polling cycle - execution completes, re-fetches the last page with new events
@@ -872,13 +872,13 @@ describe("HistoryPoller", () => {
 
       // Verify we have both original and new events from the last page
       expect(finalEvents).toContainEqual(
-        expect.objectContaining({ Id: "page3-event1" })
+        expect.objectContaining({ Id: "page3-event1" }),
       ); // Original
       expect(finalEvents).toContainEqual(
-        expect.objectContaining({ Id: "page3-event2" })
+        expect.objectContaining({ Id: "page3-event2" }),
       ); // New
       expect(finalEvents).toContainEqual(
-        expect.objectContaining({ Id: "page3-event3" })
+        expect.objectContaining({ Id: "page3-event3" }),
       ); // New
 
       // Total: 2 from early pages + 3 from re-fetched last page = 5 events

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-factory.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-factory.test.ts
@@ -1,6 +1,14 @@
-import { Event, OperationType, OperationStatus, Operation } from "@aws-sdk/client-lambda";
+import {
+  Event,
+  OperationType,
+  OperationStatus,
+  Operation,
+} from "@aws-sdk/client-lambda";
 import { OperationEvents } from "../../../../common/operations/operation-with-data";
-import { createOperation, populateOperationDetails } from "../operation-factory";
+import {
+  createOperation,
+  populateOperationDetails,
+} from "../operation-factory";
 import { HistoryEventType } from "../history-event-types";
 import { historyEventTypes } from "../history-event-types";
 
@@ -24,7 +32,11 @@ describe("createOperation", () => {
   };
 
   it("should create operation with basic properties from event", () => {
-    const operation = createOperation(undefined, mockEvent, mockHistoryEventType);
+    const operation = createOperation(
+      undefined,
+      mockEvent,
+      mockHistoryEventType,
+    );
 
     expect(operation).toEqual({
       Id: "test-id",
@@ -62,7 +74,11 @@ describe("createOperation", () => {
       isEndEvent: true,
     };
 
-    const operation = createOperation(previousOperationEvents, mockEvent, endEventType);
+    const operation = createOperation(
+      previousOperationEvents,
+      mockEvent,
+      endEventType,
+    );
 
     expect(operation).toEqual({
       Id: "test-id",
@@ -156,7 +172,11 @@ describe("createOperation", () => {
       isEndEvent: true,
     };
 
-    const operation = createOperation(previousOperationEvents, mockEvent, nonStartEventType);
+    const operation = createOperation(
+      previousOperationEvents,
+      mockEvent,
+      nonStartEventType,
+    );
 
     expect(operation.StepDetails).toEqual({ Attempt: 1 });
     expect(operation.StartTimestamp).toEqual(new Date("2023-01-01T11:00:00Z"));
@@ -183,7 +203,11 @@ describe("createOperation", () => {
       isEndEvent: true,
     };
 
-    const operation = createOperation(previousOperationEvents, mockEvent, failedEventType);
+    const operation = createOperation(
+      previousOperationEvents,
+      mockEvent,
+      failedEventType,
+    );
 
     expect(operation.Status).toBe(OperationStatus.FAILED);
   });
@@ -204,7 +228,11 @@ describe("populateOperationDetails", () => {
     const operation: Operation = { Id: "test-id" };
 
     expect(() => {
-      populateOperationDetails(eventWithoutTimestamp, historyEventType, operation);
+      populateOperationDetails(
+        eventWithoutTimestamp,
+        historyEventType,
+        operation,
+      );
     }).toThrow("Missing required fields in event");
   });
 
@@ -315,13 +343,13 @@ describe("populateOperationDetails", () => {
     });
   });
 
-  it("should throw error for EXECUTION operation type", () => {
+  it("should populate EXECUTION operation type", () => {
     const historyEventType = historyEventTypes.ExecutionStarted;
     const operation: Operation = { Id: "test-id" };
 
-    expect(() => {
-      populateOperationDetails(baseEvent, historyEventType, operation);
-    }).toThrow("Cannot populate EXECUTION event");
+    populateOperationDetails(baseEvent, historyEventType, operation);
+
+    expect(operation.ExecutionDetails).toBeUndefined();
   });
 
   it("should handle events with both result and error", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/operation-factory.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/operation-factory.ts
@@ -3,7 +3,10 @@ import { OperationEvents } from "../../../common/operations/operation-with-data"
 import { HistoryEventType } from "./history-event-types";
 import { HistoryEventTypes } from "./operation-types";
 import { addOperationDetails } from "./operation-details";
-import { getErrorFromEvent, getPayloadFromEvent } from "./event-data-extractors";
+import {
+  getErrorFromEvent,
+  getPayloadFromEvent,
+} from "./event-data-extractors";
 
 /**
  * Creates an Operation object from an event and its history event type configuration.
@@ -18,7 +21,7 @@ import { getErrorFromEvent, getPayloadFromEvent } from "./event-data-extractors"
 export function createOperation(
   previousOperationEvents: OperationEvents | undefined,
   event: Event,
-  historyEventType: HistoryEventType
+  historyEventType: HistoryEventType,
 ): Operation {
   const operation: Operation = {
     // Most fields are immutable, so they should get overwritten by previous events.
@@ -64,7 +67,7 @@ export function createOperation(
 export function populateOperationDetails(
   event: Event,
   historyEventType: HistoryEventTypes,
-  operation: Operation
+  operation: Operation,
 ) {
   if (!event.EventTimestamp) {
     throw new Error("Missing required fields in event");
@@ -95,7 +98,7 @@ export function populateOperationDetails(
             ? new Date(
                 event.EventTimestamp.getTime() +
                   event.StepFailedDetails.RetryDetails.NextAttemptDelaySeconds *
-                    1000
+                    1000,
               )
             : undefined,
       });
@@ -106,7 +109,10 @@ export function populateOperationDetails(
       });
       break;
     case "EXECUTION":
-      throw new Error("Cannot populate EXECUTION event");
+      addOperationDetails(operation, historyEventType.operationDetailPlace, {
+        InputPayload: event.ExecutionStartedDetails?.Input?.Payload,
+      });
+      break;
     default:
       break;
   }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/process-history-events.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/process-history-events.ts
@@ -1,4 +1,4 @@
-import { Event, EventType, OperationType } from "@aws-sdk/client-lambda";
+import { Event, EventType } from "@aws-sdk/client-lambda";
 import { OperationEvents } from "../../../common/operations/operation-with-data";
 import { historyEventTypes } from "./history-event-types";
 import { createOperation, populateOperationDetails } from "./operation-factory";
@@ -35,11 +35,6 @@ export function historyEventsToOperationEvents(
     }
 
     const historyEventType = historyEventTypes[event.EventType];
-
-    if (historyEventType.operationType === OperationType.EXECUTION) {
-      // Skip populating the EXECUTION operation type
-      continue;
-    }
 
     if (!event[historyEventType.detailPlace]) {
       throw new Error(`Details missing for event "${event.Id}"`);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
@@ -1,4 +1,4 @@
-import { OperationStatus } from "@aws-sdk/client-lambda";
+import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
 import { IndexedOperations } from "../indexed-operations";
 
 describe("IndexedOperations", () => {
@@ -83,7 +83,7 @@ describe("IndexedOperations", () => {
       // Verify initial state
       expect(indexed.getOperations()).toHaveLength(1);
       expect(indexed.getById("op1")?.operation.Status).toBe(
-        OperationStatus.STARTED
+        OperationStatus.STARTED,
       );
 
       // Add operation with same ID but different properties
@@ -110,7 +110,7 @@ describe("IndexedOperations", () => {
       // Should also be accessible by index and return the updated operation
       const retrievedByIndex = indexed.getByIndex(0);
       expect(retrievedByIndex?.operation.Status).toBe(
-        OperationStatus.SUCCEEDED
+        OperationStatus.SUCCEEDED,
       );
       expect(retrievedByIndex?.operation.Name).toBe("operation1-updated");
     });
@@ -178,7 +178,7 @@ describe("IndexedOperations", () => {
       // Verify it can be found by original name
       expect(indexed.getByNameAndIndex("original-name", 0)).toBeDefined();
       expect(indexed.getByNameAndIndex("original-name", 0)?.operation.Id).toBe(
-        "op1"
+        "op1",
       );
 
       // Add operation with same ID but different name
@@ -195,16 +195,16 @@ describe("IndexedOperations", () => {
       // Should be accessible by new name
       expect(indexed.getByNameAndIndex("updated-name", 0)).toBeDefined();
       expect(indexed.getByNameAndIndex("updated-name", 0)?.operation.Id).toBe(
-        "op1"
+        "op1",
       );
       expect(
-        indexed.getByNameAndIndex("updated-name", 0)?.operation.Status
+        indexed.getByNameAndIndex("updated-name", 0)?.operation.Status,
       ).toBe(OperationStatus.SUCCEEDED);
 
       // Should still be accessible by original name (since the name index contains both entries)
       expect(indexed.getByNameAndIndex("original-name", 0)).toBeDefined();
       expect(indexed.getByNameAndIndex("original-name", 0)?.operation.Id).toBe(
-        "op1"
+        "op1",
       );
     });
 
@@ -239,10 +239,10 @@ describe("IndexedOperations", () => {
 
       // Verify each operation can be found
       expect(
-        allOperations.find((op) => op.operation.Id === "op1")
+        allOperations.find((op) => op.operation.Id === "op1"),
       ).toBeDefined();
       expect(
-        allOperations.find((op) => op.operation.Id === "op2")
+        allOperations.find((op) => op.operation.Id === "op2"),
       ).toBeDefined();
 
       // Add an operation with same ID as existing one
@@ -262,7 +262,7 @@ describe("IndexedOperations", () => {
       expect(updatedOperations).toHaveLength(2);
 
       const foundOp1 = updatedOperations.find(
-        (op) => op.operation.Id === "op1"
+        (op) => op.operation.Id === "op1",
       );
       expect(foundOp1?.operation.Name).toBe("operation1-updated");
       expect(foundOp1?.operation.Status).toBe(OperationStatus.SUCCEEDED);
@@ -334,6 +334,277 @@ describe("IndexedOperations", () => {
       const historyEvents = indexed.getHistoryEvents();
 
       expect(historyEvents).toHaveLength(0);
+    });
+
+    describe("previousHistoryIndex filtering", () => {
+      it("should add all events when adding new operations", () => {
+        const indexed = new IndexedOperations([]);
+
+        const operations = [
+          {
+            operation: {
+              Id: "op1",
+              Name: "operation1",
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 1 }, { EventId: 2 }],
+          },
+          {
+            operation: {
+              Id: "op2",
+              Name: "operation2",
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [{ EventId: 3 }, { EventId: 4 }],
+          },
+        ];
+
+        indexed.addOperations(operations);
+        const historyEvents = indexed.getHistoryEvents();
+
+        expect(historyEvents).toHaveLength(4);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3, 4]);
+      });
+
+      it("should only add new events when updating existing operations with additional events", () => {
+        const indexed = new IndexedOperations([]);
+
+        // Add initial operation with 2 events
+        const initialOperation = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.STARTED,
+          },
+          events: [{ EventId: 1 }, { EventId: 2 }],
+        };
+
+        indexed.addOperations([initialOperation]);
+        let historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(2);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2]);
+
+        // Update same operation with 2 additional events (4 total)
+        const updatedOperation = {
+          operation: {
+            Id: "op1", // Same ID
+            Name: "operation1",
+            Status: OperationStatus.SUCCEEDED,
+          },
+          events: [
+            { EventId: 1 }, // Existing
+            { EventId: 2 }, // Existing
+            { EventId: 3 }, // New
+            { EventId: 4 }, // New
+          ],
+        };
+
+        indexed.addOperations([updatedOperation]);
+        historyEvents = indexed.getHistoryEvents();
+
+        // Should now have 4 events total (original 2 + new 2)
+        expect(historyEvents).toHaveLength(4);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3, 4]);
+      });
+
+      it("should not add duplicate events when updating operation with same events", () => {
+        const indexed = new IndexedOperations([]);
+
+        const operation = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.STARTED,
+          },
+          events: [{ EventId: 1 }, { EventId: 2 }],
+        };
+
+        // Add operation twice
+        indexed.addOperations([operation]);
+        indexed.addOperations([operation]);
+
+        const historyEvents = indexed.getHistoryEvents();
+
+        // Should only have 2 events, not 4
+        expect(historyEvents).toHaveLength(2);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2]);
+      });
+
+      it("should handle operations with no events", () => {
+        const indexed = new IndexedOperations([]);
+
+        const operationWithoutEvents = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.STARTED,
+          },
+          events: [],
+        };
+
+        indexed.addOperations([operationWithoutEvents]);
+        let historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(0);
+
+        // Update with events
+        const operationWithEvents = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.SUCCEEDED,
+          },
+          events: [{ EventId: 1 }],
+        };
+
+        indexed.addOperations([operationWithEvents]);
+        historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(1);
+        expect(historyEvents[0].EventId).toBe(1);
+      });
+
+      it("should handle multiple operations being updated with different event counts", () => {
+        const indexed = new IndexedOperations([]);
+
+        // Initial operations
+        const initialOperations = [
+          {
+            operation: {
+              Id: "op1",
+              Name: "operation1",
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 1 }],
+          },
+          {
+            operation: {
+              Id: "op2",
+              Name: "operation2",
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 2 }, { EventId: 3 }],
+          },
+        ];
+
+        indexed.addOperations(initialOperations);
+        let historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(3);
+
+        // Update both operations with additional events
+        const updatedOperations = [
+          {
+            operation: {
+              Id: "op1",
+              Name: "operation1",
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [
+              { EventId: 1 }, // Existing
+              { EventId: 4 }, // New
+            ],
+          },
+          {
+            operation: {
+              Id: "op2",
+              Name: "operation2",
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [
+              { EventId: 2 }, // Existing
+              { EventId: 3 }, // Existing
+              { EventId: 5 }, // New
+              { EventId: 6 }, // New
+            ],
+          },
+        ];
+
+        indexed.addOperations(updatedOperations);
+        historyEvents = indexed.getHistoryEvents();
+
+        // Should have original 3 + 1 new from op1 + 2 new from op2 = 6 total
+        expect(historyEvents).toHaveLength(6);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3, 4, 5, 6]);
+      });
+
+      it("should preserve event order when adding operations sequentially", () => {
+        const indexed = new IndexedOperations([]);
+
+        // Add first operation
+        indexed.addOperations([
+          {
+            operation: {
+              Id: "op1",
+              Name: "operation1",
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 1 }],
+          },
+        ]);
+
+        // Add second operation
+        indexed.addOperations([
+          {
+            operation: {
+              Id: "op2",
+              Name: "operation2",
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 2 }],
+          },
+        ]);
+
+        // Update first operation
+        indexed.addOperations([
+          {
+            operation: {
+              Id: "op1",
+              Name: "operation1",
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [{ EventId: 1 }, { EventId: 3 }],
+          },
+        ]);
+
+        const historyEvents = indexed.getHistoryEvents();
+
+        // Events should be in the order they were added to history
+        expect(historyEvents).toHaveLength(3);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3]);
+      });
+
+      it("should handle edge case where new operation has fewer events than existing", () => {
+        const indexed = new IndexedOperations([]);
+
+        // Add operation with multiple events
+        const operationWithManyEvents = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.STARTED,
+          },
+          events: [{ EventId: 1 }, { EventId: 2 }, { EventId: 3 }],
+        };
+
+        indexed.addOperations([operationWithManyEvents]);
+        let historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(3);
+
+        // Update with fewer events (this shouldn't normally happen in practice, but testing edge case)
+        const operationWithFewerEvents = {
+          operation: {
+            Id: "op1",
+            Name: "operation1",
+            Status: OperationStatus.FAILED,
+          },
+          events: [{ EventId: 1 }, { EventId: 2 }],
+        };
+
+        indexed.addOperations([operationWithFewerEvents]);
+        historyEvents = indexed.getHistoryEvents();
+
+        // Should still have original 3 events (no new events added since slice(3) of 2-element array is empty)
+        expect(historyEvents).toHaveLength(3);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3]);
+      });
     });
   });
 
@@ -558,7 +829,7 @@ describe("IndexedOperations", () => {
           },
         ]);
       }).toThrow(
-        "Cannot change ParentId of operation child1 from parent1 to new-parent"
+        "Cannot change ParentId of operation child1 from parent1 to new-parent",
       );
 
       // parent1 should still have both children (no change)
@@ -602,6 +873,302 @@ describe("IndexedOperations", () => {
       const children = indexed.getOperationChildren("");
       expect(children).toHaveLength(1);
       expect(children[0].operation.Id).toBe("child");
+    });
+  });
+
+  describe("executionOperation handling", () => {
+    describe("should exclude execution operations from main indexes", () => {
+      const executionOperation = {
+        operation: {
+          Id: "execution-1",
+          Name: "my-execution",
+          Type: OperationType.EXECUTION,
+          Status: OperationStatus.STARTED,
+        },
+        events: [
+          {
+            EventId: 100,
+          },
+        ],
+      };
+
+      const regularOperation = {
+        operation: {
+          Id: "step-1",
+          Name: "my-step",
+          Type: OperationType.STEP,
+          Status: OperationStatus.SUCCEEDED,
+        },
+        events: [
+          {
+            EventId: 101,
+          },
+        ],
+      };
+
+      it("should not include execution operations in getOperations()", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        const operations = indexed.getOperations();
+
+        // Should only contain the regular operation, not the execution operation
+        expect(operations).toHaveLength(1);
+        expect(operations[0].operation.Id).toBe("step-1");
+        expect(operations[0].operation.Type).toBe(OperationType.STEP);
+      });
+
+      it("should not find execution operations with getById()", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        // Regular operation should be found
+        expect(indexed.getById("step-1")).toBeDefined();
+        expect(indexed.getById("step-1")?.operation.Type).toBe(
+          OperationType.STEP,
+        );
+
+        // Execution operation should NOT be found via getById
+        expect(indexed.getById("execution-1")).toBeUndefined();
+      });
+
+      it("should not find execution operations with getByIndex()", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        // Should only have one operation accessible by index (the regular operation)
+        expect(indexed.getByIndex(0)).toBeDefined();
+        expect(indexed.getByIndex(0)?.operation.Id).toBe("step-1");
+        expect(indexed.getByIndex(0)?.operation.Type).toBe(OperationType.STEP);
+
+        // Second index should be undefined since execution operation is excluded
+        expect(indexed.getByIndex(1)).toBeUndefined();
+      });
+
+      it("should not find execution operations with getByNameAndIndex()", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        // Regular operation should be found by name
+        expect(indexed.getByNameAndIndex("my-step")).toBeDefined();
+        expect(indexed.getByNameAndIndex("my-step")?.operation.Id).toBe(
+          "step-1",
+        );
+
+        // Execution operation should NOT be found by name
+        expect(indexed.getByNameAndIndex("my-execution")).toBeUndefined();
+      });
+
+      it("should still include execution operation events in history", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        const historyEvents = indexed.getHistoryEvents();
+
+        // Should include events from both operations
+        expect(historyEvents).toHaveLength(2);
+        expect(historyEvents.map((e) => e.EventId)).toContain(100);
+        expect(historyEvents.map((e) => e.EventId)).toContain(101);
+      });
+
+      it("should handle multiple execution operations by keeping the last one", () => {
+        const firstExecution = {
+          operation: {
+            Id: "execution-1",
+            Name: "first-execution",
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          },
+          events: [{ EventId: 100 }],
+        };
+
+        const secondExecution = {
+          operation: {
+            Id: "execution-2",
+            Name: "second-execution",
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.SUCCEEDED,
+          },
+          events: [{ EventId: 200 }],
+        };
+
+        const indexed = new IndexedOperations([
+          firstExecution,
+          regularOperation,
+          secondExecution,
+        ]);
+
+        // Should still only have one regular operation
+        expect(indexed.getOperations()).toHaveLength(1);
+        expect(indexed.getOperations()[0].operation.Id).toBe("step-1");
+
+        // Should have events from all operations including both executions
+        const historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(3);
+        expect(historyEvents.map((e) => e.EventId)).toContain(100);
+        expect(historyEvents.map((e) => e.EventId)).toContain(101);
+        expect(historyEvents.map((e) => e.EventId)).toContain(200);
+      });
+
+      it("should handle updating execution operation with same ID", () => {
+        const indexed = new IndexedOperations([
+          executionOperation,
+          regularOperation,
+        ]);
+
+        // Add updated execution with same ID but additional events
+        const updatedExecution = {
+          operation: {
+            Id: "execution-1", // Same ID
+            Name: "my-execution-updated",
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.SUCCEEDED,
+          },
+          events: [
+            { EventId: 100 }, // Existing
+            { EventId: 102 }, // New
+          ],
+        };
+
+        indexed.addOperations([updatedExecution]);
+
+        // Should still only have one regular operation
+        expect(indexed.getOperations()).toHaveLength(1);
+        expect(indexed.getOperations()[0].operation.Id).toBe("step-1");
+
+        // Should have events from both operations plus the new execution event
+        const historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(3);
+        expect(historyEvents.map((e) => e.EventId)).toContain(100);
+        expect(historyEvents.map((e) => e.EventId)).toContain(101);
+        expect(historyEvents.map((e) => e.EventId)).toContain(102);
+      });
+
+      it("should handle execution operations with parent-child relationships (execution operations cannot have parents but can be parents)", () => {
+        const executionWithChild = {
+          operation: {
+            Id: "execution-parent",
+            Name: "parent-execution",
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          },
+          events: [{ EventId: 300 }],
+        };
+
+        const childOfExecution = {
+          operation: {
+            Id: "child-of-execution",
+            Name: "child-step",
+            Type: OperationType.STEP,
+            ParentId: "execution-parent",
+            Status: OperationStatus.SUCCEEDED,
+          },
+          events: [{ EventId: 301 }],
+        };
+
+        const indexed = new IndexedOperations([
+          executionWithChild,
+          childOfExecution,
+        ]);
+
+        // Regular operations should be indexed
+        expect(indexed.getOperations()).toHaveLength(1);
+        expect(indexed.getOperations()[0].operation.Id).toBe(
+          "child-of-execution",
+        );
+
+        // Should be able to find children of execution operation
+        const children = indexed.getOperationChildren("execution-parent");
+        expect(children).toHaveLength(1);
+        expect(children[0].operation.Id).toBe("child-of-execution");
+        expect(children[0].operation.ParentId).toBe("execution-parent");
+
+        // History should include events from both
+        const historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(2);
+        expect(historyEvents.map((e) => e.EventId)).toContain(300);
+        expect(historyEvents.map((e) => e.EventId)).toContain(301);
+      });
+
+      it("should handle mixed operations with execution operations", () => {
+        const operations = [
+          {
+            operation: {
+              Id: "step-1",
+              Name: "first-step",
+              Type: OperationType.STEP,
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [{ EventId: 1 }],
+          },
+          {
+            operation: {
+              Id: "execution-1",
+              Name: "execution",
+              Type: OperationType.EXECUTION,
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 2 }],
+          },
+          {
+            operation: {
+              Id: "wait-1",
+              Name: "wait-operation",
+              Type: OperationType.WAIT,
+              Status: OperationStatus.STARTED,
+            },
+            events: [{ EventId: 3 }],
+          },
+          {
+            operation: {
+              Id: "context-1",
+              Name: "context-operation",
+              Type: OperationType.CONTEXT,
+              Status: OperationStatus.SUCCEEDED,
+            },
+            events: [{ EventId: 4 }],
+          },
+        ];
+
+        const indexed = new IndexedOperations(operations);
+
+        // Should only have non-execution operations
+        const allOps = indexed.getOperations();
+        expect(allOps).toHaveLength(3);
+
+        const operationTypes = allOps.map((op) => op.operation.Type);
+        expect(operationTypes).toContain(OperationType.STEP);
+        expect(operationTypes).toContain(OperationType.WAIT);
+        expect(operationTypes).toContain(OperationType.CONTEXT);
+        expect(operationTypes).not.toContain(OperationType.EXECUTION);
+
+        // Should find non-execution operations by ID
+        expect(indexed.getById("step-1")).toBeDefined();
+        expect(indexed.getById("wait-1")).toBeDefined();
+        expect(indexed.getById("context-1")).toBeDefined();
+        expect(indexed.getById("execution-1")).toBeUndefined();
+
+        // Should find non-execution operations by name
+        expect(indexed.getByNameAndIndex("first-step")).toBeDefined();
+        expect(indexed.getByNameAndIndex("wait-operation")).toBeDefined();
+        expect(indexed.getByNameAndIndex("context-operation")).toBeDefined();
+        expect(indexed.getByNameAndIndex("execution")).toBeUndefined();
+
+        // History should include all events
+        const historyEvents = indexed.getHistoryEvents();
+        expect(historyEvents).toHaveLength(4);
+        expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2, 3, 4]);
+      });
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/test-execution-state.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/test-execution-state.ts
@@ -1,7 +1,7 @@
 import { ErrorObject, ExecutionStatus } from "@aws-sdk/client-lambda";
 
 export interface TestExecutionResult {
-  status: ExecutionStatus | undefined;
+  status?: ExecutionStatus;
   result?: string;
   error?: ErrorObject;
 }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
@@ -50,6 +50,17 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
     });
     expect(execution.getHistoryEvents()).toEqual([
       {
+        EventId: 1,
+        EventTimestamp: expect.any(Number),
+        EventType: "ExecutionStarted",
+        ExecutionStartedDetails: {
+          Input: {
+            Payload: "{}",
+          },
+        },
+        Id: expect.any(String),
+      },
+      {
         EventType: "ChainedInvokeStarted",
         SubType: "ChainedInvoke",
         EventId: 2,
@@ -77,6 +88,23 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
             }),
           },
         },
+      },
+      {
+        EventId: 4,
+        EventTimestamp: expect.any(Number),
+        EventType: "ExecutionSucceeded",
+        ExecutionSucceededDetails: {
+          Result: {
+            Payload: JSON.stringify({
+              durableResult: {
+                type: "durable",
+                input: "bar",
+                message: "durable test result",
+              },
+            }),
+          },
+        },
+        Id: expect.any(String),
       },
     ]);
     expect(execution.getResult()).toEqual({

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -26,7 +26,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         const result = await context.step(() => Promise.resolve("completed"));
         return { success: true, step: result };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -47,7 +47,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         await context.wait("wait", 100);
         return { success: true, step: "completed" };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -103,7 +103,7 @@ describe("LocalDurableTestRunner Integration", () => {
         received: JSON.stringify(event),
         timestamp: Date.now(),
         message: "Handler completed successfully",
-      })
+      }),
     );
 
     const runner = new LocalDurableTestRunner({
@@ -144,7 +144,7 @@ describe("LocalDurableTestRunner Integration", () => {
           completedWaits: 2,
           finalStep: "done",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -170,11 +170,11 @@ describe("LocalDurableTestRunner Integration", () => {
     // Verify MockOperation data for both wait operations
     expect(firstWait.getWaitDetails()?.waitSeconds).toBe(50);
     expect(firstWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
     expect(secondWait.getWaitDetails()?.waitSeconds).toBe(50);
     expect(secondWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
   });
 
@@ -189,7 +189,7 @@ describe("LocalDurableTestRunner Integration", () => {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -221,13 +221,13 @@ describe("LocalDurableTestRunner Integration", () => {
         await context.step("fetch-user", () => Promise.resolve(undefined));
 
         await context.runInChildContext("parent", () =>
-          Promise.resolve(undefined)
+          Promise.resolve(undefined),
         );
 
         await context.wait(1000);
 
         return "result";
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -245,7 +245,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         await context.step("fetch-user-1", () => Promise.resolve("user-1"));
         await context.step("fetch-user-2", () => Promise.resolve("user-2"));
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -274,14 +274,14 @@ describe("LocalDurableTestRunner Integration", () => {
             await childContext.wait("child-wait", 1000);
 
             return Promise.resolve({ userId: 123, name: "John Doe" });
-          }
+          },
         );
 
         return {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -313,7 +313,7 @@ describe("LocalDurableTestRunner Integration", () => {
     // Verify wait step
     expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(1);
     expect(waitStep.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
   });
 
@@ -327,7 +327,7 @@ describe("LocalDurableTestRunner Integration", () => {
             const shouldRetry = attemptsMade <= 5;
             return { shouldRetry, delaySeconds: 1 + attemptsMade };
           },
-        }
+        },
       );
       return { success: true, step: "completed" };
     });
@@ -379,7 +379,7 @@ describe("LocalDurableTestRunner Integration", () => {
             shouldRetry: true,
             delaySeconds: 1,
           }),
-        }
+        },
       );
       return { success: true, step: "completed" };
     });
@@ -423,17 +423,17 @@ describe("LocalDurableTestRunner Integration", () => {
                 await grandChildContext.wait("grandchild-wait-1", 1000);
                 await grandChildContext.wait("grandchild-wait-2", 1000);
                 return "grandchild-context";
-              }
+              },
             );
 
             await childContext.wait("child-wait-2", 1000);
 
             return "parent-context";
-          }
+          },
         );
 
         return stepResult;
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -486,7 +486,7 @@ describe("LocalDurableTestRunner Integration", () => {
           result: stepResult,
           completed: true,
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -542,7 +542,7 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // For each invocation, get its operations
     const invocationOperations = invocations.map((inv) =>
-      inv.getOperations().map((op) => op.getOperationData()?.Id)
+      inv.getOperations().map((op) => op.getOperationData()?.Id),
     );
 
     // Verify exact operations in each invocation
@@ -559,6 +559,17 @@ describe("LocalDurableTestRunner Integration", () => {
     // TODO: update timestamps to Date objects
     expect(result.getHistoryEvents()).toEqual([
       {
+        EventType: "ExecutionStarted",
+        EventId: 1,
+        Id: expect.any(String),
+        EventTimestamp: expect.any(Number),
+        ExecutionStartedDetails: {
+          Input: {
+            Payload: "{}",
+          },
+        },
+      },
+      {
         EventType: "WaitStarted",
         SubType: "Wait",
         EventId: 2,
@@ -572,10 +583,10 @@ describe("LocalDurableTestRunner Integration", () => {
       },
       {
         EventType: "WaitSucceeded",
-        SubType: "Wait",
         EventId: 3,
         Id: "c4ca4238a0b92382",
         Name: "wait-invocation-1",
+        SubType: "Wait",
         EventTimestamp: expect.any(Number),
         WaitSucceededDetails: { Duration: 1 },
       },
@@ -597,10 +608,7 @@ describe("LocalDurableTestRunner Integration", () => {
         EventTimestamp: expect.any(Number),
         StepSucceededDetails: {
           Result: {
-            Payload: JSON.stringify({
-              processed: true,
-              timestamp: resultData.result.timestamp,
-            }),
+            Payload: JSON.stringify(resultData.result),
           },
           RetryDetails: {},
         },
@@ -619,12 +627,23 @@ describe("LocalDurableTestRunner Integration", () => {
       },
       {
         EventType: "WaitSucceeded",
-        SubType: "Wait",
         EventId: 7,
+        SubType: "Wait",
         Id: "eccbc87e4b5ce2fe",
         Name: "wait-invocation-2",
         EventTimestamp: expect.any(Number),
         WaitSucceededDetails: { Duration: 1 },
+      },
+      {
+        EventType: "ExecutionSucceeded",
+        EventId: 8,
+        Id: expect.any(String),
+        EventTimestamp: expect.any(Number),
+        ExecutionSucceededDetails: {
+          Result: {
+            Payload: JSON.stringify(resultData),
+          },
+        },
       },
     ]);
   });
@@ -644,14 +663,14 @@ describe("LocalDurableTestRunner Integration", () => {
 
         // This step runs after all parallel waits complete
         await context.step("after-parallel", () =>
-          Promise.resolve("completed")
+          Promise.resolve("completed"),
         );
 
         return {
           parallelResults: results,
           completed: true,
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
@@ -21,18 +21,18 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             await childContext.wait("child-wait", 1000);
 
             return Promise.resolve({ userId: 123, name: "John Doe" });
-          }
+          },
         );
 
         await context.step("failing-step", () =>
-          Promise.reject(new Error("there was an error"))
+          Promise.reject(new Error("there was an error")),
         );
 
         return {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -80,7 +80,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
       async (event: unknown, context: DurableContext) => {
         try {
           await context.step("error-step", () =>
-            Promise.resolve({ success: true })
+            Promise.resolve({ success: true }),
           );
           return { status: "success" };
         } catch (error) {
@@ -89,7 +89,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             message: error instanceof Error ? error.message : "Unknown error",
           };
         }
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -124,7 +124,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             },
             {
               retryStrategy: () => ({ shouldRetry: false }),
-            }
+            },
           );
           results.push(result1);
         } catch (error) {
@@ -145,7 +145,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
         }
 
         return { results };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -173,15 +173,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const result1 = await context.step("custom-step", () =>
-          Promise.resolve({ default: "implementation" })
+          Promise.resolve({ default: "implementation" }),
         );
 
         const result2 = await context.step("custom-step-2", () =>
-          Promise.resolve({ default: "implementation" })
+          Promise.resolve({ default: "implementation" }),
         );
 
         return { first: result1, second: result2 };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -193,7 +193,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const customStep2 = runner.getOperation("custom-step-2");
 
     customStep.mockImplementationOnce(() =>
-      Promise.resolve({ custom: "once-implementation" })
+      Promise.resolve({ custom: "once-implementation" }),
     );
     customStep2.mockResolvedValue({ standard: "mock" });
 
@@ -211,15 +211,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const result1 = await context.step("step-name", () =>
-          Promise.resolve({ order: 1 })
+          Promise.resolve({ order: 1 }),
         );
 
         const result2 = await context.step("step-name", () =>
-          Promise.resolve({ order: 2 })
+          Promise.resolve({ order: 2 }),
         );
 
         return { results: [result1, result2] };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -265,19 +265,19 @@ describe("LocalDurableTestRunner mocking Integration", () => {
               async (innerChildContext) => {
                 await innerChildContext.wait("deep-wait", 5000);
                 return { level: "inner", data: "deep-data" };
-              }
+              },
             );
 
             const stepResult = await outerChildContext.step("outer-step", () =>
-              Promise.resolve({ level: "outer", inner: innerResult })
+              Promise.resolve({ level: "outer", inner: innerResult }),
             );
 
             return stepResult;
-          }
+          },
         );
 
         return { final: outerResult };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -320,13 +320,13 @@ describe("LocalDurableTestRunner mocking Integration", () => {
 
         for (let i = 0; i < 3; i++) {
           const result = await context.step("repeated-step", () =>
-            Promise.resolve({ iteration: i, original: true })
+            Promise.resolve({ iteration: i, original: true }),
           );
           results.push(result);
         }
 
         return { results };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -365,17 +365,17 @@ describe("LocalDurableTestRunner mocking Integration", () => {
         await context.step("before-wait", () =>
           Promise.resolve({
             completed: "before-wait",
-          })
+          }),
         );
 
         await context.wait("wait", 10000);
 
         const stepResult = await context.step("after-wait", () =>
-          Promise.resolve({ completed: "after-wait" })
+          Promise.resolve({ completed: "after-wait" }),
         );
 
         return { waitCompleted: true, step: stepResult };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -390,7 +390,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     wait.mockResolvedValue({ completed: "mocked-after-wait" });
 
     await expect(
-      runner.run({ payload: { test: "wait-mocking" } })
+      runner.run({ payload: { test: "wait-mocking" } }),
     ).rejects.toThrow("Wait step cannot be mocked");
 
     expect(beforeWait.getStepDetails()?.result).toEqual({
@@ -404,11 +404,11 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         await context.step("executed-step", () =>
-          Promise.resolve({ executed: true })
+          Promise.resolve({ executed: true }),
         );
 
         return { success: true };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -417,7 +417,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     });
 
     const executedStep = runner.getOperation<{ executed: string }>(
-      "executed-step"
+      "executed-step",
     );
     const nonExecutedStep = runner.getOperation<never>("non-executed-step");
 
@@ -438,15 +438,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const stepByName = await context.step("named-step", () =>
-          Promise.resolve({ type: "named" })
+          Promise.resolve({ type: "named" }),
         );
 
         const stepByIndex = await context.step("indexed-step", () =>
-          Promise.resolve({ type: "indexed" })
+          Promise.resolve({ type: "indexed" }),
         );
 
         return { named: stepByName, indexed: stepByIndex };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -469,7 +469,11 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     });
 
     // Verify both operations have results
-    expect(namedStep.getStepDetails()).toBeDefined();
-    expect(indexedStep.getStepDetails()).toBeDefined();
+    expect(namedStep.getStepDetails()?.result).toEqual({
+      type: "mocked-named",
+    });
+    expect(indexedStep.getStepDetails()?.result).toEqual({
+      type: "mocked-indexed",
+    });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/checkpoint-api-client.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/checkpoint-api-client.ts
@@ -3,7 +3,7 @@ import {
   OperationInvocationIdMap,
 } from "../../../checkpoint-server/storage/checkpoint-manager";
 import { InvocationResult } from "../../../checkpoint-server/storage/execution-manager";
-import { Operation } from "@aws-sdk/client-lambda";
+import { ErrorObject, Operation } from "@aws-sdk/client-lambda";
 import {
   API_PATHS,
   HTTP_METHODS,
@@ -39,7 +39,7 @@ export class CheckpointApiClient {
    */
   async pollCheckpointData(
     executionId: ExecutionId,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<{
     operations: CheckpointOperation[];
     operationInvocationIdMap: OperationInvocationIdMap;
@@ -64,12 +64,16 @@ export class CheckpointApiClient {
     executionId: ExecutionId;
     operationId: string;
     operationData: Operation;
+    payload?: string;
+    error?: ErrorObject;
   }): Promise<void> {
     return this.makeRequest({
       path: getUpdateCheckpointDataPath(params.executionId, params.operationId),
       method: HTTP_METHODS.POST,
       body: JSON.stringify({
         operationData: params.operationData,
+        payload: params.payload,
+        error: params.error,
       }),
     });
   }
@@ -110,7 +114,7 @@ export class CheckpointApiClient {
     if (!response.ok) {
       const errorText = await response.text();
       const error = new Error(
-        `Error making HTTP request to ${path}: status: ${response.status}, ${errorText}`
+        `Error making HTTP request to ${path}: status: ${response.status}, ${errorText}`,
       );
       throw error;
     }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
@@ -39,7 +39,7 @@ describe("LocalOperationStorage", () => {
           Id: "op1",
         },
         {
-          EventId: 1,
+          EventId: 2,
           EventType: EventType.StepSucceeded,
           EventTimestamp: new Date("2026-01-01"),
           StepSucceededDetails: {
@@ -61,7 +61,7 @@ describe("LocalOperationStorage", () => {
       },
       events: [
         {
-          EventId: 2,
+          EventId: 3,
           EventType: EventType.WaitStarted,
           EventTimestamp: new Date("2026-01-01"),
           WaitStartedDetails: {
@@ -71,7 +71,7 @@ describe("LocalOperationStorage", () => {
           Id: "op2",
         },
         {
-          EventId: 3,
+          EventId: 4,
           EventType: EventType.WaitSucceeded,
           EventTimestamp: new Date("2026-01-02"),
           WaitSucceededDetails: {},
@@ -89,7 +89,7 @@ describe("LocalOperationStorage", () => {
       },
       events: [
         {
-          EventId: 4,
+          EventId: 5,
           EventType: EventType.CallbackStarted,
           EventTimestamp: new Date("2026-01-02"),
           StepSucceededDetails: {},
@@ -97,7 +97,7 @@ describe("LocalOperationStorage", () => {
           Id: "op3",
         },
         {
-          EventId: 5,
+          EventId: 6,
           EventType: EventType.CallbackSucceeded,
           EventTimestamp: new Date("2026-01-03"),
           StepSucceededDetails: {},
@@ -126,13 +126,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operation
@@ -160,13 +160,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "operation1", index: 1 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operation
@@ -195,13 +195,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { index: 1 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operation
@@ -229,13 +229,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "nonexistent" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operation
@@ -261,13 +261,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operation
@@ -293,19 +293,19 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation1 = new MockOperation(
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const mockOperation2 = new MockOperation(
         { id: "op2" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Register the mock operations
@@ -339,13 +339,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "test-op" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       storage.registerOperation({
@@ -382,7 +382,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       // Add operations first
@@ -393,7 +393,7 @@ describe("LocalOperationStorage", () => {
         { id: "op2" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       storage.registerOperation({
         operation: mockOperation,
@@ -413,13 +413,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { id: "" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       ); // Empty string is falsy but valid
 
       storage.registerOperation({
@@ -456,13 +456,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       ); // Empty string is falsy but valid
 
       storage.registerOperation({
@@ -499,13 +499,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { index: 0 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       ); // 0 is falsy but valid index
 
       storage.registerOperation({
@@ -552,7 +552,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       // Add operations first
@@ -563,7 +563,7 @@ describe("LocalOperationStorage", () => {
         { id: "op2" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       storage.registerOperation({
         operation: mockOperation,
@@ -585,25 +585,25 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation1 = new MockOperation(
         { name: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const mockOperation2 = new MockOperation(
         { name: "op2" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const mockOperation3 = new MockOperation(
         { index: 0 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Spy on the registerMocks method of each mock operation
@@ -650,7 +650,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       const executionId = createExecutionId("test-execution-id");
@@ -666,25 +666,25 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const idBasedMock = new MockOperation(
         { id: "test-id" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const nameBasedMock = new MockOperation(
         { name: "test-name", index: 1 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const indexBasedMock = new MockOperation(
         { index: 2 },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       // Spy on registerMocks methods
@@ -729,13 +729,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "nonexistent-op" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       const registerMocksSpy = jest.spyOn(mockOperation, "registerMocks");
@@ -767,13 +767,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       storage.registerOperation({
@@ -795,13 +795,13 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const mockOperation = new MockOperation(
         { name: "nonexistent" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       storage.registerOperation({
@@ -824,7 +824,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       // Populate with empty array
@@ -840,19 +840,19 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
       const populatedOperation = new MockOperation(
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       const nonPopulatedOperation = new MockOperation(
         { name: "nonexistent" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
 
       storage.registerOperation({
@@ -881,7 +881,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       // Populate operations first
@@ -893,7 +893,7 @@ describe("LocalOperationStorage", () => {
         { id: "op1" },
         mockWaitManager,
         mockIndexedOperations,
-        mockDurableApiClient
+        mockDurableApiClient,
       );
       storage.registerOperation({
         operation: mockOperation,
@@ -917,12 +917,12 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         mockIndexedOperations,
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       storage.populateOperations(sampleOperations);
       expect(storage.getHistoryEvents()).toEqual(
-        sampleOperations.flatMap((op) => op.events)
+        sampleOperations.flatMap((op) => op.events),
       );
     });
 
@@ -931,11 +931,11 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         new IndexedOperations(sampleOperations),
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       expect(storage.getHistoryEvents()).toEqual(
-        sampleOperations.flatMap((op) => op.events)
+        sampleOperations.flatMap((op) => op.events),
       );
     });
 
@@ -944,7 +944,7 @@ describe("LocalOperationStorage", () => {
         mockWaitManager,
         new IndexedOperations(sampleOperations),
         mockDurableApiClient,
-        mockCallback
+        mockCallback,
       );
 
       const populatedOperations = sampleOperations.concat([


### PR DESCRIPTION
*Issue #, if available:*

DAR-SDK-302

*Description of changes:*

Adding missing execution events to local runner history. Now, the execution events are correctly returned from the server, and the testing lib can now also notify the server to generate the completion execution event.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
