### PR TITLE
fix(sdk): ensure consistent error handling across handlers

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -49,6 +49,12 @@ export abstract class DurableOperationError extends Error {
           cause,
           errorObject.ErrorData,
         );
+      case "ChildContextError":
+        return new ChildContextError(
+          errorObject.ErrorMessage || "Child context failed",
+          cause,
+          errorObject.ErrorData,
+        );
       default:
         return new StepError(
           errorObject.ErrorMessage || "Unknown error",
@@ -102,5 +108,16 @@ export class InvokeError extends DurableOperationError {
 
   constructor(message?: string, cause?: Error, errorData?: string) {
     super(message || "Invoke failed", cause, errorData);
+  }
+}
+
+/**
+ * Error thrown when a child context operation fails
+ */
+export class ChildContextError extends DurableOperationError {
+  readonly errorType = "ChildContextError";
+
+  constructor(message?: string, cause?: Error, errorData?: string) {
+    super(message || "Child context failed", cause, errorData);
   }
 }

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -29,6 +29,7 @@ export {
   StepError,
   CallbackError,
   InvokeError,
+  ChildContextError,
 } from "./errors/durable-error/durable-error";
 export {
   defaultSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -152,6 +152,7 @@ export interface DurableContext {
    * @param name - Step name for tracking and debugging
    * @param fn - Function to execute in the child context
    * @param config - Optional configuration for serialization and sub-typing
+   * @throws \{ChildContextError\} When the child context function fails
    * @example
    * ```typescript
    * const result = await context.runInChildContext(
@@ -176,6 +177,7 @@ export interface DurableContext {
    * Runs a function in a child context with isolated state and execution tracking
    * @param fn - Function to execute in the child context
    * @param config - Optional configuration for serialization and sub-typing
+   * @throws \{ChildContextError\} When the child context function fails
    * @example
    * ```typescript
    * const result = await context.runInChildContext(


### PR DESCRIPTION
    **ChildContextError Consistency:**
    - Always wrap errors in ChildContextError in executeChildContext
    - Preserve original error message and pass error as cause
    - Handle both Error objects and non-Error values consistently
    - Add test for child context error  with no Error field

    **StepError Consistency:**
    - Wrap generic errors in StepError at handler level
    - Preserve DurableOperationError instances and specific error types
    - Add test to verify Error objects are wrapped with correct message/cause

    **StepInterruptedError Handling:**
    - Pass StepInterruptedError to retry strategy for decision making
    - Wrap StepInterruptedError in StepError when retry is exhausted
    - Update tests to verify proper error wrapping and retry flow

    **Test Coverage Improvements:**
    - Add test for FAIL status handling in runInChildContext replay mode
    - Add test for child context without Error field
    - Add test for Error object wrapping in step handler
    - Verify StepInterruptedError -> retry strategy -> StepError flow
