### PR TITLE
fix(sdk): preserve JSDoc comments in generated declaration files

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "clean": "rm -rf dist dist-cjs node_modules",
-    "build": "concurrently npm:build:esm npm:build:cjs",
+    "build": "concurrently npm:build:esm npm:build:cjs && npm run build:types",
     "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
     "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",
+    "build:types": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build && npm run test",
     "lint": "eslint",
     "pretest": "npm run lint",

--- a/packages/aws-durable-execution-sdk-js-testing/tsconfig.build.json
+++ b/packages/aws-durable-execution-sdk-js-testing/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/aws-durable-execution-sdk-js-testing/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-testing/tsconfig.json
@@ -8,7 +8,6 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "isolatedModules": true,
-    "emitDeclarationOnly": true,
     "module": "esnext",
     "moduleResolution": "bundler"
   },

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -24,9 +24,10 @@
   ],
   "scripts": {
     "prebuild": "npm run lint:fix",
-    "build": "concurrently npm:build:esm npm:build:cjs",
+    "build": "concurrently npm:build:esm npm:build:cjs && npm run build:types",
     "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
     "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,8 +56,8 @@ export function createBuildOptions(options, mode) {
       plugins: [
         typescript({
           noEmitOnError: true,
-          declaration: true,
-          declarationMap: true,
+          declaration: false,
+          declarationMap: false,
           outDir: "./dist",
           exclude: ["**/__tests__/**/*"],
         }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "removeComments": true
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
*Description of changes:*

The root cause of missing JSDoc documentation in IDEs was the "removeComments": true option in the root tsconfig.json, which was stripping all comments—
including JSDoc—from the generated TypeScript declaration files (.d.ts). When developers consumed the SDK as a dependency, their IDEs only had access to
these compiled declaration files, not the source code, so they couldn't see any documentation when hovering over methods like context.step(). To fix this,
we removed the removeComments option and restructured the build process to use tsc directly for generating declaration files (via a new build:types script),
while keeping Rollup solely for bundling JavaScript. We also disabled Rollup's declaration generation to avoid conflicts. Now when the package is built,
the JSDoc comments from the source interface definitions in src/types/index.ts are preserved in the generated dist/types/index.d.ts files, ensuring that
consumers of the SDK see full documentation with descriptions, parameter details, and code examples directly in their IDE when using the library.

- Remove 'removeComments' option from root tsconfig.json to preserve JSDoc in .d.ts files
- Add separate build:types script to generate declarations using tsc directly
- Disable declaration generation in Rollup to avoid conflicts

This ensures that consumers of the SDK see full documentation with descriptions, parameter details, and examples when hovering over methods in their IDE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
