### PR TITLE
feat(sdk): add serdes and itemSerdes to concurrent execution configs

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -22,8 +22,8 @@ import {
   Logger,
   InvokeConfig,
   DurableExecutionMode,
+  BatchResult,
 } from "../../types";
-import { BatchResult } from "../../handlers/concurrent-execution-handler/batch-result";
 import { Context } from "aws-lambda";
 import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
 import { createStepHandler } from "../../handlers/step-handler/step-handler";
@@ -356,8 +356,8 @@ class DurableContextImpl implements DurableContext {
   map<TInput, TOutput>(
     nameOrItems: string | undefined | TInput[],
     itemsOrMapFunc: TInput[] | MapFunc<TInput, TOutput>,
-    mapFuncOrConfig?: MapFunc<TInput, TOutput> | MapConfig<TInput>,
-    maybeConfig?: MapConfig<TInput>,
+    mapFuncOrConfig?: MapFunc<TInput, TOutput> | MapConfig<TInput, TOutput>,
+    maybeConfig?: MapConfig<TInput, TOutput>,
   ): Promise<BatchResult<TOutput>> {
     return this.withModeManagement(() => {
       const mapHandler = createMapHandler(
@@ -380,8 +380,8 @@ class DurableContextImpl implements DurableContext {
       | (ParallelFunc<T> | NamedParallelBranch<T>)[],
     branchesOrConfig?:
       | (ParallelFunc<T> | NamedParallelBranch<T>)[]
-      | ParallelConfig,
-    maybeConfig?: ParallelConfig,
+      | ParallelConfig<T>,
+    maybeConfig?: ParallelConfig<T>,
   ): Promise<BatchResult<T>> {
     return this.withModeManagement(() => {
       const parallelHandler = createParallelHandler(
@@ -397,8 +397,10 @@ class DurableContextImpl implements DurableContext {
     itemsOrExecutor?:
       | ConcurrentExecutionItem<TItem>[]
       | ConcurrentExecutor<TItem, TResult>,
-    executorOrConfig?: ConcurrentExecutor<TItem, TResult> | ConcurrencyConfig,
-    maybeConfig?: ConcurrencyConfig,
+    executorOrConfig?:
+      | ConcurrentExecutor<TItem, TResult>
+      | ConcurrencyConfig<TResult>,
+    maybeConfig?: ConcurrencyConfig<TResult>,
   ): Promise<BatchResult<TResult>> {
     return this.withModeManagement(() => {
       const concurrentExecutionHandler = createConcurrentExecutionHandler(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
@@ -1,35 +1,4 @@
-import { BatchItemStatus } from "../../types";
-
-export interface BatchItem<R> {
-  result?: R;
-  error?: Error;
-  index: number;
-  status: BatchItemStatus;
-}
-
-export interface BatchResult<R> {
-  all: Array<BatchItem<R>>;
-
-  succeeded(): Array<BatchItem<R> & { result: R }>;
-  failed(): Array<BatchItem<R> & { error: Error }>;
-  started(): Array<BatchItem<R> & { status: BatchItemStatus.STARTED }>;
-
-  status: BatchItemStatus.SUCCEEDED | BatchItemStatus.FAILED;
-  completionReason:
-    | "ALL_COMPLETED"
-    | "MIN_SUCCESSFUL_REACHED"
-    | "FAILURE_TOLERANCE_EXCEEDED";
-  hasFailure: boolean;
-
-  throwIfError(): void;
-  getResults(): Array<R>;
-  getErrors(): Array<Error>;
-
-  successCount: number;
-  failureCount: number;
-  startedCount: number;
-  totalCount: number;
-}
+import { BatchItemStatus, BatchItem, BatchResult } from "../../types";
 
 export class BatchResultImpl<R> implements BatchResult<R> {
   constructor(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
@@ -6,9 +6,9 @@ import {
   ConcurrentExecutionItem,
   ConcurrentExecutor,
   OperationSubType,
+  BatchResult,
 } from "../../types";
 import { log } from "../../utils/logger/logger";
-import { BatchResult } from "../concurrent-execution-handler/batch-result";
 import { createMapSummaryGenerator } from "../../utils/summary-generators/summary-generators";
 
 export const createMapHandler = (
@@ -18,13 +18,13 @@ export const createMapHandler = (
   return async <TInput, TOutput>(
     nameOrItems: string | undefined | TInput[],
     itemsOrMapFunc?: TInput[] | MapFunc<TInput, TOutput>,
-    mapFuncOrConfig?: MapFunc<TInput, TOutput> | MapConfig<TInput>,
-    maybeConfig?: MapConfig<TInput>,
+    mapFuncOrConfig?: MapFunc<TInput, TOutput> | MapConfig<TInput, TOutput>,
+    maybeConfig?: MapConfig<TInput, TOutput>,
   ): Promise<BatchResult<TOutput>> => {
     let name: string | undefined;
     let items: TInput[];
     let mapFunc: MapFunc<TInput, TOutput>;
-    let config: MapConfig<TInput> | undefined;
+    let config: MapConfig<TInput, TOutput> | undefined;
 
     // Parse overloaded parameters
     if (typeof nameOrItems === "string" || nameOrItems === undefined) {
@@ -37,7 +37,7 @@ export const createMapHandler = (
       // Case: map(items, mapFunc, config?)
       items = nameOrItems;
       mapFunc = itemsOrMapFunc as MapFunc<TInput, TOutput>;
-      config = mapFuncOrConfig as MapConfig<TInput>;
+      config = mapFuncOrConfig as MapConfig<TInput, TOutput>;
     }
 
     log("🗺️", "Starting map operation:", {
@@ -78,6 +78,8 @@ export const createMapHandler = (
       iterationSubType: OperationSubType.MAP_ITERATION,
       summaryGenerator: createMapSummaryGenerator(),
       completionConfig: config?.completionConfig,
+      serdes: config?.serdes,
+      itemSerdes: config?.itemSerdes,
     });
 
     log("🗺️", "Map operation completed successfully:", {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
@@ -7,9 +7,9 @@ import {
   ConcurrentExecutor,
   OperationSubType,
   NamedParallelBranch,
+  BatchResult,
 } from "../../types";
 import { log } from "../../utils/logger/logger";
-import { BatchResult } from "../concurrent-execution-handler/batch-result";
 import { createParallelSummaryGenerator } from "../../utils/summary-generators/summary-generators";
 
 export const createParallelHandler = (
@@ -23,12 +23,12 @@ export const createParallelHandler = (
       | (ParallelFunc<T> | NamedParallelBranch<T>)[],
     branchesOrConfig?:
       | (ParallelFunc<T> | NamedParallelBranch<T>)[]
-      | ParallelConfig,
-    maybeConfig?: ParallelConfig,
+      | ParallelConfig<T>,
+    maybeConfig?: ParallelConfig<T>,
   ): Promise<BatchResult<T>> => {
     let name: string | undefined;
     let branches: (ParallelFunc<T> | NamedParallelBranch<T>)[];
-    let config: ParallelConfig | undefined;
+    let config: ParallelConfig<T> | undefined;
 
     // Parse overloaded parameters
     if (typeof nameOrBranches === "string" || nameOrBranches === undefined) {
@@ -42,7 +42,7 @@ export const createParallelHandler = (
     } else {
       // Case: parallel(branches, config?)
       branches = nameOrBranches;
-      config = branchesOrConfig as ParallelConfig;
+      config = branchesOrConfig as ParallelConfig<T>;
     }
 
     // Validate inputs
@@ -111,6 +111,8 @@ export const createParallelHandler = (
       iterationSubType: OperationSubType.PARALLEL_BRANCH,
       summaryGenerator: createParallelSummaryGenerator(),
       completionConfig: config?.completionConfig,
+      serdes: config?.serdes,
+      itemSerdes: config?.itemSerdes,
     });
 
     log("🔀", "Parallel operation completed successfully:", {

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-batch-result.ts
@@ -1,8 +1,4 @@
-import {
-  BatchResult,
-  BatchItem,
-} from "../handlers/concurrent-execution-handler/batch-result";
-import { BatchItemStatus } from "../types";
+import { BatchResult, BatchItem, BatchItemStatus } from "../types";
 
 export class MockBatchResult<R> implements BatchResult<R> {
   constructor(

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
@@ -1,4 +1,4 @@
-import { BatchResult } from "../../handlers/concurrent-execution-handler/batch-result";
+import { BatchResult } from "../../types";
 
 /**
  * Creates a predefined summary generator for parallel operations


### PR DESCRIPTION
Add serdes configuration support to MapConfig, ParallelConfig, and ConcurrencyConfig to enable custom serialization for parent and child contexts in concurrent operations.

*Description of changes:*
- Add serdes and itemSerdes fields to MapConfig, ParallelConfig, and ConcurrencyConfig
- Move type definitions (ConcurrentExecutionItem, ConcurrentExecutor, BatchResult, BatchItem, ConcurrencyConfig) from handler files to types/index.ts
- Update all handlers to pass serdes/itemSerdes to runInChildContext calls
- Use config.serdes for summary deserialization in replay mode (with defaultSerdes fallback)
- Fix generic type parameters to remove unnecessary defaults (= unknown)
- Update all imports to use centralized type definitions from types/index.ts

The serdes field configures serialization for the parent runInChildContext (entire operation), while itemSerdes configures serialization for each item/branch/iteration's child context.

*Issue #, if available:* #151 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
