### PR TITLE
fix(sdk): correct summary parsing in replay mode for large payloads

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/map-large-scale.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/__tests__/map-large-scale.test.ts
@@ -1,10 +1,6 @@
 import { handler } from "../map-large-scale";
 import { createTests } from "./shared/test-helper";
 
-// Skip this test in unit tests due to ReplayChildren not being implemented in testing library
-// This test should only run in integration tests against real AWS Lambda
-const testMethod = process.env.TEST_TYPE === "integration" ? it : it.skip;
-
 createTests({
   name: "map-large-scale test",
   functionName: "map-large-scale",
@@ -13,7 +9,7 @@ createTests({
     skipTime: true, // Skip wait delays for faster testing
   },
   tests: (runner) => {
-    testMethod("should handle 50 items with 100KB each using map", async () => {
+    it("should handle 50 items with 100KB each using map", async () => {
       const execution = await runner.run();
       const result = execution.getResult() as any;
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/checkpoint-manager.ts
@@ -268,6 +268,10 @@ export class CheckpointManager {
           ...copied.operation.ContextDetails,
           Result: inputUpdate.Payload,
           Error: inputUpdate.Error,
+          // Preserve ReplayChildren from ContextOptions if provided
+          ReplayChildren:
+            inputUpdate.ContextOptions?.ReplayChildren ??
+            copied.operation.ContextDetails?.ReplayChildren,
         };
         break;
     }

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
@@ -1,7 +1,6 @@
 import { ConcurrencyController } from "./concurrent-execution-handler";
 import {
   DurableContext,
-  BatchItemStatus,
   DurableExecutionMode,
   ExecutionContext,
 } from "../../types";
@@ -37,11 +36,12 @@ describe("ConcurrencyController - Replay Mode", () => {
     const entityId = "parent-step";
 
     const initialResultSummary = JSON.stringify({
-      all: [
-        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
-      ],
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 2,
+      failureCount: 0,
       completionReason: "ALL_COMPLETED",
+      status: "SUCCEEDED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {
@@ -98,15 +98,12 @@ describe("ConcurrencyController - Replay Mode", () => {
     const entityId = "parent-step";
 
     const initialResultSummary = JSON.stringify({
-      all: [
-        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        {
-          index: 1,
-          error: { message: "error" },
-          status: BatchItemStatus.FAILED,
-        },
-      ],
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 1,
+      failureCount: 1,
       completionReason: "ALL_COMPLETED",
+      status: "FAILED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {
@@ -177,11 +174,12 @@ describe("ConcurrencyController - Replay Mode", () => {
     const entityId = "parent-step";
 
     const initialResultSummary = JSON.stringify({
-      all: [
-        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
-      ],
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 2,
+      failureCount: 0,
       completionReason: "ALL_COMPLETED",
+      status: "SUCCEEDED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {
@@ -233,11 +231,12 @@ describe("ConcurrencyController - Replay Mode", () => {
 
     // Items 0 and 2 completed, item 1 was incomplete
     const initialResultSummary = JSON.stringify({
-      all: [
-        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        { index: 2, result: "result3", status: BatchItemStatus.SUCCEEDED },
-      ],
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 2,
+      failureCount: 0,
       completionReason: "ALL_COMPLETED",
+      status: "SUCCEEDED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {
@@ -366,14 +365,12 @@ describe("ConcurrencyController - Replay Mode", () => {
     const entityId = "parent-step";
 
     const initialResultSummary = JSON.stringify({
-      all: [
-        {
-          index: 0,
-          error: { message: "string error" },
-          status: BatchItemStatus.FAILED,
-        },
-      ],
+      type: "MapResult",
+      totalCount: 1,
+      successCount: 0,
+      failureCount: 1,
       completionReason: "ALL_COMPLETED",
+      status: "FAILED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {
@@ -424,11 +421,12 @@ describe("ConcurrencyController - Replay Mode", () => {
     const entityId = "parent-step";
 
     const initialResultSummary = JSON.stringify({
-      all: [
-        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        { index: 1, result: "result2", status: BatchItemStatus.SUCCEEDED },
-      ],
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 2,
+      failureCount: 0,
       completionReason: "MIN_SUCCESSFUL_REACHED",
+      status: "SUCCEEDED",
     });
 
     mockExecutionContext.getStepData.mockImplementation((id: string) => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -63,9 +63,13 @@ export class ConcurrencyController {
               entityId: entityId,
               durableExecutionArn: executionContext.durableExecutionArn,
             });
-            if (parsedSummary && typeof parsedSummary === "object") {
-              const initialResult = restoreBatchResult<R>(parsedSummary);
-              targetTotalCount = initialResult.totalCount;
+            if (
+              parsedSummary &&
+              typeof parsedSummary === "object" &&
+              "totalCount" in parsedSummary
+            ) {
+              // Read totalCount directly from summary metadata
+              targetTotalCount = parsedSummary.totalCount as number;
               log("📊", "Found initial execution count:", {
                 targetTotalCount,
               });
@@ -90,7 +94,7 @@ export class ConcurrencyController {
       } else {
         log(
           "⚠️",
-          "No target count or context found, falling back to concurrent execution",
+          "No valid target count or context found, falling back to concurrent execution",
         );
       }
     }


### PR DESCRIPTION
- Fix concurrent execution handler to read totalCount directly from summary metadata instead of trying to restore it as BatchResult
- Fix checkpoint manager to preserve ReplayChildren flag during operation completion
- Resolves issue where successCount was 0 in replay mode when payload exceeded 256KB limit
- Ensures proper BatchResult restoration and correct itemsProcessed calculation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
