### PR TITLE
feat(sdk): add replay mode to execute concurrent (map/parallel)

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.integration.test.ts
@@ -1,0 +1,56 @@
+import { createTestDurableContext } from "../../testing/create-test-durable-context";
+import { DurableExecutionMode } from "../../types";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+
+describe("DurableContext Integration Tests", () => {
+  it("should handle replay mode and skip operations correctly", async () => {
+    // Create context in replay mode with existing operations
+    const existingOperations = [
+      {
+        Id: "1",
+        Status: OperationStatus.SUCCEEDED,
+      },
+      {
+        Id: "2",
+        Status: OperationStatus.SUCCEEDED,
+      },
+    ];
+
+    const { context } = createTestDurableContext({
+      durableExecutionMode: DurableExecutionMode.ReplayMode,
+      existingOperations,
+    });
+
+    // Execute steps - they should replay from existing operations
+    const result1 = await context.step("step-1", async () => "value1");
+    const result2 = await context.step("step-2", async () => "value2");
+
+    // In replay mode, steps should execute
+    expect(result1).toBeDefined();
+    expect(result2).toBeDefined();
+  });
+
+  it("should transition from replay to execution mode", async () => {
+    // Create context with only one existing operation
+    const existingOperations = [
+      {
+        Id: "1",
+        Status: OperationStatus.SUCCEEDED,
+      },
+    ];
+
+    const { context } = createTestDurableContext({
+      durableExecutionMode: DurableExecutionMode.ReplayMode,
+      existingOperations,
+    });
+
+    // First step replays
+    const result1 = await context.step("step-1", async () => "value1");
+
+    // Second step should transition to execution mode (no existing operation)
+    const result2 = await context.step("step-2", async () => "value2");
+
+    expect(result1).toBeDefined();
+    expect(result2).toBe("value2");
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -99,6 +99,15 @@ class DurableContextImpl implements DurableContext {
       : `${nextCounter}`;
   }
 
+  /**
+   * Skips the next operation by incrementing the step counter.
+   * Used internally by concurrent execution handler during replay to skip incomplete items.
+   * @internal
+   */
+  private skipNextOperation(): void {
+    this._stepCounter++;
+  }
+
   private checkAndUpdateReplayMode(): void {
     if (this.durableExecutionMode === DurableExecutionMode.ReplayMode) {
       const nextStepId = this.getNextStepId();
@@ -375,6 +384,7 @@ class DurableContextImpl implements DurableContext {
       const concurrentExecutionHandler = createConcurrentExecutionHandler(
         this.executionContext,
         this.runInChildContext.bind(this),
+        this.skipNextOperation.bind(this),
       );
       return concurrentExecutionHandler(
         nameOrItems,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.integration.test.ts
@@ -1,0 +1,160 @@
+import { createTestDurableContext } from "../../testing/create-test-durable-context";
+import { BatchItemStatus } from "../../types";
+
+describe("ConcurrentExecutionHandler Integration Tests", () => {
+  it("should execute items concurrently with real DurableContext", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = [
+      { id: "item-1", data: { value: 1 }, index: 0 },
+      { id: "item-2", data: { value: 2 }, index: 1 },
+      { id: "item-3", data: { value: 3 }, index: 2 },
+    ];
+
+    const executionOrder: number[] = [];
+
+    const result = await context.executeConcurrently(
+      items,
+      async (item) => {
+        executionOrder.push(item.data.value);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return item.data.value * 2;
+      },
+      { maxConcurrency: 2 },
+    );
+
+    expect(result.totalCount).toBe(3);
+    expect(result.successCount).toBe(3);
+    expect(result.failureCount).toBe(0);
+    expect(result.all).toHaveLength(3);
+
+    const successfulResults = result.succeeded();
+    expect(successfulResults).toHaveLength(3);
+    expect(successfulResults.map((r) => r.result)).toEqual([2, 4, 6]);
+
+    expect(
+      result.all.every((item) => item.status === BatchItemStatus.SUCCEEDED),
+    ).toBe(true);
+  });
+
+  it("should respect maxConcurrency limit", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      id: `item-${i}`,
+      data: { value: i },
+      index: i,
+    }));
+
+    let maxConcurrent = 0;
+    let currentConcurrent = 0;
+
+    const result = await context.executeConcurrently(
+      items,
+      async (item) => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        currentConcurrent--;
+        return item.data.value;
+      },
+      { maxConcurrency: 3 },
+    );
+
+    expect(result.totalCount).toBe(10);
+    expect(result.successCount).toBe(10);
+    expect(maxConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  it("should use child context for each item execution", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = [
+      { id: "item-1", data: { value: 1 }, index: 0 },
+      { id: "item-2", data: { value: 2 }, index: 1 },
+    ];
+
+    const childContexts: any[] = [];
+
+    const result = await context.executeConcurrently(
+      items,
+      async (item, childContext) => {
+        childContexts.push(childContext);
+
+        // Use child context to run a step
+        const stepResult = await childContext.step(
+          `process-${item.id}`,
+          async () => item.data.value * 10,
+        );
+
+        return stepResult;
+      },
+    );
+
+    expect(result.successCount).toBe(2);
+    expect(childContexts).toHaveLength(2);
+    expect(childContexts[0]).toBeDefined();
+    expect(childContexts[1]).toBeDefined();
+
+    const results = result.succeeded().map((r) => r.result);
+    expect(results).toEqual([10, 20]);
+  });
+
+  it("should support early termination with minSuccessful", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      id: `item-${i}`,
+      data: { value: i },
+      index: i,
+    }));
+
+    let executedCount = 0;
+
+    const result = await context.executeConcurrently(
+      items,
+      async (item) => {
+        executedCount++;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return item.data.value;
+      },
+      {
+        maxConcurrency: 2,
+        completionConfig: {
+          minSuccessful: 3,
+        },
+      },
+    );
+
+    expect(result.successCount).toBeGreaterThanOrEqual(3);
+    expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+    expect(executedCount).toBeLessThan(10);
+  });
+
+  it("should execute items with proper isolation between child contexts", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = [
+      { id: "task-1", data: { multiplier: 2 }, index: 0 },
+      { id: "task-2", data: { multiplier: 3 }, index: 1 },
+      { id: "task-3", data: { multiplier: 4 }, index: 2 },
+    ];
+
+    const result = await context.executeConcurrently(
+      "process-tasks",
+      items,
+      async (item) => {
+        // Simulate some async work
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return 10 * item.data.multiplier;
+      },
+      { maxConcurrency: 2 },
+    );
+
+    expect(result.totalCount).toBe(3);
+    expect(result.successCount).toBe(3);
+    expect(result.getResults()).toEqual([20, 30, 40]);
+    expect(result.status).toBe(BatchItemStatus.SUCCEEDED);
+    expect(result.hasFailure).toBe(false);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
@@ -1,0 +1,363 @@
+import { ConcurrencyController } from "./concurrent-execution-handler";
+import {
+  DurableContext,
+  BatchItemStatus,
+  DurableExecutionMode,
+  ExecutionContext,
+} from "../../types";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+
+describe("ConcurrencyController - Replay Mode", () => {
+  let controller: ConcurrencyController;
+  let mockParentContext: jest.Mocked<DurableContext>;
+  let mockExecutionContext: jest.Mocked<ExecutionContext>;
+  let mockSkipNextOperation: jest.Mock;
+
+  beforeEach(() => {
+    mockSkipNextOperation = jest.fn();
+    controller = new ConcurrencyController(
+      "test-operation",
+      mockSkipNextOperation,
+    );
+    mockParentContext = {
+      runInChildContext: jest.fn(),
+    } as any;
+    mockExecutionContext = {
+      getStepData: jest.fn(),
+    } as any;
+  });
+
+  it("should replay only completed items in ReplaySucceededContext mode", async () => {
+    const items = [
+      { id: "item-0", data: "data1", index: 0 },
+      { id: "item-1", data: "data2", index: 1 },
+      { id: "item-2", data: "data3", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      all: [
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1` || id === `${entityId}-2`) {
+        return { Status: OperationStatus.SUCCEEDED };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      async (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return await (fn as any)({} as any);
+      },
+    );
+
+    executor.mockResolvedValueOnce("result1").mockResolvedValueOnce("result2");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(2);
+    expect(result.totalCount).toBe(2);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("should handle failed items during replay", async () => {
+    const items = [
+      { id: "item-0", data: "data1", index: 0 },
+      { id: "item-1", data: "data2", index: 1 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      all: [
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        {
+          index: 1,
+          error: { message: "error" },
+          status: BatchItemStatus.FAILED,
+        },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1`) {
+        return { Status: OperationStatus.SUCCEEDED };
+      }
+      if (id === `${entityId}-2`) {
+        return { Status: OperationStatus.FAILED };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      async (nameOrFn, fnOrConfig) => {
+        const name = typeof nameOrFn === "string" ? nameOrFn : undefined;
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        if (name === "item-1") {
+          throw new Error("Replay error");
+        }
+        return await (fn as any)({} as any);
+      },
+    );
+
+    executor.mockResolvedValueOnce("result1");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.totalCount).toBe(2);
+  });
+
+  it("should stop replay early when target count is reached", async () => {
+    const items = [
+      { id: "item-0", data: "data1", index: 0 },
+      { id: "item-1", data: "data2", index: 1 },
+      { id: "item-2", data: "data3", index: 2 },
+      { id: "item-3", data: "data4", index: 3 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      all: [
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1` || id === `${entityId}-2`) {
+        return { Status: OperationStatus.SUCCEEDED };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockResolvedValue("result");
+    executor.mockResolvedValue("result");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.totalCount).toBe(2);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("should skip incomplete items during replay", async () => {
+    const items = [
+      { id: "item-0", data: "data1", index: 0 },
+      { id: "item-1", data: "data2", index: 1 },
+      { id: "item-2", data: "data3", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    // Items 0 and 2 completed, item 1 was incomplete
+    const initialResultSummary = JSON.stringify({
+      all: [
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        { index: 2, result: "result3", status: BatchItemStatus.SUCCEEDED },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1`) {
+        return { Status: OperationStatus.SUCCEEDED };
+      }
+      // Item 1 incomplete (entityId-2)
+      if (id === `${entityId}-2`) {
+        return undefined;
+      }
+      // Item 2 completed (entityId-3)
+      if (id === `${entityId}-3`) {
+        return { Status: OperationStatus.SUCCEEDED };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockResolvedValue("result");
+    executor.mockResolvedValue("result");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.totalCount).toBe(2);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fallback to concurrent execution when no target count found", async () => {
+    const items = [{ id: "item-0", data: "data1", index: 0 }];
+    const executor = jest.fn().mockResolvedValue("result");
+
+    mockExecutionContext.getStepData.mockReturnValue(undefined);
+    mockParentContext.runInChildContext.mockResolvedValue("result");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      "parent-step",
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+  });
+
+  it("should fallback to concurrent execution when summary parsing fails", async () => {
+    const items = [{ id: "item-0", data: "data1", index: 0 }];
+    const executor = jest.fn().mockResolvedValue("result");
+    const entityId = "parent-step";
+
+    mockExecutionContext.getStepData.mockReturnValue({
+      Status: OperationStatus.SUCCEEDED,
+      ContextDetails: { Result: "invalid json" },
+    });
+    mockParentContext.runInChildContext.mockResolvedValue("result");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+  });
+
+  it("should use ExecutionMode for first-time execution", async () => {
+    const items = [
+      { id: "item-0", data: "data1", index: 0 },
+      { id: "item-1", data: "data2", index: 1 },
+    ];
+    const executor = jest.fn().mockResolvedValue("result");
+
+    mockParentContext.runInChildContext.mockResolvedValue("result");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ExecutionMode,
+    );
+
+    expect(result.successCount).toBe(2);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("should handle non-Error thrown values during replay", async () => {
+    const items = [{ id: "item-0", data: "data1", index: 0 }];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      all: [
+        {
+          index: 0,
+          error: { message: "string error" },
+          status: BatchItemStatus.FAILED,
+        },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1`) {
+        return { Status: OperationStatus.FAILED };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockRejectedValue("string error");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.failureCount).toBe(1);
+    expect(result.failed()[0].error).toBeInstanceOf(Error);
+    expect(result.failed()[0].error?.message).toBe("string error");
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -20,6 +20,7 @@ describe("Concurrent Execution Handler", () => {
     concurrentExecutionHandler = createConcurrentExecutionHandler(
       mockExecutionContext,
       mockRunInChildContext,
+      jest.fn(),
     );
   });
 
@@ -416,7 +417,7 @@ describe("ConcurrencyController", () => {
   let mockParentContext: jest.Mocked<DurableContext>;
 
   beforeEach(() => {
-    controller = new ConcurrencyController("test-operation");
+    controller = new ConcurrencyController("test-operation", jest.fn());
     mockParentContext = {
       runInChildContext: jest.fn(),
     } as any;
@@ -655,7 +656,10 @@ describe("ConcurrencyController", () => {
     });
 
     it("should handle verbose logging", async () => {
-      const verboseController = new ConcurrencyController("verbose-test");
+      const verboseController = new ConcurrencyController(
+        "verbose-test",
+        jest.fn(),
+      );
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn();
 
@@ -750,7 +754,10 @@ describe("ConcurrencyController", () => {
 
     it("should execute with iterationSubType and cover the actual execution path", async () => {
       // Create a new controller for this test to ensure clean state
-      const testController = new ConcurrencyController("test-operation");
+      const testController = new ConcurrencyController(
+        "test-operation",
+        jest.fn(),
+      );
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn().mockResolvedValue("test-result");
       const config = { iterationSubType: "TEST_ITERATION_TYPE" };

--- a/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
@@ -1,0 +1,99 @@
+import { Context } from "aws-lambda";
+import { Operation } from "@aws-sdk/client-lambda";
+import { createDurableContext } from "../context/durable-context/durable-context";
+import { ExecutionState } from "../storage/storage-provider";
+import { TerminationManager } from "../termination-manager/termination-manager";
+import {
+  DurableContext,
+  ExecutionContext,
+  DurableExecutionMode,
+} from "../types";
+import { getStepData as getStepDataUtil } from "../utils/step-id-utils/step-id-utils";
+
+/**
+ * In-memory storage for testing - no API calls
+ */
+class InMemoryStorage implements ExecutionState {
+  private operations: Operation[] = [];
+
+  async getStepData(): Promise<{ Operations: Operation[] }> {
+    return { Operations: this.operations };
+  }
+
+  async checkpoint(): Promise<Record<string, never>> {
+    return {};
+  }
+
+  addOperation(operation: Operation): void {
+    this.operations.push(operation);
+  }
+
+  getOperations(): Operation[] {
+    return this.operations;
+  }
+}
+
+/**
+ * Creates a real DurableContext with mocked storage for integration testing
+ */
+export function createTestDurableContext(options?: {
+  stepPrefix?: string;
+  durableExecutionMode?: DurableExecutionMode;
+  existingOperations?: Operation[];
+  lambdaContext?: Partial<Context>;
+}): {
+  context: DurableContext;
+  storage: InMemoryStorage;
+  executionContext: ExecutionContext;
+} {
+  const storage = new InMemoryStorage();
+
+  // Add existing operations if provided
+  if (options?.existingOperations) {
+    options.existingOperations.forEach((op) => storage.addOperation(op));
+  }
+
+  const stepData: Record<string, Operation> = {};
+  storage.getOperations().forEach((op) => {
+    if (op.Id) {
+      stepData[op.Id] = op;
+    }
+  });
+
+  const executionContext: ExecutionContext = {
+    state: storage,
+    _stepData: stepData,
+    terminationManager: new TerminationManager(),
+    durableExecutionArn:
+      "arn:aws:lambda:us-east-1:123456789012:durable-execution:test",
+    getStepData(stepId: string): Operation | undefined {
+      return getStepDataUtil(stepData, stepId);
+    },
+  };
+
+  const mockLambdaContext: Context = {
+    callbackWaitsForEmptyEventLoop: false,
+    functionName: "test-function",
+    functionVersion: "1",
+    invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789012:function:test",
+    memoryLimitInMB: "128",
+    awsRequestId: "test-request-id",
+    logGroupName: "/aws/lambda/test",
+    logStreamName: "test-stream",
+    getRemainingTimeInMillis: () => 30000,
+    done: () => {},
+    fail: () => {},
+    succeed: () => {},
+    ...options?.lambdaContext,
+  };
+
+  const context = createDurableContext(
+    executionContext,
+    mockLambdaContext,
+    options?.durableExecutionMode || DurableExecutionMode.ExecutionMode,
+    options?.stepPrefix,
+    "test-checkpoint-token",
+  );
+
+  return { context, storage, executionContext };
+}


### PR DESCRIPTION
*Description of changes:*
When rerunning map and parallel operations with large payloads, we face two key challenges in handling unfinished executions:
- We must exclude any items that didn't complete during the first execution
- We need to maintain consistency by ensuring the final result contains the same number of items as the original execution

Changes:
- Execute concurrent handle replay mode different that initial execution to make it deterministic for big payload
- Add skipNextOperation() method to DurableContext to increment step counter
- Update ConcurrencyController to use skipNextOperation when skipping incomplete items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
