### PR TITLE
feat(sdk): replace polling with event-based operation tracking

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -636,4 +636,44 @@ describe("DurableContext", () => {
       expect(secondStepId).toBe("3");
     });
   });
+
+  describe("operationsEmitter", () => {
+    it("should pass operationsEmitter to step handler", async () => {
+      const executionContext = createMockExecutionContext();
+      const context = createDurableContext(
+        executionContext,
+        mockContext,
+        DurableExecutionMode.ExecutionMode,
+      );
+
+      const { createStepHandler } = jest.requireMock(
+        "../../handlers/step-handler/step-handler",
+      );
+
+      let capturedGetOperationsEmitter: (() => any) | undefined;
+      createStepHandler.mockImplementation(
+        (
+          _ctx: any,
+          _checkpoint: any,
+          _parentCtx: any,
+          _createStepId: any,
+          _createLogger: any,
+          _addOp: any,
+          _removeOp: any,
+          _hasOp: any,
+          getOperationsEmitter: () => any,
+        ): (() => Promise<string>) => {
+          capturedGetOperationsEmitter = getOperationsEmitter;
+          return async () => "result";
+        },
+      );
+
+      await context.step("test", async () => "value");
+
+      expect(capturedGetOperationsEmitter).toBeDefined();
+      const emitter = capturedGetOperationsEmitter!();
+      expect(emitter).toBeDefined();
+      expect(typeof emitter.emit).toBe("function");
+    });
+  });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -24,6 +24,7 @@ jest.mock("../../utils/wait-before-continue/wait-before-continue", () => ({
   waitBeforeContinue: jest.fn().mockResolvedValue({ reason: "operations" }),
 }));
 import { TEST_CONSTANTS } from "../../testing/test-constants";
