### PR TITLE
feat(sdk): classify checkpoint errors based on AWS SDK response

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -206,6 +206,9 @@ describe("WaitForCallback Operations Integration", () => {
       const firstCallbackResult = JSON.stringify({ step: 1 });
       await firstCallbackOp.sendCallbackSuccess(firstCallbackResult);
 
+      // Add small delay to ensure previous invocation completes before next callback
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
       // Wait for second callback and complete it
       await secondCallbackOp.waitForData(WaitingOperationStatus.STARTED);
       const secondCallbackResult = JSON.stringify({ step: 2 });

--- a/packages/aws-durable-execution-sdk-js/src/errors/checkpoint-errors/checkpoint-errors.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/checkpoint-errors/checkpoint-errors.test.ts
@@ -1,16 +1,22 @@
-import { CheckpointFailedError } from "./checkpoint-errors";
+import {
+  CheckpointUnrecoverableInvocationError,
+  CheckpointUnrecoverableExecutionError,
+} from "./checkpoint-errors";
 import {
   UnrecoverableError,
   UnrecoverableInvocationError,
+  UnrecoverableExecutionError,
   isUnrecoverableError,
+  isUnrecoverableInvocationError,
+  isUnrecoverableExecutionError,
 } from "../unrecoverable-error/unrecoverable-error";
 import { TerminationReason } from "../../termination-manager/types";
 
-describe("CheckpointFailedError", () => {
+describe("CheckpointUnrecoverableInvocationError", () => {
   it("should create error with default message", () => {
-    const error = new CheckpointFailedError();
+    const error = new CheckpointUnrecoverableInvocationError();
 
-    expect(error.name).toBe("CheckpointFailedError");
+    expect(error.name).toBe("CheckpointUnrecoverableInvocationError");
     expect(error.message).toBe(
       "[Unrecoverable Invocation] Checkpoint operation failed",
     );
@@ -22,7 +28,9 @@ describe("CheckpointFailedError", () => {
   });
 
   it("should create error with custom message", () => {
-    const error = new CheckpointFailedError("Custom checkpoint error");
+    const error = new CheckpointUnrecoverableInvocationError(
+      "Custom checkpoint error",
+    );
 
     expect(error.message).toBe(
       "[Unrecoverable Invocation] Custom checkpoint error",
@@ -33,8 +41,11 @@ describe("CheckpointFailedError", () => {
   });
 
   it("should create error with original error", () => {
-    const originalError = new Error("Database connection failed");
-    const error = new CheckpointFailedError("Checkpoint failed", originalError);
+    const originalError = new Error("5xx server error");
+    const error = new CheckpointUnrecoverableInvocationError(
+      "Checkpoint failed",
+      originalError,
+    );
 
     expect(error.message).toBe("[Unrecoverable Invocation] Checkpoint failed");
     expect(error.originalError).toBe(originalError);
@@ -43,7 +54,58 @@ describe("CheckpointFailedError", () => {
   });
 
   it("should be detected by isUnrecoverableError", () => {
-    const error = new CheckpointFailedError();
+    const error = new CheckpointUnrecoverableInvocationError();
     expect(isUnrecoverableError(error)).toBe(true);
+    expect(isUnrecoverableInvocationError(error)).toBe(true);
+    expect(isUnrecoverableExecutionError(error)).toBe(false);
+  });
+});
+
+describe("CheckpointUnrecoverableExecutionError", () => {
+  it("should create error with default message", () => {
+    const error = new CheckpointUnrecoverableExecutionError();
+
+    expect(error.name).toBe("CheckpointUnrecoverableExecutionError");
+    expect(error.message).toBe(
+      "[Unrecoverable Execution] Checkpoint operation failed",
+    );
+    expect(error.terminationReason).toBe(TerminationReason.CHECKPOINT_FAILED);
+    expect(error.isUnrecoverable).toBe(true);
+    expect(error.isUnrecoverableExecution).toBe(true);
+    expect(error).toBeInstanceOf(UnrecoverableError);
+    expect(error).toBeInstanceOf(UnrecoverableExecutionError);
+  });
+
+  it("should create error with custom message", () => {
+    const error = new CheckpointUnrecoverableExecutionError(
+      "Custom checkpoint error",
+    );
+
+    expect(error.message).toBe(
+      "[Unrecoverable Execution] Custom checkpoint error",
+    );
+    expect(error.terminationReason).toBe(TerminationReason.CHECKPOINT_FAILED);
+    expect(error.isUnrecoverable).toBe(true);
+    expect(error.isUnrecoverableExecution).toBe(true);
+  });
+
+  it("should create error with original error", () => {
+    const originalError = new Error("Invalid parameter");
+    const error = new CheckpointUnrecoverableExecutionError(
+      "Checkpoint failed",
+      originalError,
+    );
+
+    expect(error.message).toBe("[Unrecoverable Execution] Checkpoint failed");
+    expect(error.originalError).toBe(originalError);
+    expect(error.stack).toContain("Caused by:");
+    expect(error.stack).toContain(originalError.stack);
+  });
+
+  it("should be detected by isUnrecoverableError", () => {
+    const error = new CheckpointUnrecoverableExecutionError();
+    expect(isUnrecoverableError(error)).toBe(true);
+    expect(isUnrecoverableExecutionError(error)).toBe(true);
+    expect(isUnrecoverableInvocationError(error)).toBe(false);
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/errors/checkpoint-errors/checkpoint-errors.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/checkpoint-errors/checkpoint-errors.ts
@@ -1,12 +1,28 @@
 import { TerminationReason } from "../../termination-manager/types";
-import { UnrecoverableInvocationError } from "../unrecoverable-error/unrecoverable-error";
+import {
+  UnrecoverableInvocationError,
+  UnrecoverableExecutionError,
+} from "../unrecoverable-error/unrecoverable-error";
 
 /**
- * Error thrown when a checkpoint operation fails
- * This is an unrecoverable invocation error that will terminate the current Lambda invocation,
- * but the execution might be able to continue with a new invocation
+ * Error thrown when a checkpoint operation fails due to invocation-level issues
+ * (e.g., 5xx errors, invalid checkpoint token)
+ * This will terminate the current Lambda invocation, but the execution can continue with a new invocation
  */
-export class CheckpointFailedError extends UnrecoverableInvocationError {
+export class CheckpointUnrecoverableInvocationError extends UnrecoverableInvocationError {
+  readonly terminationReason = TerminationReason.CHECKPOINT_FAILED;
+
+  constructor(message?: string, originalError?: Error) {
+    super(message || "Checkpoint operation failed", originalError);
+  }
+}
+
+/**
+ * Error thrown when a checkpoint operation fails due to execution-level issues
+ * (e.g., 4xx errors other than invalid checkpoint token)
+ * This will terminate the entire execution and cannot be recovered
+ */
+export class CheckpointUnrecoverableExecutionError extends UnrecoverableExecutionError {
   readonly terminationReason = TerminationReason.CHECKPOINT_FAILED;
 
   constructor(message?: string, originalError?: Error) {

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager.ts
@@ -45,6 +45,7 @@ export class TerminationManager extends EventEmitter {
     this.terminationDetails = {
       reason: options.reason ?? TerminationReason.OPERATION_TERMINATED,
       message: options.message ?? "Operation terminated",
+      error: options.error,
       cleanup: options.cleanup,
     };
 
@@ -72,6 +73,7 @@ export class TerminationManager extends EventEmitter {
     return {
       reason: details.reason,
       message: details.message,
+      error: details.error,
     };
   }
 }

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/types.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/types.ts
@@ -23,11 +23,13 @@ export enum TerminationReason {
 export interface TerminationResponse {
   reason: TerminationReason;
   message: string;
+  error?: Error;
 }
 
 export interface TerminationOptions {
   reason?: TerminationReason;
   message?: string;
+  error?: Error;
   cleanup?: () => Promise<void>;
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
@@ -1,0 +1,98 @@
+import { CheckpointHandler } from "./checkpoint";
+import {
+  CheckpointUnrecoverableInvocationError,
+  CheckpointUnrecoverableExecutionError,
+} from "../../errors/checkpoint-errors/checkpoint-errors";
+import { ExecutionContext } from "../../types";
+import { EventEmitter } from "events";
+
+describe("Checkpoint Error Classification", () => {
+  let handler: CheckpointHandler;
+  let mockContext: ExecutionContext;
+
+  beforeEach(() => {
+    mockContext = {
+      _stepData: {},
+      durableExecutionArn: "arn:test",
+      state: {
+        checkpoint: jest.fn(),
+        getStepData: jest.fn(),
+      },
+      terminationManager: {
+        terminate: jest.fn(),
+        getTerminationPromise: jest.fn(),
+      },
+    } as any;
+
+    const emitter = new EventEmitter();
+    handler = new CheckpointHandler(mockContext, "test-token", emitter);
+  });
+
+  it("should classify 4xx InvalidParameterValueException with Invalid Checkpoint Token as invocation error", () => {
+    const awsError = {
+      name: "InvalidParameterValueException",
+      message: "Invalid Checkpoint Token: token expired",
+      $metadata: { httpStatusCode: 400 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(result.message).toContain("Invalid Checkpoint Token");
+  });
+
+  it("should classify other 4xx errors as execution error", () => {
+    const awsError = {
+      name: "ValidationException",
+      message: "Invalid parameter value",
+      $metadata: { httpStatusCode: 400 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+    expect(result.message).toContain("Invalid parameter value");
+  });
+
+  it("should classify 4xx InvalidParameterValueException without Invalid Checkpoint Token as execution error", () => {
+    const awsError = {
+      name: "InvalidParameterValueException",
+      message: "Some other invalid parameter",
+      $metadata: { httpStatusCode: 400 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+    expect(result.message).toContain("Some other invalid parameter");
+  });
+
+  it("should classify 5xx errors as invocation error", () => {
+    const awsError = {
+      name: "InternalServerError",
+      message: "Service unavailable",
+      $metadata: { httpStatusCode: 500 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(result.message).toContain("Service unavailable");
+  });
+
+  it("should classify unknown errors as invocation error", () => {
+    const unknownError = new Error("Network timeout");
+
+    const result = (handler as any).classifyCheckpointError(unknownError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(result.message).toContain("Network timeout");
+  });
+
+  it("should preserve original error in classified error", () => {
+    const originalError = new Error("Original error");
+    const result = (handler as any).classifyCheckpointError(originalError);
+
+    expect(result.originalError).toBe(originalError);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -395,11 +395,14 @@ describe("CheckpointHandler", () => {
       // Wait for async processing
       await new Promise((resolve) => setImmediate(resolve));
 
-      // Should terminate execution
-      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
-        reason: TerminationReason.CHECKPOINT_FAILED,
-        message: "Checkpoint batch failed: Checkpoint API failed",
-      });
+      // Should terminate execution with error object
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: TerminationReason.CHECKPOINT_FAILED,
+          message: expect.stringContaining("Checkpoint failed"),
+          error: expect.any(Error),
+        }),
+      );
     });
 
     it("should continue processing subsequent batches after an error", async () => {
@@ -448,11 +451,14 @@ describe("CheckpointHandler", () => {
       // Wait for async processing
       await new Promise((resolve) => setImmediate(resolve));
 
-      // Verify termination was called with correct message
-      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
-        reason: TerminationReason.CHECKPOINT_FAILED,
-        message: "Checkpoint batch failed: Specific checkpoint error message",
-      });
+      // Verify termination was called with error object
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: TerminationReason.CHECKPOINT_FAILED,
+          message: expect.stringContaining("Specific checkpoint error message"),
+          error: expect.any(Error),
+        }),
+      );
     });
 
     it("should handle non-Error objects thrown during checkpoint", async () => {
@@ -469,11 +475,14 @@ describe("CheckpointHandler", () => {
       // Wait for async processing
       await new Promise((resolve) => setImmediate(resolve));
 
-      // Verify termination was called with correct message
-      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
-        reason: TerminationReason.CHECKPOINT_FAILED,
-        message: "Checkpoint batch failed: String error",
-      });
+      // Verify termination was called with error object
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: TerminationReason.CHECKPOINT_FAILED,
+          message: expect.stringContaining("String error"),
+          error: expect.any(Error),
+        }),
+      );
     });
   });
 
@@ -891,10 +900,13 @@ describe("deleteCheckpointHandler", () => {
       // Wait for async processing
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
-        reason: TerminationReason.CHECKPOINT_FAILED,
-        message: "Checkpoint batch failed: Checkpoint failed",
-      });
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: TerminationReason.CHECKPOINT_FAILED,
+          message: expect.stringContaining("Checkpoint failed"),
+          error: expect.any(Error),
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
- Add CheckpointUnrecoverableInvocationError for 5xx and invalid token errors
- Add CheckpointUnrecoverableExecutionError for other 4xx errors
- Implement error classification logic in checkpoint handler
- Pass classified error through termination manager
- Update tests to properly mock termination flow
- Remove dead code and invalid tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
