### PR TITLE
fix(sdk): handle circular references in checkpoint logging

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/logger.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-console */
+import { safeStringify } from "../safe-stringify/safe-stringify";
 
 export const log = (emoji: string, message: string, data?: unknown): void => {
   if (process.env.DURABLE_VERBOSE_MODE === "true") {
-    console.log(
-      `${emoji} ${message}`,
-      data ? JSON.stringify(data, null, 2) : "",
-    );
+    console.log(`${emoji} ${message}`, data ? safeStringify(data) : "");
   }
 };

--- a/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.test.ts
@@ -1,0 +1,69 @@
+import { safeStringify } from "./safe-stringify";
+
+describe("safeStringify", () => {
+  it("should stringify simple objects", () => {
+    const obj = { name: "test", value: 42 };
+    const result = safeStringify(obj);
+    expect(result).toBe(JSON.stringify(obj, null, 2));
+  });
+
+  it("should handle circular references", () => {
+    const obj: any = { name: "test" };
+    obj.self = obj;
+    const result = safeStringify(obj);
+    expect(result).toContain('"name": "test"');
+    expect(result).toContain('"self": "[Circular]"');
+  });
+
+  it("should handle nested circular references", () => {
+    const obj: any = { a: { b: {} } };
+    obj.a.b.c = obj;
+    const result = safeStringify(obj);
+    expect(result).toContain('"c": "[Circular]"');
+  });
+
+  it("should handle arrays with circular references", () => {
+    const arr: any[] = [1, 2];
+    arr.push(arr);
+    const result = safeStringify(arr);
+    expect(result).toContain("[Circular]");
+  });
+
+  it("should handle null and undefined", () => {
+    expect(safeStringify(null)).toBe("null");
+    expect(safeStringify(undefined)).toBe(undefined);
+  });
+
+  it("should handle primitives", () => {
+    expect(safeStringify("string")).toBe('"string"');
+    expect(safeStringify(42)).toBe("42");
+    expect(safeStringify(true)).toBe("true");
+  });
+
+  it("should return fallback for non-serializable values", () => {
+    const obj = { fn: (): void => {} };
+    const result = safeStringify(obj);
+    expect(result).toContain("{}");
+  });
+
+  it("should handle BigInt values that cannot be serialized", () => {
+    const obj = { value: BigInt(9007199254740991) };
+    const result = safeStringify(obj);
+    expect(result).toBe("[Unable to stringify]");
+  });
+
+  it("should handle Error objects", () => {
+    const error = new Error("hello world");
+    const result = safeStringify(error);
+    expect(result).toContain('"message": "hello world"');
+    expect(result).toContain('"name": "Error"');
+    expect(result).toContain('"stack"');
+  });
+
+  it("should handle nested Error objects", () => {
+    const obj = { error: new Error("nested error"), data: "test" };
+    const result = safeStringify(obj);
+    expect(result).toContain('"message": "nested error"');
+    expect(result).toContain('"data": "test"');
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.ts
@@ -1,0 +1,28 @@
+export const safeStringify = (data: unknown): string => {
+  try {
+    const seen = new WeakSet();
+    return JSON.stringify(
+      data,
+      (key, value) => {
+        if (typeof value === "object" && value !== null) {
+          if (seen.has(value)) return "[Circular]";
+          seen.add(value);
+
+          // Handle Error objects by extracting their properties
+          if (value instanceof Error) {
+            return {
+              ...value,
+              name: value.name,
+              message: value.message,
+              stack: value.stack,
+            };
+          }
+        }
+        return value;
+      },
+      2,
+    );
+  } catch {
+    return "[Unable to stringify]";
+  }
+};


### PR DESCRIPTION
Problem:
The SDK crashed when logging checkpoint data that contained circular references (e.g., HTTP request/response objects with req.res and res.req circular links
). The error occurred in the logger utility at line 68 when JSON.stringify() attempted to serialize circular structures:
```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'IncomingMessage'
    |     property 'req' -> object with constructor 'ClientRequest'
    --- property 'res' closes the circle
```

Root Cause:
The log() function in src/utils/logger/logger.ts used JSON.stringify() directly without handling circular references, causing the Lambda function to crash
with an unhandled promise rejection.

Changes:
1. Created safeStringify() utility that uses a WeakSet to detect and handle circular references
2. Circular references are replaced with "[Circular]" markers instead of crashing
3. Minimal performance overhead (O(1) operations, automatic garbage collection)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
