### PR TITLE
ci: increase integ test timeout, only cleanup on failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,21 +2,21 @@ name: Integration Tests
 
 on:
   push:
-    branches: [ "main", "development" ]
+    branches: ["main", "development"]
     paths:
-      - 'packages/aws-durable-execution-**'
-      - 'packages/client-lambda/**'
-      - '.github/workflows/integration-tests.yml'
-      - '.github/workflows/scripts/integration-test/**'
-      - '.github/model/**'
+      - "packages/aws-durable-execution-**"
+      - "packages/client-lambda/**"
+      - ".github/workflows/integration-tests.yml"
+      - ".github/workflows/scripts/integration-test/**"
+      - ".github/model/**"
   pull_request:
-    branches: [ "main", "development"]
+    branches: ["main", "development"]
     paths:
-      - 'packages/aws-durable-execution-**'
-      - 'packages/client-lambda/**'
-      - '.github/workflows/integration-tests.yml'
-      - '.github/workflows/scripts/integration-test/**'
-      - '.github/model/**'
+      - "packages/aws-durable-execution-**"
+      - "packages/client-lambda/**"
+      - ".github/workflows/integration-tests.yml"
+      - ".github/workflows/scripts/integration-test/**"
+      - ".github/model/**"
   workflow_dispatch:
 
 env:
@@ -24,8 +24,8 @@ env:
 
 # permission can be added at job level or workflow level
 permissions:
-  id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 jobs:
   setup:
@@ -33,134 +33,131 @@ jobs:
     outputs:
       function-name-map: ${{ steps.deploy-functions.outputs.function-name-map }}
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-        cache: 'npm'
+      - uses: actions/checkout@v4
 
-    - name: Configure AWS credentials (OIDC for main workflow)
-      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
-        role-session-name: githubIntegrationTest
-        aws-region: ${{ env.AWS_REGION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
 
-    - name: Install custom Lambda model
-      run: |
-        aws configure add-model --service-model file://.github/model/lambda.json --service-name lambda
+      - name: Configure AWS credentials (OIDC for main workflow)
+        if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+          role-session-name: githubIntegrationTest
+          aws-region: ${{ env.AWS_REGION }}
 
-    - name: Install dependencies
-      run:
-        npm run install-all
+      - name: Install custom Lambda model
+        run: |
+          aws configure add-model --service-model file://.github/model/lambda.json --service-name lambda
 
-    - name: Build project
-      run:
-        npm run build
+      - name: Install dependencies
+        run: npm run install-all
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: built-artifacts
-        path: |
-          packages/**/dist/*
-          packages/**/dist-cjs/*
-          package.json
-    
-    - name: Deploy functions
-      env:
-        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-        INVOKE_ACCOUNT_ID: ${{ secrets.INVOKE_ACCOUNT_ID }}
-        KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
-        GITHUB_EVENT_NAME: ${{ github.event_name }}
-        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-      run:
-        node .github/workflows/scripts/integration-test/integration-test.js --deploy-only
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-artifacts
+          path: |
+            packages/**/dist/*
+            packages/**/dist-cjs/*
+            package.json
+
+      - name: Deploy functions
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+          INVOKE_ACCOUNT_ID: ${{ secrets.INVOKE_ACCOUNT_ID }}
+          KMS_KEY_ARN: ${{ secrets.KMS_KEY_ARN }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+        run: node .github/workflows/scripts/integration-test/integration-test.js --deploy-only
 
   jest-integration-test:
     needs: setup
     runs-on: ubuntu-latest
     name: Jest Integration Tests
-    
+
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-        cache: 'npm'
-    
-    - name: Configure AWS credentials (OIDC for main workflow)
-      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
-        role-session-name: githubIntegrationTest
-        aws-region: ${{ env.AWS_REGION }}
+      - uses: actions/checkout@v4
 
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: built-artifacts
-        path: .
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
 
-    - name: Install dependencies
-      run: |
-        npm run install-all
-    
-    - name: Run Jest integration tests
-      env:
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-        FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
-        GITHUB_EVENT_NAME: ${{ github.event_name }}
-        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      run: |
-         node .github/workflows/scripts/integration-test/integration-test.js --test-only
+      - name: Configure AWS credentials (OIDC for main workflow)
+        if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+          role-session-name: githubIntegrationTest
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: built-artifacts
+          path: .
+
+      - name: Install dependencies
+        run: |
+          npm run install-all
+
+      - name: Run Jest integration tests
+        env:
+          LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+          FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+        run: |
+          node .github/workflows/scripts/integration-test/integration-test.js --test-only
 
   cleanup:
     needs: [setup, jest-integration-test]
     runs-on: ubuntu-latest
-    if: always()
-    
+    if: ${{ !failure() }}
+
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-        cache: 'npm'
+      - uses: actions/checkout@v4
 
-    - name: Download build artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: built-artifacts
-        path: .
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
 
-    - name: Install dependencies
-      run: |
-        npm run install-all
-    
-    - name: Configure AWS credentials (OIDC for main workflow)
-      if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
-        role-session-name: githubIntegrationTest
-        aws-region: ${{ env.AWS_REGION }}
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: built-artifacts
+          path: .
 
-    - name: Cleanup Lambda functions
-      env:
-        LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-        FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
-        GITHUB_EVENT_NAME: ${{ github.event_name }}
-        GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      run: |
-        node .github/workflows/scripts/integration-test/integration-test.js --cleanup-only
+      - name: Install dependencies
+        run: |
+          npm run install-all
+
+      - name: Configure AWS credentials (OIDC for main workflow)
+        if: github.event_name != 'workflow_dispatch' || github.actor != 'nektos/act'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+          role-session-name: githubIntegrationTest
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Cleanup Lambda functions
+        env:
+          LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+          FUNCTION_NAME_MAP: ${{ needs.setup.outputs.function-name-map }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+        run: |
+          node .github/workflows/scripts/integration-test/integration-test.js --cleanup-only

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix",
-    "*.{js,mjs,ts,md,json}": "prettier --write"
+    "*.{js,mjs,ts,md,json,yml}": "prettier --write"
   },
   "private": true
 }

--- a/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
+++ b/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
@@ -6,5 +6,5 @@ const defaultPreset = createDefaultPreset();
 module.exports = {
   ...defaultPreset,
   testMatch: ["**/__tests__/**.test.ts"],
-  testTimeout: 30000,
+  testTimeout: 60000,
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Tests are timing out after 30 seconds. Increasing the timeout to 1 minute, and also changing the workflow to only cleanup when it's not failed. This will allow retrying the integration tests to work better.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