+import { EventEmitter } from "events";
 
 // Mock the logger to avoid console output during tests
 jest.mock("../../utils/logger/logger", () => ({
@@ -75,6 +76,7 @@ describe("Callback Handler", () => {
       mockCheckpoint,
       createStepId,
       mockHasRunningOperations,
+      () => new EventEmitter(),
     );
   });
 
@@ -415,6 +417,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Initially STARTED, then becomes the target status after waitBeforeContinue
@@ -877,6 +880,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         jest.fn().mockReturnValue(false),
+        () => new EventEmitter(),
       );
 
       const result = callbackHandler(undefined, config);
@@ -914,6 +918,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Set up a started callback
@@ -938,15 +943,17 @@ describe("Callback Handler", () => {
       promise.then(() => {}).catch(() => {});
 
       // Verify waitBeforeContinue was called with correct parameters
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: false,
-        stepId: expect.any(String),
-        context: mockExecutionContext,
-        hasRunningOperations: mockHasRunningOperations,
-        pollingInterval: 1000,
-      });
+      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: false,
+          stepId: expect.any(String),
+          context: mockExecutionContext,
+          hasRunningOperations: mockHasRunningOperations,
+          pollingInterval: 1000,
+        }),
+      );
     });
 
     test("should check both operations and status when operations are running", async () => {
@@ -957,6 +964,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -997,6 +1005,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Set up a started callback that remains started
@@ -1028,6 +1037,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1061,6 +1071,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1083,15 +1094,17 @@ describe("Callback Handler", () => {
       promise.catch(() => {});
 
       // Should call waitBeforeContinue through catch -> then delegation
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: false,
-        stepId: expect.any(String),
-        context: mockExecutionContext,
-        hasRunningOperations: mockHasRunningOperations,
-        pollingInterval: 1000,
-      });
+      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: false,
+          stepId: expect.any(String),
+          context: mockExecutionContext,
+          hasRunningOperations: mockHasRunningOperations,
+          pollingInterval: 1000,
+        }),
+      );
     });
 
     test("should handle finally() method with same logic as then()", async () => {
@@ -1102,6 +1115,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1124,15 +1138,17 @@ describe("Callback Handler", () => {
       promise.finally(() => {});
 
       // Should call waitBeforeContinue through finally -> then delegation
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: false,
-        stepId: expect.any(String),
-        context: mockExecutionContext,
-        hasRunningOperations: mockHasRunningOperations,
-        pollingInterval: 1000,
-      });
+      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: false,
+          stepId: expect.any(String),
+          context: mockExecutionContext,
+          hasRunningOperations: mockHasRunningOperations,
+          pollingInterval: 1000,
+        }),
+      );
     });
 
     test("should pass hasRunningOperations function to createCallback", async () => {
@@ -1145,6 +1161,7 @@ describe("Callback Handler", () => {
           mockCheckpoint,
           createStepId,
           mockHasRunningOperations,
+          () => new EventEmitter(),
         );
       }).not.toThrow();
 
@@ -1154,6 +1171,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1178,6 +1196,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1215,6 +1234,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Initially STARTED, then becomes SUCCEEDED after waitBeforeContinue
@@ -1273,6 +1293,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Initially STARTED, then becomes FAILED after waitBeforeContinue
@@ -1334,6 +1355,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       mockExecutionContext.getStepData.mockReturnValue({
@@ -1465,6 +1487,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       let callCount = 0;
@@ -1510,6 +1533,7 @@ describe("Callback Handler", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       let callCount = 0;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
@@ -6,6 +6,7 @@ import { hashId } from "../../utils/step-id-utils/step-id-utils";
 import { createMockExecutionContext } from "../../testing/mock-context";
 import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
 import { createErrorObjectFromError } from "../../utils/error-object/error-object";
+import { EventEmitter } from "events";
 
 describe("Callback Handler Promise Interface", () => {
   let mockContext: ExecutionContext;
@@ -47,6 +48,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -60,6 +62,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -85,6 +88,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -111,6 +115,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -137,6 +142,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -156,6 +162,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const [promise] = await callbackHandler<string>("test-callback");
@@ -211,6 +218,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0; // Reset to ensure we get step-1
@@ -253,6 +261,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;
@@ -293,6 +302,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Create completed callback (step-1)
@@ -351,6 +361,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;
@@ -385,6 +396,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;
@@ -423,6 +435,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;
@@ -476,6 +489,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       // Force the step ID to be "step-1" to match our mock
@@ -492,6 +506,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;
@@ -509,6 +524,7 @@ describe("Callback Handler Promise Interface", () => {
         mockCheckpoint,
         createStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepIdCounter = 0;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -6,6 +6,7 @@ import {
   OperationAction,
 } from "@aws-sdk/client-lambda";
 import { TerminationReason } from "../../termination-manager/types";
+import { EventEmitter } from "events";
 
 // Mock dependencies
 jest.mock("../../utils/checkpoint/checkpoint");
@@ -94,6 +95,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await invokeHandler("test-function", { test: "data" });
@@ -126,6 +128,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await invokeHandler("test-invoke", "test-function", {
@@ -159,6 +162,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await invokeHandler("test-function", { test: "data" });
@@ -196,6 +200,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       await expect(
@@ -222,6 +227,7 @@ describe("InvokeHandler", () => {
           mockCheckpointFn,
           mockCreateStepId,
           mockHasRunningOperations,
+          () => new EventEmitter(),
         );
 
         await expect(
@@ -243,6 +249,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       await expect(
@@ -279,6 +286,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await invokeHandler("test-function", { test: "data" });
@@ -288,14 +296,16 @@ describe("InvokeHandler", () => {
         "⏳",
         "Invoke test-function still in progress, waiting for other operations",
       );
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: false,
-        stepId: "test-step-1",
-        context: mockContext,
-        hasRunningOperations: mockHasRunningOperations,
-      });
+      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: false,
+          stepId: "test-step-1",
+          context: mockContext,
+          hasRunningOperations: mockHasRunningOperations,
+        }),
+      );
       expect(mockTerminate).toHaveBeenCalledTimes(0);
     });
 
@@ -312,6 +322,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       await expect(
@@ -344,6 +355,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await invokeHandler("test-function", { test: "data" });
@@ -353,14 +365,16 @@ describe("InvokeHandler", () => {
         "⏳",
         "Invoke test-function still in progress, waiting for other operations",
       );
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: false,
-        stepId: "test-step-1",
-        context: mockContext,
-        hasRunningOperations: mockHasRunningOperations,
-      });
+      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: false,
+          stepId: "test-step-1",
+          context: mockContext,
+          hasRunningOperations: mockHasRunningOperations,
+        }),
+      );
       expect(mockTerminate).toHaveBeenCalledTimes(0);
     });
 
@@ -378,6 +392,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
         "parent-123",
       );
 
@@ -427,6 +442,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
         "parent-123",
       );
 
@@ -462,6 +478,7 @@ describe("InvokeHandler", () => {
         mockCheckpointFn,
         mockCreateStepId,
         mockHasRunningOperations,
+        () => new EventEmitter(),
         "parent-123",
       );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -14,12 +14,14 @@ import {
   safeDeserialize,
 } from "../../errors/serdes-errors/serdes-errors";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
+import { EventEmitter } from "events";
 
 export const createInvokeHandler = (
   context: ExecutionContext,
   checkpoint: ReturnType<typeof createCheckpoint>,
   createStepId: () => string,
   hasRunningOperations: () => boolean,
+  getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ): {
   <I, O>(funcId: string, input: I, config?: InvokeConfig<I, O>): Promise<O>;
@@ -109,6 +111,7 @@ export const createInvokeHandler = (
             stepId,
             context,
             hasRunningOperations,
+            operationsEmitter: getOperationsEmitter(),
           });
           continue; // Re-evaluate status after waiting
         }

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -17,6 +17,7 @@ import {
 import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
 import { hashId, getStepData } from "../../utils/step-id-utils/step-id-utils";
 import { createErrorObjectFromError } from "../../utils/error-object/error-object";
+import { EventEmitter } from "events";
 
 jest.mock("../../utils/retry/retry-presets/retry-presets", () => ({
   retryPresets: {
@@ -31,10 +32,13 @@ describe("Step Handler", () => {
   let createStepId: jest.Mock;
   let stepHandler: ReturnType<typeof createStepHandler>;
   let mockTerminationManager: jest.Mocked<TerminationManager>;
+  let mockOperationsEmitter: EventEmitter;
 
   beforeEach(() => {
     // Reset all mocks before each test to ensure isolation
     jest.resetAllMocks();
+
+    mockOperationsEmitter = new EventEmitter();
 
     // Create a mock termination manager
     mockTerminationManager = {
@@ -79,6 +83,7 @@ describe("Step Handler", () => {
       jest.fn(), // addRunningOperation
       jest.fn(), // removeRunningOperation
       jest.fn(() => false), // hasRunningOperations
+      () => mockOperationsEmitter,
     );
 
     // Reset the mock for retryPresets.default

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
@@ -8,6 +8,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { TerminationReason } from "../../termination-manager/types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
+import { EventEmitter } from "events";
 
 describe("Step Handler Timing Tests", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
@@ -55,6 +56,7 @@ describe("Step Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       stepHandlerWithMocks("test-step", stepFn, {
@@ -103,6 +105,7 @@ describe("Step Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await stepHandlerWithMocks("test-step", stepFn);
@@ -157,6 +160,7 @@ describe("Step Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await stepHandlerWithMocks("test-step", stepFn, {
@@ -207,6 +211,7 @@ describe("Step Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
       );
 
       const result = await stepHandlerWithMocks("test-step", stepFn, {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -28,6 +28,7 @@ import {
   safeSerialize,
   safeDeserialize,
 } from "../../errors/serdes-errors/serdes-errors";
+import { EventEmitter } from "events";
 import { isUnrecoverableError } from "../../errors/unrecoverable-error/unrecoverable-error";
 import { createErrorObjectFromError } from "../../utils/error-object/error-object";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
@@ -40,6 +41,7 @@ const waitForContinuation = async (
   stepId: string,
   name: string | undefined,
   hasRunningOperations: () => boolean,
+  getOperationsEmitter: () => EventEmitter,
   checkpoint: ReturnType<typeof createCheckpoint>,
 ): Promise<void> => {
   const stepData = context.getStepData(stepId);
@@ -63,6 +65,7 @@ const waitForContinuation = async (
     stepId,
     context,
     hasRunningOperations,
+    operationsEmitter: getOperationsEmitter(),
     checkpoint,
   });
 
@@ -78,6 +81,7 @@ export const createStepHandler = (
   addRunningOperation: (stepId: string) => void,
   removeRunningOperation: (stepId: string) => void,
   hasRunningOperations: () => boolean,
+  getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ) => {
   return async <T>(
@@ -128,6 +132,7 @@ export const createStepHandler = (
             stepId,
             name,
             hasRunningOperations,
+            getOperationsEmitter,
             checkpoint,
           );
           continue; // Re-evaluate step status after waiting
@@ -197,6 +202,7 @@ export const createStepHandler = (
                 stepId,
                 name,
                 hasRunningOperations,
+                getOperationsEmitter,
                 checkpoint,
               );
               continue; // Re-evaluate step status after waiting
@@ -215,6 +221,7 @@ export const createStepHandler = (
           addRunningOperation,
           removeRunningOperation,
           hasRunningOperations,
+          getOperationsEmitter,
           parentId,
           options,
         );
@@ -265,6 +272,7 @@ export const executeStep = async <T>(
   addRunningOperation: (stepId: string) => void,
   removeRunningOperation: (stepId: string) => void,
   hasRunningOperations: () => boolean,
+  getOperationsEmitter: () => EventEmitter,
   parentId: string | undefined,
   options?: StepConfig<T>,
 ): Promise<T | typeof CONTINUE_MAIN_LOOP> => {
@@ -438,6 +446,7 @@ export const executeStep = async <T>(
         stepId,
         name,
         hasRunningOperations,
+        getOperationsEmitter,
         checkpoint,
       );
       return CONTINUE_MAIN_LOOP;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
@@ -15,6 +15,7 @@ import { TerminationReason } from "../../termination-manager/types";
 import { OperationType, OperationStatus } from "@aws-sdk/client-lambda";
 import { hashId, getStepData } from "../../utils/step-id-utils/step-id-utils";
 import { createErrorObjectFromError } from "../../utils/error-object/error-object";
+import { EventEmitter } from "events";
 
 describe("WaitForCondition Handler", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
@@ -69,6 +70,7 @@ describe("WaitForCondition Handler", () => {
       jest.fn(), // addRunningOperation
       jest.fn(), // removeRunningOperation
       jest.fn(() => false), // hasRunningOperations
+      () => new EventEmitter(), // getOperationsEmitter
       "parent-123", // parentId
     );
   });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
@@ -12,6 +12,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { TerminationReason } from "../../termination-manager/types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
+import { EventEmitter } from "events";
 
 describe("WaitForCondition Handler Timing Tests", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
@@ -51,6 +52,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
       jest.fn(),
       jest.fn(),
       jest.fn().mockReturnValue(false),
+      () => new EventEmitter(),
       undefined, // parentId
     );
   });
@@ -76,6 +78,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
         undefined, // parentId
       );
 
@@ -133,6 +136,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
         undefined, // parentId
       );
 
@@ -194,6 +198,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
         undefined, // parentId
       );
 
@@ -270,6 +275,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
         undefined, // parentId
       );
 
@@ -343,6 +349,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         jest.fn(),
         jest.fn(),
         mockHasRunningOperations,
+        () => new EventEmitter(),
         undefined, // parentId
       );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -9,12 +9,14 @@ import { log } from "../../utils/logger/logger";
 import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
 import { TerminationReason } from "../../termination-manager/types";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
+import { EventEmitter } from "events";
 
 export const createWaitHandler = (
   context: ExecutionContext,
   checkpoint: ReturnType<typeof createCheckpoint>,
   createStepId: () => string,
   hasRunningOperations: () => boolean,
+  getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ): {
   (name: string, seconds: number): Promise<void>;
@@ -81,6 +83,7 @@ export const createWaitHandler = (
         stepId,
         context,
         hasRunningOperations,
+        operationsEmitter: getOperationsEmitter(),
         checkpoint,
       });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
@@ -1,10 +1,12 @@
 import { waitBeforeContinue } from "./wait-before-continue";
 import { ExecutionContext } from "../../types";
 import { OperationStatus, Operation } from "@aws-sdk/client-lambda";
+import { EventEmitter } from "events";
 
 describe("waitBeforeContinue", () => {
   let mockContext: jest.Mocked<ExecutionContext>;
   let mockHasRunningOperations: jest.Mock;
+  let mockOperationsEmitter: EventEmitter;
   let timers: NodeJS.Timeout[] = [];
 
   beforeEach(() => {
@@ -12,6 +14,7 @@ describe("waitBeforeContinue", () => {
       getStepData: jest.fn(),
     } as any;
     mockHasRunningOperations = jest.fn();
+    mockOperationsEmitter = new EventEmitter();
     timers = [];
   });
 
@@ -32,12 +35,14 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
       pollingInterval: 10, // Fast polling for test
     });
 
     // Complete operations after 50ms
     const timer = setTimeout(() => {
       operationsRunning = false;
+      mockOperationsEmitter.emit("allOperationsComplete");
     }, 50);
     timers.push(timer);
 
@@ -56,6 +61,7 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
     });
 
     expect(result.reason).toBe("timer");
@@ -73,6 +79,7 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
     });
 
     expect(result.reason).toBe("timer");
@@ -92,6 +99,7 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
       pollingInterval: 10, // Fast polling for test
     });
 
@@ -113,6 +121,7 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
     });
 
     expect(result.reason).toBe("timeout");
@@ -132,6 +141,7 @@ describe("waitBeforeContinue", () => {
       stepId: "test-step",
       context: mockContext,
       hasRunningOperations: mockHasRunningOperations,
+      operationsEmitter: mockOperationsEmitter,
       checkpoint: mockCheckpoint,
     });
 


### PR DESCRIPTION
    Replace 100ms polling mechanism with EventEmitter-based approach for detecting
    when all operations complete. This provides instant detection and eliminates
    unnecessary polling overhead.

    Changes:
    - Add EventEmitter to DurableContextImpl for operation lifecycle events
    - Emit 'allOperationsComplete' event when last operation is removed
    - Update waitBeforeContinue to listen for events instead of polling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
