### PR TITLE
feat(testing-sdk): add run-durable CLI to execute functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/eslint-plugin-durable-functions",
     "postpublish": "git restore .",
     "clean": "rm -rf node_modules && npm run clean --workspaces --if-present",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "run-durable": "ORIGINAL_CWD=$PWD npm run run-durable -w packages/aws-durable-execution-sdk-js-testing --"
   },
   "repository": {
     "type": "git",

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "node": ">=20"
   },
+  "bin": {
+    "run-durable": "./dist/cli/run-durable.js"
+  },
   "scripts": {
     "clean": "rm -rf dist dist-cjs node_modules",
     "build": "concurrently npm:build:esm npm:build:cjs && npm run build:types",
@@ -17,7 +20,8 @@
     "prepublishOnly": "npm run build && npm run test",
     "lint": "eslint",
     "pretest": "npm run lint",
-    "test": "jest --config jest.config.mjs --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}"
+    "test": "jest --config jest.config.mjs --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}",
+    "run-durable": "tsx src/cli/run-durable.ts"
   },
   "exports": {
     ".": {

--- a/packages/aws-durable-execution-sdk-js-testing/src/cli/README.md
+++ b/packages/aws-durable-execution-sdk-js-testing/src/cli/README.md
@@ -1,0 +1,45 @@
+# run-durable CLI
+
+A command-line tool to quickly run and test durable functions locally without writing test code.
+
+## Usage
+
+From the monorepo root:
+
+```bash
+npm run run-durable <path-to-handler-file>
+```
+
+From the testing package:
+
+```bash
+npm run run-durable <path-to-handler-file>
+```
+
+## Examples
+
+```bash
+# Run hello-world example
+npm run run-durable packages/aws-durable-execution-sdk-js-examples/src/examples/hello-world.ts
+
+# Run comprehensive operations
+npm run run-durable packages/aws-durable-execution-sdk-js-examples/src/examples/comprehensive-operations.ts
+
+# Run step with retry
+npm run run-durable packages/aws-durable-execution-sdk-js-examples/src/examples/step-with-retry.ts
+```
+
+## Output
+
+The CLI will:
+
+1. Start a local checkpoint server
+2. Execute the durable function
+3. Print a table of all operations with details (name, type, status, timing)
+4. Display the execution status
+5. Show the result (or error if failed)
+
+## Requirements
+
+- The file must export a `handler` or `default` export
+- The handler must be wrapped with `withDurableFunctions()`

--- a/packages/aws-durable-execution-sdk-js-testing/src/cli/run-durable.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/cli/run-durable.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { LocalDurableTestRunner } from "../test-runner/local";
+import { pathToFileURL } from "url";
+import { resolve } from "path";
+import type {
+  LambdaHandler,
+  DurableExecutionInvocationInput,
+} from "@aws/durable-execution-sdk-js";
+
+async function runDurable() {
+  const filePath = process.argv[2];
+
+  if (!filePath) {
+    console.error("Usage: run-durable <path-to-handler-file>");
+    console.error("Example: run-durable ./src/examples/hello-world.ts");
+    process.exit(1);
+  }
+
+  // Use ORIGINAL_CWD if set (from root npm script), otherwise use INIT_CWD (npm's original dir), fallback to cwd
+  const basePath =
+    process.env.ORIGINAL_CWD ?? process.env.INIT_CWD ?? process.cwd();
+  const absolutePath = resolve(basePath, filePath);
+  const fileUrl = pathToFileURL(absolutePath).href;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const module: { handler?: unknown; default?: unknown } = await import(
+      fileUrl
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const handler = (module.handler ??
+      module.default) as LambdaHandler<DurableExecutionInvocationInput>;
+
+    await LocalDurableTestRunner.setupTestEnvironment();
+
+    const runner = new LocalDurableTestRunner({
+      handlerFunction: handler,
+      skipTime: true,
+    });
+
+    console.log(`Running durable function from: ${filePath}\n`);
+
+    const execution = await runner.run();
+
+    execution.print();
+
+    console.log("\nExecution Status:", execution.getStatus());
+
+    try {
+      const result = execution.getResult();
+      console.log("\nResult:");
+      console.log(JSON.stringify(result, null, 2));
+    } catch {
+      const err = execution.getError();
+      console.log("\nError:");
+      console.log(JSON.stringify(err, null, 2));
+    }
+
+    await LocalDurableTestRunner.teardownTestEnvironment();
+  } catch (error) {
+    console.error("Error running durable function:", error);
+    process.exit(1);
+  }
+}
+
+void runDurable();


### PR DESCRIPTION
## Description

Adds a run-durable CLI command to the testing SDK that allows developers to quickly execute and inspect durable functions without
writing test code.

## What's Changed

• **New CLI tool** (src/cli/run-durable.ts): Executes any durable function file and displays results
• **Package updates**: Added bin entry and npm scripts for easy access
• **Documentation**: CLI usage guide and updated README

## Usage

bash
### From monorepo root
npm run run-durable packages/aws-durable-execution-sdk-js-examples/src/examples/hello-world.ts

### From testing package
npm run run-durable ../path/to/handler.ts


## Output

The CLI automatically:
• Starts a local checkpoint server
• Executes the durable function
• Prints an operations table with timing and status
• Displays execution status and result/error JSON

## Example Output
```
┌─────────┬──────────┬──────┬────────┬─────────┬─────────────┬────────────────────────────┬────────────────────────────┬──────────┐
│ (index) │ parentId │ name │ type   │ subType │ status      │ startTime                  │ endTime                    │ duration │
├─────────┼──────────┼──────┼────────┼─────────┼─────────────┼────────────────────────────┼────────────────────────────┼──────────┤
│ 0       │ '-'      │ '-'  │ 'STEP' │ 'Step'  │ 'SUCCEEDED' │ '2025-10-15T21:07:38.000Z' │ '2025-10-15T21:07:38.000Z' │ '0ms'    │
└─────────┴──────────┴──────┴────────┴─────────┴─────────────┴────────────────────────────┴────────────────────────────┴──────────┘
```
Execution Status: SUCCEEDED

Result:
"step completed"


## Benefits

• **Faster development**: Test functions instantly without writing test boilerplate
• **Better debugging**: Visual operations table shows execution flow
• **Easy exploration**: Try examples and prototypes quickly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
