### PR TITLE
refactor(sdk): use constant for operations complete event name

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -43,6 +43,8 @@ import { createDefaultLogger } from "../../utils/logger/default-logger";
 import { createModeAwareLogger } from "../../utils/logger/mode-aware-logger";
 import { EventEmitter } from "events";
 
+export const OPERATIONS_COMPLETE_EVENT = "allOperationsComplete";
+
 class DurableContextImpl implements DurableContext {
   private _stepPrefix?: string;
   private _stepCounter: number = 0;
@@ -157,7 +159,7 @@ class DurableContextImpl implements DurableContext {
   private removeRunningOperation(stepId: string): void {
     this.runningOperations.delete(stepId);
     if (this.runningOperations.size === 0) {
-      this.operationsEmitter.emit("allOperationsComplete");
+      this.operationsEmitter.emit(OPERATIONS_COMPLETE_EVENT);
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
@@ -14,6 +14,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { TerminationReason } from "../../termination-manager/types";
 import { hashId, getStepData } from "../../utils/step-id-utils/step-id-utils";
 import { EventEmitter } from "events";
+import { OPERATIONS_COMPLETE_EVENT } from "../../context/durable-context/durable-context";
 
 // Mock the logger to avoid console output during tests
 jest.mock("../../utils/logger/logger", () => ({
@@ -248,7 +249,7 @@ describe("Wait Handler", () => {
       // Simulate operations completing after 150ms
       setTimeout(() => {
         operationsRunning = false;
-        mockOperationsEmitter.emit("allOperationsComplete");
+        mockOperationsEmitter.emit(OPERATIONS_COMPLETE_EVENT);
       }, 150);
 
       // Wait for the event to be processed and terminate
@@ -303,7 +304,7 @@ describe("Wait Handler", () => {
       // Simulate step operation completing (after 1 second)
       setTimeout(() => {
         operationsRunning = false;
-        mockOperationsEmitter.emit("allOperationsComplete");
+        mockOperationsEmitter.emit(OPERATIONS_COMPLETE_EVENT);
       }, 100);
 
       // Wait for operations to complete and handler to terminate

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
@@ -2,6 +2,7 @@ import { waitBeforeContinue } from "./wait-before-continue";
 import { ExecutionContext } from "../../types";
 import { OperationStatus, Operation } from "@aws-sdk/client-lambda";
 import { EventEmitter } from "events";
+import { OPERATIONS_COMPLETE_EVENT } from "../../context/durable-context/durable-context";
 
 describe("waitBeforeContinue", () => {
   let mockContext: jest.Mocked<ExecutionContext>;
@@ -42,7 +43,7 @@ describe("waitBeforeContinue", () => {
     // Complete operations after 50ms
     const timer = setTimeout(() => {
       operationsRunning = false;
-      mockOperationsEmitter.emit("allOperationsComplete");
+      mockOperationsEmitter.emit(OPERATIONS_COMPLETE_EVENT);
     }, 50);
     timers.push(timer);
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext } from "../../types";
 import { createCheckpoint } from "../checkpoint/checkpoint";
 import { EventEmitter } from "events";
+import { OPERATIONS_COMPLETE_EVENT } from "../../context/durable-context/durable-context";
 
 export interface WaitBeforeContinueOptions {
   /** Check if operations are still running */
@@ -96,9 +97,9 @@ export async function waitBeforeContinue(
           const handler = (): void => {
             resolve({ reason: "operations" });
           };
-          operationsEmitter.once("allOperationsComplete", handler);
+          operationsEmitter.once(OPERATIONS_COMPLETE_EVENT, handler);
           cleanupFns.push(() =>
-            operationsEmitter.off("allOperationsComplete", handler),
+            operationsEmitter.off(OPERATIONS_COMPLETE_EVENT, handler),
           );
         }
       },


### PR DESCRIPTION
Replace hardcoded 'allOperationsComplete' string with OPERATIONS_COMPLETE_EVENT constant to improve maintainability and prevent typos.

*Description of changes:*
- Export OPERATIONS_COMPLETE_EVENT constant from durable-context
- Update emit and listener calls to use the constant
- Update test files to use the constant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
