### PR TITLE
ci: use qualified ARN for invoke

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,6 +119,7 @@ jobs:
         FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       run: |
          node .github/workflows/scripts/integration-test/integration-test.js --test-only
 
@@ -160,5 +161,6 @@ jobs:
         FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       run: |
         node .github/workflows/scripts/integration-test/integration-test.js --cleanup-only


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Backend added validation which only allows qualified ARNs for invoke. Updating the integration test here to use that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
