### PR TITLE
fix(testing-sdk): update wait status when handler is not re-invoked

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/promise-all-wait.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/promise-all-wait.test.ts
@@ -1,0 +1,27 @@
+import { handler } from "../promise-all-wait";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "promise-all-wait test",
+  functionName: "promise-all-wait",
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  handler,
+  tests: (runner) => {
+    it("should complete all waits and wait for max duration", async () => {
+      const execution = await runner.run();
+
+      const wait1Op = runner.getOperation("wait-1");
+      const wait2Op = runner.getOperation("wait-2");
+      const wait3Op = runner.getOperation("wait-3");
+
+      expect(execution.getResult()).toEqual([null, null, null]);
+      expect(execution.getOperations()).toHaveLength(4);
+
+      expect(wait1Op.getWaitDetails()!.waitSeconds!).toBe(1);
+      expect(wait2Op.getWaitDetails()!.waitSeconds!).toBe(2);
+      expect(wait3Op.getStepDetails()!.result).toBeUndefined();
+    }, 10000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/shared/test-helper.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/shared/test-helper.ts
@@ -16,6 +16,9 @@ export interface TestDefinition<ResultType> {
     isCloud: boolean,
   ) => void;
   invocationType?: InvocationType;
+  localRunnerConfig?: {
+    skipTime?: boolean;
+  };
 }
 
 /**
@@ -66,7 +69,7 @@ export function createTests<ResultType>(testDef: TestDefinition<ResultType>) {
     const runner: LocalDurableTestRunner<ResultType> =
       new LocalDurableTestRunner({
         handlerFunction: testDef.handler,
-        skipTime: true,
+        skipTime: testDef.localRunnerConfig?.skipTime ?? true,
       });
 
     beforeEach(() => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-wait.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-wait.ts
@@ -1,0 +1,25 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Promise All With Wait",
+  description: "Waiting for all wait state promises to complete",
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const promise1 = context.wait("wait-1", 1);
+    const promise2 = context.wait("wait-2", 2);
+    const promise3 = context.step(
+      "wait-3",
+      () => new Promise((resolve) => setTimeout(resolve, 3000)),
+    );
+
+    const results = await context.promise.all([promise1, promise2, promise3]);
+
+    return results;
+  },
+);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix bug in testing library where wait status was not updated when the wait state completed, which caused the overall execution to hang.

Adding an example for this case as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
