### PR TITLE
feat(examples): migrate waitForCallback tests from testing lib

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
+++ b/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
@@ -6,5 +6,5 @@ const defaultPreset = createDefaultPreset();
 module.exports = {
   ...defaultPreset,
   testMatch: ["**/__tests__/**.test.ts"],
-  testTimeout: 60000,
+  testTimeout: 90000,
 };

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-anonymous.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-anonymous.test.ts
@@ -1,0 +1,40 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-anonymous";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-anonymous test",
+  functionName: "wait-for-callback-anonymous",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle basic waitForCallback with anonymous submitter", async () => {
+      // Start the execution (this will pause at the callback)
+      const executionPromise = runner.run();
+
+      const callbackOperation = runner.getOperationByIndex(1);
+
+      // Wait for the operation to be available
+      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
+      const callbackResult = JSON.stringify({
+        data: "callback_completed",
+      });
+      // Simulate external system completing the callback
+      await callbackOperation.sendCallbackSuccess(callbackResult);
+
+      // Now the execution should complete
+      const result = await executionPromise;
+
+      expect(result.getResult()).toEqual({
+        callbackResult: callbackResult,
+        completed: true,
+      });
+
+      // Verify operations were tracked
+      expect(result.getOperations().length).toBeGreaterThan(0);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-child-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-child-context.test.ts
@@ -1,0 +1,57 @@
+import {
+  InvocationType,
+  OperationStatus,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-child-context";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-child-context test",
+  functionName: "wait-for-callback-child-context",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle waitForCallback within child contexts", async () => {
+      // Get operations - parent callback, child context, child wait, child callback
+      const parentCallbackOp = runner.getOperation("parent-callback-op");
+      const childContextOp = runner.getOperation("child-context-with-callback");
+      const childCallbackOp = runner.getOperation("child-callback-op");
+
+      const executionPromise = runner.run({
+        payload: { test: "child-context-callbacks" },
+      });
+
+      // Wait for parent callback to start
+      await parentCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      const parentCallbackResult = JSON.stringify({
+        parentData: "parent-completed",
+      });
+      await parentCallbackOp.sendCallbackSuccess(parentCallbackResult);
+
+      // Wait for child callback to start
+      await childCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      const childCallbackResult = JSON.stringify({ childData: 42 });
+      await childCallbackOp.sendCallbackSuccess(childCallbackResult);
+
+      const result = await executionPromise;
+
+      expect(result.getResult()).toEqual({
+        parentResult: parentCallbackResult,
+        childContextResult: {
+          childResult: childCallbackResult,
+          childProcessed: true,
+        },
+      });
+
+      // Verify child operations are accessible
+      const childOperations = childContextOp.getChildOperations();
+      expect(childOperations).toHaveLength(2); // wait + waitForCallback
+
+      const completedOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(completedOperations.length).toBe(8);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-failing-submitter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-failing-submitter.test.ts
@@ -1,0 +1,21 @@
+import { InvocationType } from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-failing-submitter";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-failing-submitter test",
+  functionName: "wait-for-callback-failing-submitter",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    // Pending resolution of https://github.com/aws/aws-durable-execution-sdk-js/issues/199
+    it.skip("should handle waitForCallback with failing submitter function errors", async () => {
+      const execution = await runner.run();
+
+      expect(execution.getResult()).toEqual({
+        success: false,
+        error: "Submitter failed",
+      });
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-failures.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-failures.test.ts
@@ -1,0 +1,40 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-failures";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-failures test",
+  functionName: "wait-for-callback-failures",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle waitForCallback with callback failure scenarios", async () => {
+      // Start the execution (this will pause at the callback)
+      const executionPromise = runner.run();
+
+      const callbackOperation = runner.getOperationByIndex(1);
+
+      // Wait for the operation to be available (submitter succeeded)
+      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
+
+      // Simulate external system failing the callback
+      await callbackOperation.sendCallbackFailure({
+        ErrorMessage: "External API failure",
+        ErrorType: "APIException",
+      });
+
+      const result = await executionPromise;
+
+      expect(result.getResult()).toEqual({
+        success: false,
+        error: "Callback failed",
+      });
+
+      const completedOperations = result.getOperations();
+      expect(completedOperations.length).toEqual(3);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-heartbeat-sends.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-heartbeat-sends.test.ts
@@ -1,0 +1,60 @@
+import {
+  InvocationType,
+  OperationStatus,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-heartbeat-sends";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-heartbeat-sends test",
+  functionName: "wait-for-callback-heartbeat-sends",
+  handler,
+  invocationType: InvocationType.Event,
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  tests: (runner, isCloud) => {
+    it("should handle waitForCallback heartbeat scenarios during long-running submitter execution", async () => {
+      const executionPromise = runner.run({
+        payload: { isCloud },
+      });
+
+      const callbackOperation = runner.getOperationByIndex(1);
+
+      // Wait for the operation to be available
+      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
+
+      // Send heartbeat to keep the callback alive during processing
+      await callbackOperation.sendCallbackHeartbeat();
+
+      // Wait a bit more to simulate callback processing time
+      await new Promise((resolve) => setTimeout(resolve, isCloud ? 7000 : 600));
+
+      // Send another heartbeat
+      await callbackOperation.sendCallbackHeartbeat();
+
+      // Finally complete the callback
+      const callbackResult = JSON.stringify({
+        processed: 1000,
+      });
+      await callbackOperation.sendCallbackSuccess(callbackResult);
+
+      const result = await executionPromise;
+
+      const resultData = result.getResult() as {
+        callbackResult: string;
+        completed: boolean;
+      };
+
+      expect(resultData.callbackResult).toEqual(callbackResult);
+      expect(resultData.completed).toBe(true);
+
+      // Should have completed operations with successful callback
+      const completedOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(completedOperations.length).toBeGreaterThan(0);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-mixed-ops.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-mixed-ops.test.ts
@@ -1,0 +1,51 @@
+import {
+  InvocationType,
+  OperationStatus,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-mixed-ops";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-mixed-ops test",
+  functionName: "wait-for-callback-mixed-ops",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle waitForCallback mixed with steps, waits, and other operations", async () => {
+      const callbackOperation = runner.getOperation("wait-for-callback");
+
+      const executionPromise = runner.run();
+
+      // Wait for callback to start (other operations complete synchronously with skipTime)
+      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
+
+      // Complete the callback
+      const callbackResult = JSON.stringify({ processed: true });
+      await callbackOperation.sendCallbackSuccess(callbackResult);
+
+      const result = await executionPromise;
+
+      const resultData = result.getResult() as {
+        stepResult: { userId: number; name: string };
+        callbackResult: { processed: boolean };
+        finalStep: { status: string; timestamp: number };
+        workflowCompleted: boolean;
+      };
+
+      expect(resultData).toMatchObject({
+        stepResult: { userId: 123, name: "John Doe" },
+        callbackResult: JSON.stringify({ processed: true }),
+        finalStep: { status: "completed" },
+        workflowCompleted: true,
+      });
+      expect(typeof resultData.finalStep.timestamp).toBe("number");
+
+      // Verify all operations were tracked - should have wait, step, waitForCallback (context + callback + submitter), wait, step
+      const completedOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(completedOperations.length).toBe(7);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-nested.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-nested.test.ts
@@ -1,0 +1,65 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-nested";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-nested test",
+  functionName: "wait-for-callback-nested",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle nested waitForCallback operations in child contexts", async () => {
+      // Get operations - outer callback, outer context, inner callback, inner context, deep wait, nested callback
+      const outerCallbackOp = runner.getOperation("outer-callback-op");
+      const outerContextOp = runner.getOperation("outer-child-context");
+      const innerCallbackOp = runner.getOperation("inner-callback-op");
+      const innerContextOp = runner.getOperation("inner-child-context");
+      const nestedCallbackOp = runner.getOperation("nested-callback-op");
+
+      const executionPromise = runner.run();
+
+      // Complete callbacks in sequence
+      await outerCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      const outerCallbackResult = JSON.stringify({ level: "outer-completed" });
+      await outerCallbackOp.sendCallbackSuccess(outerCallbackResult);
+
+      await innerCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      const innerCallbackResult = JSON.stringify({ level: "inner-completed" });
+      await innerCallbackOp.sendCallbackSuccess(innerCallbackResult);
+
+      await nestedCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      const nestedCallbackResult = JSON.stringify({
+        level: "nested-completed",
+      });
+      await nestedCallbackOp.sendCallbackSuccess(nestedCallbackResult);
+
+      const result = await executionPromise;
+
+      expect(result.getResult()).toEqual({
+        outerCallback: outerCallbackResult,
+        nestedResults: {
+          innerCallback: innerCallbackResult,
+          deepNested: {
+            nestedCallback: nestedCallbackResult,
+            deepLevel: "inner-child",
+          },
+          level: "outer-child",
+        },
+      });
+
+      // Verify child operations hierarchy
+      const outerChildren = outerContextOp.getChildOperations();
+      expect(outerChildren).toHaveLength(2); // inner callback + inner context
+
+      const innerChildren = innerContextOp.getChildOperations();
+      expect(innerChildren).toHaveLength(2); // deep wait + nested callback
+
+      // Should have tracked all operations
+      const completedOperations = result.getOperations();
+      expect(completedOperations.length).toBe(12);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-serdes.test.ts
@@ -1,0 +1,83 @@
+import {
+  InvocationType,
+  OperationStatus,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "../wait-for-callback-serdes";
+import { createTests } from "./shared/test-helper";
+
+// Define CustomData type to match handler
+interface CustomData {
+  id: number;
+  message: string;
+  timestamp: Date;
+  metadata: {
+    version: string;
+    processed: boolean;
+  };
+}
+
+// Custom serdes from handler (needed for test)
+const customSerdes = {
+  serialize: async (
+    data: CustomData | undefined,
+  ): Promise<string | undefined> => {
+    if (data === undefined) return Promise.resolve(undefined);
+    return Promise.resolve(
+      JSON.stringify({
+        ...data,
+        timestamp: data.timestamp.toISOString(),
+        _serializedBy: "custom-serdes-v1",
+      }),
+    );
+  },
+};
+
+createTests({
+  name: "wait-for-callback-serdes test",
+  functionName: "wait-for-callback-serdes",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle waitForCallback with custom serdes configuration", async () => {
+      const executionPromise = runner.run();
+
+      const callbackOperation = runner.getOperation("custom-serdes-callback");
+
+      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
+
+      // Send data that requires custom serialization
+      const testData: CustomData = {
+        id: 42,
+        message: "Hello Custom Serdes",
+        timestamp: new Date("2025-06-15T12:30:45Z"),
+        metadata: {
+          version: "2.0.0",
+          processed: true,
+        },
+      };
+
+      // Serialize the data using custom serdes for sending
+      const serializedData = await customSerdes.serialize(testData);
+      await callbackOperation.sendCallbackSuccess(serializedData!);
+
+      const result = await executionPromise;
+
+      expect(result.getResult()).toEqual(
+        JSON.parse(
+          // the result will always get stringified since it's the lambda response
+          JSON.stringify({
+            receivedData: testData,
+            isDateObject: true,
+          }),
+        ),
+      );
+
+      // Should have completed operations with successful callback
+      const completedOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(completedOperations.length).toBeGreaterThan(0);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-timeout.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/wait-for-callback-timeout.test.ts
@@ -1,0 +1,22 @@
+import { InvocationType } from "@aws-sdk/client-lambda";
+import { handler } from "../wait-for-callback-timeout";
+import { createTests } from "./shared/test-helper";
+
+createTests({
+  name: "wait-for-callback-timeout test",
+  functionName: "wait-for-callback-timeout",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should handle waitForCallback timeout scenarios", async () => {
+      const result = await runner.run({
+        payload: { test: "timeout-scenario" },
+      });
+
+      expect(result.getResult()).toEqual({
+        success: false,
+        error: "Callback failed",
+      });
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-anonymous.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-anonymous.ts
@@ -1,0 +1,25 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Anonymous Submitter",
+  description:
+    "Demonstrates waitForCallback with anonymous (inline) submitter function",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    const result = await context.waitForCallback<{ data: string }>(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return Promise.resolve();
+    });
+
+    return {
+      callbackResult: result,
+      completed: true,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-child-context.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-child-context.ts
@@ -1,0 +1,43 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Child Context",
+  description: "Demonstrates waitForCallback operations within child contexts",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    const parentResult = await context.waitForCallback<{
+      parentData: string;
+    }>("parent-callback-op", async () => {
+      return Promise.resolve();
+    });
+
+    const childContextResult = await context.runInChildContext(
+      "child-context-with-callback",
+      async (childContext) => {
+        await childContext.wait("child-wait", 1);
+
+        const childCallbackResult = await childContext.waitForCallback<{
+          childData: number;
+        }>("child-callback-op", async () => {
+          return Promise.resolve();
+        });
+
+        return {
+          childResult: childCallbackResult,
+          childProcessed: true,
+        };
+      },
+    );
+
+    return {
+      parentResult,
+      childContextResult,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-failing-submitter.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-failing-submitter.ts
@@ -1,0 +1,43 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Failing Submitter",
+  description:
+    "Demonstrates waitForCallback with submitter function that fails",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    try {
+      const result = await context.waitForCallback<{ data: string }>(
+        "failing-submitter-callback",
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+
+          // Submitter fails
+          throw new Error("Submitter failed");
+        },
+        {
+          retryStrategy: (_, attemptCount) => ({
+            shouldRetry: attemptCount < 3,
+            delaySeconds: 1,
+          }),
+        },
+      );
+
+      return {
+        callbackResult: result,
+        success: true,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-failures.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-failures.ts
@@ -1,0 +1,35 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Callback Failures",
+  description:
+    "Demonstrates handling of callback failure scenarios where submitter succeeds but external system fails",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    try {
+      const result = await context.waitForCallback<{ data: string }>(
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          // Submitter succeeds - simulates successful external API call setup
+          return Promise.resolve();
+        },
+      );
+
+      return {
+        callbackResult: result,
+        success: true,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-heartbeat-sends.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-heartbeat-sends.ts
@@ -1,0 +1,38 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Heartbeat Sends",
+  description:
+    "Demonstrates sending heartbeats during long-running callback processing",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: {
+      isCloud: boolean;
+    },
+    context: DurableContext,
+  ) => {
+    const result = await context.waitForCallback<{ processed: number }>(
+      async () => {
+        // Simulate long-running submitter function
+        await new Promise((resolve) =>
+          setTimeout(resolve, event.isCloud ? 5000 : 100),
+        );
+        return Promise.resolve();
+      },
+      {
+        heartbeatTimeout: event.isCloud ? 15 : 1,
+      },
+    );
+
+    return {
+      callbackResult: result,
+      completed: true,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-mixed-ops.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-mixed-ops.ts
@@ -1,0 +1,46 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Mixed Operations",
+  description:
+    "Demonstrates waitForCallback combined with steps, waits, and other operations",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    // Mix waitForCallback with other operation types
+    await context.wait("initial-wait", 1);
+
+    const stepResult = await context.step("fetch-user-data", () => {
+      return Promise.resolve({ userId: 123, name: "John Doe" });
+    });
+
+    const callbackResult = await context.waitForCallback<{
+      processed: boolean;
+    }>("wait-for-callback", async () => {
+      // Submitter uses data from previous step
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return Promise.resolve();
+    });
+
+    await context.wait("final-wait", 2);
+
+    const finalStep = await context.step("finalize-processing", () => {
+      return Promise.resolve({
+        status: "completed",
+        timestamp: Date.now(),
+      });
+    });
+
+    return {
+      stepResult,
+      callbackResult,
+      finalStep,
+      workflowCompleted: true,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-nested.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-nested.ts
@@ -1,0 +1,64 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Nested Contexts",
+  description:
+    "Demonstrates nested waitForCallback operations across multiple child context levels",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    const outerResult = await context.waitForCallback<{ level: string }>(
+      "outer-callback-op",
+      async () => {
+        return Promise.resolve();
+      },
+    );
+
+    const nestedResult = await context.runInChildContext(
+      "outer-child-context",
+      async (outerChildContext) => {
+        const innerResult = await outerChildContext.waitForCallback<{
+          level: string;
+        }>("inner-callback-op", async () => {
+          return Promise.resolve();
+        });
+
+        // Nested child context with another callback
+        const deepNestedResult = await outerChildContext.runInChildContext(
+          "inner-child-context",
+          async (innerChildContext) => {
+            await innerChildContext.wait("deep-wait", 5);
+
+            const nestedCallbackResult =
+              await innerChildContext.waitForCallback<{
+                level: string;
+              }>("nested-callback-op", async () => {
+                return Promise.resolve();
+              });
+
+            return {
+              nestedCallback: nestedCallbackResult,
+              deepLevel: "inner-child",
+            };
+          },
+        );
+
+        return {
+          innerCallback: innerResult,
+          deepNested: deepNestedResult,
+          level: "outer-child",
+        };
+      },
+    );
+
+    return {
+      outerCallback: outerResult,
+      nestedResults: nestedResult,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-serdes.ts
@@ -1,0 +1,78 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Custom Serdes",
+  description:
+    "Demonstrates waitForCallback with custom serialization/deserialization",
+};
+
+interface CustomData {
+  id: number;
+  message: string;
+  timestamp: Date;
+  metadata: {
+    version: string;
+    processed: boolean;
+  };
+}
+
+const customSerdes = {
+  serialize: async (
+    data: CustomData | undefined,
+  ): Promise<string | undefined> => {
+    if (data === undefined) return Promise.resolve(undefined);
+    return Promise.resolve(
+      JSON.stringify({
+        ...data,
+        timestamp: data.timestamp.toISOString(),
+        _serializedBy: "custom-serdes-v1",
+      }),
+    );
+  },
+  deserialize: async (
+    str: string | undefined,
+  ): Promise<CustomData | undefined> => {
+    if (str === undefined) return Promise.resolve(undefined);
+    const parsed = JSON.parse(str) as {
+      id: number;
+      message: string;
+      timestamp: string;
+      metadata: {
+        version: string;
+        processed: boolean;
+      };
+      _serializedBy: string;
+    };
+    return Promise.resolve({
+      id: parsed.id,
+      message: parsed.message,
+      timestamp: new Date(parsed.timestamp),
+      metadata: parsed.metadata,
+    });
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    const result = await context.waitForCallback<CustomData>(
+      "custom-serdes-callback",
+      async () => {
+        // Submitter succeeds
+        return Promise.resolve();
+      },
+      {
+        serdes: customSerdes,
+        timeout: 300,
+      },
+    );
+
+    return {
+      receivedData: result,
+      isDateObject: result.timestamp instanceof Date,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback-timeout.ts
@@ -1,0 +1,36 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Timeout",
+  description: "Demonstrates waitForCallback timeout scenarios",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    try {
+      const result = await context.waitForCallback<{ data: string }>(
+        async () => {
+          // Submitter succeeds but callback never completes
+          return Promise.resolve();
+        },
+        {
+          timeout: 1, // 1 second timeout
+        },
+      );
+
+      return {
+        callbackResult: result,
+        success: true,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
@@ -616,8 +616,8 @@ describe("CloudDurableTestRunner", () => {
         EventType: EventType.StepStarted,
         EventId: 1,
         Id: "1",
+        Name: "processData",
         StepStartedDetails: {
-          Name: "processData",
           Input: '{"input": "test"}',
         },
       };
@@ -631,6 +631,7 @@ describe("CloudDurableTestRunner", () => {
           Result: {
             Payload: '{"result": "processed"}',
           },
+          RetryDetails: {},
         },
       };
 
@@ -643,6 +644,10 @@ describe("CloudDurableTestRunner", () => {
           Status: ExecutionStatus.SUCCEEDED,
           Result: '{"result": "processed"}',
           $metadata: {},
+          StartTimestamp: new Date(),
+          DurableExecutionArn: "",
+          DurableExecutionName: "",
+          FunctionArn: "",
         },
       });
 
@@ -660,6 +665,7 @@ describe("CloudDurableTestRunner", () => {
       expect(result.getResult()).toBeDefined();
       expect(operation.getOperationData()).toEqual({
         Id: "1",
+        Name: "processData",
         StartTimestamp: expect.any(Date),
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.STEP,

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operation-storage.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operation-storage.ts
@@ -35,14 +35,17 @@ export class OperationStorage {
           ? this.indexedOperations.getById(trackedOperation.params.id)
           : null,
       () =>
-        trackedOperation.params.name !== undefined
+        trackedOperation.params.name !== undefined &&
+        trackedOperation.params.id === undefined
           ? this.indexedOperations.getByNameAndIndex(
               trackedOperation.params.name,
               trackedOperation.params.index,
             )
           : null,
       () =>
-        trackedOperation.params.index !== undefined
+        trackedOperation.params.index !== undefined &&
+        trackedOperation.params.name === undefined &&
+        trackedOperation.params.id === undefined
           ? this.indexedOperations.getByIndex(trackedOperation.params.index)
           : null,
     ];

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -14,620 +14,6 @@ afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
  * Tests the complete waitForCallback workflow including submitter execution and callback completion.
  */
 describe("WaitForCallback Operations Integration", () => {
-  it("should handle basic waitForCallback with anonymous submitter", async () => {
-    let receivedCallbackId: string | undefined;
-
-    const handler = withDurableExecution<unknown, unknown>(
-      async (_event: unknown, context: DurableContext) => {
-        const result = await context.waitForCallback<{ data: string }>(
-          async (callbackId) => {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            receivedCallbackId = callbackId;
-            return Promise.resolve();
-          },
-        );
-
-        return {
-          callbackResult: result,
-          submitterReceived: (receivedCallbackId?.length ?? 0) > 0,
-          completed: true,
-        };
-      },
-    );
-
-    const runner = new LocalDurableTestRunner({
-      handlerFunction: handler,
-      skipTime: true,
-    });
-
-    // Start the execution (this will pause at the callback)
-    const executionPromise = runner.run({
-      payload: { test: "waitForCallback-anonymous" },
-    });
-
-    const callbackOperation = runner.getOperationByIndex<{ data: string }>(1);
-
-    // Wait for the operation to be available
-    await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-    const callbackResult = JSON.stringify({
-      data: "callback_completed",
-    });
-    // Simulate external system completing the callback
-    await callbackOperation.sendCallbackSuccess(callbackResult);
-
-    // Now the execution should complete
-    const result = await executionPromise;
-
-    expect(result.getResult()).toEqual({
-      callbackResult: callbackResult,
-      submitterReceived: true,
-      completed: true,
-    });
-    expect(receivedCallbackId).toBeDefined();
-  });
-
-  it("should handle basic waitForCallback with named submitter", async () => {
-    let receivedCallbackId: string | undefined; // simulates a side-effect since it's outside the handler
-    const handler = withDurableExecution<unknown, unknown>(
-      async (_event: unknown, context: DurableContext) => {
-        const result = await context.waitForCallback<{ data: string }>(
-          async (callbackId) => {
-            receivedCallbackId = callbackId;
-            return Promise.resolve();
-          },
-        );
-
-        return {
-          callbackResult: result,
-          completed: true,
-          callbackId: receivedCallbackId,
-        };
-      },
-    );
-
-    const runner = new LocalDurableTestRunner({
-      handlerFunction: handler,
-      skipTime: true,
-    });
-
-    // Start the execution (this will pause at the callback)
-    const executionPromise = runner.run();
-
-    const callbackOperation = runner.getOperationByIndex<{ data: string }>(1);
-
-    // Wait for the operation to be available
-    await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-    // Simulate external system completing the callback
-    const callbackResult = JSON.stringify({
-      data: "callback_completed",
-    });
-    await callbackOperation.sendCallbackSuccess(callbackResult);
-
-    // Now the execution should complete
-    const result = await executionPromise;
-
-    const callbackDetails = callbackOperation.getCallbackDetails();
-    expect(result.getResult()).toEqual({
-      callbackResult,
-      completed: true,
-      callbackId: callbackDetails?.callbackId,
-    });
-  });
-
-  // Error Handling & Submitter Function Variants Category
-  describe("Error Handling & Submitter Function Variants", () => {
-    it("should handle waitForCallback with submitter function synchronous errors", async () => {
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              () => {
-                throw new Error("Submitter failed immediately");
-              },
-            );
-
-            return {
-              callbackResult: result,
-              success: true,
-            };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-            };
-          }
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const result = await runner.run({
-        payload: { test: "submitter-sync-error" },
-      });
-
-      expect(result.getResult()).toEqual({
-        success: false,
-        error: "Submitter failed immediately",
-      });
-
-      // Should have no succeeded operations since submitter failed before callback was created
-      const succeededOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(succeededOperations.length).toEqual(0);
-    });
-
-    it("should handle waitForCallback with submitter function returning rejected promises", async () => {
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              () => {
-                return Promise.reject(new Error("Async submitter failure"));
-              },
-            );
-
-            return {
-              callbackResult: result,
-              success: true,
-            };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-            };
-          }
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const result = await runner.run({
-        payload: { test: "submitter-async-error" },
-      });
-
-      expect(result.getResult()).toEqual({
-        success: false,
-        error: "Async submitter failure",
-      });
-
-      // Should have no succeeded operations since submitter failed
-      const succeededOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(succeededOperations.length).toEqual(0);
-    });
-
-    it("should handle waitForCallback with callback failure scenarios", async () => {
-      let receivedCallbackId: string | undefined;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              async (callbackId) => {
-                receivedCallbackId = callbackId;
-                await new Promise((resolve) => setTimeout(resolve, 1000));
-                // Submitter succeeds - simulates successful external API call setup
-                return Promise.resolve();
-              },
-            );
-
-            return {
-              callbackResult: result,
-              success: true,
-            };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-              callbackId: receivedCallbackId,
-            };
-          }
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      // Start the execution (this will pause at the callback)
-      const executionPromise = runner.run({
-        payload: { test: "callback-failure" },
-      });
-
-      const callbackOperation = runner.getOperationByIndex<{ data: string }>(1);
-
-      // Wait for the operation to be available (submitter succeeded)
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Simulate external system failing the callback
-      await callbackOperation.sendCallbackFailure({
-        ErrorMessage: "External API failure",
-        ErrorType: "APIException",
-      });
-
-      const result = await executionPromise;
-
-      expect(result.getResult()).toEqual({
-        success: false,
-        error: "Callback failed",
-        callbackId: receivedCallbackId,
-      });
-
-      expect(receivedCallbackId).toBeDefined();
-
-      const completedOperations = result.getOperations();
-      expect(completedOperations.length).toEqual(3);
-    });
-
-    it("should handle waitForCallback mixed success/failure scenarios", async () => {
-      let scenario1CallbackId: string | undefined;
-      let scenario2CallbackId: string | undefined;
-
-      // Test scenario where submitter fails but callback would have succeeded
-      const handler1 = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              (callbackId) => {
-                scenario1CallbackId = callbackId;
-                // Simulate submitter that fails after receiving callback ID
-                throw new Error("Submitter failed after callback creation");
-              },
-            );
-
-            return { success: true, result };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-              scenario: "submitter-fails-after-callback-creation",
-            };
-          }
-        },
-      );
-
-      const runner1 = new LocalDurableTestRunner({
-        handlerFunction: handler1,
-        skipTime: true,
-      });
-
-      const result1 = await runner1.run({
-        payload: { test: "mixed-scenario-1" },
-      });
-
-      expect(result1.getResult()).toEqual({
-        success: false,
-        error: "Submitter failed after callback creation",
-        scenario: "submitter-fails-after-callback-creation",
-      });
-
-      // Test scenario where submitter succeeds but callback fails (covered in previous test)
-      // This test demonstrates the contrast between the two scenarios
-      const handler2 = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          const result = await context.waitForCallback<{ data: string }>(
-            (callbackId) => {
-              scenario2CallbackId = callbackId;
-              // Submitter succeeds
-              return Promise.resolve();
-            },
-          );
-
-          return {
-            success: true,
-            result,
-            scenario: "submitter-succeeds-callback-succeeds",
-          };
-        },
-      );
-
-      const runner2 = new LocalDurableTestRunner({
-        handlerFunction: handler2,
-        skipTime: true,
-      });
-
-      const executionPromise2 = runner2.run({
-        payload: { test: "mixed-scenario-2" },
-      });
-
-      const callbackOperation2 = runner2.getOperationByIndex<{ data: string }>(
-        1,
-      );
-      await callbackOperation2.waitForData(WaitingOperationStatus.STARTED);
-
-      const callbackResult = JSON.stringify({ data: "success-data" });
-      await callbackOperation2.sendCallbackSuccess(callbackResult);
-
-      const result2 = await executionPromise2;
-
-      expect(result2.getResult()).toEqual({
-        success: true,
-        result: callbackResult,
-        scenario: "submitter-succeeds-callback-succeeds",
-      });
-
-      expect(scenario1CallbackId).toBeDefined();
-      expect(scenario2CallbackId).toBeDefined();
-    });
-
-    it("should handle waitForCallback with complex submitter function errors", async () => {
-      let callbackId: string | undefined;
-      let sideEffectCounter = 0;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              async (id) => {
-                callbackId = id;
-
-                // Simulate complex submitter that performs multiple operations
-                sideEffectCounter++;
-
-                // First async operation succeeds
-                await new Promise((resolve) => setTimeout(resolve, 10));
-                sideEffectCounter++;
-
-                // Second async operation succeeds
-                await Promise.resolve({ step: 1 });
-                sideEffectCounter++;
-
-                // Third operation fails
-                throw new Error("Complex submitter failed at step 3");
-              },
-              {
-                retryStrategy: (_, attemptCount) => ({
-                  shouldRetry: attemptCount < 3,
-                  delaySeconds: 1,
-                }),
-              },
-            );
-
-            return {
-              callbackResult: result,
-              success: true,
-            };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-              sideEffects: sideEffectCounter,
-              callbackId: callbackId,
-            };
-          }
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const result = await runner.run({
-        payload: { test: "complex-submitter-error" },
-      });
-
-      expect(result.getResult()).toEqual({
-        success: false,
-        error: "Complex submitter failed at step 3",
-        // Retries 6 times (default maxAttempts)
-        sideEffects: 18,
-        callbackId: expect.any(String),
-      });
-
-      // Verify that callback ID was generated before failure
-      expect(callbackId).toBeDefined();
-      expect(sideEffectCounter).toBe(18);
-
-      // Should have no succeeded operations since submitter failed
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toEqual(0);
-    });
-  });
-
-  // Timeout and Heartbeat Tests Category
-  describe("Timeout and Heartbeat Tests", () => {
-    it("should handle waitForCallback with heartbeat timeout configuration", async () => {
-      let receivedCallbackId: string | undefined;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          const result = await context.waitForCallback<{ data: string }>(
-            async (callbackId) => {
-              receivedCallbackId = callbackId;
-              // Submitter succeeds - simulates external API call setup
-              return Promise.resolve();
-            },
-            {
-              heartbeatTimeout: 2, // 2 seconds heartbeat timeout
-              timeout: 300, // 5 minute total timeout
-            },
-          );
-
-          return {
-            callbackResult: result,
-            heartbeatEnabled: true,
-            completed: true,
-          };
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      // Start the execution (this will pause at the callback)
-      const executionPromise = runner.run({
-        payload: { test: "heartbeat-timeout-config" },
-      });
-
-      const callbackOperation = runner.getOperationByIndex<{ data: string }>(1);
-
-      // Wait for the operation to be available
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Verify callback details include timeout configuration
-      const callbackDetails = callbackOperation.getCallbackDetails();
-      expect(callbackDetails?.callbackId).toBeDefined();
-
-      const callbackResult = JSON.stringify({
-        data: "heartbeat-completed",
-      });
-      // Complete the callback successfully
-      await callbackOperation.sendCallbackSuccess(callbackResult);
-
-      const result = await executionPromise;
-
-      expect(result.getResult()).toEqual({
-        callbackResult: callbackResult,
-        heartbeatEnabled: true,
-        completed: true,
-      });
-
-      expect(receivedCallbackId).toBeDefined();
-
-      // Should have completed operations with successful callback
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBeGreaterThan(0);
-    });
-
-    it("should handle waitForCallback heartbeat scenarios during long-running submitter execution", async () => {
-      let receivedCallbackId: string | undefined;
-      let submitterStartTime: number;
-      let submitterEndTime: number;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          const result = await context.waitForCallback<{ processed: number }>(
-            async (callbackId) => {
-              receivedCallbackId = callbackId;
-              submitterStartTime = Date.now();
-
-              // Simulate long-running submitter function
-              // In real scenario, this would be setting up external systems
-              await new Promise((resolve) => setTimeout(resolve, 100));
-
-              submitterEndTime = Date.now();
-              return Promise.resolve();
-            },
-            {
-              heartbeatTimeout: 1, // 1 second heartbeat timeout
-            },
-          );
-
-          return {
-            callbackResult: result,
-            submitterDuration: submitterEndTime - submitterStartTime,
-            callbackId: receivedCallbackId,
-          };
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-      }); // Use real time for this test to demonstrate heartbeat behavior
-
-      const executionPromise = runner.run({
-        payload: { test: "heartbeat-long-submitter" },
-      });
-
-      const callbackOperation = runner.getOperationByIndex<{
-        processed: number;
-      }>(1);
-
-      // Wait for the operation to be available (submitter completes)
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Send heartbeat to keep the callback alive during processing
-      await callbackOperation.sendCallbackHeartbeat();
-
-      // Wait a bit more to simulate processing time
-      await new Promise((resolve) => setTimeout(resolve, 600));
-
-      // Send another heartbeat
-      await callbackOperation.sendCallbackHeartbeat();
-
-      // Finally complete the callback
-      const callbackResult = JSON.stringify({
-        processed: 1000,
-      });
-      await callbackOperation.sendCallbackSuccess(callbackResult);
-
-      const result = await executionPromise;
-
-      const resultData = result.getResult() as {
-        callbackResult: string;
-        submitterDuration: number;
-        callbackId: string;
-      };
-
-      expect(resultData.callbackResult).toEqual(callbackResult);
-      expect(resultData.submitterDuration).toBeGreaterThan(50); // Should take at least 100ms
-      expect(resultData.callbackId).toBeDefined();
-
-      // Should have completed operations with successful callback
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBeGreaterThan(0);
-    });
-
-    it("should handle waitForCallback timeout scenarios", async () => {
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          try {
-            const result = await context.waitForCallback<{ data: string }>(
-              async () => {
-                // Submitter succeeds but callback never completes
-                return Promise.resolve();
-              },
-              {
-                timeout: 1, // 1 second timeout
-              },
-            );
-
-            return {
-              callbackResult: result,
-              success: true,
-            };
-          } catch (error) {
-            return {
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
-            };
-          }
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-      });
-
-      const result = await runner.run({
-        payload: { test: "timeout-scenario" },
-      });
-
-      expect(result.getResult()).toEqual({
-        success: false,
-        error: "Callback failed",
-      });
-    });
-  });
-
   // Concurrent and Complex Workflow Tests Category
   describe("Concurrent and Complex Workflow Tests", () => {
     // todo: add test when language SDK adds concurrency support
@@ -760,194 +146,6 @@ describe("WaitForCallback Operations Integration", () => {
       expect(new Set([callback1Id, callback2Id, callback3Id]).size).toBe(3);
     });
 
-    it("should handle waitForCallback mixed with steps, waits, and other operations", async () => {
-      let callbackId: string | undefined;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          // Mix waitForCallback with other operation types
-          await context.wait("initial-wait", 50);
-
-          const stepResult = await context.step("fetch-user-data", () => {
-            return Promise.resolve({ userId: 123, name: "John Doe" });
-          });
-
-          const callbackResult = await context.waitForCallback<{
-            processed: boolean;
-          }>("wait-for-callback", async (id) => {
-            callbackId = id;
-            // Submitter uses data from previous step
-            await new Promise((resolve) => setTimeout(resolve, 10));
-            return Promise.resolve();
-          });
-
-          await context.wait("final-wait", 25);
-
-          const finalStep = await context.step("finalize-processing", () => {
-            return Promise.resolve({
-              status: "completed",
-              timestamp: Date.now(),
-            });
-          });
-
-          return {
-            stepResult,
-            callbackResult,
-            finalStep,
-            callbackId,
-            workflowCompleted: true,
-          };
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const callbackOperation = runner.getOperation<{
-        processed: boolean;
-      }>("wait-for-callback");
-
-      const executionPromise = runner.run({
-        payload: { test: "mixed-operations" },
-      });
-
-      // Wait for callback to start (other operations complete synchronously with skipTime)
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Complete the callback
-      const callbackResult = JSON.stringify({ processed: true });
-      await callbackOperation.sendCallbackSuccess(callbackResult);
-
-      const result = await executionPromise;
-
-      const resultData = result.getResult() as {
-        stepResult: { userId: number; name: string };
-        callbackResult: { processed: boolean };
-        finalStep: { status: string; timestamp: number };
-        callbackId: string;
-        workflowCompleted: boolean;
-      };
-
-      expect(resultData).toMatchObject({
-        stepResult: { userId: 123, name: "John Doe" },
-        callbackResult: JSON.stringify({ processed: true }),
-        finalStep: { status: "completed" },
-        workflowCompleted: true,
-      });
-      expect(resultData.callbackId).toBeDefined();
-      expect(typeof resultData.finalStep.timestamp).toBe("number");
-
-      // Verify all operations were tracked - should have wait, step, waitForCallback (context + callback + submitter), wait, step
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBe(7);
-    });
-
-    it("should handle waitForCallback within child contexts", async () => {
-      let parentCallbackId: string | undefined;
-      let childCallbackId: string | undefined;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          const parentResult = await context.waitForCallback<{
-            parentData: string;
-          }>("parent-callback-op", async (callbackId) => {
-            parentCallbackId = callbackId;
-            return Promise.resolve();
-          });
-
-          const childContextResult = await context.runInChildContext(
-            "child-context-with-callback",
-            async (childContext) => {
-              await childContext.wait("child-wait", 100);
-
-              const childCallbackResult = await childContext.waitForCallback<{
-                childData: number;
-              }>("child-callback-op", async (callbackId) => {
-                childCallbackId = callbackId;
-                return Promise.resolve();
-              });
-
-              return {
-                childResult: childCallbackResult,
-                childProcessed: true,
-              };
-            },
-          );
-
-          return {
-            parentResult,
-            childContextResult,
-            callbackIds: {
-              parent: parentCallbackId,
-              child: childCallbackId,
-            },
-          };
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      // Get operations - parent callback, child context, child wait, child callback
-      const parentCallbackOp = runner.getOperation<{
-        parentData: string;
-      }>("parent-callback-op");
-      const childContextOp = runner.getOperation("child-context-with-callback");
-      const childCallbackOp = runner.getOperation<{ childData: number }>(
-        "child-callback-op",
-      );
-
-      const executionPromise = runner.run({
-        payload: { test: "child-context-callbacks" },
-      });
-
-      // Wait for parent callback to start
-      await parentCallbackOp.waitForData(WaitingOperationStatus.STARTED);
-      const parentCallbackResult = JSON.stringify({
-        parentData: "parent-completed",
-      });
-      await parentCallbackOp.sendCallbackSuccess(parentCallbackResult);
-
-      // Wait for child callback to start
-      await childCallbackOp.waitForData(WaitingOperationStatus.STARTED);
-      const childCallbackResult = JSON.stringify({ childData: 42 });
-      await childCallbackOp.sendCallbackSuccess(childCallbackResult);
-
-      const result = await executionPromise;
-
-      expect(result.getResult()).toEqual({
-        parentResult: parentCallbackResult,
-        childContextResult: {
-          childResult: childCallbackResult,
-          childProcessed: true,
-        },
-        callbackIds: {
-          parent: expect.any(String),
-          child: expect.any(String),
-        },
-      });
-
-      // Verify child operations are accessible
-      const childOperations = childContextOp.getChildOperations();
-      expect(childOperations).toHaveLength(2); // wait + waitForCallback
-
-      // Verify unique callback IDs
-      expect(parentCallbackId).toBeDefined();
-      expect(childCallbackId).toBeDefined();
-      expect(parentCallbackId).not.toBe(childCallbackId);
-
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBe(8);
-    });
-
     it("should handle multiple invocations tracking with waitForCallback operations", async () => {
       let firstCallbackId: string | undefined;
       let secondCallbackId: string | undefined;
@@ -1049,71 +247,29 @@ describe("WaitForCallback Operations Integration", () => {
       expect(secondCallbackId).toBeDefined();
       expect(firstCallbackId).not.toBe(secondCallbackId);
     });
+  });
 
-    it("should handle nested waitForCallback operations in child contexts", async () => {
-      let outerCallbackId: string | undefined;
-      let innerCallbackId: string | undefined;
-      let nestedCallbackId: string | undefined;
-
+  describe("Error Handling & Submitter Function Variants", () => {
+    it("should handle waitForCallback with submitter function synchronous errors", async () => {
       const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
-          const outerResult = await context.waitForCallback<{ level: string }>(
-            "outer-callback-op",
-            async (callbackId) => {
-              outerCallbackId = callbackId;
-              return Promise.resolve();
-            },
-          );
+          try {
+            const result = await context.waitForCallback<{ data: string }>(
+              () => {
+                throw new Error("Submitter failed immediately");
+              },
+            );
 
-          const nestedResult = await context.runInChildContext(
-            "outer-child-context",
-            async (outerChildContext) => {
-              const innerResult = await outerChildContext.waitForCallback<{
-                level: string;
-              }>("inner-callback-op", async (callbackId) => {
-                innerCallbackId = callbackId;
-                return Promise.resolve();
-              });
-
-              // Nested child context with another callback
-              const deepNestedResult =
-                await outerChildContext.runInChildContext(
-                  "inner-child-context",
-                  async (innerChildContext) => {
-                    await innerChildContext.wait("deep-wait", 50);
-
-                    const nestedCallbackResult =
-                      await innerChildContext.waitForCallback<{
-                        level: string;
-                      }>("nested-callback-op", async (callbackId) => {
-                        nestedCallbackId = callbackId;
-                        return Promise.resolve();
-                      });
-
-                    return {
-                      nestedCallback: nestedCallbackResult,
-                      deepLevel: "inner-child",
-                    };
-                  },
-                );
-
-              return {
-                innerCallback: innerResult,
-                deepNested: deepNestedResult,
-                level: "outer-child",
-              };
-            },
-          );
-
-          return {
-            outerCallback: outerResult,
-            nestedResults: nestedResult,
-            allCallbackIds: {
-              outer: outerCallbackId,
-              inner: innerCallbackId,
-              nested: nestedCallbackId,
-            },
-          };
+            return {
+              callbackResult: result,
+              success: true,
+            };
+          } catch (error) {
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
         },
       );
 
@@ -1122,282 +278,140 @@ describe("WaitForCallback Operations Integration", () => {
         skipTime: true,
       });
 
-      // Get operations - outer callback, outer context, inner callback, inner context, deep wait, nested callback
-      const outerCallbackOp = runner.getOperation<{ level: string }>(
-        "outer-callback-op",
-      );
-      const outerContextOp = runner.getOperation("outer-child-context");
-      const innerCallbackOp = runner.getOperation<{ level: string }>(
-        "inner-callback-op",
-      );
-      const innerContextOp = runner.getOperation("inner-child-context");
-      const nestedCallbackOp = runner.getOperation<{ level: string }>(
-        "nested-callback-op",
-      );
-
-      const executionPromise = runner.run({
-        payload: { test: "nested-child-callbacks" },
+      const result = await runner.run({
+        payload: { test: "submitter-sync-error" },
       });
-
-      // Complete callbacks in sequence
-      await outerCallbackOp.waitForData(WaitingOperationStatus.STARTED);
-      const outerCallbackResult = JSON.stringify({ level: "outer-completed" });
-      await outerCallbackOp.sendCallbackSuccess(outerCallbackResult);
-
-      await innerCallbackOp.waitForData(WaitingOperationStatus.STARTED);
-      const innerCallbackResult = JSON.stringify({ level: "inner-completed" });
-      await innerCallbackOp.sendCallbackSuccess(innerCallbackResult);
-
-      await nestedCallbackOp.waitForData(WaitingOperationStatus.STARTED);
-      const nestedCallbackResult = JSON.stringify({
-        level: "nested-completed",
-      });
-      await nestedCallbackOp.sendCallbackSuccess(nestedCallbackResult);
-
-      const result = await executionPromise;
 
       expect(result.getResult()).toEqual({
-        outerCallback: outerCallbackResult,
-        nestedResults: {
-          innerCallback: innerCallbackResult,
-          deepNested: {
-            nestedCallback: nestedCallbackResult,
-            deepLevel: "inner-child",
-          },
-          level: "outer-child",
-        },
-        allCallbackIds: {
-          outer: expect.any(String),
-          inner: expect.any(String),
-          nested: expect.any(String),
-        },
+        success: false,
+        error: "Submitter failed immediately",
       });
 
-      // Verify child operations hierarchy
-      const outerChildren = outerContextOp.getChildOperations();
-      expect(outerChildren).toHaveLength(2); // inner callback + inner context
+      // Should have no succeeded operations since submitter failed before callback was created
+      const succeededOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(succeededOperations.length).toEqual(0);
+    });
 
-      const innerChildren = innerContextOp.getChildOperations();
-      expect(innerChildren).toHaveLength(2); // deep wait + nested callback
+    it("should handle waitForCallback with submitter function returning rejected promises", async () => {
+      const handler = withDurableExecution<unknown, unknown>(
+        async (_event: unknown, context: DurableContext) => {
+          try {
+            const result = await context.waitForCallback<{ data: string }>(
+              () => {
+                return Promise.reject(new Error("Async submitter failure"));
+              },
+            );
 
-      // Verify all callback IDs are unique
-      expect(outerCallbackId).toBeDefined();
-      expect(innerCallbackId).toBeDefined();
-      expect(nestedCallbackId).toBeDefined();
-      expect(
-        new Set([outerCallbackId, innerCallbackId, nestedCallbackId]).size,
-      ).toBe(3);
+            return {
+              callbackResult: result,
+              success: true,
+            };
+          } catch (error) {
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      );
 
-      // Should have tracked all operations
-      const completedOperations = result.getOperations();
-      expect(completedOperations.length).toBe(12);
+      const runner = new LocalDurableTestRunner({
+        handlerFunction: handler,
+        skipTime: true,
+      });
+
+      const result = await runner.run({
+        payload: { test: "submitter-async-error" },
+      });
+
+      expect(result.getResult()).toEqual({
+        success: false,
+        error: "Async submitter failure",
+      });
+
+      // Should have no succeeded operations since submitter failed
+      const succeededOperations = result.getOperations({
+        status: OperationStatus.SUCCEEDED,
+      });
+      expect(succeededOperations.length).toEqual(0);
     });
   });
 
-  // Advanced Configuration Tests Category
-  describe("Advanced Configuration Tests", () => {
-    it("should handle waitForCallback with custom timeout settings", async () => {
-      let receivedCallbackId: string | undefined;
+  it("should handle waitForCallback with complex submitter function errors", async () => {
+    let callbackId: string | undefined;
+    let sideEffectCounter = 0;
 
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
+    const handler = withDurableExecution<unknown, unknown>(
+      async (_event: unknown, context: DurableContext) => {
+        try {
           const result = await context.waitForCallback<{ data: string }>(
-            "custom-timeout-callback",
-            async (callbackId) => {
-              receivedCallbackId = callbackId;
-              return Promise.resolve();
+            async (id) => {
+              callbackId = id;
+
+              // Simulate complex submitter that performs multiple operations
+              sideEffectCounter++;
+
+              // First async operation succeeds
+              await new Promise((resolve) => setTimeout(resolve, 10));
+              sideEffectCounter++;
+
+              // Second async operation succeeds
+              await Promise.resolve({ step: 1 });
+              sideEffectCounter++;
+
+              // Third operation fails
+              throw new Error("Complex submitter failed at step 3");
             },
             {
-              timeout: 120, // 2 minutes custom timeout
-              heartbeatTimeout: 5, // 5 seconds heartbeat timeout
+              retryStrategy: (_, attemptCount) => ({
+                shouldRetry: attemptCount < 3,
+                delaySeconds: 1,
+              }),
             },
           );
 
           return {
             callbackResult: result,
-            timeoutConfigured: true,
-            callbackId: receivedCallbackId,
+            success: true,
           };
-        },
-      );
-
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const executionPromise = runner.run({
-        payload: { test: "custom-timeout-config" },
-      });
-
-      const callbackOperation = runner.getOperation<{ data: string }>(
-        "custom-timeout-callback",
-      );
-
-      // Wait for the operation to be available
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Verify callback details include custom timeout configuration
-      const callbackDetails = callbackOperation.getCallbackDetails();
-      expect(callbackDetails?.callbackId).toBeDefined();
-
-      // Complete the callback successfully
-      const customTimeoutResult = JSON.stringify({
-        data: "custom-timeout-completed",
-      });
-      await callbackOperation.sendCallbackSuccess(customTimeoutResult);
-
-      const result = await executionPromise;
-
-      expect(result.getResult()).toEqual({
-        callbackResult: customTimeoutResult,
-        timeoutConfigured: true,
-        callbackId: expect.any(String),
-      });
-
-      expect(receivedCallbackId).toBeDefined();
-
-      // Should have completed operations with successful callback
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBeGreaterThan(0);
-    });
-
-    it("should handle waitForCallback with custom serdes configuration", async () => {
-      interface CustomData {
-        id: number;
-        message: string;
-        timestamp: Date;
-        metadata: {
-          version: string;
-          processed: boolean;
-        };
-      }
-
-      const customSerdes = {
-        serialize: async (
-          data: CustomData | undefined,
-        ): Promise<string | undefined> => {
-          if (data === undefined) return Promise.resolve(undefined);
-          return Promise.resolve(
-            JSON.stringify({
-              ...data,
-              timestamp: data.timestamp.toISOString(),
-              _serializedBy: "custom-serdes-v1",
-            }),
-          );
-        },
-        deserialize: async (
-          str: string | undefined,
-        ): Promise<CustomData | undefined> => {
-          if (str === undefined) return Promise.resolve(undefined);
-          const parsed = JSON.parse(str) as {
-            id: number;
-            message: string;
-            timestamp: string;
-            metadata: {
-              version: string;
-              processed: boolean;
-            };
-            _serializedBy: string;
-          };
-          return Promise.resolve({
-            id: parsed.id,
-            message: parsed.message,
-            timestamp: new Date(parsed.timestamp),
-            metadata: parsed.metadata,
-          });
-        },
-      };
-
-      let receivedCallbackId: string | undefined;
-      let submitterData: CustomData | undefined;
-
-      const handler = withDurableExecution<unknown, unknown>(
-        async (_event: unknown, context: DurableContext) => {
-          const result = await context.waitForCallback<CustomData>(
-            "custom-serdes-callback",
-            async (callbackId) => {
-              receivedCallbackId = callbackId;
-              // Submitter can access the custom data type
-              submitterData = {
-                id: 999,
-                message: "submitter-data",
-                timestamp: new Date("2025-01-01T00:00:00Z"),
-                metadata: {
-                  version: "1.0.0",
-                  processed: false,
-                },
-              };
-              return Promise.resolve();
-            },
-            {
-              serdes: customSerdes,
-              timeout: 300,
-            },
-          );
-
+        } catch (error) {
           return {
-            receivedData: result,
-            submitterData,
-            isDateObject: result.timestamp instanceof Date,
-            serdesUsed: true,
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            sideEffects: sideEffectCounter,
+            callbackId: callbackId,
           };
-        },
-      );
+        }
+      },
+    );
 
-      const runner = new LocalDurableTestRunner({
-        handlerFunction: handler,
-        skipTime: true,
-      });
-
-      const executionPromise = runner.run({
-        payload: { test: "custom-serdes" },
-      });
-
-      const callbackOperation = runner.getOperation<CustomData>(
-        "custom-serdes-callback",
-      );
-
-      await callbackOperation.waitForData(WaitingOperationStatus.STARTED);
-
-      // Send data that requires custom serialization
-      const testData: CustomData = {
-        id: 42,
-        message: "Hello Custom Serdes",
-        timestamp: new Date("2025-06-15T12:30:45Z"),
-        metadata: {
-          version: "2.0.0",
-          processed: true,
-        },
-      };
-
-      // Serialize the data using custom serdes for sending
-      const serializedData = await customSerdes.serialize(testData);
-      await callbackOperation.sendCallbackSuccess(serializedData!);
-
-      const result = await executionPromise;
-
-      expect(result.getResult()).toEqual(
-        JSON.parse(
-          // the result will always get stringified since it's the lambda response
-          JSON.stringify({
-            receivedData: testData,
-            submitterData: submitterData,
-            isDateObject: true,
-            serdesUsed: true,
-          }),
-        ),
-      );
-
-      expect(receivedCallbackId).toBeDefined();
-
-      // Should have completed operations with successful callback
-      const completedOperations = result.getOperations({
-        status: OperationStatus.SUCCEEDED,
-      });
-      expect(completedOperations.length).toBeGreaterThan(0);
+    const runner = new LocalDurableTestRunner({
+      handlerFunction: handler,
+      skipTime: true,
     });
+
+    const result = await runner.run({
+      payload: { test: "complex-submitter-error" },
+    });
+
+    expect(result.getResult()).toEqual({
+      success: false,
+      error: "Complex submitter failed at step 3",
+      // Retries 6 times (default maxAttempts)
+      sideEffects: 18,
+      callbackId: expect.any(String),
+    });
+
+    // Verify that callback ID was generated before failure
+    expect(callbackId).toBeDefined();
+    expect(sideEffectCounter).toBe(18);
+
+    // Should have no succeeded operations since submitter failed
+    const completedOperations = result.getOperations({
+      status: OperationStatus.SUCCEEDED,
+    });
+    expect(completedOperations.length).toEqual(0);
   });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Moving waitForCallback tests from testing lib to examples.

The three tests that are not moved yet are pending these issues:
- https://github.com/aws/aws-durable-execution-sdk-js/issues/188
- https://github.com/aws/aws-durable-execution-sdk-js/issues/189
- https://github.com/aws/aws-durable-execution-sdk-js/issues/199

Also included:
- Fix a bug in cloud runner where it was populating the wrong data
- Increase test timeout to 90 seconds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
