### PR TITLE
fix(sdk): preserve undefined result from handler without fallback

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -269,10 +269,11 @@ describe("withDurableExecution", () => {
     const wrappedHandler = withDurableExecution(mockHandler);
     const response = await wrappedHandler(mockEvent, mockContext);
 
-    // Verify - should use fallback "undefined" string
+    // Verify - Result should be undefined (not empty string) when handler returns undefined
+    // JSON.stringify(undefined) returns undefined, which is preserved in the Result field
     expect(response).toEqual({
       Status: InvocationStatus.SUCCEEDED,
-      Result: "",
+      Result: undefined,
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -162,7 +162,7 @@ async function runHandler<Input, Output>(
     // If response size is acceptable, return the response
     return {
       Status: InvocationStatus.SUCCEEDED,
-      Result: serializedResult || "",
+      Result: serializedResult,
     };
   } catch (error) {
     log("❌", "Handler threw an error:", error);


### PR DESCRIPTION
*Description of changes:*

- Remove unnecessary || "" fallback when setting Result field
- Result field is optional (Result?: string) in type definition
- undefined properly represents 'no value' vs empty string
- Update test to verify undefined is preserved intact in Result field
- Add explicit test documentation for undefined behavior

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
