### PR TITLE
feat(sdk): add replay validation to detect non-deterministic execution

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/non-deterministic-error/non-deterministic-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/non-deterministic-error/non-deterministic-error.ts
@@ -1,0 +1,14 @@
+import { UnrecoverableExecutionError } from "../unrecoverable-error/unrecoverable-error";
+import { TerminationReason } from "../../termination-manager/types";
+
+/**
+ * Error thrown when non-deterministic code is detected during replay
+ */
+export class NonDeterministicExecutionError extends UnrecoverableExecutionError {
+  readonly terminationReason = TerminationReason.CUSTOM;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "NonDeterministicExecutionError";
+  }
+}

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -14,6 +14,7 @@ import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
 import { CallbackError } from "../../errors/callback-error/callback-error";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
+import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
 
 const createPassThroughSerdes = <T>(): Serdes<T> => ({
   serialize: async (value: T | undefined) => value as string | undefined,
@@ -182,6 +183,18 @@ export const createCallback = (
     });
 
     const stepData = context.getStepData(stepId);
+
+    // Validate replay consistency
+    validateReplayConsistency(
+      stepId,
+      {
+        type: OperationType.CALLBACK,
+        name,
+        subType: OperationSubType.CALLBACK,
+      },
+      stepData,
+      context,
+    );
 
     // Check if callback already exists and is completed
     if (stepData?.Status === OperationStatus.SUCCEEDED) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/promise-interface.test.ts
@@ -1,5 +1,5 @@
 import { createCallback } from "./callback";
-import { ExecutionContext } from "../../types";
+import { ExecutionContext, OperationSubType } from "../../types";
 import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
 import { TerminationReason } from "../../termination-manager/types";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
@@ -28,7 +28,9 @@ describe("Callback Handler Promise Interface", () => {
       const hashedStepId = hashId(stepId) as any;
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: "STARTED" as any,
         CallbackDetails: {
@@ -204,7 +206,9 @@ describe("Callback Handler Promise Interface", () => {
 
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         CallbackDetails: {
@@ -247,7 +251,9 @@ describe("Callback Handler Promise Interface", () => {
 
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.FAILED,
         CallbackDetails: {
@@ -288,7 +294,9 @@ describe("Callback Handler Promise Interface", () => {
       const completedHashedStepId = hashId(completedStepId);
       mockContext._stepData[completedHashedStepId] = {
         Id: completedHashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         CallbackDetails: {
@@ -347,7 +355,9 @@ describe("Callback Handler Promise Interface", () => {
 
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.FAILED,
         CallbackDetails: {
@@ -382,7 +392,9 @@ describe("Callback Handler Promise Interface", () => {
 
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.FAILED,
         CallbackDetails: {
@@ -421,7 +433,9 @@ describe("Callback Handler Promise Interface", () => {
 
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: OperationStatus.FAILED,
         CallbackDetails: {
@@ -474,7 +488,9 @@ describe("Callback Handler Promise Interface", () => {
       const hashedStepId = hashId(stepId);
       mockContext._stepData[hashedStepId] = {
         Id: hashedStepId,
-        Type: OperationType.STEP,
+        Type: OperationType.CALLBACK,
+        SubType: OperationSubType.CALLBACK,
+        Name: "test-callback",
         StartTimestamp: new Date(),
         Status: "STARTED" as any,
         CallbackDetails: {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -15,6 +15,7 @@ import {
 } from "../../errors/serdes-errors/serdes-errors";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
+import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
 
 export const createInvokeHandler = (
   context: ExecutionContext,
@@ -65,6 +66,18 @@ export const createInvokeHandler = (
     while (true) {
       // Check if we have existing step data
       const stepData = context.getStepData(stepId);
+
+      // Validate replay consistency
+      validateReplayConsistency(
+        stepId,
+        {
+          type: OperationType.CHAINED_INVOKE,
+          name,
+          subType: OperationSubType.CHAINED_INVOKE,
+        },
+        stepData,
+        context,
+      );
 
       if (stepData?.Status === OperationStatus.SUCCEEDED) {
         // Return cached result - no need to check for errors in successful operations

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -32,6 +32,7 @@ import { EventEmitter } from "events";
 import { isUnrecoverableError } from "../../errors/unrecoverable-error/unrecoverable-error";
 import { createErrorObjectFromError } from "../../utils/error-object/error-object";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
+import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
 
 // Special symbol to indicate that the main loop should continue
 const CONTINUE_MAIN_LOOP = Symbol("CONTINUE_MAIN_LOOP");
@@ -110,6 +111,18 @@ export const createStepHandler = (
     while (true) {
       try {
         const stepData = context.getStepData(stepId);
+
+        // Validate replay consistency
+        validateReplayConsistency(
+          stepId,
+          {
+            type: OperationType.STEP,
+            name,
+            subType: OperationSubType.STEP,
+          },
+          stepData,
+          context,
+        );
 
         if (stepData?.Status === OperationStatus.SUCCEEDED) {
           return await handleCompletedStep<T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -10,6 +10,7 @@ import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
 import { TerminationReason } from "../../termination-manager/types";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
+import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
 
 export const createWaitHandler = (
   context: ExecutionContext,
@@ -42,6 +43,19 @@ export const createWaitHandler = (
     // Main wait logic - can be re-executed if step data changes
     while (true) {
       let stepData = context.getStepData(stepId);
+
+      // Validate replay consistency
+      validateReplayConsistency(
+        stepId,
+        {
+          type: OperationType.WAIT,
+          name: actualName,
+          subType: OperationSubType.WAIT,
+        },
+        stepData,
+        context,
+      );
+
       if (stepData?.Status === OperationStatus.SUCCEEDED) {
         log("⏭️", "Wait already completed:", { stepId });
         return;

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.test.ts
@@ -1,0 +1,197 @@
+import { validateReplayConsistency } from "./replay-validation";
+import { Operation, OperationType } from "@aws-sdk/client-lambda";
+import { OperationSubType, ExecutionContext } from "../../types";
+import { terminateForUnrecoverableError } from "../termination-helper/termination-helper";
+
+jest.mock("../termination-helper/termination-helper");
+
+describe("validateReplayConsistency", () => {
+  const mockContext = {} as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not validate when checkpoint data is undefined", () => {
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: "test",
+        subType: OperationSubType.STEP,
+      },
+      undefined,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).not.toHaveBeenCalled();
+  });
+
+  it("should pass validation when all fields match", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "test",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: "test",
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).not.toHaveBeenCalled();
+  });
+
+  it("should pass validation when name is undefined in both", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: undefined,
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: undefined,
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).not.toHaveBeenCalled();
+  });
+
+  it("should terminate when operation type mismatches", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "test",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.WAIT,
+        name: "test",
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        message: expect.stringContaining("Operation type mismatch"),
+      }),
+      "step1",
+    );
+  });
+
+  it("should terminate when operation name mismatches", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "test1",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: "test2",
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        message: expect.stringContaining("Operation name mismatch"),
+      }),
+      "step1",
+    );
+  });
+
+  it("should terminate when name changes from defined to undefined", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "test",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: undefined,
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        message: expect.stringContaining("Operation name mismatch"),
+      }),
+      "step1",
+    );
+  });
+
+  it("should terminate when operation subtype mismatches", () => {
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "test",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: "test",
+        subType: OperationSubType.WAIT,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        message: expect.stringContaining("Operation subtype mismatch"),
+      }),
+      "step1",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.ts
@@ -1,0 +1,50 @@
+import { Operation, OperationType } from "@aws-sdk/client-lambda";
+import { OperationSubType, ExecutionContext } from "../../types";
+import { terminateForUnrecoverableError } from "../termination-helper/termination-helper";
+import { NonDeterministicExecutionError } from "../../errors/non-deterministic-error/non-deterministic-error";
+
+export const validateReplayConsistency = (
+  stepId: string,
+  currentOperation: {
+    type: OperationType;
+    name: string | undefined;
+    subType: OperationSubType;
+  },
+  checkpointData: Operation | undefined,
+  context: ExecutionContext,
+): void => {
+  // Skip validation if no checkpoint data exists or if Type is undefined (first execution)
+  if (!checkpointData || !checkpointData.Type) {
+    return;
+  }
+
+  // Validate operation type
+  if (checkpointData.Type !== currentOperation.type) {
+    const error = new NonDeterministicExecutionError(
+      `Non-deterministic execution detected: Operation type mismatch for step "${stepId}". ` +
+        `Expected type "${checkpointData.Type}", but got "${currentOperation.type}". ` +
+        `This indicates non-deterministic control flow in your workflow code.`,
+    );
+    terminateForUnrecoverableError(context, error, stepId);
+  }
+
+  // Validate operation name (including undefined)
+  if (checkpointData.Name !== currentOperation.name) {
+    const error = new NonDeterministicExecutionError(
+      `Non-deterministic execution detected: Operation name mismatch for step "${stepId}". ` +
+        `Expected name "${checkpointData.Name ?? "undefined"}", but got "${currentOperation.name ?? "undefined"}". ` +
+        `This indicates non-deterministic control flow in your workflow code.`,
+    );
+    terminateForUnrecoverableError(context, error, stepId);
+  }
+
+  // Validate operation subtype
+  if (checkpointData.SubType !== currentOperation.subType) {
+    const error = new NonDeterministicExecutionError(
+      `Non-deterministic execution detected: Operation subtype mismatch for step "${stepId}". ` +
+        `Expected subtype "${checkpointData.SubType}", but got "${currentOperation.subType}". ` +
+        `This indicates non-deterministic control flow in your workflow code.`,
+    );
+    terminateForUnrecoverableError(context, error, stepId);
+  }
+};

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
@@ -1,9 +1,9 @@
 import {
   createParallelSummaryGenerator,
   createMapSummaryGenerator,
-} from "./summary-generators/summary-generators";
-import { BatchResultImpl } from "../handlers/concurrent-execution-handler/batch-result";
-import { BatchItemStatus } from "../types";
+} from "./summary-generators";
+import { BatchResultImpl } from "../../handlers/concurrent-execution-handler/batch-result";
+import { BatchItemStatus } from "../../types";
 
 describe("Summary Generators", () => {
   describe("createParallelSummaryGenerator", () => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
@@ -1,10 +1,10 @@
 import {
   terminate,
   terminateForUnrecoverableError,
-} from "./termination-helper/termination-helper";
-import { ExecutionContext } from "../types";
-import { UnrecoverableError } from "../errors/unrecoverable-error/unrecoverable-error";
-import { TerminationReason } from "../termination-manager/types";
+} from "./termination-helper";
+import { ExecutionContext } from "../../types";
+import { UnrecoverableError } from "../../errors/unrecoverable-error/unrecoverable-error";
+import { TerminationReason } from "../../termination-manager/types";
 
 describe("termination helpers", () => {
   let mockContext: jest.Mocked<ExecutionContext>;


### PR DESCRIPTION
*Description of changes:*
Implements validation to detect non-deterministic code during replay by checking:
- Operation type consistency (STEP, WAIT, CALLBACK, etc.)
- Operation name consistency (including undefined values)
- Operation subtype consistency

When mismatches are detected, execution terminates with NonDeterministicExecutionError providing clear error messages to help developers identify the issue.

Validation is integrated into all operation handlers: step, invoke, wait, callback, and run-in-child-context (which covers map, parallel, and concurrent operations).

*Issue #, if available:* #149 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
