### PR TITLE
refactor(sdk): rename withDurableFunctions to withDurableExecution

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/ADDING_EXAMPLES.md
+++ b/packages/aws-durable-execution-sdk-js-examples/ADDING_EXAMPLES.md
@@ -11,10 +11,10 @@ Create your example in `src/examples/your-example.ts`:
 ```typescript
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     // Your durable function logic here
     const result = await context.step(async () => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/logger-example.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/logger-example.test.ts
@@ -1,8 +1,8 @@
 import { loggerExample } from "../logger-example";
-import { withDurableFunctions } from "@aws/durable-execution-sdk-js";
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
 import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
 
-const handler = withDurableFunctions(loggerExample);
+const handler = withDurableExecution(loggerExample);
 
 describe("logger-example test (local)", () => {
   beforeAll(() => LocalDurableTestRunner.setupTestEnvironment());

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/block-example.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/block-example.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Handler started");
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/comprehensive-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/comprehensive-operations.ts
@@ -1,6 +1,6 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
 interface ComprehensiveExampleInput {
@@ -14,7 +14,7 @@ interface ComprehensiveExampleInput {
  * - ctx.map: Map operation with multiple iterations
  * - ctx.parallel: Parallel execution of multiple branches
  */
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: ComprehensiveExampleInput, context: DurableContext) => {
     console.log("Starting comprehensive operations example with event:", event);
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-operations.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     // Start multiple concurrent operations using runInChildContext
     const task1 = context.runInChildContext(

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/concurrent-wait.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Before waits");
     await Promise.all([

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const [callbackPromise, callbackId] =
       await context.createCallback<string>();

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/hello-world.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/hello-world.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Hello world from a durable function!");
     return "Hello World!";

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-basic.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const items = [1, 2, 3, 4, 5];
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-basic.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const results = await context.parallel(
       "parallel",

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel-wait.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Before waits");
     await context.parallel("parent-block", [

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const promise1 = context.step(async () => "success");
     const promise2 = context.step(async () => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const promise1 = context.step(async () => "result 1");
     const promise2 = context.step(async () => "result 2");

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-any.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-any.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const promise1 = context.step(async () => {
       throw new Error("failure 1");

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-combinators.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-combinators.ts
@@ -1,6 +1,6 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
 interface PromiseCombinatorsInput {
@@ -15,7 +15,7 @@ interface PromiseCombinatorsInput {
  * - context.promise.any: Get the first successful promise
  *
  */
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: PromiseCombinatorsInput, context: DurableContext) => {
     console.log("Starting promise combinators example with event:", event);
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-race.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-race.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const promise1 = context.step(async () => {
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.runInChildContext(
       async (childContext: DurableContext) => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step-basic.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.step(async () => {
       return "step completed";

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step-named.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step-named.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.step("process-data", async () => {
       return `processed: ${event.data || "default"}`;

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step-with-retry.ts
@@ -1,10 +1,10 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
   StepSemantics,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.step(
       async () => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/steps-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/steps-with-retry.ts
@@ -1,6 +1,6 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 
@@ -27,7 +27,7 @@ interface HandlerInput {
   name: string;
 }
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: HandlerInput, context: DurableContext) => {
     let item;
     try {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback.ts
@@ -1,13 +1,13 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
 const mySubmitterFunction = async (callbackId: string): Promise<void> => {
   console.log(`Calling my external system with callback id: ${callbackId}`);
 };
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Hello world before callback!");
     const result = await context.waitForCallback(

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-condition.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-condition.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.waitForCondition(
       async (state: number) => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-named.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-named.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Starting wait operation");
     await context.wait("wait-2-seconds", 2);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait.ts
@@ -1,9 +1,9 @@
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
-export const handler = withDurableFunctions(
+export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     console.log("Hello world before wait!");
     await context.wait(2);

--- a/packages/aws-durable-execution-sdk-js-testing/src/cli/README.md
+++ b/packages/aws-durable-execution-sdk-js-testing/src/cli/README.md
@@ -42,4 +42,4 @@ The CLI will:
 ## Requirements
 
 - The file must export a `handler` or `default` export
-- The handler must be wrapped with `withDurableFunctions()`
+- The handler must be wrapped with `withDurableExecution()`

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/callback-operations.integration.test.ts
@@ -2,7 +2,7 @@ import { LocalDurableTestRunner } from "../../local-durable-test-runner";
 import { WaitingOperationStatus } from "../../../durable-test-runner";
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 import { OperationType } from "@aws-sdk/client-lambda";
 
@@ -15,7 +15,7 @@ afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
  */
 describe("Callback Operations Integration", () => {
   it("should handle callback operations with success completion", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         // Create callback - returns [promise, callbackId]
         const [callbackPromise, callbackId] = await context.createCallback(
@@ -77,7 +77,7 @@ describe("Callback Operations Integration", () => {
   });
 
   it("should handle callback operations with failure", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         try {
           const [callbackPromise] = await context.createCallback(
@@ -131,7 +131,7 @@ describe("Callback Operations Integration", () => {
 
   // todo: should use time skipping instead of real timers to reduce the length of this test
   it("should handle callback heartbeats", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         const [callbackPromise] = await context.createCallback(
           "long-running-task",
@@ -179,7 +179,7 @@ describe("Callback Operations Integration", () => {
   });
 
   it("should time out if there are no callback heartbeats", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         const [callbackPromise] = await context.createCallback(
           "long-running-task",
@@ -207,7 +207,7 @@ describe("Callback Operations Integration", () => {
   });
 
   it("should time out if callback times out", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         const [callbackPromise] = await context.createCallback(
           "long-running-task",
@@ -235,7 +235,7 @@ describe("Callback Operations Integration", () => {
   });
 
   it("should handle multiple concurrent callback operations", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         // Start multiple callbacks concurrently
         const [promise1] = await context.createCallback("api-call-1", {
@@ -315,7 +315,7 @@ describe("Callback Operations Integration", () => {
   });
 
   it("should handle callback operations mixed with other operation types", async () => {
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         // Mix callback with step and wait operations
         await context.wait("initial-wait", 100);
@@ -410,7 +410,7 @@ describe("Callback Operations Integration", () => {
       },
     };
 
-    const handler = withDurableFunctions(
+    const handler = withDurableExecution(
       async (event: unknown, context: DurableContext) => {
         const [callbackPromise] = await context.createCallback<CustomData>(
           "custom-serdes-callback",

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
@@ -1,4 +1,4 @@
-import { withDurableFunctions } from "@aws/durable-execution-sdk-js";
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
 import { LocalDurableTestRunner } from "../../local-durable-test-runner";
 
 beforeAll(() => LocalDurableTestRunner.setupTestEnvironment());
@@ -6,7 +6,7 @@ afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
 
 describe("LocalDurableTestRunner Invoke operations integration", () => {
   it("should invoke a function with no input and return the result", async () => {
-    const handler = withDurableFunctions(async (_, ctx) => {
+    const handler = withDurableExecution(async (_, ctx) => {
       const result = await ctx.invoke(
         "durableOperation",
         "myDurableFunctionArn",
@@ -28,7 +28,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
 
     runner.registerDurableFunction(
       "myDurableFunctionArn",
-      withDurableFunctions(async ({ durableInput }, ctx) => {
+      withDurableExecution(async ({ durableInput }, ctx) => {
         const stepResult = await ctx.step("hello world", () => {
           return Promise.resolve("durable test result");
         });
@@ -118,7 +118,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
 
   // TODO: handling errors for callback and checkpoint updates
   it.skip("should fail execution if invoking a function that does not exist", async () => {
-    const handler = withDurableFunctions(async (_, ctx) => {
+    const handler = withDurableExecution(async (_, ctx) => {
       await ctx.invoke("durableOperation", "nonExistentFunction", {
         durableInput: "bar",
       });
@@ -131,7 +131,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
 
     runner.registerDurableFunction(
       "myFunctionArn",
-      withDurableFunctions(async ({ nonDurableInput }) => {
+      withDurableExecution(async ({ nonDurableInput }) => {
         return Promise.resolve({
           type: "non-durable",
           input: nonDurableInput,

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -2,7 +2,7 @@ import { LocalDurableTestRunner } from "../../local-durable-test-runner";
 import { WaitingOperationStatus } from "../../../durable-test-runner";
 import {
   DurableContext,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 
@@ -17,7 +17,7 @@ describe("WaitForCallback Operations Integration", () => {
   it("should handle basic waitForCallback with anonymous submitter", async () => {
     let receivedCallbackId: string | undefined;
 
-    const handler = withDurableFunctions<unknown, unknown>(
+    const handler = withDurableExecution<unknown, unknown>(
       async (_event: unknown, context: DurableContext) => {
         const result = await context.waitForCallback<{ data: string }>(
           async (callbackId) => {
@@ -68,7 +68,7 @@ describe("WaitForCallback Operations Integration", () => {
 
   it("should handle basic waitForCallback with named submitter", async () => {
     let receivedCallbackId: string | undefined; // simulates a side-effect since it's outside the handler
-    const handler = withDurableFunctions<unknown, unknown>(
+    const handler = withDurableExecution<unknown, unknown>(
       async (_event: unknown, context: DurableContext) => {
         const result = await context.waitForCallback<{ data: string }>(
           async (callbackId) => {
@@ -117,7 +117,7 @@ describe("WaitForCallback Operations Integration", () => {
   // Error Handling & Submitter Function Variants Category
   describe("Error Handling & Submitter Function Variants", () => {
     it("should handle waitForCallback with submitter function synchronous errors", async () => {
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -161,7 +161,7 @@ describe("WaitForCallback Operations Integration", () => {
     });
 
     it("should handle waitForCallback with submitter function returning rejected promises", async () => {
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -207,7 +207,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with callback failure scenarios", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -273,7 +273,7 @@ describe("WaitForCallback Operations Integration", () => {
       let scenario2CallbackId: string | undefined;
 
       // Test scenario where submitter fails but callback would have succeeded
-      const handler1 = withDurableFunctions<unknown, unknown>(
+      const handler1 = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -312,7 +312,7 @@ describe("WaitForCallback Operations Integration", () => {
 
       // Test scenario where submitter succeeds but callback fails (covered in previous test)
       // This test demonstrates the contrast between the two scenarios
-      const handler2 = withDurableFunctions<unknown, unknown>(
+      const handler2 = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             (callbackId) => {
@@ -363,7 +363,7 @@ describe("WaitForCallback Operations Integration", () => {
       let callbackId: string | undefined;
       let sideEffectCounter = 0;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -441,7 +441,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with heartbeat timeout configuration", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             async (callbackId) => {
@@ -510,7 +510,7 @@ describe("WaitForCallback Operations Integration", () => {
       let submitterStartTime: number;
       let submitterEndTime: number;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ processed: number }>(
             async (callbackId) => {
@@ -587,7 +587,7 @@ describe("WaitForCallback Operations Integration", () => {
     });
 
     it("should handle waitForCallback timeout scenarios", async () => {
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
             const result = await context.waitForCallback<{ data: string }>(
@@ -636,7 +636,7 @@ describe("WaitForCallback Operations Integration", () => {
       let callback2Id: string | undefined;
       let callback3Id: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           // Start multiple waitForCallback operations concurrently
           const parallelResult = await context.parallel([
@@ -763,7 +763,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback mixed with steps, waits, and other operations", async () => {
       let callbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           // Mix waitForCallback with other operation types
           await context.wait("initial-wait", 50);
@@ -850,7 +850,7 @@ describe("WaitForCallback Operations Integration", () => {
       let parentCallbackId: string | undefined;
       let childCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const parentResult = await context.waitForCallback<{
             parentData: string;
@@ -952,7 +952,7 @@ describe("WaitForCallback Operations Integration", () => {
       let firstCallbackId: string | undefined;
       let secondCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           await context.wait("wait-invocation-1", 1);
 
@@ -1055,7 +1055,7 @@ describe("WaitForCallback Operations Integration", () => {
       let innerCallbackId: string | undefined;
       let nestedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const outerResult = await context.waitForCallback<{ level: string }>(
             "outer-callback-op",
@@ -1199,7 +1199,7 @@ describe("WaitForCallback Operations Integration", () => {
     it("should handle waitForCallback with custom timeout settings", async () => {
       let receivedCallbackId: string | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<{ data: string }>(
             "custom-timeout-callback",
@@ -1314,7 +1314,7 @@ describe("WaitForCallback Operations Integration", () => {
       let receivedCallbackId: string | undefined;
       let submitterData: CustomData | undefined;
 
-      const handler = withDurableFunctions<unknown, unknown>(
+      const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           const result = await context.waitForCallback<CustomData>(
             "custom-serdes-callback",

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/invoke-handler.ts
@@ -1,7 +1,7 @@
 import { Operation } from "@aws-sdk/client-lambda";
 import { Context } from "aws-lambda";
 import {
-  withDurableFunctions,
+  withDurableExecution,
   DurableExecutionInvocationOutput,
 } from "@aws/durable-execution-sdk-js";
 import { randomUUID } from "node:crypto";
@@ -55,7 +55,7 @@ export class InvokeHandler {
    * @returns Promise resolving to the handler's output
    */
   async invoke(
-    handler: ReturnType<typeof withDurableFunctions>,
+    handler: ReturnType<typeof withDurableExecution>,
     parameters: HandlerParameters,
   ): Promise<DurableExecutionInvocationOutput> {
     const invocationEvent = this.buildInvocationEvent(parameters);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
@@ -6,7 +6,7 @@ import {
 import {
   DurableExecutionInvocationInput,
   LambdaHandler,
-  withDurableFunctions,
+  withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 import { LocalOperationStorage } from "./operations/local-operation-storage";
 import { OperationWaitManager } from "./operations/operation-wait-manager";
@@ -30,7 +30,7 @@ import {
 import { getDurableExecutionsClient } from "./api-client/durable-executions-client";
 
 export type LocalTestRunnerHandlerFunction = ReturnType<
-  typeof withDurableFunctions
+  typeof withDurableExecution
 >;
 
 export type { LocalDurableTestRunnerParameters };
@@ -155,20 +155,20 @@ export class LocalDurableTestRunner<ResultType>
    * Registers a durable function handler that can be invoked during durable execution testing.
    *
    * @param functionName - The name/ARN of the function that will be used in context.invoke() calls
-   * @param durableHandler - The durable function handler created with withDurableFunctions
+   * @param durableHandler - The durable function handler created with withDurableExecution
    * @returns This LocalDurableTestRunner instance for method chaining
    *
    * @example
    * ```typescript
    * import { LocalDurableTestRunner } from '@aws/durable-execution-sdk-js-testing';
