### PR TITLE
feat(sdk): add event-based tracking for step status changes

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -68,7 +68,11 @@ class DurableContextImpl implements DurableContext {
     this._stepPrefix = stepPrefix;
     this._parentId = parentId;
     this.contextLogger = inheritedLogger || null;
-    this.checkpoint = createCheckpoint(executionContext, checkpointToken || "");
+    this.checkpoint = createCheckpoint(
+      executionContext,
+      checkpointToken || "",
+      this.operationsEmitter,
+    );
     this.durableExecutionMode = durableExecutionMode;
 
     const getLogger = (): Logger => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -951,7 +951,6 @@ describe("Callback Handler", () => {
           stepId: expect.any(String),
           context: mockExecutionContext,
           hasRunningOperations: mockHasRunningOperations,
-          pollingInterval: 1000,
         }),
       );
     });
@@ -1102,7 +1101,6 @@ describe("Callback Handler", () => {
           stepId: expect.any(String),
           context: mockExecutionContext,
           hasRunningOperations: mockHasRunningOperations,
-          pollingInterval: 1000,
         }),
       );
     });
@@ -1146,7 +1144,6 @@ describe("Callback Handler", () => {
           stepId: expect.any(String),
           context: mockExecutionContext,
           hasRunningOperations: mockHasRunningOperations,
-          pollingInterval: 1000,
         }),
       );
     });
@@ -1186,44 +1183,6 @@ describe("Callback Handler", () => {
       promise.then(() => {}).catch(() => {});
 
       expect(mockHasRunningOperations).toHaveBeenCalled();
-    });
-
-    test("should use 1000ms polling interval for waitBeforeContinue", async () => {
-      const mockHasRunningOperations = jest.fn().mockReturnValue(true);
-
-      const callbackHandler = createCallback(
-        mockExecutionContext,
-        mockCheckpoint,
-        createStepId,
-        mockHasRunningOperations,
-        () => new EventEmitter(),
-      );
-
-      mockExecutionContext.getStepData.mockReturnValue({
-        Id: TEST_CONSTANTS.CALLBACK_ID,
-        Type: OperationType.CALLBACK,
-        StartTimestamp: new Date(),
-        Status: OperationStatus.STARTED,
-        CallbackDetails: { CallbackId: "callback-123" },
-      });
-
-      const [promise] = await callbackHandler<string>("test-callback");
-
-      // Mock waitBeforeContinue
-      const mockWaitBeforeContinue = (
-        await import("../../utils/wait-before-continue/wait-before-continue")
-      ).waitBeforeContinue as jest.Mock;
-      mockWaitBeforeContinue.mockResolvedValue({ reason: "operations" });
-
-      // Trigger the promise
-      promise.then(() => {}).catch(() => {});
-
-      // Verify 1000ms polling interval is used
-      expect(mockWaitBeforeContinue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pollingInterval: 1000,
-        }),
-      );
     });
 
     test("should handle callback completion during operation wait (SUCCEEDED path)", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -49,7 +49,6 @@ export class TerminatingPromise<T> implements Promise<T> {
           context: this.context,
           hasRunningOperations: this.hasRunningOperations,
           operationsEmitter: this.operationsEmitter,
-          pollingInterval: 1000,
         });
       }
 

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
@@ -5,14 +5,17 @@ import {
   deleteCheckpoint,
 } from "../utils/checkpoint/checkpoint";
 import { ExecutionContext } from "../types";
