### PR TITLE
feat(sdk): improve retry strategy with standard jitter patterns

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -419,14 +419,14 @@ describe("WaitForCallback Operations Integration", () => {
       expect(result.getResult()).toEqual({
         success: false,
         error: "Complex submitter failed at step 3",
-        // Retries 3 times
-        sideEffects: 9,
+        // Retries 6 times (default maxAttempts)
+        sideEffects: 18,
         callbackId: expect.any(String),
       });
 
       // Verify that callback ID was generated before failure
       expect(callbackId).toBeDefined();
-      expect(sideEffectCounter).toBe(9);
+      expect(sideEffectCounter).toBe(18);
 
       // Should have no succeeded operations since submitter failed
       const completedOperations = result.getOperations({

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -21,6 +21,7 @@ export {
   Logger,
   LambdaHandler,
   InvokeConfig,
+  JitterStrategy,
 } from "./types";
 export { StepInterruptedError } from "./errors/step-errors/step-errors";
 export {
@@ -35,3 +36,8 @@ export {
   createWaitStrategy,
   WaitStrategyConfig,
 } from "./utils/wait-strategy/wait-strategy-config";
+export {
+  createRetryStrategy,
+  RetryStrategyConfig,
+} from "./utils/retry/retry-config";
+export { retryPresets } from "./utils/retry/retry-presets/retry-presets";

--- a/packages/aws-durable-execution-sdk-js/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/index.ts
@@ -693,6 +693,20 @@ export enum StepSemantics {
 }
 
 /**
+ * Jitter strategy for retry delays to prevent thundering herd problem
+ * @remarks
+ * Jitter adds randomness to retry delays to spread out retry attempts when multiple operations fail simultaneously
+ */
+export enum JitterStrategy {
+  /** No jitter - use exact calculated delay */
+  NONE = "NONE",
+  /** Full jitter - random delay between 0 and calculated delay */
+  FULL = "FULL",
+  /** Half jitter - random delay between 50% and 100% of calculated delay */
+  HALF = "HALF",
+}
+
+/**
  * Configuration options for step operations
  */
 export interface StepConfig<T> {

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
@@ -1,17 +1,43 @@
-import { createRetryStrategy } from "../retry-config";
+import { createRetryStrategy, JitterStrategy } from "../retry-config";
 
+/**
+ * Pre-configured retry strategies for common use cases
+ * @example
+ * ```typescript
+ * // Use default retry preset (3 attempts with exponential backoff)
+ * await context.step('my-step', async () => {
+ *   return await someOperation();
+ * }, { retryStrategy: retryPresets.default });
+ *
+ * // Use no-retry preset (fail immediately on error)
+ * await context.step('critical-step', async () => {
+ *   return await criticalOperation();
+ * }, { retryStrategy: retryPresets.noRetry });
+ * ```
+ */
 export const retryPresets = {
-  // Default retries, will be used automatically if retryConfig is missing
+  /**
+   * Default retry strategy with exponential backoff
+   * - 6 total attempts (1 initial + 5 retries)
+   * - Initial delay: 5 seconds
+   * - Max delay: 60 seconds
+   * - Backoff rate: 2x
+   * - Jitter: FULL (randomizes delay between 0 and calculated delay)
+   * - Total max wait time less than 150 seconds (2:30)
+   */
   default: createRetryStrategy({
-    maxAttempts: 3,
+    maxAttempts: 6,
     initialDelaySeconds: 5,
     maxDelaySeconds: 60,
     backoffRate: 2,
-    jitterSeconds: 1,
+    jitter: JitterStrategy.FULL,
   }),
 
-  // No retries - fail immediately on first error
+  /**
+   * No retry strategy - fails immediately on first error
+   * - 1 total attempt (no retries)
+   */
   noRetry: createRetryStrategy({
-    maxAttempts: 0,
+    maxAttempts: 1,
   }),
 };


### PR DESCRIPTION
- Replace jitterSeconds with JitterStrategy enum (NONE, FULL, HALF)
- Fix noRetry preset: maxAttempts 0→1 for semantic correctness
- Update default preset: maxAttempts 3→6 (~2.25min total retry time)
- Ensure retry delays are always integers ≥1 second
- Add comprehensive TSDoc for retry configuration
- Export retry utilities (createRetryStrategy, retryPresets, JitterStrategy)
- Add unit test

BREAKING CHANGE: jitterSeconds parameter replaced with jitter enum

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
