### PR TITLE
fix(sdk): update wait calls to use seconds instead of milliseconds

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/comprehensive-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/comprehensive-operations.test.ts
@@ -24,7 +24,7 @@ createTests({
       // parallelResults is now a BatchResult object
       expect(result.parallelResults.all).toHaveLength(3);
       expect(
-        result.parallelResults.all.map((item: any) => item.result)
+        result.parallelResults.all.map((item: any) => item.result),
       ).toEqual(["apple", "banana", "orange"]);
       expect(result.parallelResults.completionReason).toBe("ALL_COMPLETED");
 
@@ -32,21 +32,21 @@ createTests({
       expect(result.summary.totalOperations).toBe(4);
       expect(result.summary.stepResult).toBe("Step 1 completed successfully");
       expect(
-        result.summary.numbersProcessed.all.map((item: any) => item.result)
+        result.summary.numbersProcessed.all.map((item: any) => item.result),
       ).toEqual([1, 2, 3, 4, 5]);
       expect(
-        result.summary.fruitsSelected.all.map((item: any) => item.result)
+        result.summary.fruitsSelected.all.map((item: any) => item.result),
       ).toEqual(["apple", "banana", "orange"]);
 
       const step1Op = runner.getOperation("step1");
 
       expect(step1Op).toBeDefined();
       expect(step1Op.getStepDetails()?.result).toBe(
-        "Step 1 completed successfully"
+        "Step 1 completed successfully",
       );
       const waitOp = runner.getOperationByIndex(1); // Wait should be the second operation
 
-      expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(5);
+      expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(1);
       // Verify map results - now BatchResult object
       expect(result.mapResults.all).toHaveLength(5);
       expect(result.mapResults.all.map((item: any) => item.result)).toEqual([
@@ -63,7 +63,7 @@ createTests({
       // Verify parallel results - now BatchResult object
       expect(result.parallelResults.all).toHaveLength(3);
       expect(
-        result.parallelResults.all.map((item: any) => item.result)
+        result.parallelResults.all.map((item: any) => item.result),
       ).toEqual(["apple", "banana", "orange"]);
 
       // Verify individual parallel step operations exist
@@ -84,10 +84,10 @@ createTests({
       expect(result.summary.totalOperations).toBe(4);
       expect(result.summary.stepResult).toBe("Step 1 completed successfully");
       expect(
-        result.summary.numbersProcessed.all.map((item: any) => item.result)
+        result.summary.numbersProcessed.all.map((item: any) => item.result),
       ).toEqual([1, 2, 3, 4, 5]);
       expect(
-        result.summary.fruitsSelected.all.map((item: any) => item.result)
+        result.summary.fruitsSelected.all.map((item: any) => item.result),
       ).toEqual(["apple", "banana", "orange"]);
 
       // Verify execution completed successfully

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/steps-with-retry.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/steps-with-retry.test.ts
@@ -72,9 +72,9 @@ describe("steps-with-retry", () => {
       data: { S: "found-item" },
     });
 
-    // Verify wait operation was called (5 second wait between polls)
+    // Verify wait operation was called (1 second wait between polls)
     const waitOp = durableTestRunner.getOperationByIndex(1);
-    expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(5);
+    expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(1);
   });
 
   it("should retry failed DynamoDB calls according to retry strategy", async () => {
@@ -109,7 +109,7 @@ describe("steps-with-retry", () => {
       errorMessage: "Persistent failure",
       errorType: "Error",
       stackTrace: expect.any(Array),
-    }
+    };
 
     const result = await durableTestRunner.run();
     const error = result.getError();
@@ -119,7 +119,7 @@ describe("steps-with-retry", () => {
     // Verify that step operations were attempted
     const stepOp = durableTestRunner.getOperationByIndex(0);
     expect(stepOp.getStepDetails()?.result).toBeUndefined();
-    expect(stepOp.getStepDetails()?.error).toEqual(expectedErrorObject)
+    expect(stepOp.getStepDetails()?.error).toEqual(expectedErrorObject);
   });
 
   it("should fail when item is not found after maximum polls", async () => {
@@ -141,6 +141,6 @@ describe("steps-with-retry", () => {
 
     // Should have wait operations between polls
     const waitOp = durableTestRunner.getOperationByIndex(1);
-    expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(5);
+    expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(1);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-named.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-named.test.ts
@@ -8,10 +8,10 @@ createTests({
   tests: (runner) => {
     it("should call wait for 5 seconds", async () => {
       const execution = await runner.run();
-      const waitOp = runner.getOperation("wait-5-seconds");
+      const waitOp = runner.getOperation("wait-2-seconds");
 
       expect(execution.getResult()).toBe("wait finished");
-      expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(5);
+      expect(waitOp.getWaitDetails()?.waitSeconds).toEqual(2);
     });
   },
 });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait.test.ts
@@ -7,12 +7,11 @@ createTests({
   handler,
   tests: (runner) => {
     it("should call wait for 10 seconds", async () => {
-      
       const execution = await runner.run();
-      
+
       const waitStep = runner.getOperationByIndex(0);
       expect(execution.getResult()).toBe("Function Completed");
-      expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(10);
+      expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(2);
     });
   },
 });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/block-example.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/block-example.ts
@@ -19,7 +19,7 @@ export const handler = withDurableFunctions(
           async () => {
             console.log("Inside nested step");
             return "nested step result";
-          }
+          },
         );
 
         // Nested block with its own child context
@@ -29,20 +29,20 @@ export const handler = withDurableFunctions(
             console.log("Inside nested block");
 
             // Use the grandchild context for further nested operations
-            await grandchildContext.wait(1000);
+            await grandchildContext.wait(1);
 
             return "nested block result";
-          }
+          },
         );
 
         return {
           nestedStep: nestedResult,
           nestedBlock: nestedBlockResult,
         };
-      }
+      },
     );
 
     console.log("Block completed with result:", result);
     return result;
-  }
+  },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/comprehensive-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/comprehensive-operations.ts
@@ -24,8 +24,8 @@ export const handler = withDurableFunctions(
       return "Step 1 completed successfully";
     });
 
-    // Step 2: ctx.wait - Wait for 5 seconds
-    await context.wait(5000);
+    // Step 2: ctx.wait - Wait for 1 second
+    await context.wait(1);
 
     // Step 3: ctx.map - Map with 5 iterations returning numbers 1 to 5
     const mapInput = [1, 2, 3, 4, 5];
@@ -33,14 +33,13 @@ export const handler = withDurableFunctions(
       "map-numbers",
       mapInput,
       async (ctx, item, index) => {
-        
         // Each iteration returns the number (1 to 5)
         const result = await ctx.step(`map-step-${index}`, async () => {
           return item;
         });
-        
+
         return result;
-      }
+      },
     );
 
     // Step 4: ctx.parallel - 3 branches, each returning a fruit name
@@ -85,5 +84,5 @@ export const handler = withDurableFunctions(
     };
 
     return finalResult;
-  }
+  },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-operations.ts
@@ -1,21 +1,38 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
+export const handler = withDurableFunctions(
+  async (event: any, context: DurableContext) => {
     // Start multiple concurrent operations using runInChildContext
-    const task1 = context.runInChildContext("block-1", async (childContext: DurableContext) => {
-        const result = await childContext.step("step-1", async () => "task 1 result");
-        await childContext.wait("wait-1",1000);
+    const task1 = context.runInChildContext(
+      "block-1",
+      async (childContext: DurableContext) => {
+        const result = await childContext.step(
+          "step-1",
+          async () => "task 1 result",
+        );
+        await childContext.wait("wait-1", 1);
         return result;
-    });
-    
-    const task2 = context.runInChildContext("block-2", async (childContext: DurableContext) => {
-        const result = await childContext.step("step-2", async () => "task 2 result");
-        await childContext.wait("wait-2", 2000);
+      },
+    );
+
+    const task2 = context.runInChildContext(
+      "block-2",
+      async (childContext: DurableContext) => {
+        const result = await childContext.step(
+          "step-2",
+          async () => "task 2 result",
+        );
+        await childContext.wait("wait-2", 2);
         return result;
-    });
-    
+      },
+    );
+
     // Wait for both to complete
     const results = await context.promise.all([task1, task2]);
-    
+
     return results;
-});
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-wait.ts
@@ -1,17 +1,16 @@
 import {
-    DurableContext,
-    withDurableFunctions,
+  DurableContext,
+  withDurableFunctions,
 } from "@aws/durable-execution-sdk-js";
 
 export const handler = withDurableFunctions(
-    async (event: any, context: DurableContext) => {
-        console.log("Before waits");
-        await Promise.all([
-            context.wait("wait-1-second", 1000),
-            context.wait("wait-5-seconds", 5000),
-            context.wait("wait-10-seconds",10000),
-        ])
-        console.log("After waits");
-        return "Completed waits";
-    }
+  async (event: any, context: DurableContext) => {
+    console.log("Before waits");
+    await Promise.all([
+      context.wait("wait-1-second", 1),
+      context.wait("wait-2-seconds", 2),
+    ]);
+    console.log("After waits");
+    return "Completed waits";
+  },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
@@ -22,7 +22,7 @@ export const handler = withDurableFunctions(
 
     // context.wait() terminates the current execution and restarts it later,
     // ensuring getResults() functions correctly during workflow replay
-    await context.wait(1000);
+    await context.wait(1);
 
     return results.getResults();
   },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-basic.ts
@@ -1,24 +1,33 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
-    const results = await context.parallel("parallel", [
+export const handler = withDurableFunctions(
+  async (event: any, context: DurableContext) => {
+    const results = await context.parallel(
+      "parallel",
+      [
         async (childContext) => {
-            return await childContext.step(async () => {
-                return "task 1 completed";
-            });
+          return await childContext.step(async () => {
+            return "task 1 completed";
+          });
         },
         async (childContext) => {
-            return await childContext.step(async () => {
-                return "task 2 completed";
-            });
+          return await childContext.step(async () => {
+            return "task 2 completed";
+          });
         },
         async (childContext) => {
-            await childContext.wait(1000);
-            return "task 3 completed after wait";
-        }
-    ], {
-        maxConcurrency: 2
-    });
-    
+          await childContext.wait(1);
+          return "task 3 completed after wait";
+        },
+      ],
+      {
+        maxConcurrency: 2,
+      },
+    );
+
     return results.getResults();
-});
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-wait.ts
@@ -7,11 +7,14 @@ export const handler = withDurableFunctions(
   async (event: any, context: DurableContext) => {
     console.log("Before waits");
     await context.parallel("parent-block", [
-        async (childContext: DurableContext) => await childContext.wait("wait-1-second", 1000),
-        async (childContext: DurableContext) => await childContext.wait("wait-2-seconds", 2000),
-        async (childContext: DurableContext) => await childContext.wait("wait-5-seconds", 5000),
+      async (childContext: DurableContext) =>
+        await childContext.wait("wait-1-second", 1),
+      async (childContext: DurableContext) =>
+        await childContext.wait("wait-2-seconds", 2),
+      async (childContext: DurableContext) =>
+        await childContext.wait("wait-5-seconds", 5),
     ]);
     console.log("After waits");
     return "Completed waits";
-  }
+  },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/steps-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/steps-with-retry.ts
@@ -1,4 +1,7 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 
 const ddbClient = new DynamoDBClient();
@@ -24,51 +27,53 @@ interface HandlerInput {
   name: string;
 }
 
-export const handler = withDurableFunctions(async (event: HandlerInput, context: DurableContext) => {
-  let item;
-  try {
-    let pollCount = 0;
-    while (pollCount < 5) {
-      pollCount += 1;
-      // Lookup the item in DDB
-      const getResponse = await context.step(async () => {
-        console.log(`Poll #${pollCount}`);
-        // Fail 50% of the time
-        if (Math.random() < 0.5) {
-          throw new Error("Random failure");
-        }
-        return await ddbClient.send(
-          new GetItemCommand({
-            TableName: "TEST",
-            Key: {
-              id: {
-                S: event.name,
+export const handler = withDurableFunctions(
+  async (event: HandlerInput, context: DurableContext) => {
+    let item;
+    try {
+      let pollCount = 0;
+      while (pollCount < 5) {
+        pollCount += 1;
+        // Lookup the item in DDB
+        const getResponse = await context.step(async () => {
+          console.log(`Poll #${pollCount}`);
+          // Fail 50% of the time
+          if (Math.random() < 0.5) {
+            throw new Error("Random failure");
+          }
+          return await ddbClient.send(
+            new GetItemCommand({
+              TableName: "TEST",
+              Key: {
+                id: {
+                  S: event.name,
+                },
               },
-            },
-          }),
-        );
-      }, STEP_CONFIG_WITH_RETRY_FAILURES_AFTER_1_SECOND_5_TIMES);
+            }),
+          );
+        }, STEP_CONFIG_WITH_RETRY_FAILURES_AFTER_1_SECOND_5_TIMES);
 
-      // Did the item exist in DDB?
-      if (getResponse.Item) {
-        item = getResponse.Item;
-        break;
+        // Did the item exist in DDB?
+        if (getResponse.Item) {
+          item = getResponse.Item;
+          break;
+        }
+
+        // Wait 1 second until next poll
+        await context.wait(1);
       }
-
-      // Wait 5 seconds until next poll
-      await context.wait(5000);
+    } catch (e) {
+      console.error("Failing - DDB Retries Exhausted. ", e);
+      throw e;
     }
-  } catch (e) {
-    console.error("Failing - DDB Retries Exhausted. ", e);
-    throw e;
-  }
 
-  if (!item) {
-    console.error("Failing - DDB Item Not Found.");
-    throw new Error("Item Not Found");
-  }
+    if (!item) {
+      console.error("Failing - DDB Item Not Found.");
+      throw new Error("Item Not Found");
+    }
 
-  // We found the item!
-  console.log(`Success - Item was found: `, item);
-  return item;
-});
+    // We found the item!
+    console.log(`Success - Item was found: `, item);
+    return item;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-named.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-named.ts
@@ -1,8 +1,13 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
+export const handler = withDurableFunctions(
+  async (event: any, context: DurableContext) => {
     console.log("Starting wait operation");
-    await context.wait("wait-5-seconds", 5000);
+    await context.wait("wait-2-seconds", 2);
     console.log("Wait completed");
     return "wait finished";
-});
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait.ts
@@ -1,8 +1,13 @@
-import {DurableContext, withDurableFunctions} from "@aws/durable-execution-sdk-js";
+import {
+  DurableContext,
+  withDurableFunctions,
+} from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(async (event: any, context: DurableContext) => {
+export const handler = withDurableFunctions(
+  async (event: any, context: DurableContext) => {
     console.log("Hello world before wait!");
-    await context.wait(10000);
+    await context.wait(2);
     console.log("Hello world after wait!");
-    return "Function Completed"
-});
+    return "Function Completed";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -26,7 +26,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         const result = await context.step(() => Promise.resolve("completed"));
         return { success: true, step: result };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -47,7 +47,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         await context.wait("wait", 100);
         return { success: true, step: "completed" };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -103,7 +103,7 @@ describe("LocalDurableTestRunner Integration", () => {
         received: JSON.stringify(event),
         timestamp: Date.now(),
         message: "Handler completed successfully",
-      })
+      }),
     );
 
     const runner = new LocalDurableTestRunner({
@@ -137,14 +137,14 @@ describe("LocalDurableTestRunner Integration", () => {
   it("should handle multiple wait operations", async () => {
     const handler = withDurableFunctions(
       async (_event: unknown, context: DurableContext) => {
-        await context.wait("wait-1", 50000);
-        await context.wait("wait-2", 50000);
+        await context.wait("wait-1", 50);
+        await context.wait("wait-2", 50);
 
         return {
           completedWaits: 2,
           finalStep: "done",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -170,11 +170,11 @@ describe("LocalDurableTestRunner Integration", () => {
     // Verify MockOperation data for both wait operations
     expect(firstWait.getWaitDetails()?.waitSeconds).toBe(50);
     expect(firstWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
     expect(secondWait.getWaitDetails()?.waitSeconds).toBe(50);
     expect(secondWait.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
   });
 
@@ -189,7 +189,7 @@ describe("LocalDurableTestRunner Integration", () => {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -221,13 +221,13 @@ describe("LocalDurableTestRunner Integration", () => {
         await context.step("fetch-user", () => Promise.resolve(undefined));
 
         await context.runInChildContext("parent", () =>
-          Promise.resolve(undefined)
+          Promise.resolve(undefined),
         );
 
-        await context.wait(1000);
+        await context.wait(1);
 
         return "result";
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -245,7 +245,7 @@ describe("LocalDurableTestRunner Integration", () => {
       async (event: unknown, context: DurableContext) => {
         await context.step("fetch-user-1", () => Promise.resolve("user-1"));
         await context.step("fetch-user-2", () => Promise.resolve("user-2"));
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -271,17 +271,17 @@ describe("LocalDurableTestRunner Integration", () => {
         const stepResult = await context.runInChildContext(
           "parent-context",
           async (childContext) => {
-            await childContext.wait("child-wait", 1000);
+            await childContext.wait("child-wait", 1);
 
             return Promise.resolve({ userId: 123, name: "John Doe" });
-          }
+          },
         );
 
         return {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -313,7 +313,7 @@ describe("LocalDurableTestRunner Integration", () => {
     // Verify wait step
     expect(waitStep.getWaitDetails()?.waitSeconds).toEqual(1);
     expect(waitStep.getWaitDetails()?.scheduledEndTimestamp).toBeInstanceOf(
-      Date
+      Date,
     );
   });
 
@@ -327,7 +327,7 @@ describe("LocalDurableTestRunner Integration", () => {
             const shouldRetry = attemptsMade <= 5;
             return { shouldRetry, delaySeconds: 1 + attemptsMade };
           },
-        }
+        },
       );
       return { success: true, step: "completed" };
     });
@@ -379,7 +379,7 @@ describe("LocalDurableTestRunner Integration", () => {
             shouldRetry: true,
             delaySeconds: 1,
           }),
-        }
+        },
       );
       return { success: true, step: "completed" };
     });
@@ -423,17 +423,17 @@ describe("LocalDurableTestRunner Integration", () => {
                 await grandChildContext.wait("grandchild-wait-1", 1000);
                 await grandChildContext.wait("grandchild-wait-2", 1000);
                 return "grandchild-context";
-              }
+              },
             );
 
             await childContext.wait("child-wait-2", 1000);
 
             return "parent-context";
-          }
+          },
         );
 
         return stepResult;
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -471,7 +471,7 @@ describe("LocalDurableTestRunner Integration", () => {
     const handler = withDurableFunctions(
       async (_event: unknown, context: DurableContext) => {
         // First wait operation - this will run in invocation index 0
-        await context.wait("wait-invocation-1", 1000);
+        await context.wait("wait-invocation-1", 1);
 
         // This will execute in invocation index 1
         const stepResult = await context.step("process-data-step", () => {
@@ -479,14 +479,14 @@ describe("LocalDurableTestRunner Integration", () => {
         });
 
         // Second wait operation - this will run in invocation index 1
-        await context.wait("wait-invocation-2", 1000);
+        await context.wait("wait-invocation-2", 1);
 
         // Third invocation will only return the result
         return {
           result: stepResult,
           completed: true,
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -542,7 +542,7 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // For each invocation, get its operations
     const invocationOperations = invocations.map((inv) =>
-      inv.getOperations().map((op) => op.getOperationData()?.Id)
+      inv.getOperations().map((op) => op.getOperationData()?.Id),
     );
 
     // Verify exact operations in each invocation
@@ -644,14 +644,14 @@ describe("LocalDurableTestRunner Integration", () => {
 
         // This step runs after all parallel waits complete
         await context.step("after-parallel", () =>
-          Promise.resolve("completed")
+          Promise.resolve("completed"),
         );
 
         return {
           parallelResults: results,
           completed: true,
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/mocking.integration.test.ts
@@ -21,18 +21,18 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             await childContext.wait("child-wait", 1000);
 
             return Promise.resolve({ userId: 123, name: "John Doe" });
-          }
+          },
         );
 
         await context.step("failing-step", () =>
-          Promise.reject(new Error("there was an error"))
+          Promise.reject(new Error("there was an error")),
         );
 
         return {
           user: stepResult,
           final: "processed",
         };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -80,7 +80,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
       async (event: unknown, context: DurableContext) => {
         try {
           await context.step("error-step", () =>
-            Promise.resolve({ success: true })
+            Promise.resolve({ success: true }),
           );
           return { status: "success" };
         } catch (error) {
@@ -89,7 +89,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             message: error instanceof Error ? error.message : "Unknown error",
           };
         }
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -124,7 +124,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
             },
             {
               retryStrategy: () => ({ shouldRetry: false }),
-            }
+            },
           );
           results.push(result1);
         } catch (error) {
@@ -145,7 +145,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
         }
 
         return { results };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -173,15 +173,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const result1 = await context.step("custom-step", () =>
-          Promise.resolve({ default: "implementation" })
+          Promise.resolve({ default: "implementation" }),
         );
 
         const result2 = await context.step("custom-step-2", () =>
-          Promise.resolve({ default: "implementation" })
+          Promise.resolve({ default: "implementation" }),
         );
 
         return { first: result1, second: result2 };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -193,7 +193,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const customStep2 = runner.getOperation("custom-step-2");
 
     customStep.mockImplementationOnce(() =>
-      Promise.resolve({ custom: "once-implementation" })
+      Promise.resolve({ custom: "once-implementation" }),
     );
     customStep2.mockResolvedValue({ standard: "mock" });
 
@@ -211,15 +211,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const result1 = await context.step("step-name", () =>
-          Promise.resolve({ order: 1 })
+          Promise.resolve({ order: 1 }),
         );
 
         const result2 = await context.step("step-name", () =>
-          Promise.resolve({ order: 2 })
+          Promise.resolve({ order: 2 }),
         );
 
         return { results: [result1, result2] };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -265,19 +265,19 @@ describe("LocalDurableTestRunner mocking Integration", () => {
               async (innerChildContext) => {
                 await innerChildContext.wait("deep-wait", 5000);
                 return { level: "inner", data: "deep-data" };
-              }
+              },
             );
 
             const stepResult = await outerChildContext.step("outer-step", () =>
-              Promise.resolve({ level: "outer", inner: innerResult })
+              Promise.resolve({ level: "outer", inner: innerResult }),
             );
 
             return stepResult;
-          }
+          },
         );
 
         return { final: outerResult };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -320,13 +320,13 @@ describe("LocalDurableTestRunner mocking Integration", () => {
 
         for (let i = 0; i < 3; i++) {
           const result = await context.step("repeated-step", () =>
-            Promise.resolve({ iteration: i, original: true })
+            Promise.resolve({ iteration: i, original: true }),
           );
           results.push(result);
         }
 
         return { results };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -365,17 +365,17 @@ describe("LocalDurableTestRunner mocking Integration", () => {
         await context.step("before-wait", () =>
           Promise.resolve({
             completed: "before-wait",
-          })
+          }),
         );
 
-        await context.wait("wait", 10000);
+        await context.wait("wait", 10);
 
         const stepResult = await context.step("after-wait", () =>
-          Promise.resolve({ completed: "after-wait" })
+          Promise.resolve({ completed: "after-wait" }),
         );
 
         return { waitCompleted: true, step: stepResult };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -390,7 +390,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     wait.mockResolvedValue({ completed: "mocked-after-wait" });
 
     await expect(
-      runner.run({ payload: { test: "wait-mocking" } })
+      runner.run({ payload: { test: "wait-mocking" } }),
     ).rejects.toThrow("Wait step cannot be mocked");
 
     expect(beforeWait.getStepDetails()?.result).toEqual({
@@ -404,11 +404,11 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         await context.step("executed-step", () =>
-          Promise.resolve({ executed: true })
+          Promise.resolve({ executed: true }),
         );
 
         return { success: true };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({
@@ -417,7 +417,7 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     });
 
     const executedStep = runner.getOperation<{ executed: string }>(
-      "executed-step"
+      "executed-step",
     );
     const nonExecutedStep = runner.getOperation<never>("non-executed-step");
 
@@ -438,15 +438,15 @@ describe("LocalDurableTestRunner mocking Integration", () => {
     const handler = withDurableFunctions(
       async (event: unknown, context: DurableContext) => {
         const stepByName = await context.step("named-step", () =>
-          Promise.resolve({ type: "named" })
+          Promise.resolve({ type: "named" }),
         );
 
         const stepByIndex = await context.step("indexed-step", () =>
-          Promise.resolve({ type: "indexed" })
+          Promise.resolve({ type: "indexed" }),
         );
 
         return { named: stepByName, indexed: stepByIndex };
-      }
+      },
     );
 
     const runner = new LocalDurableTestRunner({

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -954,7 +954,7 @@ describe("WaitForCallback Operations Integration", () => {
 
       const handler = withDurableFunctions<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
-          await context.wait("wait-invocation-1", 1000);
+          await context.wait("wait-invocation-1", 1);
 
           const callbackResult1 = await context.waitForCallback<{
             step: number;
@@ -967,7 +967,7 @@ describe("WaitForCallback Operations Integration", () => {
             return Promise.resolve({ processed: true, step: 1 });
           });
 
-          await context.wait("wait-invocation-2", 1000);
+          await context.wait("wait-invocation-2", 1);
 
           const callbackResult2 = await context.waitForCallback<{
             step: number;

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -246,7 +246,7 @@ class DurableContextImpl implements DurableContext {
     }
   }
 
-  wait(nameOrMillis: string | number, maybeMillis?: number): Promise<void> {
+  wait(nameOrSeconds: string | number, maybeSeconds?: number): Promise<void> {
     const shouldSwitchToExecutionMode = this.captureExecutionState();
 
     this.checkAndUpdateReplayMode();
@@ -260,10 +260,10 @@ class DurableContextImpl implements DurableContext {
       this.hasRunningOperations.bind(this),
     );
     try {
-      if (typeof nameOrMillis === "string") {
-        return waitHandler(nameOrMillis, maybeMillis!);
+      if (typeof nameOrSeconds === "string") {
+        return waitHandler(nameOrSeconds, maybeSeconds!);
       } else {
-        return waitHandler(nameOrMillis);
+        return waitHandler(nameOrSeconds);
       }
     } finally {
       if (shouldSwitchToExecutionMode) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
@@ -65,7 +65,7 @@ describe("Wait Handler", () => {
       Status: OperationStatus.SUCCEEDED,
     } as Operation;
 
-    await waitHandler("test-wait", 1000);
+    await waitHandler("test-wait", 1);
 
     // Verify checkpoint was not called
     expect(mockCheckpoint).not.toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe("Wait Handler", () => {
       Type: OperationType.WAIT,
       Name: undefined,
       WaitOptions: {
-        WaitSeconds: 0.5,
+        WaitSeconds: 500,
       },
     });
 
@@ -102,7 +102,7 @@ describe("Wait Handler", () => {
 
   test("should checkpoint at start and terminate with WAIT_SCHEDULED reason", async () => {
     // Call the wait handler but don't await it (it will never resolve)
-    waitHandler("test-wait", 1000);
+    waitHandler("test-wait", 1);
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -128,7 +128,7 @@ describe("Wait Handler", () => {
 
   test("should use stepId as message when name is not provided", async () => {
     // Call the wait handler but don't await it (it will never resolve)
-    waitHandler(1000);
+    waitHandler(1);
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -158,7 +158,7 @@ describe("Wait Handler", () => {
         .mock(mockCallback);
 
       // Wait handler should throw an error when mocks are detected
-      await expect(waitHandler("test-wait", 1000)).rejects.toThrow(
+      await expect(waitHandler("test-wait", 1)).rejects.toThrow(
         "Wait step cannot be mocked",
       );
 
@@ -179,7 +179,7 @@ describe("Wait Handler", () => {
         .mock(mockCallback);
 
       // Wait handler should throw an error when mocks are detected
-      await expect(waitHandler(1000)).rejects.toThrow(
+      await expect(waitHandler(1)).rejects.toThrow(
         "Wait step cannot be mocked",
       );
 
@@ -209,7 +209,7 @@ describe("Wait Handler", () => {
         "Wait step cannot be mocked",
       );
 
-      await expect(waitHandler("wait-2", 1000)).rejects.toThrow(
+      await expect(waitHandler("wait-2", 1)).rejects.toThrow(
         "Wait step cannot be mocked",
       );
 
@@ -235,7 +235,7 @@ describe("Wait Handler", () => {
         Status: OperationStatus.SUCCEEDED,
       } as Operation;
 
-      await waitHandler("completed-wait", 1000);
+      await waitHandler("completed-wait", 1);
 
       // Should skip execution entirely (no mock check occurs for completed operations)
       expect(mockCheckpoint).not.toHaveBeenCalled();
@@ -249,7 +249,7 @@ describe("Wait Handler", () => {
       mockExecutionContext.parentId = "parent-step-123";
 
       // Call the wait handler but don't await it (it will never resolve)
-      waitHandler("test-wait-with-parent", 1000);
+      waitHandler("test-wait-with-parent", 1);
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -284,7 +284,7 @@ describe("Wait Handler", () => {
         Type: OperationType.WAIT,
         Name: "test-wait-without-parent",
         WaitOptions: {
-          WaitSeconds: 5,
+          WaitSeconds: 5000,
         },
       });
     });
@@ -299,7 +299,7 @@ describe("Wait Handler", () => {
           mockHasRunningOperations,
         );
 
-        waitHandler("test-wait", 1000);
+        waitHandler("test-wait", 1);
         await new Promise((resolve) => setTimeout(resolve, 50));
 
         expect(
@@ -325,7 +325,7 @@ describe("Wait Handler", () => {
           mockHasRunningOperations,
         );
 
-        waitHandler("test-wait", 1000);
+        waitHandler("test-wait", 1);
         await new Promise((resolve) => setTimeout(resolve, 50));
 
         expect(mockCheckpoint).not.toHaveBeenCalled();
@@ -342,7 +342,7 @@ describe("Wait Handler", () => {
           mockHasRunningOperations,
         );
 
-        waitHandler("test-wait", 1000);
+        waitHandler("test-wait", 1);
         await new Promise((resolve) => setTimeout(resolve, 50));
 
         expect(mockCheckpoint).toHaveBeenCalledWith("test-step-id", {
@@ -376,7 +376,7 @@ describe("Wait Handler", () => {
         );
 
         // Start the wait handler (don't await - it will wait for operations)
-        const waitPromise = waitHandler("test-wait", 1000);
+        const waitPromise = waitHandler("test-wait", 1);
 
         // Give it time to enter the waiting logic
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -18,24 +18,24 @@ export const createWaitHandler = (
   createStepId: () => string,
   hasRunningOperations: () => boolean,
 ): {
-  (name: string, millis: number): Promise<void>;
-  (millis: number): Promise<void>;
+  (name: string, seconds: number): Promise<void>;
+  (seconds: number): Promise<void>;
 } => {
-  function waitHandler(name: string, millis: number): Promise<void>;
-  function waitHandler(millis: number): Promise<void>;
+  function waitHandler(name: string, seconds: number): Promise<void>;
+  function waitHandler(seconds: number): Promise<void>;
   async function waitHandler(
-    nameOrMillis: string | number,
-    millis?: number,
+    nameOrSeconds: string | number,
+    seconds?: number,
   ): Promise<void> {
-    const isNameFirst = typeof nameOrMillis === "string";
-    const actualName = isNameFirst ? nameOrMillis : undefined;
-    const actualMillis = isNameFirst ? millis! : nameOrMillis;
+    const isNameFirst = typeof nameOrSeconds === "string";
+    const actualName = isNameFirst ? nameOrSeconds : undefined;
+    const actualSeconds = isNameFirst ? seconds! : nameOrSeconds;
     const stepId = createStepId();
 
     log(context.isVerbose, "⏲️", "Wait requested:", {
       stepId,
       name: actualName,
-      millis: actualMillis,
+      seconds: actualSeconds,
     });
 
     // Main wait logic - can be re-executed if step data changes
@@ -63,7 +63,7 @@ export const createWaitHandler = (
           Type: OperationType.WAIT,
           Name: actualName,
           WaitOptions: {
-            WaitSeconds: actualMillis / 1000,
+            WaitSeconds: actualSeconds,
           },
         });
       }


### PR DESCRIPTION
*Description of changes:*

    - Update examples to use seconds: comprehensive-operations, map-basic, steps-with-retry, concurrent-wait
    - Update testing library integration tests to use seconds

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