+import { EventEmitter } from "events";
 
 describe("TerminationManager Checkpoint Integration", () => {
   let terminationManager: TerminationManager;
   let mockContext: ExecutionContext;
+  let mockEmitter: EventEmitter;
 
   beforeEach(() => {
     deleteCheckpoint();
     terminationManager = new TerminationManager();
+    mockEmitter = new EventEmitter();
 
     mockContext = {
       durableExecutionArn: "test-arn",
@@ -32,7 +35,11 @@ describe("TerminationManager Checkpoint Integration", () => {
   });
 
   test("should set checkpoint terminating flag when terminate is called", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     // Checkpoint should work before termination
     await checkpoint("step-1", {
@@ -60,7 +67,11 @@ describe("TerminationManager Checkpoint Integration", () => {
   });
 
   test("should prevent force checkpoint after termination", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
     const mockCheckpointFn = mockContext.state.checkpoint as jest.Mock;
 
     // Queue a checkpoint first
@@ -94,7 +105,11 @@ describe("TerminationManager Checkpoint Integration", () => {
   });
 
   test("should set terminating flag immediately when terminate is called", () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     // Terminate
     terminationManager.terminate();
@@ -112,7 +127,11 @@ describe("TerminationManager Checkpoint Integration", () => {
   });
 
   test("should handle multiple terminate calls gracefully", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     terminationManager.terminate();
     terminationManager.terminate();

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-ancestor-checking.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-ancestor-checking.test.ts
@@ -4,6 +4,7 @@ import { ExecutionContext } from "../../types";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
 import { CheckpointHandler } from "./checkpoint";
 import { hashId, getStepData } from "../step-id-utils/step-id-utils";
+import { EventEmitter } from "events";
 
 // Mock dependencies
 jest.mock("../../utils/logger/logger", () => ({
@@ -15,11 +16,13 @@ describe("CheckpointHandler - Ancestor Checking", () => {
   let mockState: any;
   let mockContext: ExecutionContext;
   let checkpointHandler: CheckpointHandler;
+  let mockEmitter: EventEmitter;
 
   const mockNewTaskToken = "new-task-token";
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEmitter = new EventEmitter();
 
     mockTerminationManager = new TerminationManager();
     jest.spyOn(mockTerminationManager, "terminate");
@@ -44,6 +47,7 @@ describe("CheckpointHandler - Ancestor Checking", () => {
     checkpointHandler = new CheckpointHandler(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
@@ -5,6 +5,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { hashId } from "../step-id-utils/step-id-utils";
 import { createMockExecutionContext } from "../../testing/mock-context";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
+import { EventEmitter } from "events";
 
 // Mock dependencies
 jest.mock("../../utils/logger/logger", () => ({
@@ -15,11 +16,13 @@ describe("Checkpoint Integration Tests", () => {
   let mockTerminationManager: TerminationManager;
   let mockState: any;
   let mockContext: ExecutionContext;
+  let mockEmitter: EventEmitter;
 
   const mockNewTaskToken = "new-task-token";
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEmitter = new EventEmitter();
 
     mockTerminationManager = new TerminationManager();
     jest.spyOn(mockTerminationManager, "terminate");
@@ -41,6 +44,7 @@ describe("Checkpoint Integration Tests", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create many concurrent checkpoint requests
@@ -71,6 +75,7 @@ describe("Checkpoint Integration Tests", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create checkpoints with different operation types and actions
@@ -148,6 +153,7 @@ describe("Checkpoint Integration Tests", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create many requests (previously would have been split by max batch size)
@@ -180,6 +186,7 @@ describe("Checkpoint Integration Tests", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create many requests (previously would have required multiple batches)
@@ -216,10 +223,12 @@ describe("Checkpoint Integration Tests", () => {
     const checkpoint1 = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     const checkpoint2 = createCheckpoint(
       mockContext2,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     ); // Should return same handler (first context)
 
     // Execute checkpoints - both should use the first context (mockContext)

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
@@ -9,13 +9,16 @@ import {
 } from "@aws-sdk/client-lambda";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
 import { getStepData } from "../step-id-utils/step-id-utils";
+import { EventEmitter } from "events";
 
 describe("CheckpointHandler - StepData Update", () => {
   let mockContext: ExecutionContext;
   let mockState: any;
   let checkpointHandler: CheckpointHandler;
+  let mockEmitter: EventEmitter;
 
   beforeEach(() => {
+    mockEmitter = new EventEmitter();
     mockState = {
       checkpoint: jest.fn(),
     };
@@ -43,6 +46,7 @@ describe("CheckpointHandler - StepData Update", () => {
     checkpointHandler = new CheckpointHandler(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
@@ -6,14 +6,17 @@ import {
 import { ExecutionContext } from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import * as logger from "../logger/logger";
+import { EventEmitter } from "events";
 
 describe("Checkpoint Termination Flag", () => {
   let mockContext: ExecutionContext;
   let logSpy: jest.SpyInstance;
+  let mockEmitter: EventEmitter;
 
   beforeEach(() => {
     deleteCheckpoint();
     logSpy = jest.spyOn(logger, "log").mockImplementation();
+    mockEmitter = new EventEmitter();
 
     mockContext = {
       durableExecutionArn: "test-arn",
@@ -34,7 +37,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should skip checkpoint when termination flag is set", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     setCheckpointTerminating();
 
@@ -47,7 +54,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should skip forceCheckpoint when termination flag is set", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     setCheckpointTerminating();
 
@@ -57,7 +68,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should allow checkpoint before termination flag is set", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     await checkpoint("test-step", {
       Action: "START",
@@ -71,7 +86,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should prevent new checkpoints after setTerminating is called", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     // First checkpoint should work
     await checkpoint("step-1", {
@@ -96,7 +115,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should call setCheckpointTerminating through checkpoint.setTerminating", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     checkpoint.setTerminating();
 
@@ -109,7 +132,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should log when checkpoint is skipped due to termination", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     setCheckpointTerminating();
 
@@ -126,7 +153,11 @@ describe("Checkpoint Termination Flag", () => {
   });
 
   test("should log when force checkpoint is skipped due to termination", async () => {
-    const checkpoint = createCheckpoint(mockContext, "initial-token");
+    const checkpoint = createCheckpoint(
+      mockContext,
+      "initial-token",
+      mockEmitter,
+    );
 
     setCheckpointTerminating();
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -13,6 +13,7 @@ import {
   deleteCheckpoint,
 } from "./checkpoint";
 import { hashId, getStepData } from "../step-id-utils/step-id-utils";
+import { EventEmitter } from "events";
 
 // Mock dependencies
 jest.mock("../../utils/logger/logger", () => ({
@@ -24,11 +25,13 @@ describe("CheckpointHandler", () => {
   let mockState: any;
   let mockContext: ExecutionContext;
   let checkpointHandler: CheckpointHandler;
+  let mockEmitter: EventEmitter;
 
   const mockNewTaskToken = "new-task-token";
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEmitter = new EventEmitter();
 
     mockTerminationManager = new TerminationManager();
     jest.spyOn(mockTerminationManager, "terminate");
@@ -53,6 +56,7 @@ describe("CheckpointHandler", () => {
     checkpointHandler = new CheckpointHandler(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
   });
 
@@ -554,10 +558,12 @@ describe("deleteCheckpointHandler", () => {
   let mockState2: any;
   let mockContext1: ExecutionContext;
   let mockContext2: ExecutionContext;
+  let mockEmitter: EventEmitter;
 
   beforeEach(() => {
     jest.clearAllMocks();
     deleteCheckpoint(); // Clear singleton before each test
+    mockEmitter = new EventEmitter();
 
     mockTerminationManager = new TerminationManager();
     jest.spyOn(mockTerminationManager, "terminate");
@@ -605,6 +611,7 @@ describe("deleteCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext1,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Verify handler exists by using it
@@ -618,6 +625,7 @@ describe("deleteCheckpointHandler", () => {
     const checkpoint1New = createCheckpoint(
       mockContext1,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // The new handler should be a different instance, evidenced by separate batching behavior
@@ -633,10 +641,12 @@ describe("deleteCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext1,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     const checkpoint2 = createCheckpoint(
       mockContext2,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     ); // This replaces the first
 
     // Use the first handler (checkpoint1's context) - both calls will be batched
@@ -660,6 +670,7 @@ describe("deleteCheckpointHandler", () => {
     const checkpoint3 = createCheckpoint(
       mockContext1,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     await checkpoint3("step-3", { Action: OperationAction.START });
     // After cleanup, new handler is created, so this is a separate call
@@ -674,12 +685,14 @@ describe("deleteCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext1,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Try to create with second context - should return same handler (first context)
     const checkpoint2 = createCheckpoint(
       mockContext2,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Both checkpoint functions should use the first context (mockContext1)
@@ -703,7 +716,11 @@ describe("deleteCheckpointHandler", () => {
 
   describe("forceCheckpoint", () => {
     it("should call checkpoint API with empty updates when no items in queue", async () => {
-      const checkpoint = createCheckpoint(mockContext1, "test-token");
+      const checkpoint = createCheckpoint(
+        mockContext1,
+        "test-token",
+        mockEmitter,
+      );
 
       await checkpoint.force();
 
@@ -715,7 +732,11 @@ describe("deleteCheckpointHandler", () => {
     });
 
     it("should not make additional checkpoint call when force is called during ongoing checkpoint", async () => {
-      const checkpoint = createCheckpoint(mockContext1, "test-token");
+      const checkpoint = createCheckpoint(
+        mockContext1,
+        "test-token",
+        mockEmitter,
+      );
 
       // Make checkpoint API slow to simulate ongoing processing
       let resolveCheckpoint!: (value: any) => void;
@@ -771,7 +792,11 @@ describe("deleteCheckpointHandler", () => {
     });
 
     it("should terminate execution when force checkpoint fails", async () => {
-      const checkpoint = createCheckpoint(mockContext1, "test-token");
+      const checkpoint = createCheckpoint(
+        mockContext1,
+        "test-token",
+        mockEmitter,
+      );
       const error = new Error("Checkpoint failed");
       mockState1.checkpoint.mockRejectedValue(error);
 
@@ -799,10 +824,12 @@ describe("createCheckpointHandler", () => {
   let mockTerminationManager: TerminationManager;
   let mockState: any;
   let mockContext: ExecutionContext;
+  let mockEmitter: EventEmitter;
 
   beforeEach(() => {
     jest.clearAllMocks();
     deleteCheckpoint(); // Clear singleton before each test
+    mockEmitter = new EventEmitter();
 
     mockTerminationManager = new TerminationManager();
     jest.spyOn(mockTerminationManager, "terminate");
@@ -836,6 +863,7 @@ describe("createCheckpointHandler", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     await checkpoint(mockStepId, checkpointData);
 
@@ -862,6 +890,7 @@ describe("createCheckpointHandler", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Mock checkpoint to delay so we can test batching
@@ -912,10 +941,12 @@ describe("createCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     const checkpoint2 = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Mock to delay first checkpoint
@@ -953,10 +984,12 @@ describe("createCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     const checkpoint2 = createCheckpoint(
       mockContext2,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     ); // Should return same handler (first context)
 
     // Execute checkpoints - both should use the first context (mockContext)
@@ -989,10 +1022,12 @@ describe("createCheckpointHandler", () => {
     const checkpoint1 = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
     const checkpoint2 = createCheckpoint(
       mockContext2,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Execute checkpoints from both contexts
@@ -1018,6 +1053,7 @@ describe("createCheckpointHandler", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create large payload data that will exceed 750KB when combined
@@ -1051,6 +1087,7 @@ describe("createCheckpointHandler", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Create items where first is large enough to trigger size limit
@@ -1095,6 +1132,7 @@ describe("createCheckpointHandler", () => {
     const checkpoint = createCheckpoint(
       mockContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
     );
 
     // Mock checkpoint response with operations

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -300,6 +300,7 @@ describe("withDurableExecution", () => {
     expect(createCheckpoint).toHaveBeenCalledWith(
       mockExecutionContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      expect.any(Object),
     );
     expect(mockCheckpoint).toHaveBeenCalledWith(
       expect.stringMatching(/^execution-result-\d+$/),
@@ -344,6 +345,7 @@ describe("withDurableExecution", () => {
     expect(createCheckpoint).toHaveBeenCalledWith(
       mockExecutionContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      expect.any(Object),
     );
     expect(mockCheckpoint).toHaveBeenCalledWith(
       expect.stringMatching(/^execution-result-\d+$/),
@@ -382,6 +384,7 @@ describe("withDurableExecution", () => {
     expect(createCheckpoint).toHaveBeenCalledWith(
       mockExecutionContext,
       TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      expect.any(Object), // EventEmitter
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -1,6 +1,7 @@
 import { OperationType } from "@aws-sdk/client-lambda";
 import { Context } from "aws-lambda";
 import { createDurableContext } from "./context/durable-context/durable-context";
+import { EventEmitter } from "events";
 
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { CheckpointFailedError } from "./errors/checkpoint-errors/checkpoint-errors";
@@ -129,7 +130,12 @@ async function runHandler<Input, Output>(
       );
 
       // Create a checkpoint handler to save the large result
-      const checkpoint = createCheckpoint(executionContext, checkpointToken);
+      const stepDataEmitter = new EventEmitter();
+      const checkpoint = createCheckpoint(
+        executionContext,
+        checkpointToken,
+        stepDataEmitter,
+      );
       const stepId = `execution-result-${Date.now()}`;
 
       try {


### PR DESCRIPTION
Replace polling with EventEmitter-based approach for detecting step status changes from checkpoint updates. This completes the event-driven architecture by eliminating all polling mechanisms.

*Description of changes:*
- Add STEP_DATA_UPDATED_EVENT constant in checkpoint.ts
- Emit event when checkpoint updates step data from API response
- Update waitBeforeContinue to listen for status change events
- Hash stepId before comparing with emitted operation IDs
- Thread stepDataEmitter through checkpoint and all test files
- Add test coverage for immediate status change detection
- Remove pollingInterval parameter (no longer needed)
- Update all affected test files and expectations

All polling eliminated - both operation completion and status changes now use event-driven approach for instant detection with zero overhead.

*Issue #, if available:*
Resolves #146 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
