### PR TITLE
fix(eslint-plugin): fix variable shadowing bug

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,15 +15,15 @@ export default [
   },
   {
     files: [
-      "packages/examples/src/examples/**/*.ts",
-      "packages/examples/src/examples/**/*.js",
+      "packages/aws-durable-execution-sdk-js-examples/src/examples/**/*.ts",
+      "packages/aws-durable-execution-sdk-js-examples/src/examples/**/*.js",
+      "test-eslint.ts",
     ],
     plugins: {
-      "lambda-durable-functions-eslint-js": durableFunctionsPlugin,
+      "aws-durable-execution-eslint": durableFunctionsPlugin,
     },
     rules: {
-      "lambda-durable-functions-eslint-js/no-nested-durable-operations":
-        "error",
+      "aws-durable-execution-eslint/no-nested-durable-operations": "error",
     },
     languageOptions: {
       parser: typescriptParser,

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/__tests__/no-nested-durable-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/__tests__/no-nested-durable-operations.test.ts
@@ -13,4 +13,132 @@ describe("no-nested-durable-operations", () => {
     expect(meta.docs?.description).toContain("same context object");
     expect(meta.messages?.sameContextUsage).toBeDefined();
   });
+
+  it("should create rule function", () => {
+    const mockContext = {
+      report: jest.fn(),
+    };
+
+    const rule = noNestedDurableOperations.create(mockContext as any);
+    expect(rule).toBeDefined();
+    expect(rule.CallExpression).toBeDefined();
+    expect(rule["CallExpression:exit"]).toBeDefined();
+  });
+
+  it("should handle variable shadowing correctly", () => {
+    const mockContext = {
+      report: jest.fn(),
+    };
+
+    const rule = noNestedDurableOperations.create(mockContext as any);
+
+    // Create mock nodes with proper parent structure for shadowing
+    const outerParam = { type: "Identifier", name: "context" };
+    const innerParam = { type: "Identifier", name: "context" };
+
+    const outerFunction: any = {
+      type: "ArrowFunctionExpression",
+      params: [outerParam],
+      parent: null,
+    };
+
+    const innerFunction: any = {
+      type: "ArrowFunctionExpression",
+      params: [innerParam],
+      parent: outerFunction,
+    };
+
+    const outerContextNode: any = {
+      type: "Identifier",
+      name: "context",
+      parent: outerFunction,
+    };
+
+    const innerContextNode: any = {
+      type: "Identifier",
+      name: "context",
+      parent: innerFunction,
+    };
+
+    const outerStepNode: any = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        property: { type: "Identifier", name: "step" },
+        object: outerContextNode,
+      },
+      arguments: [],
+      parent: outerFunction,
+    };
+
+    const innerStepNode: any = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        property: { type: "Identifier", name: "step" },
+        object: innerContextNode,
+      },
+      arguments: [],
+      parent: innerFunction,
+    };
+
+    // Set up parent relationships
+    outerContextNode.parent = outerStepNode;
+    innerContextNode.parent = innerStepNode;
+
+    // First call with outer context
+    rule.CallExpression!(outerStepNode);
+    expect(mockContext.report).not.toHaveBeenCalled();
+
+    // Second call with shadowed inner context (different declaration)
+    rule.CallExpression!(innerStepNode);
+    expect(mockContext.report).not.toHaveBeenCalled();
+  });
+
+  it("should detect same context reuse", () => {
+    const mockContext = {
+      report: jest.fn(),
+    };
+
+    const rule = noNestedDurableOperations.create(mockContext as any);
+
+    // Create mock nodes with same declaration
+    const param = { type: "Identifier", name: "context" };
+    const func: any = {
+      type: "ArrowFunctionExpression",
+      params: [param],
+      parent: null,
+    };
+
+    const contextNode: any = {
+      type: "Identifier",
+      name: "context",
+      parent: func,
+    };
+
+    const stepNode: any = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        property: { type: "Identifier", name: "step" },
+        object: contextNode,
+      },
+      arguments: [],
+      parent: func,
+    };
+
+    contextNode.parent = stepNode;
+
+    // First call - should not report
+    rule.CallExpression!(stepNode);
+    expect(mockContext.report).not.toHaveBeenCalled();
+
+    // Second call with same declaration - should report
+    rule.CallExpression!(stepNode);
+    expect(mockContext.report).toHaveBeenCalledWith({
+      node: stepNode,
+      messageId: "sameContextUsage",
+      data: { contextName: "context" },
+    });
+  });
 });


### PR DESCRIPTION
- Add ESLint plugin to SDK package configuration with consistent naming
- Fix variable shadowing detection in no-nested-durable-operations rule
- Update rule to track actual variable declarations instead of just names
- Add comprehensive tests for variable shadowing scenarios
- Ensure consistent plugin naming across root and package configs

*Issue #, if available:*
#170 

*Description:*
The no-nested-durable-operations rule has a bug where it incorrectly flags valid JavaScript variable shadowing as problematic nested context usage

• ESLint should detect when developers use outer context objects inside nested operations like runInChildContext
• Valid JavaScript variable shadowing should not trigger false positives

```typescript
// This should NOT trigger an error (valid shadowing)
context.runInChildContext("block", async (context) => {
  await context.wait(1000); // Different 'context' variable
});

// This SHOULD trigger an error (actual nested usage)
context.runInChildContext("block", async (childCtx) => {
  await context.wait(1000); // Using outer 'context' - BAD
});
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
