### PR TITLE
feat(examples): add large-scale map examples with conditional testing

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/map-large-scale.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/map-large-scale.test.ts
@@ -1,0 +1,36 @@
+import { handler } from "../map-large-scale";
+import { createTests } from "./shared/test-helper";
+
+// Skip this test in unit tests due to ReplayChildren not being implemented in testing library
+// This test should only run in integration tests against real AWS Lambda
+const testMethod = process.env.TEST_TYPE === "integration" ? it : it.skip;
+
+createTests({
+  name: "map-large-scale test",
+  functionName: "map-large-scale",
+  handler,
+  localRunnerConfig: {
+    skipTime: true, // Skip wait delays for faster testing
+  },
+  tests: (runner) => {
+    testMethod("should handle 50 items with 100KB each using map", async () => {
+      const execution = await runner.run();
+      const result = execution.getResult() as any;
+
+      // Verify the execution succeeded
+      expect(execution.getStatus()).toBe("SUCCEEDED");
+      expect(result.success).toBe(true);
+
+      // Verify the expected number of items were processed (50 items)
+      expect(result.summary.itemsProcessed).toBe(50);
+      expect(result.summary.allItemsProcessed).toBe(true);
+
+      // Verify data size expectations (~5MB total from 50 items × 100KB each)
+      expect(result.summary.totalDataSizeMB).toBeGreaterThan(4); // Should be ~5MB
+      expect(result.summary.totalDataSizeMB).toBeLessThan(6);
+      expect(result.summary.totalDataSizeBytes).toBeGreaterThan(5000000); // ~5MB
+      expect(result.summary.averageItemSize).toBeGreaterThan(100000); // ~100KB per item
+      expect(result.summary.maxConcurrency).toBe(10);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-large-scale.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-large-scale.ts
@@ -1,0 +1,86 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../types";
+
+export const config: ExampleConfig = {
+  name: "Large Scale Map",
+  description: "Test map with 50 iterations, each returning 100KB data",
+};
+
+/**
+ * Generate a string of approximately the specified size in KB
+ */
+function generateLargeString(sizeInKB: number): string {
+  const targetSize = sizeInKB * 1024; // Convert KB to bytes
+  const baseString = "B".repeat(1000); // 1KB string
+  const repetitions = Math.floor(targetSize / 1000);
+  const remainder = targetSize % 1000;
+
+  return baseString.repeat(repetitions) + "B".repeat(remainder);
+}
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // Create array of 50 items (more manageable for testing)
+    const items = Array.from({ length: 50 }, (_, i) => i + 1);
+
+    const results = await context.map(
+      "large-scale-map",
+      items,
+      async (context: DurableContext, item: number, index: number) => {
+        return await context.step(`process-item-${item}`, async () => {
+          // Generate 100KB of data for each item
+          const data = generateLargeString(100);
+          return {
+            itemId: item,
+            index: index,
+            dataSize: data.length,
+            data: data,
+            processed: true,
+          };
+        });
+      },
+      {
+        maxConcurrency: 10, // Process 10 items concurrently
+      },
+    );
+
+    await context.wait("wait1", 1);
+
+    // Process results immediately after map operation
+    // Note: After wait operations, the BatchResult may be summarized and lose getResults() method
+    let finalResults: any[] = [];
+    let totalDataSize = 0;
+    let allItemsProcessed = false;
+
+    // Full BatchResult available - extract data now
+    finalResults = results.getResults();
+    totalDataSize = finalResults.reduce(
+      (sum, result) => sum + result.dataSize,
+      0,
+    );
+    allItemsProcessed = finalResults.every((result) => result.processed);
+
+    const totalSizeInMB = Math.round(totalDataSize / (1024 * 1024));
+
+    const summary = {
+      itemsProcessed: results.successCount,
+      totalDataSizeMB: totalSizeInMB,
+      totalDataSizeBytes: totalDataSize,
+      maxConcurrency: 10,
+      averageItemSize: Math.round(totalDataSize / results.successCount),
+      allItemsProcessed: allItemsProcessed,
+    };
+
+    await context.wait("wait2", 1);
+
+    return {
+      success: true,
+      message:
+        "Successfully processed 50 items with substantial data using map",
+      summary: summary,
+    };
+  },
+);


### PR DESCRIPTION
- Add runInChildContext example handling 256KB+ data with wait operations
- Add map example processing 50 items with 100KB each (~5MB total)
- Configure tests to skip in unit tests due to ReplayChildren limitation
- Tests run only in integration mode with TEST_TYPE=integration
- Demonstrates proper handling of large data across replay scenarios