### PR TITLE
fix(sdk): handle STOPPED status in invoke-handler

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -174,35 +174,40 @@ describe("InvokeHandler", () => {
       );
     });
 
-    it.each([OperationStatus.FAILED, OperationStatus.TIMED_OUT])(
-      "should throw error when operation status is %s",
-      async (status) => {
-        const mockGetStepData = jest.fn().mockReturnValue({
-          Status: status,
-          ChainedInvokeDetails: {
-            Error: {
-              ErrorMessage: "Lambda function execution failed",
-              ErrorType: "ExecutionError",
-            },
+    it.each([
+      OperationStatus.FAILED,
+      OperationStatus.TIMED_OUT,
+      OperationStatus.STOPPED,
+    ])("should throw error when operation status is %s", async (status) => {
+      const mockGetStepData = jest.fn().mockReturnValue({
+        Status: status,
+        ChainedInvokeDetails: {
+          Error: {
+            ErrorMessage: "Lambda function execution failed",
+            ErrorType: "ExecutionError",
           },
-        });
+        },
+      });
 
-        mockContext.getStepData = mockGetStepData;
+      mockContext.getStepData = mockGetStepData;
 
-        const invokeHandler = createInvokeHandler(
-          mockContext,
-          mockCheckpointFn,
-          mockCreateStepId,
-          mockHasRunningOperations,
-        );
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+      );
 
-        await expect(
-          invokeHandler("test-function", { test: "data" }),
-        ).rejects.toThrow("Lambda function execution failed");
-      },
-    );
+      await expect(
+        invokeHandler("test-function", { test: "data" }),
+      ).rejects.toThrow("Lambda function execution failed");
+    });
 
-    it.each([OperationStatus.FAILED, OperationStatus.TIMED_OUT])(
+    it.each([
+      OperationStatus.FAILED,
+      OperationStatus.TIMED_OUT,
+      OperationStatus.STOPPED,
+    ])(
       "should throw error with default message when %s status has no error details",
       async (status) => {
         const mockGetStepData = jest.fn().mockReturnValue({

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -80,7 +80,8 @@ export const createInvokeHandler = (
 
       if (
         stepData?.Status === OperationStatus.FAILED ||
-        stepData?.Status == OperationStatus.TIMED_OUT
+        stepData?.Status === OperationStatus.TIMED_OUT ||
+        stepData?.Status === OperationStatus.STOPPED
       ) {
         // Operation failed, throw error
         const invokeDetails = stepData.ChainedInvokeDetails;


### PR DESCRIPTION
*Description of changes:*

- Add OperationStatus.STOPPED to error handling in invoke-handler
- Update unit tests to cover STOPPED status for both error scenarios
- Ensures invoke operations properly handle stopped invocations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
