### PR TITLE
feat(sdk): add termination flag to prevent checkpoint race conditions

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
@@ -1,0 +1,128 @@
+import { TerminationManager } from "./termination-manager";
+import { TerminationReason } from "./types";
+import {
+  createCheckpoint,
+  deleteCheckpoint,
+} from "../utils/checkpoint/checkpoint";
+import { ExecutionContext } from "../types";
+
+describe("TerminationManager Checkpoint Integration", () => {
+  let terminationManager: TerminationManager;
+  let mockContext: ExecutionContext;
+
+  beforeEach(() => {
+    deleteCheckpoint();
+    terminationManager = new TerminationManager();
+
+    mockContext = {
+      durableExecutionArn: "test-arn",
+      state: {
+        checkpoint: jest.fn().mockResolvedValue({
+          CheckpointToken: "new-token",
+          NewExecutionState: { Operations: [] },
+        }),
+      },
+      _stepData: {},
+      terminationManager,
+    } as unknown as ExecutionContext;
+  });
+
+  afterEach(() => {
+    deleteCheckpoint();
+  });
+
+  test("should set checkpoint terminating flag when terminate is called", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    // Checkpoint should work before termination
+    await checkpoint("step-1", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockContext.state.checkpoint).toHaveBeenCalledTimes(1);
+
+    // Trigger termination
+    terminationManager.terminate({
+      reason: TerminationReason.OPERATION_TERMINATED,
+      message: "Test termination",
+    });
+
+    // Checkpoint should be blocked after termination
+    await checkpoint("step-2", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockContext.state.checkpoint).toHaveBeenCalledTimes(1);
+  });
+
+  test("should prevent force checkpoint after termination", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const mockCheckpointFn = mockContext.state.checkpoint as jest.Mock;
+
+    // Queue a checkpoint first
+    await checkpoint("step-1", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    // Force checkpoint should work before termination
+    await checkpoint.force();
+    await new Promise((resolve) => setImmediate(resolve));
+    const callsBeforeTermination = mockCheckpointFn.mock.calls.length;
+
+    // Trigger termination
+    terminationManager.terminate({
+      reason: TerminationReason.CHECKPOINT_FAILED,
+    });
+
+    // Queue another checkpoint
+    await checkpoint("step-2", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    // Force checkpoint should be blocked after termination
+    await checkpoint.force();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Should not have made any additional calls after termination
+    expect(mockCheckpointFn).toHaveBeenCalledTimes(callsBeforeTermination);
+  });
+
+  test("should set terminating flag immediately when terminate is called", () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    // Terminate
+    terminationManager.terminate();
+
+    // Immediately try to checkpoint (synchronously)
+    const checkpointPromise = checkpoint("step-1", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    // Should resolve immediately without calling API
+    return checkpointPromise.then(() => {
+      expect(mockContext.state.checkpoint).not.toHaveBeenCalled();
+    });
+  });
+
+  test("should handle multiple terminate calls gracefully", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    terminationManager.terminate();
+    terminationManager.terminate();
+    terminationManager.terminate();
+
+    await checkpoint("step-1", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    expect(mockContext.state.checkpoint).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager.ts
@@ -18,6 +18,7 @@ import {
   TerminationResponse,
   TerminationReason,
 } from "./types";
+import { setCheckpointTerminating } from "../utils/checkpoint/checkpoint";
 
 export class TerminationManager extends EventEmitter {
   private isTerminated = false;
@@ -37,6 +38,10 @@ export class TerminationManager extends EventEmitter {
     if (this.isTerminated) return;
 
     this.isTerminated = true;
+
+    // Set checkpoint termination flag before any other termination logic
+    setCheckpointTerminating();
+
     this.terminationDetails = {
       reason: options.reason ?? TerminationReason.OPERATION_TERMINATED,
       message: options.message ?? "Operation terminated",

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-checkpoint.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-checkpoint.ts
@@ -3,6 +3,7 @@ import { OperationUpdate } from "@aws-sdk/client-lambda";
 export type CheckpointFunction = {
   (stepId: string, data: Partial<OperationUpdate>): Promise<void>;
   force(): Promise<void>;
+  setTerminating(): void;
 };
 
 export const createMockCheckpoint = (
@@ -16,6 +17,7 @@ export const createMockCheckpoint = (
   );
   const mockCheckpoint = Object.assign(mockFn, {
     force: jest.fn().mockResolvedValue(undefined),
+    setTerminating: jest.fn(),
   }) as jest.MockedFunction<CheckpointFunction>;
 
   return mockCheckpoint;

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
@@ -1,0 +1,140 @@
+import {
+  createCheckpoint,
+  deleteCheckpoint,
+  setCheckpointTerminating,
+} from "./checkpoint";
+import { ExecutionContext } from "../../types";
+import { TerminationManager } from "../../termination-manager/termination-manager";
+import * as logger from "../logger/logger";
+
+describe("Checkpoint Termination Flag", () => {
+  let mockContext: ExecutionContext;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    deleteCheckpoint();
+    logSpy = jest.spyOn(logger, "log").mockImplementation();
+
+    mockContext = {
+      durableExecutionArn: "test-arn",
+      state: {
+        checkpoint: jest.fn().mockResolvedValue({
+          CheckpointToken: "new-token",
+          NewExecutionState: { Operations: [] },
+        }),
+      },
+      _stepData: {},
+      terminationManager: new TerminationManager(),
+    } as unknown as ExecutionContext;
+  });
+
+  afterEach(() => {
+    deleteCheckpoint();
+    logSpy.mockRestore();
+  });
+
+  test("should skip checkpoint when termination flag is set", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    setCheckpointTerminating();
+
+    await checkpoint("test-step", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    expect(mockContext.state.checkpoint).not.toHaveBeenCalled();
+  });
+
+  test("should skip forceCheckpoint when termination flag is set", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    setCheckpointTerminating();
+
+    await checkpoint.force();
+
+    expect(mockContext.state.checkpoint).not.toHaveBeenCalled();
+  });
+
+  test("should allow checkpoint before termination flag is set", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    await checkpoint("test-step", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    // Wait for async processing
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockContext.state.checkpoint).toHaveBeenCalled();
+  });
+
+  test("should prevent new checkpoints after setTerminating is called", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    // First checkpoint should work
+    await checkpoint("step-1", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockContext.state.checkpoint).toHaveBeenCalledTimes(1);
+
+    // Set termination flag
+    setCheckpointTerminating();
+
+    // Second checkpoint should be skipped
+    await checkpoint("step-2", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockContext.state.checkpoint).toHaveBeenCalledTimes(1);
+  });
+
+  test("should call setCheckpointTerminating through checkpoint.setTerminating", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    checkpoint.setTerminating();
+
+    await checkpoint("test-step", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    expect(mockContext.state.checkpoint).not.toHaveBeenCalled();
+  });
+
+  test("should log when checkpoint is skipped due to termination", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    setCheckpointTerminating();
+
+    await checkpoint("test-step", {
+      Action: "START",
+      Type: "STEP",
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "⚠️",
+      "Checkpoint skipped - termination in progress:",
+      { stepId: "test-step" },
+    );
+  });
+
+  test("should log when force checkpoint is skipped due to termination", async () => {
+    const checkpoint = createCheckpoint(mockContext, "initial-token");
+
+    setCheckpointTerminating();
+
+    await checkpoint.force();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "⚠️",
+      "Force checkpoint skipped - termination in progress",
+    );
+  });
+});


### PR DESCRIPTION
    Add isTerminating flag to checkpoint handler to prevent checkpoint API calls
    during Lambda shutdown window. When TerminationManager.terminate() is called,
    the flag is set immediately, causing all subsequent checkpoint operations to
    resolve without making API calls.

    Changes:
    - Add isTerminating flag and setTerminating() method to CheckpointHandler
    - Call setCheckpointTerminating() in TerminationManager.terminate()
    - Update CheckpointFunction type to include setTerminating() method
    - Add new unit tests