-   * import { withDurableFunctions } from '@aws/durable-execution-sdk-js';
+   * import { withDurableExecution } from '@aws/durable-execution-sdk-js';
    *
    * const testRunner = new LocalDurableTestRunner({
    *   handlerFunction: mainHandler
    * });
    *
    * // Register a durable function
-   * const processWorkflow = withDurableFunctions(async (input, context) => {
+   * const processWorkflow = withDurableExecution(async (input, context) => {
    *   const step1 = await context.step('validate', () => validate(input));
    *   const step2 = await context.step('process', () => process(step1));
    *   return step2;

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/function-storage.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/function-storage.ts
@@ -55,7 +55,7 @@ export class FunctionStorage {
    * Durable functions are executed with their own LocalDurableTestRunner instance.
    *
    * @param functionName - The name/ARN of the function to register
-   * @param durableHandler - The durable function handler created with withDurableFunctions
+   * @param durableHandler - The durable function handler created with withDurableExecution
    */
   registerDurableFunction(
     functionName: string,

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
@@ -4,7 +4,7 @@ import {
   OperationStatus,
 } from "@aws-sdk/client-lambda";
 import {
-  withDurableFunctions,
+  withDurableExecution,
   InvocationStatus,
 } from "@aws/durable-execution-sdk-js";
 import { InvocationResult } from "../../checkpoint-server/storage/execution-manager";
@@ -44,7 +44,7 @@ export class TestExecutionOrchestrator {
   private invocationTracker: InvocationTracker;
 
   constructor(
-    private handlerFunction: ReturnType<typeof withDurableFunctions>,
+    private handlerFunction: ReturnType<typeof withDurableExecution>,
     private operationStorage: LocalOperationStorage,
     private readonly checkpointApi: CheckpointApiClient,
     private readonly scheduler: Scheduler,

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./with-durable-functions";
+export * from "./with-durable-execution";
 export {
   DurableContext,
   StepConfig,

--- a/packages/aws-durable-execution-sdk-js/src/run-durable.ts
+++ b/packages/aws-durable-execution-sdk-js/src/run-durable.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { Context } from "aws-lambda";
-import { withDurableFunctions } from "./with-durable-functions";
+import { withDurableExecution } from "./with-durable-execution";
 import { resolve } from "path";
 import { DurableExecutionInvocationInput } from "./types";
 
@@ -24,7 +24,7 @@ async function runHandler(
     }
 
     // Wrap the handler with durableFunctions
-    const wrappedHandler = withDurableFunctions(handler);
+    const wrappedHandler = withDurableExecution(handler);
 
     // Create test event
     const event = lambdaRequestJson

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -1,4 +1,4 @@
-import { withDurableFunctions } from "./with-durable-functions";
+import { withDurableExecution } from "./with-durable-execution";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { createDurableContext } from "./context/durable-context/durable-context";
 import { CheckpointFailedError } from "./errors/checkpoint-errors/checkpoint-errors";
@@ -29,7 +29,7 @@ jest.mock("./utils/logger/logger", () => ({
 const mockCheckpointToken = "test-checkpoint-token";
 const mockDurableExecutionArn = "test-durable-execution-arn";
 
-describe("withDurableFunctions", () => {
+describe("withDurableExecution", () => {
   // Setup common test variables
   const mockEvent: DurableExecutionInvocationInput = {
     CheckpointToken: mockCheckpointToken,
@@ -91,7 +91,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify
@@ -114,7 +114,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify
@@ -137,7 +137,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       CheckpointFailedError,
     );
@@ -156,7 +156,7 @@ describe("withDurableFunctions", () => {
     });
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       CheckpointFailedError,
     );
@@ -175,7 +175,7 @@ describe("withDurableFunctions", () => {
     });
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify
@@ -218,7 +218,7 @@ describe("withDurableFunctions", () => {
     });
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await wrappedHandler(mockEvent, mockContext);
 
     // Verify setTimeout was called
@@ -248,7 +248,7 @@ describe("withDurableFunctions", () => {
     );
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify
@@ -266,7 +266,7 @@ describe("withDurableFunctions", () => {
     );
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify - should use fallback "undefined" string
@@ -288,7 +288,7 @@ describe("withDurableFunctions", () => {
     );
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify
@@ -328,7 +328,7 @@ describe("withDurableFunctions", () => {
     );
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       CheckpointFailedError,
     );
@@ -366,7 +366,7 @@ describe("withDurableFunctions", () => {
     );
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       CheckpointFailedError,
     );
@@ -393,7 +393,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       SerializationFailedError,
     );
@@ -419,7 +419,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute & Verify
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
       CustomInvocationError,
     );
@@ -445,7 +445,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
     // Verify - UnrecoverableExecutionError should be returned as failed invocation, not thrown
@@ -468,7 +468,7 @@ describe("withDurableFunctions", () => {
     ); // Never resolves
 
     // Execute
-    const wrappedHandler = withDurableFunctions(mockHandler);
+    const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
     expect(deleteCheckpoint).toHaveBeenCalledTimes(1);
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -183,7 +183,7 @@ async function runHandler<Input, Output>(
   }
 }
 
-export const withDurableFunctions = <Input, Output>(
+export const withDurableExecution = <Input, Output>(
   handler: DurableHandler<Input, Output>,
 ): LambdaHandler<DurableExecutionInvocationInput> => {
   return async (
@@ -208,3 +208,8 @@ export const withDurableFunctions = <Input, Output>(
     }
   };
 };
+
+/**
+ * @deprecated Use `withDurableExecution` instead. This alias will be removed in a future version.
+ */
+export const withDurableFunctions = withDurableExecution;


### PR DESCRIPTION
- Renamed core wrapper function from withDurableFunctions to withDurableExecution
- Updated all imports and usages across SDK, testing SDK, and examples
- Renamed source files: with-durable-functions.ts -> with-durable-execution.ts
- Added deprecated alias export for backward compatibility
- All tests passing (614 SDK tests, 40 example tests)
- Breaking change mitigated by deprecated alias that maintains old API