### PR TITLE
chore: export ESM output files as .mjs files

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist-cjs/index.js"
     }
   },

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -5,16 +5,13 @@
   "version": "0.1.0",
   "repository": "ssh:github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js",
   "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js",
-  "main": "dist-cjs/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=20"
   },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist-cjs/index.js"
     }
   },

--- a/packages/aws-durable-execution-sdk-js/rollup.config.mjs
+++ b/packages/aws-durable-execution-sdk-js/rollup.config.mjs
@@ -5,7 +5,7 @@ import { createBuildOptions } from "../../rollup.config.js";
 const config = {
   input: "./src/index.ts",
   output: {
-    file: "index.js",
+    file: "index",
     inlineDynamicImports: true,
   },
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,6 @@ import json from "@rollup/plugin-json";
 const plugins = [json()];
 
 const commonOutputOptions = {
-  entryFileNames: "[name].js",
-  chunkFileNames: "[name].js",
   assetFileNames: "[name].[ext]",
   sourcemap: true,
   sourcemapExcludeSources: true,
@@ -66,8 +64,12 @@ export function createBuildOptions(options, mode) {
       output: {
         ...commonOutputOptions,
         ...options.output,
+        entryFileNames: "[name].mjs",
+        chunkFileNames: "[name].mjs",
         dir: options.output?.file ? undefined : "dist",
-        file: options.output?.file ? `dist/${options.output.file}` : undefined,
+        file: options.output?.file
+          ? `dist/${options.output.file}.mjs`
+          : undefined,
         format: "esm",
       },
     };
@@ -89,9 +91,11 @@ export function createBuildOptions(options, mode) {
     output: {
       ...commonOutputOptions,
       ...options.output,
+      entryFileNames: "[name].js",
+      chunkFileNames: "[name].js",
       dir: options.output?.file ? undefined : "dist-cjs",
       file: options.output?.file
-        ? `dist-cjs/${options.output.file}`
+        ? `dist-cjs/${options.output.file}.js`
         : undefined,
       format: "cjs",
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We were running into this error when importing the SDK using an `index.mjs` file:

```
SyntaxError: Named export 'withDurableExecution' not found. The requested module '@aws/durable-execution-sdk-js'
is a CommonJS module, which may not support all module.exports as named exports.

CommonJS modules can always be imported via the default export, for example using:

import pkg from '@aws/durable-execution-sdk-js';
const { withDurableExecution } = pkg;
```

This is due to using the newer `exports` field in `package.json` instead of the `main/module/types` field. The newer field enforces requirements more strictly, in particular that if the imported files are `.js` files, it will use the module type of the `package.json`, which in our case is `CJS` since we don't have `"type": "module"` in our `package.json`. Therefore, it tries to import our `.js` files we specified in the `exports` field of `import` as `CJS`, which doesn't work.

The older fields do not enforce this, and will happily import `js` files as either `CJS` or `ESM`. To fix this, I'm changing the `ESM` import to use `.mjs` files instead of `.js` files to explicitly specify the files as `ESM` instead of `CJS`. Our `.js` files for CJS can remain, since those can still be imported as `CJS`.

Another option is to use `"type": "module"` and changing the `CJS` require field to be `.cjs` instead, or to remove the `exports` field in favour of the legacy fields.

TODO:
- We need to have examples that import as ESM instead of CJS to test this thoroughly (created issue: https://github.com/aws/aws-durable-execution-sdk-js/issues/180)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
