### PR TITLE
fix(sdk): handle PENDING status in invoke-handler

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -92,7 +92,10 @@ export const createInvokeHandler = (
         throw error;
       }
 
-      if (stepData?.Status === OperationStatus.STARTED) {
+      if (
+        stepData?.Status === OperationStatus.STARTED ||
+        stepData?.Status === OperationStatus.PENDING
+      ) {
         // Operation is still running, check for other operations before terminating
         if (hasRunningOperations()) {
           log(


### PR DESCRIPTION
*Description of changes:*

- Add PENDING status handling alongside STARTED status in invoke-handler
- Both statuses now follow same logic: wait if other operations running, terminate if not
- Add comprehensive unit tests for PENDING status scenarios
- Ensures consistent behavior for all in-progress operation states

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
