### PR TITLE
refactor(sdk): convert DurableContext to class-based implementation

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.test.ts
@@ -155,32 +155,6 @@ describe("Promise Handler", () => {
         "error without name",
       );
     });
-
-    it("should handle non-array values in errorAwareSerdes", async () => {
-      mockStep.mockImplementation(async (name, fn, config) => {
-        // Test the serdes with non-array values
-        if (config?.serdes) {
-          // Test serialize with non-array value
-          const nonArrayValue = { someProperty: "value" };
-          const serialized = await config.serdes.serialize(nonArrayValue, {
-            entityId: "test",
-            durableExecutionArn: "arn",
-          });
-          expect(serialized).toBe(JSON.stringify(nonArrayValue));
-
-          // Test deserialize with non-array value
-          const deserialized = await config.serdes.deserialize(serialized, {
-            entityId: "test",
-            durableExecutionArn: "arn",
-          });
-          expect(deserialized).toEqual(nonArrayValue);
-        }
-
-        return await fn();
-      });
-
-      await promiseHandler.allSettled([Promise.resolve(1)]);
-    });
   });
 
   describe("retry behavior", () => {

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -89,10 +89,11 @@ export type DurableExecutionInvocationOutput =
   | DurableExecutionInvocationOutputFailed
   | DurableExecutionInvocationOutputPending;
 
-export interface DurableContext extends Context {
-  _stepPrefix?: string;
-  _stepCounter: number;
-  _durableExecutionMode: DurableExecutionMode;
+export interface DurableContext {
+  /**
+   * The underlying AWS Lambda context
+   */
+  lambdaContext: Context;
   /**
    * Logger instance for this context, enriched with execution context information
    */


### PR DESCRIPTION
*Description of changes:*

- Refactor DurableContext from interface extending Context to class-based implementation
- Add lambdaContext property to access AWS Lambda context instead of direct inheritance
- Encapsulate internal state (_stepPrefix, _stepCounter, _durableExecutionMode) as private
- Improve type safety by replacing 'any' types with proper generics in promise handlers
- Fix lint warnings and improve code maintainability

Breaking Changes:
- DurableContext no longer extends AWS Lambda Context
- Access Lambda context properties via context.lambdaContext instead of direct access
- Internal properties are now private and not accessible externally

Benefits:
- Better encapsulation and data hiding
- Clearer API separation between durable operations and Lambda context
- Improved type safety


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
