### PR TITLE
refactor(sdk): remove function name extraction feature

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/documents/CONCEPTS.md
+++ b/packages/aws-durable-execution-sdk-js/src/documents/CONCEPTS.md
@@ -300,12 +300,7 @@ All durable operations accept an optional `name` parameter for operational visib
 // With name
 await context.step("fetch-user", async () => fetchUser(userId));
 
-// Without name (uses function name if available)
-await context.step(async function fetchUser() {
-  return fetchUser(userId);
-});
-
-// Anonymous (name remains unset)
+// Without name (name remains unset)
 await context.step(async () => fetchUser(userId));
 ```
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -102,50 +102,6 @@ describe("Step Handler", () => {
     expect(stepFn.mock.calls[0][0]).toHaveProperty("logger");
   });
 
-  test("should extract function name when no explicit name is provided", async () => {
-    async function myStepFunction(): Promise<string> {
-      return "step-result";
-    }
-
-    await stepHandler(myStepFunction);
-
-    // Verify checkpoint was called with the extracted function name
-    expect(mockCheckpoint).toHaveBeenCalledWith(
-      "test-step-id",
-      expect.objectContaining({
-        Name: "myStepFunction",
-      }),
-    );
-  });
-
-  test("should use explicit name over function name", async () => {
-    async function myStepFunction(): Promise<string> {
-      return "step-result";
-    }
-
-    await stepHandler("explicit-name", myStepFunction);
-
-    // Verify checkpoint was called with the explicit name, not the function name
-    expect(mockCheckpoint).toHaveBeenCalledWith(
-      "test-step-id",
-      expect.objectContaining({
-        Name: "explicit-name",
-      }),
-    );
-  });
-
-  test("should handle anonymous functions without name", async () => {
-    await stepHandler(async () => "step-result");
-
-    // Verify checkpoint was called without a name (arrow functions have empty string name, which is falsy)
-    expect(mockCheckpoint).toHaveBeenCalledWith(
-      "test-step-id",
-      expect.objectContaining({
-        Name: undefined,
-      }),
-    );
-  });
-
   test("should checkpoint at start and finish with AT_MOST_ONCE_PER_RETRY semantics", async () => {
     const stepFn = jest.fn().mockResolvedValue("step-result");
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -103,11 +103,6 @@ export const createStepHandler = (
       options = fnOrOptions as StepConfig<T>;
     }
 
-    // Extract function name if name is not provided
-    if (!name && fn.name) {
-      name = fn.name;
-    }
-
     const stepId = createStepId();
 
     log("▶️", "Running step:", { stepId, name, options });


### PR DESCRIPTION
*Description of changes:*

- Removed automatic function name extraction from step handler
- Function name extraction doesn't work well with minified code
- Developers should provide explicit names for better clarity
- Removed related tests and documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
