### PR TITLE
feat(examples): add simple invoke tests

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/simple/invoke-simple.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/simple/invoke-simple.test.ts
@@ -1,0 +1,111 @@
+import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
+import { createTests } from "../../../utils/test-helper";
+import { handler } from "./invoke-simple";
+import { handler as namedWaitHandler } from "../../wait/named/wait-named";
+import { handler as handlerErrorHandler } from "../../handler-error/handler-error";
+import { handler as nonDurableHandler } from "../../non-durable/non-durable";
+import { handler as namedStepHandler } from "../../step/named/step-named";
+
+createTests({
+  name: "invoke-simple",
+  functionName: "invoke-simple",
+  handler,
+  tests: function (runner, _, functionNameMap) {
+    it("should run invoke with basic wait state", async () => {
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerDurableFunction(
+          functionNameMap.getFunctionName("wait-named"),
+          namedWaitHandler,
+        );
+      }
+
+      const result = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName("wait-named"),
+        },
+      });
+      expect(result.getResult()).toBe("wait finished");
+    });
+
+    it("should run invoke with step and payload", async () => {
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerDurableFunction(
+          functionNameMap.getFunctionName("step-named"),
+          namedStepHandler,
+        );
+      }
+
+      const result = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName("step-named"),
+          payload: {
+            data: "data from parent",
+          },
+        },
+      });
+      expect(result.getResult()).toEqual("processed: data from parent");
+    });
+
+    it("should run invoke with child function failure", async () => {
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerDurableFunction(
+          functionNameMap.getFunctionName("handler-error"),
+          handlerErrorHandler,
+        );
+      }
+
+      const result = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName("handler-error"),
+        },
+      });
+      expect(result.getError()).toEqual({
+        errorMessage: "Intentional handler failure",
+        errorType: "InvokeError",
+      });
+    });
+
+    it("should run invoke with non-durable function success", async () => {
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerFunction(
+          functionNameMap.getFunctionName("non-durable"),
+          nonDurableHandler,
+        );
+      }
+
+      const result = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName("non-durable"),
+        },
+      });
+      expect(result.getResult()).toEqual({
+        status: 200,
+        body: JSON.stringify({
+          message: "Hello from Lambda!",
+        }),
+      });
+    });
+
+    it("should run invoke with non-durable function failure", async () => {
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerFunction(
+          functionNameMap.getFunctionName("non-durable"),
+          nonDurableHandler,
+        );
+      }
+
+      const result = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName("non-durable"),
+          payload: {
+            failure: true,
+          },
+        },
+      });
+      expect(result.getError()).toEqual({
+        errorMessage: "This is a failure",
+        errorType: "InvokeError",
+      });
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/simple/invoke-simple.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/simple/invoke-simple.ts
@@ -1,0 +1,24 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Invoke Simple",
+  description:
+    "Demonstrates a simple invoke, returning the result of the invoke",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: {
+      functionName: string;
+      payload: Record<string, any>;
+    },
+    context: DurableContext,
+  ) => {
+    const result = await context.invoke(event.functionName, event.payload);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/non-durable/non-durable.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/non-durable/non-durable.ts
@@ -1,0 +1,20 @@
+import { ExampleConfig } from "../../types";
+
+export const config: ExampleConfig = {
+  name: "Non-Durable",
+  description: "A simple non-durable function used for testing.",
+  durableConfig: null,
+};
+
+export const handler = async (event: { failure: boolean }) => {
+  if (event.failure) {
+    throw new Error("This is a failure");
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  return {
+    status: 200,
+    body: JSON.stringify({ message: "Hello from Lambda!" }),
+  };
+};

--- a/packages/aws-durable-execution-sdk-js-examples/src/types/index.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/types/index.ts
@@ -5,13 +5,12 @@ export interface ExampleConfig {
   description?: string;
   /**
    * The durable config of the function. By default, RetentionPeriodInDays will be set to 7 days
-   * and ExecutionTimeout will be set to 60 seconds.
+   * and ExecutionTimeout will be set to 60 seconds. Null if function is not durable.
    */
-  durableConfig?: DurableConfig;
+  durableConfig?: DurableConfig | null;
 }
 
 export type ExamplesWithConfig = ExampleConfig & {
-  durableConfig: DurableConfig;
   path: string;
   handler: string;
 };

--- a/packages/aws-durable-execution-sdk-js-examples/src/utils/examples.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/utils/examples.ts
@@ -46,12 +46,18 @@ export class Examples {
         ? config.description
         : undefined;
 
+    const durableConfig =
+      "durableConfig" in config && typeof config.durableConfig === "object"
+        ? config.durableConfig
+        : undefined;
+
     return {
       name: config.name,
       description,
       path: examplePath,
       handler: handlerName,
-      durableConfig: DEFAULT_DURABLE_CONFIG,
+      durableConfig:
+        durableConfig === undefined ? DEFAULT_DURABLE_CONFIG : durableConfig,
     };
   }
 

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -361,6 +361,30 @@ Resources:
           DURABLE_VERBOSE_MODE: "true"
     Metadata:
       SkipBuild: "True"
+  InvokeSimple:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: InvokeSimple-TypeScript
+      CodeUri: ./dist
+      Handler: invoke-simple.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "true"
+    Metadata:
+      SkipBuild: "True"
   LoggerAfterCallback:
     Type: AWS::Serverless::Function
     Properties:
@@ -535,6 +559,30 @@ Resources:
       FunctionName: NoReplayExecution-TypeScript
       CodeUri: ./dist
       Handler: no-replay-execution.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "true"
+    Metadata:
+      SkipBuild: "True"
+  NonDurable:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: NonDurable-TypeScript
+      CodeUri: ./dist
+      Handler: non-durable.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
@@ -363,7 +363,7 @@ describe("LocalDurableTestRunner", () => {
   });
 
   describe("registerFunctions", () => {
-    it("should register functions with function storage", () => {
+    it("should register durable functions with function storage", () => {
       const runner = new LocalDurableTestRunner({
         handlerFunction: mockHandlerFunction,
       });
@@ -372,6 +372,43 @@ describe("LocalDurableTestRunner", () => {
 
       runner.registerDurableFunction("durableFunction", mockDurableHandler);
 
+      expect(mockFunctionStorage.registerDurableFunction).toHaveBeenCalledWith(
+        "durableFunction",
+        mockDurableHandler,
+      );
+    });
+
+    it("should register functions with function storage", () => {
+      const runner = new LocalDurableTestRunner({
+        handlerFunction: mockHandlerFunction,
+      });
+
+      const mockHandler = jest.fn();
+
+      runner.registerFunction("function", mockHandler);
+
+      expect(mockFunctionStorage.registerFunction).toHaveBeenCalledWith(
+        "function",
+        mockHandler,
+      );
+    });
+
+    it("should register durable and non-durable functions with function storage", () => {
+      const runner = new LocalDurableTestRunner({
+        handlerFunction: mockHandlerFunction,
+      });
+
+      const mockHandler = jest.fn();
+      const mockDurableHandler = jest.fn();
+
+      runner
+        .registerFunction("function", mockHandler)
+        .registerDurableFunction("durableFunction", mockDurableHandler);
+
+      expect(mockFunctionStorage.registerFunction).toHaveBeenCalledWith(
+        "function",
+        mockHandler,
+      );
       expect(mockFunctionStorage.registerDurableFunction).toHaveBeenCalledWith(
         "durableFunction",
         mockDurableHandler,

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
@@ -28,6 +28,7 @@ import {
 } from "../common/create-durable-api-client";
 import { getDurableExecutionsClient } from "./api-client/durable-executions-client";
 import { install, InstalledClock } from "@sinonjs/fake-timers";
+import { Handler } from "aws-lambda";
 
 export type LocalTestRunnerHandlerFunction = ReturnType<
   typeof withDurableExecution
@@ -229,6 +230,43 @@ export class LocalDurableTestRunner<ResultType>
     durableHandler: LambdaHandler<DurableExecutionInvocationInput>,
   ): this {
     this.functionStorage.registerDurableFunction(functionName, durableHandler);
+    return this;
+  }
+
+  /**
+   * Registers a function handler that can be invoked during durable execution testing.
+   *
+   * @param functionName - The name/ARN of the function that will be used in context.invoke() calls
+   * @param handler - The function handler
+   * @returns This LocalDurableTestRunner instance for method chaining
+   *
+   * @example
+   * ```typescript
+   * import { LocalDurableTestRunner } from '@aws/durable-execution-sdk-js-testing';
+   * import { withDurableExecution } from '@aws/durable-execution-sdk-js';
+   *
+   * const testRunner = new LocalDurableTestRunner({
+   *   handlerFunction: mainHandler
+   * });
+   *
+   * // Register a function
+   * const handler = async (input, context) => {
+   *   const response = {
+   *      status: 200
+   *   }
+   *   return response;
+   * };
+   *
+   * testRunner.registerFunction('get-response', handler);
+   *
+   * // Chain multiple registrations
+   * testRunner
+   *   .registerFunction('workflow-a', workflowAHandler)
+   *   .registerFunction('workflow-b', workflowBHandler)
+   * ```
+   */
+  registerFunction(functionName: string, handler: Handler): this {
+    this.functionStorage.registerFunction(functionName, handler);
     return this;
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -310,6 +310,124 @@ describe("InvokeHandler", () => {
       expect(mockTerminate).toHaveBeenCalledTimes(0);
     });
 
+    it("should create checkpoint and terminate for new invoke without name and without input", async () => {
+      const mockGetStepData = jest
+        .fn()
+        .mockReturnValueOnce(undefined) // First call - no step data
+        .mockReturnValueOnce({ Status: OperationStatus.STARTED }); // After checkpoint
+
+      mockContext.getStepData = mockGetStepData;
+      mockHasRunningOperations.mockReturnValue(false); // No other operations running
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+        () => new EventEmitter(),
+        "parent-123",
+      );
+
+      await expect(invokeHandler("test-function")).rejects.toThrow(
+        "Execution terminated",
+      );
+
+      expect(mockSafeSerialize).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        "test-step-1",
+        undefined,
+        mockContext.terminationManager,
+        "test-arn",
+      );
+
+      expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
+        Id: "test-step-1",
+        ParentId: "parent-123",
+        Action: OperationAction.START,
+        SubType: OperationSubType.CHAINED_INVOKE,
+        Type: OperationType.CHAINED_INVOKE,
+        Name: undefined,
+        Payload: '{"serialized":"data"}',
+        ChainedInvokeOptions: {
+          FunctionName: "test-function",
+        },
+      });
+
+      expect(mockLog).toHaveBeenCalledWith(
+        "🔗",
+        "Invoke test-function (test-step-1) - phase 1",
+      );
+      expect(mockLog).toHaveBeenCalledWith(
+        "🚀",
+        "Invoke test-function started (phase 1)",
+      );
+      expect(mockLog).toHaveBeenCalledWith(
+        "✅",
+        "Invoke phase 1 complete:",
+        expect.anything(),
+      );
+    });
+
+    it("should create checkpoint and terminate for new invoke with name and without input", async () => {
+      const mockGetStepData = jest
+        .fn()
+        .mockReturnValueOnce(undefined) // First call - no step data
+        .mockReturnValueOnce({ Status: OperationStatus.STARTED }); // After checkpoint
+
+      mockContext.getStepData = mockGetStepData;
+      mockHasRunningOperations.mockReturnValue(false); // No other operations running
+
+      const invokeHandler = createInvokeHandler(
+        mockContext,
+        mockCheckpointFn,
+        mockCreateStepId,
+        mockHasRunningOperations,
+        () => new EventEmitter(),
+        "parent-123",
+      );
+
+      await expect(invokeHandler("test-name", "test-function")).rejects.toThrow(
+        "Execution terminated",
+      );
+
+      expect(mockSafeSerialize).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+        "test-step-1",
+        "test-name",
+        mockContext.terminationManager,
+        "test-arn",
+      );
+
+      expect(mockCheckpointFn).toHaveBeenCalledWith("test-step-1", {
+        Id: "test-step-1",
+        ParentId: "parent-123",
+        Action: OperationAction.START,
+        SubType: OperationSubType.CHAINED_INVOKE,
+        Type: OperationType.CHAINED_INVOKE,
+        Name: "test-name",
+        Payload: '{"serialized":"data"}',
+        ChainedInvokeOptions: {
+          FunctionName: "test-function",
+        },
+      });
+
+      expect(mockLog).toHaveBeenCalledWith(
+        "🔗",
+        "Invoke test-name (test-step-1) - phase 1",
+      );
+      expect(mockLog).toHaveBeenCalledWith(
+        "🚀",
+        "Invoke test-name started (phase 1)",
+      );
+      expect(mockLog).toHaveBeenCalledWith(
+        "✅",
+        "Invoke phase 1 complete:",
+        expect.anything(),
+      );
+    });
+
     it("should create checkpoint and terminate for new invoke without name", async () => {
       const mockGetStepData = jest
         .fn()

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -34,25 +34,25 @@ export const createInvokeHandler = (
 ): {
   <I, O>(
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
   <I, O>(
     name: string,
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
 } => {
   function invokeHandler<I, O>(
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
   function invokeHandler<I, O>(
     name: string,
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
   function invokeHandler<I, O>(
@@ -64,7 +64,9 @@ export const createInvokeHandler = (
     const isNameFirst = typeof funcIdOrInput === "string";
     const name = isNameFirst ? nameOrFuncId : undefined;
     const funcId = isNameFirst ? (funcIdOrInput as string) : nameOrFuncId;
-    const input = isNameFirst ? (inputOrConfig as I) : (funcIdOrInput as I);
+    const input = isNameFirst
+      ? (inputOrConfig as I | undefined)
+      : (funcIdOrInput as I | undefined);
     const config = isNameFirst
       ? maybeConfig
       : (inputOrConfig as InvokeConfig<I, O>);

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -161,7 +161,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
   invoke<I, O>(
     name: string,
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
 
@@ -181,7 +181,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    */
   invoke<I, O>(
     funcId: string,
-    input: I,
+    input?: I,
     config?: InvokeConfig<I, O>,
   ): DurablePromise<O>;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding simple invoke tests with:
- durable handler
- non-durable handler
- failing handler
- named step with payload

Additionally:
- updating language SDK to accept calling invoke with no input, since the API supports it
- enable registering non-durable functions in testing library for invoke, since the API supports it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
