### PR TITLE
fix(testing-sdk): fix date deserialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3139,12 +3139,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.0.tgz",
-      "integrity": "sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3168,18 +3168,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.14.0.tgz",
-      "integrity": "sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.1.tgz",
+      "integrity": "sha512-V4Qc2CIb5McABYfaGiIYLTmo/vwNIK7WXI5aGveBd9UcdhbOMwcvIMxIw/DJj1S9QgOMa/7FBkarMdIC0EOTEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.4",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -3275,15 +3275,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.0.tgz",
-      "integrity": "sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/querystring-builder": "^4.2.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3345,18 +3345,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.0.tgz",
-      "integrity": "sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.5.tgz",
+      "integrity": "sha512-SIzKVTvEudFWJbxAaq7f2GvP3jh2FHDpIFI6/VAf4FOWGFZy0vnYMPSRj8PGYI8Hjt29mvmwSRgKuO3bK4ixDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-serde": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/shared-ini-file-loader": "^4.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/url-parser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/core": "^3.17.1",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3384,13 +3384,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.0.tgz",
-      "integrity": "sha512-rpTQ7D65/EAbC6VydXlxjvbifTf4IH+sADKg6JmAvhkflJO2NvDeyU9qsWUNBelJiQFcXKejUHWRSdmpJmEmiw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3398,12 +3398,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.0.tgz",
-      "integrity": "sha512-G5CJ//eqRd9OARrQu9MK1H8fNm2sMtqFh6j8/rPozhEL+Dokpvi1Og+aCixTuwDAGZUkJPk6hJT5jchbk/WCyg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3411,14 +3411,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.0.tgz",
-      "integrity": "sha512-5QgHNuWdT9j9GwMPPJCKxy2KDxZ3E5l4M3/5TatSZrqYVoEiqQrDfAq8I6KWZw7RZOHtVtCzEPdYz7rHZixwcA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.0",
-        "@smithy/shared-ini-file-loader": "^4.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3426,15 +3426,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.3.0.tgz",
-      "integrity": "sha512-RHZ/uWCmSNZ8cneoWEVsVwMZBKy/8123hEpm57vgGXA3Irf/Ja4v9TVshHK2ML5/IqzAZn0WhINHOP9xl+Qy6Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.3.tgz",
+      "integrity": "sha512-MAwltrDB0lZB/H6/2M5PIsISSwdI5yIh6DaBB9r0Flo9nx3y0dzl/qTMJPd7tJvPdsx6Ks/cwVzheGNYzXyNbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/querystring-builder": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3442,12 +3442,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.0.tgz",
-      "integrity": "sha512-rV6wFre0BU6n/tx2Ztn5LdvEdNZ2FasQbPQmDOPfV9QQyDmsCkOAB0osQjotRCQg+nSKFmINhyda0D3AnjSBJw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3455,12 +3455,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.0.tgz",
-      "integrity": "sha512-6POSYlmDnsLKb7r1D3SVm7RaYW6H1vcNcTWGWrF7s9+2noNYvUsm7E4tz5ZQ9HXPmKn6Hb67pBDRIjrT4w/d7Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3468,12 +3468,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.0.tgz",
-      "integrity": "sha512-Q4oFD0ZmI8yJkiPPeGUITZj++4HHYCW3pYBYfIobUCkYpI6mbkzmG1MAQQ3lJYYWj3iNqfzOenUZu+jqdPQ16A==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -3482,12 +3482,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.0.tgz",
-      "integrity": "sha512-BjATSNNyvVbQxOOlKse0b0pSezTWGMvA87SvoFoFlkRsKXVsN3bEtjCxvsNXJXfnAzlWFPaT9DmhWy1vn0sNEA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3507,12 +3507,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.0.tgz",
-      "integrity": "sha512-VCUPPtNs+rKWlqqntX0CbVvWyjhmX30JCtzO+s5dlzzxrvSfRh5SY0yxnkirvc1c80vdKQttahL71a9EsdolSQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3539,17 +3539,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.0.tgz",
-      "integrity": "sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.1.tgz",
+      "integrity": "sha512-Ngb95ryR5A9xqvQFT5mAmYkCwbXvoLavLFwmi7zVg/IowFPCfiqRfkOKnbc/ZRL8ZKJ4f+Tp6kSu6wjDQb8L/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-endpoint": "^4.3.0",
-        "@smithy/middleware-stack": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/core": "^3.17.1",
+        "@smithy/middleware-endpoint": "^4.3.5",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3557,9 +3557,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.6.0.tgz",
-      "integrity": "sha512-4lI9C8NzRPOv66FaY1LL1O/0v0aLVrq/mXP/keUa9mJOApEeae43LsLd2kZRUJw91gxOQfLIrV3OvqPgWz1YsA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3569,13 +3569,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.0.tgz",
-      "integrity": "sha512-AlBmD6Idav2ugmoAL6UtR6ItS7jU5h5RNqLMZC7QrLCoITA9NzIN3nx9GWi8g4z1pfWh2r9r96SX/jHiNwPJ9A==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3583,9 +3583,9 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.2.0.tgz",
-      "integrity": "sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
@@ -3706,12 +3706,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.0.tgz",
-      "integrity": "sha512-u9OOfDa43MjagtJZ8AapJcmimP+K2Z7szXn8xbty4aza+7P1wjFmy2ewjSbhEiYQoW1unTlOAIV165weYAaowA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.8.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3733,15 +3733,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.4.0.tgz",
-      "integrity": "sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.4.tgz",
+      "integrity": "sha512-+qDxSkiErejw1BAIXUFBSfM5xh3arbz1MmxlbMCKanDDZtVEQ7PSKW9FQS0Vud1eI/kYn0oCTVKyNzRlq+9MUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.0",
-        "@smithy/node-http-handler": "^4.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
@@ -14990,6 +14990,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "*",
+        "@smithy/smithy-client": "^4.9.1",
         "express": "^5.1.0"
       },
       "bin": {

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "*",
+    "@smithy/smithy-client": "^4.9.1",
     "express": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/checkpoint-server.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/checkpoint-server.ts
@@ -81,8 +81,10 @@ export async function startCheckpointServer(port: number) {
    */
   app.post(`${API_PATHS.START_INVOCATION}/:executionId`, (req, res) => {
     res.json(
-      executionManager.startInvocation(
-        createExecutionId(req.params.executionId),
+      convertDatesToTimestamps(
+        executionManager.startInvocation(
+          createExecutionId(req.params.executionId),
+        ),
       ),
     );
   });

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/types/operation-event.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/types/operation-event.ts
@@ -1,0 +1,18 @@
+import { Operation, Event } from "@aws-sdk/client-lambda";
+import { ConvertDatesToNumbers } from "../../types";
+import { CheckpointOperation } from "../storage/checkpoint-manager";
+import { OperationEvents } from "../../test-runner/common/operations/operation-with-data";
+
+export type SerializedOperation = ConvertDatesToNumbers<Operation>;
+export type SerializedEvent = ConvertDatesToNumbers<Event>;
+
+export interface SerializedOperationEvents {
+  operation: SerializedOperation;
+  events: SerializedEvent[];
+}
+
+export type SerializedCheckpointOperation = Omit<
+  CheckpointOperation,
+  keyof OperationEvents
+> &
+  SerializedOperationEvents;

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/types/serialized-invocation-result.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/types/serialized-invocation-result.ts
@@ -1,0 +1,9 @@
+import { InvocationResult } from "../storage/execution-manager";
+import { SerializedOperationEvents } from "./operation-event";
+
+export type SerializedInvocationResult = Omit<
+  InvocationResult,
+  "operationEvents"
+> & {
+  operationEvents: SerializedOperationEvents[];
+};

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/operation-with-data.ts
@@ -232,11 +232,7 @@ export class OperationWithData<OperationResultValue = unknown>
 
     return {
       waitSeconds: details.Duration,
-      // TODO: fix serialization of dates in API responses
-      scheduledEndTimestamp:
-        details.ScheduledEndTimestamp !== undefined
-          ? new Date(details.ScheduledEndTimestamp)
-          : undefined,
+      scheduledEndTimestamp: details.ScheduledEndTimestamp,
     };
   }
 
@@ -313,26 +309,10 @@ export class OperationWithData<OperationResultValue = unknown>
   }
 
   getStartTimestamp(): Date | undefined {
-    // TODO: remove this when the local runner converts to Date correctly
-    if (
-      typeof this.checkpointOperationData?.operation.StartTimestamp === "number"
-    ) {
-      return new Date(
-        this.checkpointOperationData.operation.StartTimestamp * 1000,
-      );
-    }
     return this.checkpointOperationData?.operation.StartTimestamp;
   }
 
   getEndTimestamp(): Date | undefined {
-    // TODO: remove this when the local runner converts to Date correctly
-    if (
-      typeof this.checkpointOperationData?.operation.EndTimestamp === "number"
-    ) {
-      return new Date(
-        this.checkpointOperationData.operation.EndTimestamp * 1000,
-      );
-    }
     return this.checkpointOperationData?.operation.EndTimestamp;
   }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
@@ -51,7 +51,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
     expect(execution.getHistoryEvents()).toEqual([
       {
         EventId: 1,
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         EventType: "ExecutionStarted",
         ExecutionStartedDetails: {
           Input: {
@@ -66,7 +66,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
         EventId: 2,
         Id: "c4ca4238a0b92382",
         Name: "durableOperation",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         ChainedInvokeStartedDetails: {
           DurableExecutionArn: "",
         },
@@ -78,7 +78,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
         EventId: 3,
         Id: "c4ca4238a0b92382",
         Name: "durableOperation",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         ChainedInvokeSucceededDetails: {
           Result: {
             Payload: JSON.stringify({
@@ -91,7 +91,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
       },
       {
         EventId: 4,
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         EventType: "ExecutionSucceeded",
         ExecutionSucceededDetails: {
           Result: {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -129,13 +129,12 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(invocationOperations[2]).toEqual([]);
 
     // Assert history events
-    // TODO: update timestamps to Date objects
     expect(result.getHistoryEvents()).toEqual([
       {
         EventType: "ExecutionStarted",
         EventId: 1,
         Id: expect.any(String),
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         ExecutionStartedDetails: {
           Input: {
             Payload: "{}",
@@ -148,10 +147,10 @@ describe("LocalDurableTestRunner Integration", () => {
         EventId: 2,
         Id: "c4ca4238a0b92382",
         Name: "wait-invocation-1",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         WaitStartedDetails: {
           Duration: 1,
-          ScheduledEndTimestamp: expect.any(Number),
+          ScheduledEndTimestamp: expect.any(Date),
         },
       },
       {
@@ -160,7 +159,7 @@ describe("LocalDurableTestRunner Integration", () => {
         Id: "c4ca4238a0b92382",
         Name: "wait-invocation-1",
         SubType: "Wait",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         WaitSucceededDetails: { Duration: 1 },
       },
       {
@@ -169,7 +168,7 @@ describe("LocalDurableTestRunner Integration", () => {
         EventId: 4,
         Id: "c81e728d9d4c2f63",
         Name: "process-data-step",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         StepStartedDetails: {},
       },
       {
@@ -178,7 +177,7 @@ describe("LocalDurableTestRunner Integration", () => {
         EventId: 5,
         Id: "c81e728d9d4c2f63",
         Name: "process-data-step",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         StepSucceededDetails: {
           Result: {
             Payload: JSON.stringify(resultData.result),
@@ -192,10 +191,10 @@ describe("LocalDurableTestRunner Integration", () => {
         EventId: 6,
         Id: "eccbc87e4b5ce2fe",
         Name: "wait-invocation-2",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         WaitStartedDetails: {
           Duration: 1,
-          ScheduledEndTimestamp: expect.any(Number),
+          ScheduledEndTimestamp: expect.any(Date),
         },
       },
       {
@@ -204,14 +203,14 @@ describe("LocalDurableTestRunner Integration", () => {
         SubType: "Wait",
         Id: "eccbc87e4b5ce2fe",
         Name: "wait-invocation-2",
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         WaitSucceededDetails: { Duration: 1 },
       },
       {
         EventType: "ExecutionSucceeded",
         EventId: 8,
         Id: expect.any(String),
-        EventTimestamp: expect.any(Number),
+        EventTimestamp: expect.any(Date),
         ExecutionSucceededDetails: {
           Result: {
             Payload: JSON.stringify(resultData),

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-event.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-event.test.ts
@@ -1,0 +1,107 @@
+import { deserializeEvent } from "../deserialize-event";
+import { SerializedEvent } from "../../../../../checkpoint-server/types/operation-event";
+
+describe("deserializeEvent", () => {
+  it("should deserialize basic event fields and convert EventTimestamp", () => {
+    const serializedEvent: SerializedEvent = {
+      EventId: 1,
+      EventTimestamp: 1609459200,
+      EventType: "ExecutionStarted",
+      Id: "event-123",
+      Name: "TestEvent",
+    };
+
+    const result = deserializeEvent(serializedEvent);
+
+    expect(result.EventId).toBe(1);
+    expect(result.EventTimestamp).toEqual(new Date(1609459200 * 1000));
+    expect(result.EventType).toBe("ExecutionStarted");
+    expect(result.Id).toBe("event-123");
+    expect(result.Name).toBe("TestEvent");
+  });
+
+  it("should deserialize InvocationCompletedDetails with timestamp conversion", () => {
+    const serializedEvent: SerializedEvent = {
+      EventId: 2,
+      EventTimestamp: 1609459200,
+      EventType: "InvocationCompleted",
+      Id: "event-inv",
+      InvocationCompletedDetails: {
+        StartTimestamp: 1609459100,
+        EndTimestamp: 1609459200,
+        RequestId: "req-123",
+      },
+    };
+
+    const result = deserializeEvent(serializedEvent);
+
+    expect(result.InvocationCompletedDetails?.StartTimestamp).toEqual(
+      new Date(1609459100 * 1000),
+    );
+    expect(result.InvocationCompletedDetails?.EndTimestamp).toEqual(
+      new Date(1609459200 * 1000),
+    );
+    expect(result.InvocationCompletedDetails?.RequestId).toBe("req-123");
+  });
+
+  it("should deserialize WaitStartedDetails with ScheduledEndTimestamp conversion", () => {
+    const serializedEvent: SerializedEvent = {
+      EventId: 3,
+      EventTimestamp: 1609459200,
+      EventType: "WaitStarted",
+      Id: "event-wait",
+      WaitStartedDetails: {
+        Duration: 3600,
+        ScheduledEndTimestamp: 1609462800,
+      },
+    };
+
+    const result = deserializeEvent(serializedEvent);
+
+    expect(result.WaitStartedDetails?.Duration).toBe(3600);
+    expect(result.WaitStartedDetails?.ScheduledEndTimestamp).toEqual(
+      new Date(1609462800 * 1000),
+    );
+  });
+
+  it("should deserialize event with nested detail objects", () => {
+    const serializedEvent: SerializedEvent = {
+      EventId: 4,
+      EventTimestamp: 1609459200,
+      EventType: "StepSucceeded",
+      Id: "event-step",
+      StepSucceededDetails: {
+        Result: {
+          Payload: '{"result": "success"}',
+        },
+        RetryDetails: {
+          CurrentAttempt: 1,
+        },
+      },
+    };
+
+    const result = deserializeEvent(serializedEvent);
+
+    expect(result.StepSucceededDetails).toBeDefined();
+    expect(result.StepSucceededDetails?.Result?.Payload).toBe(
+      '{"result": "success"}',
+    );
+    expect(result.StepSucceededDetails?.RetryDetails?.CurrentAttempt).toBe(1);
+  });
+
+  it("should handle optional fields", () => {
+    const serializedEvent: SerializedEvent = {
+      EventId: 5,
+      EventTimestamp: 1609459200,
+      EventType: "StepStarted",
+      Id: "minimal-event",
+    };
+
+    const result = deserializeEvent(serializedEvent);
+
+    expect(result.EventId).toBe(5);
+    expect(result.EventTimestamp).toEqual(new Date(1609459200 * 1000));
+    expect(result.Name).toBeUndefined();
+    expect(result.ParentId).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-operation-events.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-operation-events.test.ts
@@ -1,0 +1,200 @@
+import {
+  deserializeCheckpointOperation,
+  deserializeOperationEvent,
+  deserializeOperationEvents,
+} from "../deserialize-operation-events";
+import {
+  SerializedCheckpointOperation,
+  SerializedOperationEvents,
+} from "../../../../../checkpoint-server/types/operation-event";
+
+describe("deserialize-operation-events", () => {
+  describe("deserializeCheckpointOperation", () => {
+    it("should deserialize checkpoint operation with timestamp conversions", () => {
+      const serializedCheckpoint: SerializedCheckpointOperation = {
+        update: {
+          Id: "update-123",
+          Type: "STEP",
+          Payload: '{"data": "value"}',
+          Action: "SUCCEED",
+        },
+        operation: {
+          Id: "op-123",
+          Name: "TestOperation",
+          Type: "STEP",
+          Status: "SUCCEEDED",
+          StartTimestamp: 1609459200,
+          EndTimestamp: 1609459300,
+        },
+        events: [
+          {
+            EventId: 1,
+            EventTimestamp: 1609459200,
+            EventType: "StepStarted",
+            Id: "event-1",
+          },
+          {
+            EventId: 2,
+            EventTimestamp: 1609459300,
+            EventType: "StepSucceeded",
+            Id: "event-2",
+          },
+        ],
+      };
+
+      const result = deserializeCheckpointOperation(serializedCheckpoint);
+
+      // Check update is preserved as-is (using _json)
+      expect(result.update).toEqual({
+        Id: "update-123",
+        Type: "STEP",
+        Payload: '{"data": "value"}',
+        Action: "SUCCEED",
+      });
+
+      // Check operation timestamps are converted
+      expect(result.operation.Id).toBe("op-123");
+      expect(result.operation.StartTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result.operation.EndTimestamp).toEqual(
+        new Date(1609459300 * 1000),
+      );
+
+      // Check events array and timestamp conversions
+      expect(result.events).toHaveLength(2);
+      expect(result.events[0].EventId).toBe(1);
+      expect(result.events[0].EventTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result.events[1].EventId).toBe(2);
+      expect(result.events[1].EventTimestamp).toEqual(
+        new Date(1609459300 * 1000),
+      );
+    });
+
+    it("should handle empty events array", () => {
+      const serializedCheckpoint: SerializedCheckpointOperation = {
+        update: {
+          Id: "update-456",
+          Type: "STEP",
+          Action: "START",
+        },
+        operation: {
+          Id: "op-456",
+          Type: "STEP",
+          Status: "STARTED",
+          StartTimestamp: 1609459200,
+        },
+        events: [],
+      };
+
+      const result = deserializeCheckpointOperation(serializedCheckpoint);
+
+      expect(result.update.Id).toBe("update-456");
+      expect(result.operation.StartTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result.events).toHaveLength(0);
+    });
+  });
+
+  describe("deserializeOperationEvent", () => {
+    it("should deserialize operation event with timestamp conversions", () => {
+      const serializedOperationEvent: SerializedOperationEvents = {
+        operation: {
+          Id: "op-789",
+          Type: "STEP",
+          Status: "SUCCEEDED",
+          StartTimestamp: 1609459200,
+          EndTimestamp: 1609459300,
+        },
+        events: [
+          {
+            EventId: 1,
+            EventTimestamp: 1609459250,
+            EventType: "StepSucceeded",
+            Id: "event-1",
+          },
+        ],
+      };
+
+      const result = deserializeOperationEvent(serializedOperationEvent);
+
+      expect(result.operation.Id).toBe("op-789");
+      expect(result.operation.StartTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result.operation.EndTimestamp).toEqual(
+        new Date(1609459300 * 1000),
+      );
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].EventTimestamp).toEqual(
+        new Date(1609459250 * 1000),
+      );
+    });
+  });
+
+  describe("deserializeOperationEvents", () => {
+    it("should deserialize array of operation events", () => {
+      const serializedOperationEvents: SerializedOperationEvents[] = [
+        {
+          operation: {
+            Id: "op-1",
+            Type: "STEP",
+            Status: "SUCCEEDED",
+            StartTimestamp: 1609459200,
+          },
+          events: [
+            {
+              EventId: 1,
+              EventTimestamp: 1609459200,
+              EventType: "StepStarted",
+              Id: "event-1",
+            },
+          ],
+        },
+        {
+          operation: {
+            Id: "op-2",
+            Type: "STEP",
+            Status: "SUCCEEDED",
+            StartTimestamp: 1609459300,
+          },
+          events: [
+            {
+              EventId: 2,
+              EventTimestamp: 1609459300,
+              EventType: "StepStarted",
+              Id: "event-2",
+            },
+          ],
+        },
+      ];
+
+      const result = deserializeOperationEvents(serializedOperationEvents);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].operation.Id).toBe("op-1");
+      expect(result[0].operation.StartTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result[0].events[0].EventTimestamp).toEqual(
+        new Date(1609459200 * 1000),
+      );
+      expect(result[1].operation.Id).toBe("op-2");
+      expect(result[1].operation.StartTimestamp).toEqual(
+        new Date(1609459300 * 1000),
+      );
+      expect(result[1].events[0].EventTimestamp).toEqual(
+        new Date(1609459300 * 1000),
+      );
+    });
+
+    it("should handle empty array", () => {
+      const result = deserializeOperationEvents([]);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/__tests__/deserialize-operation.test.ts
@@ -1,0 +1,122 @@
+import { deserializeOperation } from "../deserialize-operation";
+import { SerializedOperation } from "../../../../../checkpoint-server/types/operation-event";
+
+describe("deserializeOperation", () => {
+  it("should deserialize basic operation fields and convert StartTimestamp", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-123",
+      Name: "TestOperation",
+      Type: "STEP",
+      Status: "STARTED",
+      StartTimestamp: 1609459200,
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.Id).toBe("op-123");
+    expect(result.Name).toBe("TestOperation");
+    expect(result.Type).toBe("STEP");
+    expect(result.Status).toBe("STARTED");
+    expect(result.StartTimestamp).toEqual(new Date(1609459200 * 1000));
+  });
+
+  it("should convert both StartTimestamp and EndTimestamp", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-456",
+      Type: "STEP",
+      Status: "SUCCEEDED",
+      StartTimestamp: 1609459200,
+      EndTimestamp: 1609459300,
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.StartTimestamp).toEqual(new Date(1609459200 * 1000));
+    expect(result.EndTimestamp).toEqual(new Date(1609459300 * 1000));
+  });
+
+  it("should deserialize StepDetails with NextAttemptTimestamp conversion", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-step",
+      Type: "STEP",
+      Status: "PENDING",
+      StartTimestamp: 1609459200,
+      StepDetails: {
+        Attempt: 2,
+        NextAttemptTimestamp: 1609459500,
+        Error: {
+          ErrorMessage: "Retry error",
+          ErrorType: "RetryableError",
+        },
+      },
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.StepDetails?.Attempt).toBe(2);
+    expect(result.StepDetails?.NextAttemptTimestamp).toEqual(
+      new Date(1609459500 * 1000),
+    );
+    expect(result.StepDetails?.Error?.ErrorType).toBe("RetryableError");
+  });
+
+  it("should deserialize WaitDetails with ScheduledEndTimestamp conversion", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-wait",
+      Type: "WAIT",
+      Status: "STARTED",
+      StartTimestamp: 1609459200,
+      WaitDetails: {
+        ScheduledEndTimestamp: 1609462800,
+      },
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.WaitDetails?.ScheduledEndTimestamp).toEqual(
+      new Date(1609462800 * 1000),
+    );
+  });
+
+  it("should deserialize operation with nested detail objects", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-full",
+      Type: "STEP",
+      Status: "SUCCEEDED",
+      StartTimestamp: 1609459200,
+      EndTimestamp: 1609459300,
+      StepDetails: {
+        Attempt: 1,
+        Result: '{"success": true}',
+      },
+      CallbackDetails: {
+        CallbackId: "callback-123",
+      },
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.StartTimestamp).toEqual(new Date(1609459200 * 1000));
+    expect(result.EndTimestamp).toEqual(new Date(1609459300 * 1000));
+    expect(result.StepDetails?.Attempt).toBe(1);
+    expect(result.StepDetails?.Result).toBe('{"success": true}');
+    expect(result.CallbackDetails?.CallbackId).toBe("callback-123");
+  });
+
+  it("should handle optional fields", () => {
+    const serializedOperation: SerializedOperation = {
+      Id: "op-minimal",
+      Type: "STEP",
+      Status: "STARTED",
+      StartTimestamp: 1609459200,
+    };
+
+    const result = deserializeOperation(serializedOperation);
+
+    expect(result.Id).toBe("op-minimal");
+    expect(result.StartTimestamp).toEqual(new Date(1609459200 * 1000));
+    expect(result.Name).toBeUndefined();
+    expect(result.ParentId).toBeUndefined();
+    expect(result.EndTimestamp).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-event.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-event.ts
@@ -1,0 +1,66 @@
+import {
+  _json,
+  expectInt32,
+  expectNonNull,
+  expectNumber,
+  expectString,
+  parseEpochTimestamp,
+  take,
+} from "@smithy/smithy-client";
+import { Event } from "@aws-sdk/client-lambda";
+import { SerializedEvent } from "../../../../checkpoint-server/types/operation-event";
+
+const deserializeInvocationCompletedDetails = (output: unknown) => {
+  return take(output, {
+    EndTimestamp: (_) => expectNonNull(parseEpochTimestamp(expectNumber(_))),
+    Error: _json,
+    RequestId: expectString,
+    StartTimestamp: (_) => expectNonNull(parseEpochTimestamp(expectNumber(_))),
+  }) as unknown;
+};
+
+const deserializeWaitStartedDetails = (output: unknown) => {
+  return take(output, {
+    Duration: expectInt32,
+    ScheduledEndTimestamp: (_) =>
+      expectNonNull(parseEpochTimestamp(expectNumber(_))),
+  }) as unknown;
+};
+
+export const deserializeEvent = (output: SerializedEvent) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return take(output, {
+    CallbackFailedDetails: _json,
+    CallbackStartedDetails: _json,
+    CallbackSucceededDetails: _json,
+    CallbackTimedOutDetails: _json,
+    ChainedInvokeFailedDetails: _json,
+    ChainedInvokePendingDetails: _json,
+    ChainedInvokeStartedDetails: _json,
+    ChainedInvokeStoppedDetails: _json,
+    ChainedInvokeSucceededDetails: _json,
+    ChainedInvokeTimedOutDetails: _json,
+    ContextFailedDetails: _json,
+    ContextStartedDetails: _json,
+    ContextSucceededDetails: _json,
+    EventId: expectInt32,
+    EventTimestamp: (_) => expectNonNull(parseEpochTimestamp(expectNumber(_))),
+    EventType: expectString,
+    ExecutionFailedDetails: _json,
+    ExecutionStartedDetails: _json,
+    ExecutionStoppedDetails: _json,
+    ExecutionSucceededDetails: _json,
+    ExecutionTimedOutDetails: _json,
+    Id: expectString,
+    InvocationCompletedDetails: (_) => deserializeInvocationCompletedDetails(_),
+    Name: expectString,
+    ParentId: expectString,
+    StepFailedDetails: _json,
+    StepStartedDetails: _json,
+    StepSucceededDetails: _json,
+    SubType: expectString,
+    WaitCancelledDetails: _json,
+    WaitStartedDetails: (_) => deserializeWaitStartedDetails(_),
+    WaitSucceededDetails: _json,
+  }) as Event;
+};

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-operation-events.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-operation-events.ts
@@ -1,0 +1,39 @@
+import { OperationUpdate } from "@aws-sdk/client-lambda";
+import { _json } from "@smithy/smithy-client";
+import {
+  SerializedCheckpointOperation,
+  SerializedOperationEvents,
+} from "../../../../checkpoint-server/types/operation-event";
+import { deserializeEvent } from "./deserialize-event";
+import { deserializeOperation } from "./deserialize-operation";
+
+export const deserializeCheckpointOperation = ({
+  update,
+  operation,
+  events,
+}: SerializedCheckpointOperation) => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    update: _json(update) as OperationUpdate,
+    operation: deserializeOperation(operation),
+    events: events.map((event) => deserializeEvent(event)),
+  };
+};
+
+export const deserializeOperationEvent = ({
+  operation,
+  events,
+}: SerializedOperationEvents) => {
+  return {
+    operation: deserializeOperation(operation),
+    events: events.map((event) => deserializeEvent(event)),
+  };
+};
+
+export const deserializeOperationEvents = (
+  operationEvents: SerializedOperationEvents[],
+) => {
+  return operationEvents.map((operationEvent) =>
+    deserializeOperationEvent(operationEvent),
+  );
+};

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-operation.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/deserialize/deserialize-operation.ts
@@ -1,0 +1,50 @@
+import {
+  _json,
+  expectInt32,
+  expectNonNull,
+  expectNumber,
+  expectString,
+  parseEpochTimestamp,
+  take,
+} from "@smithy/smithy-client";
+import { ConvertDatesToNumbers } from "../../../../types";
+import { Operation } from "@aws-sdk/client-lambda";
+
+export type SerializedOperation = ConvertDatesToNumbers<Operation>;
+
+const deserializeStepDetails = (output: unknown) => {
+  return take(output, {
+    Attempt: expectInt32,
+    Error: _json,
+    NextAttemptTimestamp: (_) =>
+      expectNonNull(parseEpochTimestamp(expectNumber(_))),
+    Result: expectString,
+  }) as unknown;
+};
+
+const deserializeWaitDetails = (output: unknown) => {
+  return take(output, {
+    ScheduledEndTimestamp: (_) =>
+      expectNonNull(parseEpochTimestamp(expectNumber(_))),
+  }) as unknown;
+};
+
+export const deserializeOperation = (output: SerializedOperation) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  return take(output, {
+    CallbackDetails: _json,
+    ChainedInvokeDetails: _json,
+    ContextDetails: _json,
+    EndTimestamp: (_) => expectNonNull(parseEpochTimestamp(expectNumber(_))),
+    ExecutionDetails: _json,
+    Id: expectString,
+    Name: expectString,
+    ParentId: expectString,
+    StartTimestamp: (_) => expectNonNull(parseEpochTimestamp(expectNumber(_))),
+    Status: expectString,
+    StepDetails: (_) => deserializeStepDetails(_),
+    SubType: expectString,
+    Type: expectString,
+    WaitDetails: (_) => deserializeWaitDetails(_),
+  }) as Operation;
+};


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/192

*Description of changes:*

Date deserialization is not implemented in the testing library. All dates getting passed in from the APIs end up as unix timestamps and aren't properly serialized to JS Date objects.

This uses the JS Smithy helpers to properly deserialize everything. I copied the logic from the lambda client code, for example from here: https://github.com/aws/aws-durable-execution-sdk-js/blob/development/packages/client-lambda/dist-es/protocols/Aws_restJson1.js#L4060


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
