### PR TITLE
fix(sdk): resolve circular dependency

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -200,6 +200,7 @@ describe("Durable Context", () => {
       mockParentContext,
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(mockRunInChildContextHandler).toHaveBeenCalledWith(
       "test-block",

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -234,6 +234,7 @@ class DurableContextImpl implements DurableContext {
       this.lambdaContext,
       this.createStepId.bind(this),
       () => this.contextLogger || createDefaultLogger(),
+      createDurableContext,
     );
     try {
       return blockHandler(nameOrFn, fnOrOptions, maybeOptions);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -64,12 +64,16 @@ describe("Run In Child Context Handler", () => {
       warn: jest.fn(),
       debug: jest.fn(),
     });
+    const mockCreateChildContext = jest.fn().mockReturnValue({
+      _stepPrefix: TEST_CONSTANTS.CHILD_CONTEXT_ID,
+    });
     runInChildContextHandler = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       createStepId,
       mockGetLogger,
+      mockCreateChildContext,
     );
   });
 
@@ -508,12 +512,16 @@ describe("runInChildContext with custom serdes", () => {
       debug: jest.fn(),
     });
 
+    const mockCreateChildContext = jest.fn().mockReturnValue({
+      _stepPrefix: TEST_CONSTANTS.CHILD_CONTEXT_ID,
+    });
     runInChildContext = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       mockCreateStepId,
       mockGetLogger,
+      mockCreateChildContext,
     );
   });
 
@@ -613,12 +621,16 @@ describe("Mock Integration", () => {
       warn: jest.fn(),
       debug: jest.fn(),
     });
+    const mockCreateChildContext = jest.fn().mockReturnValue({
+      _stepPrefix: TEST_CONSTANTS.CHILD_CONTEXT_ID,
+    });
     runInChildContextHandler = createRunInChildContextHandler(
       mockExecutionContext,
       mockCheckpoint,
       mockParentContext,
       createStepId,
       mockGetLogger,
+      mockCreateChildContext,
     );
   });
 


### PR DESCRIPTION
*Description of changes:*

Resolve circular dependency between durable-context and run-in-child-context-handler

- Remove direct import of createDurableContext from run-in-child-context-handler
- Add createChildContext factory function parameter to break circular dependency
- Fix variable naming conflicts (childContext -> durableChildContext)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
