### PR TITLE
fix(sdk): prevent unhandled promise rejections in promise combinators

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/promise-unhandled-rejection.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/promise-unhandled-rejection.test.ts
@@ -1,0 +1,26 @@
+import { handler } from "../promise-unhandled-rejection";
+import { createTests } from "./shared/test-helper";
+
+interface PromiseUnhandledRejectionResult {
+  successStep: string;
+}
+
+createTests({
+  name: "promise-unhandled-rejection",
+  functionName: "promise-unhandled-rejection",
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  handler,
+  tests: (runner) => {
+    it("should complete successfully despite failing steps in promise combinators", async () => {
+      const execution = await runner.run();
+      const result = execution.getResult() as PromiseUnhandledRejectionResult;
+
+      // The customer's example should return this exact result
+      expect(result).toStrictEqual({
+        successStep: "Success",
+      });
+    }, 30000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-unhandled-rejection.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-unhandled-rejection.ts
@@ -1,0 +1,42 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Promise Unhandled Rejection",
+  description: "Test that promise combinators don't cause unhandled rejections",
+};
+
+export const handler = withDurableExecution(
+  async (_event, context: DurableContext) => {
+    const failurePromise = context.step(
+      "failure-step",
+      async () => {
+        throw new Error("This step failed");
+      },
+      {
+        retryStrategy: () => ({
+          shouldRetry: false,
+        }),
+      },
+    );
+
+    try {
+      await context.promise.all([failurePromise]); // or await context.promise.any([failurePromise])
+    } catch {
+      // ignoring error should not fail execution
+    }
+    await context.wait(1);
+
+    const successStep = await context.step(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      return "Success";
+    });
+
+    return {
+      successStep,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.ts
@@ -87,12 +87,13 @@ export const createPromiseHandler = (step: DurableContext["step"]) => {
   ): Promise<T[]> => {
     const { name, promises } = parseParams(nameOrPromises, maybePromises);
 
-    // Execute Promise.all immediately to consume promises
-    // This prevents unhandled rejections during replay
-    const allPromise = Promise.all(promises);
+    // Immediately attach catch handlers to prevent unhandled rejections
+    // while preserving the original promise behavior for Promise.all
+    promises.forEach((p) => p.catch(() => {}));
 
-    // Wrap the result in a step for persistence
-    return step(name, () => allPromise, stepConfig);
+    // Wrap Promise.all execution in a step for persistence
+    // This ensures Promise.all is called inside the step where errors can be handled
+    return step(name, () => Promise.all(promises), stepConfig);
   };
 
   const allSettled = <T>(
@@ -101,12 +102,12 @@ export const createPromiseHandler = (step: DurableContext["step"]) => {
   ): Promise<PromiseSettledResult<T>[]> => {
     const { name, promises } = parseParams(nameOrPromises, maybePromises);
 
-    // Execute Promise.allSettled immediately to consume promises
-    // This prevents unhandled rejections during replay
-    const settledPromise = Promise.allSettled(promises);
+    // Immediately attach catch handlers to prevent unhandled rejections
+    // while preserving the original promise behavior for Promise.allSettled
+    promises.forEach((p) => p.catch(() => {}));
 
-    // Wrap the result in a step for persistence
-    return step(name, () => settledPromise, {
+    // Wrap Promise.allSettled execution in a step for persistence
+    return step(name, () => Promise.allSettled(promises), {
       ...stepConfig,
       serdes: createErrorAwareSerdes<T>(),
     });
@@ -118,12 +119,12 @@ export const createPromiseHandler = (step: DurableContext["step"]) => {
   ): Promise<T> => {
     const { name, promises } = parseParams(nameOrPromises, maybePromises);
 
-    // Execute Promise.any immediately to consume promises
-    // This prevents unhandled rejections during replay
-    const anyPromise = Promise.any(promises);
+    // Immediately attach catch handlers to prevent unhandled rejections
+    // while preserving the original promise behavior for Promise.any
+    promises.forEach((p) => p.catch(() => {}));
 
-    // Wrap the result in a step for persistence
-    return step(name, () => anyPromise, stepConfig);
+    // Wrap Promise.any execution in a step for persistence
+    return step(name, () => Promise.any(promises), stepConfig);
   };
 
   const race = <T>(
@@ -132,12 +133,12 @@ export const createPromiseHandler = (step: DurableContext["step"]) => {
   ): Promise<T> => {
     const { name, promises } = parseParams(nameOrPromises, maybePromises);
 
-    // Execute Promise.race immediately to consume promises
-    // This prevents unhandled rejections during replay
-    const racePromise = Promise.race(promises);
+    // Immediately attach catch handlers to prevent unhandled rejections
+    // while preserving the original promise behavior for Promise.race
+    promises.forEach((p) => p.catch(() => {}));
 
-    // Wrap the result in a step for persistence
-    return step(name, () => racePromise, stepConfig);
+    // Wrap Promise.race execution in a step for persistence
+    return step(name, () => Promise.race(promises), stepConfig);
   };
 
   return {


### PR DESCRIPTION
- Add empty catch handlers to input promises to prevent unhandled rejection warnings
- Move Promise.all/any/race execution inside step functions for proper error handling
- Fix issue where promise combinators caused unhandled rejections during replay
- Add test case demonstrating the fix works with failing steps in try/catch blocks

Resolves issue where Promise.all and Promise.any would cause unhandled promise rejections when promises were already rejected before being consumed by the combinator, particularly during replay scenarios.

*Issue #, if available:*
#194 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
