### PR TITLE
feat(sdk): use Duration interface across entire codebase

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-completion-config-issue/map-completion-config-issue.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-completion-config-issue/map-completion-config-issue.ts
@@ -58,7 +58,7 @@ export const handler = withDurableExecution(
               if (attemptCount < 2) {
                 return {
                   shouldRetry: true,
-                  delaySeconds: 1,
+                  delay: { seconds: 1 },
                 };
               }
               return {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/all-settled/promise-all-settled.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/all-settled/promise-all-settled.ts
@@ -14,7 +14,7 @@ const stepConfig: StepConfig<any> = {
   retryStrategy: (_error, attemptCount) => {
     return {
       shouldRetry: attemptCount < 3,
-      delaySeconds: 1,
+      delay: { seconds: 1 },
     };
   },
 };

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/any/promise-any.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/any/promise-any.ts
@@ -14,7 +14,7 @@ const stepConfig: StepConfig<any> = {
   retryStrategy: (_error, attemptCount) => {
     return {
       shouldRetry: attemptCount < 3,
-      delaySeconds: 1,
+      delay: { seconds: 1 },
     };
   },
 };

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/combinators/promise-combinators.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/combinators/promise-combinators.ts
@@ -18,7 +18,7 @@ const stepConfig: StepConfig<any> = {
   retryStrategy: (_error, attemptCount) => {
     return {
       shouldRetry: attemptCount < 3,
-      delaySeconds: 1,
+      delay: { seconds: 1 },
     };
   },
 };

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/retry-exhaustion/retry-exhaustion.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/retry-exhaustion/retry-exhaustion.ts
@@ -18,7 +18,7 @@ export const handler = withDurableExecution(
       {
         retryStrategy: (_, attemptsMade: number) => {
           const shouldRetry = attemptsMade <= 5;
-          return { shouldRetry, delaySeconds: 1 + attemptsMade };
+          return { shouldRetry, delay: { seconds: 1 + attemptsMade } };
         },
       },
     );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/with-failing-step/run-in-child-context-failing-step.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/with-failing-step/run-in-child-context-failing-step.ts
@@ -24,7 +24,7 @@ export const handler = withDurableExecution(
             retryStrategy: (_, attemptCount) => {
               return {
                 shouldRetry: attemptCount < 3,
-                delaySeconds: 1 * attemptCount,
+                delay: { seconds: 1 * attemptCount },
               };
             },
           },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.ts
@@ -22,7 +22,7 @@ const STEP_CONFIG_WITH_RETRY_FAILURES_AFTER_1_SECOND_5_TIMES = {
       `. Retry? ${shouldRetry}. `,
     );
     if (shouldRetry) {
-      return { shouldRetry: true, delaySeconds: 1 };
+      return { shouldRetry: true, delay: { seconds: 1 } };
     } else {
       return { shouldRetry: false };
     }

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/with-retry/step-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/with-retry/step-with-retry.ts
@@ -24,7 +24,7 @@ export const handler = withDurableExecution(
           if (attemptCount >= 3) {
             return { shouldRetry: false };
           }
-          return { shouldRetry: true, delaySeconds: attemptCount };
+          return { shouldRetry: true, delay: { seconds: attemptCount } };
         },
         semantics: StepSemantics.AtMostOncePerRetry,
       },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failing-submitter/wait-for-callback-failing-submitter.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failing-submitter/wait-for-callback-failing-submitter.ts
@@ -24,7 +24,7 @@ export const handler = withDurableExecution(
         {
           retryStrategy: (_, attemptCount) => ({
             shouldRetry: attemptCount < 3,
-            delaySeconds: 1,
+            delay: { seconds: 1 },
           }),
         },
       );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-condition/wait-for-condition.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-condition/wait-for-condition.ts
@@ -20,7 +20,7 @@ export const handler = withDurableExecution(
           if (state >= 3) {
             return { shouldContinue: false };
           }
-          return { shouldContinue: true, delaySeconds: 1 };
+          return { shouldContinue: true, delay: { seconds: 1 } };
         },
         initialState: 0,
       },

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -1,5 +1,5 @@
 import { createDurableContext } from "./durable-context";
-import { DurableExecutionMode } from "../../types";
+import { DurableExecutionMode, Duration } from "../../types";
 import { Context } from "aws-lambda";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { createMockExecutionContext } from "../../testing/mock-context";
@@ -363,10 +363,10 @@ describe("DurableContext", () => {
         initialState: {},
         waitStrategy: (): {
           shouldContinue: boolean;
-          delaySeconds: number;
+          delay: Duration;
         } => ({
           shouldContinue: true,
-          delaySeconds: 1,
+          delay: { seconds: 1 },
         }),
       };
 
@@ -397,10 +397,10 @@ describe("DurableContext", () => {
         initialState: {},
         waitStrategy: (): {
           shouldContinue: boolean;
-          delaySeconds: number;
+          delay: Duration;
         } => ({
           shouldContinue: true,
-          delaySeconds: 1,
+          delay: { seconds: 1 },
         }),
       };
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -180,7 +180,7 @@ describe("Step Handler", () => {
     const stepFn = jest.fn().mockResolvedValue("step-result");
     const mockRetryStrategy = jest
       .fn()
-      .mockReturnValue({ shouldRetry: true, delaySeconds: 10 });
+      .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics
     stepHandler("test-step", stepFn, {
@@ -357,7 +357,7 @@ describe("Step Handler", () => {
     const stepFn = jest.fn().mockRejectedValue(error);
     const mockRetryStrategy = jest
       .fn()
-      .mockReturnValue({ shouldRetry: true, delaySeconds: 10 });
+      .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler but don't await it (it will never resolve)
     stepHandler("test-step", stepFn, {
@@ -392,7 +392,7 @@ describe("Step Handler", () => {
 
     (retryPresets.default as jest.Mock).mockReturnValue({
       shouldRetry: true,
-      delaySeconds: 5,
+      delay: { seconds: 5 },
     });
 
     // Call the step handler but don't await it (it will never resolve)
@@ -556,7 +556,7 @@ describe("Step Handler", () => {
     // Mock the default retry strategy
     (retryPresets.default as jest.Mock).mockReturnValue({
       shouldRetry: true,
-      delaySeconds: 5,
+      delay: { seconds: 5 },
     });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics but no custom retry strategy
@@ -649,7 +649,7 @@ describe("Step Handler", () => {
 
     (retryPresets.default as jest.Mock).mockReturnValue({
       shouldRetry: true,
-      delaySeconds: 5,
+      delay: { seconds: 5 },
     });
 
     // Call the step handler without a name
@@ -686,7 +686,7 @@ describe("Step Handler", () => {
     // Mock the default retry strategy
     (retryPresets.default as jest.Mock).mockReturnValue({
       shouldRetry: true,
-      delaySeconds: 5,
+      delay: { seconds: 5 },
     });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics but no name
@@ -751,7 +751,7 @@ describe("Step Handler", () => {
     const stepFn = jest.fn().mockResolvedValue("step-result");
     const mockRetryStrategy = jest
       .fn()
-      .mockReturnValue({ shouldRetry: true, delaySeconds: 10 });
+      .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics
     stepHandler("test-step", stepFn, {
@@ -773,7 +773,7 @@ describe("Step Handler", () => {
     const stepFn = jest.fn().mockRejectedValue(nonErrorObject);
     const mockRetryStrategy = jest
       .fn()
-      .mockReturnValue({ shouldRetry: true, delaySeconds: 10 });
+      .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with custom retry strategy
     stepHandler("test-step", stepFn, {
@@ -805,7 +805,7 @@ describe("Step Handler", () => {
 
     (retryPresets.default as jest.Mock).mockReturnValue({
       shouldRetry: true,
-      delaySeconds: 5,
+      delay: { seconds: 5 },
     });
 
     // Call the step handler with default retry strategy

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
@@ -43,7 +43,7 @@ describe("Step Handler Timing Tests", () => {
       const stepFn = jest.fn().mockRejectedValue(new Error("Test error"));
       const mockRetryStrategy = jest
         .fn()
-        .mockReturnValue({ shouldRetry: true, delaySeconds: 1 });
+        .mockReturnValue({ shouldRetry: true, delay: { seconds: 1 } });
 
       const mockHasRunningOperations = jest.fn().mockReturnValue(false);
 
@@ -142,7 +142,7 @@ describe("Step Handler Timing Tests", () => {
       // Mock retry strategy that decides to retry the interrupted step
       const mockRetryStrategy = jest.fn().mockReturnValue({
         shouldRetry: true,
-        delaySeconds: 2,
+        delay: { seconds: 2 },
       });
 
       // Mock hasRunningOperations to trigger waitForContinuation, then allow execution
@@ -195,7 +195,7 @@ describe("Step Handler Timing Tests", () => {
 
       const mockRetryStrategy = jest
         .fn()
-        .mockReturnValue({ shouldRetry: true, delaySeconds: 1 });
+        .mockReturnValue({ shouldRetry: true, delay: { seconds: 1 } });
 
       const mockHasRunningOperations = jest
         .fn()

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -8,6 +8,7 @@ import {
   StepContext,
   Logger,
 } from "../../types";
+import { durationToSeconds } from "../../utils/duration/duration";
 import {
   terminate,
   terminateForUnrecoverableError,
@@ -193,7 +194,9 @@ export const createStepHandler = (
               currentAttempt,
               shouldRetry: retryDecision.shouldRetry,
               delaySeconds: retryDecision.shouldRetry
-                ? retryDecision.delaySeconds
+                ? retryDecision.delay
+                  ? durationToSeconds(retryDecision.delay)
+                  : undefined
                 : undefined,
             });
 
@@ -222,7 +225,9 @@ export const createStepHandler = (
                 Error: createErrorObjectFromError(error),
                 Name: name,
                 StepOptions: {
-                  NextAttemptDelaySeconds: retryDecision.delaySeconds,
+                  NextAttemptDelaySeconds: retryDecision.delay
+                    ? durationToSeconds(retryDecision.delay)
+                    : 1,
                 },
               });
 
@@ -444,7 +449,9 @@ export const executeStep = async <T>(
       currentAttempt,
       shouldRetry: retryDecision.shouldRetry,
       delaySeconds: retryDecision.shouldRetry
-        ? retryDecision.delaySeconds
+        ? retryDecision.delay
+          ? durationToSeconds(retryDecision.delay)
+          : undefined
         : undefined,
       semantics,
     });
@@ -476,7 +483,9 @@ export const executeStep = async <T>(
         Error: createErrorObjectFromError(error),
         Name: name,
         StepOptions: {
-          NextAttemptDelaySeconds: retryDecision.delaySeconds,
+          NextAttemptDelaySeconds: retryDecision.delay
+            ? durationToSeconds(retryDecision.delay)
+            : 1,
         },
       });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
@@ -262,7 +262,7 @@ describe("WaitForCondition Handler", () => {
         waitStrategy: (state, attempt) => {
           expect(state).toBe("not-ready");
           expect(attempt).toBe(1);
-          return { shouldContinue: true, delaySeconds: 30 };
+          return { shouldContinue: true, delay: { seconds: 30 } };
         },
         initialState: "initial",
       };
@@ -443,7 +443,7 @@ describe("WaitForCondition Handler", () => {
         .fn()
         .mockResolvedValue("not-ready");
       const config: WaitForConditionConfig<string> = {
-        waitStrategy: () => ({ shouldContinue: true, delaySeconds: 30 }),
+        waitStrategy: () => ({ shouldContinue: true, delay: { seconds: 30 } }),
         initialState: "initial",
       };
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
@@ -65,7 +65,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
 
       const config: WaitForConditionConfig<{ complete: boolean }> = {
         initialState: { complete: false },
-        waitStrategy: () => ({ shouldContinue: true, delaySeconds: 1 }),
+        waitStrategy: () => ({ shouldContinue: true, delay: { seconds: 1 } }),
       };
 
       const mockHasRunningOperations = jest.fn().mockReturnValue(false);
@@ -118,7 +118,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
 
       const config: WaitForConditionConfig<{ complete: boolean }> = {
         initialState: { complete: false },
-        waitStrategy: () => ({ shouldContinue: false, delaySeconds: 0 }),
+        waitStrategy: () => ({ shouldContinue: false, delay: { seconds: 0 } }),
       };
 
       // Mock hasRunningOperations to return true initially (to trigger waitForContinuation)
@@ -164,7 +164,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         initialState: { count: 0 },
         waitStrategy: (state, _attempt) => ({
           shouldContinue: state.count < 2, // Continue until count reaches 2
-          delaySeconds: 1,
+          delay: { seconds: 1 },
         }),
       };
 
@@ -238,7 +238,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         initialState: { progress: 0 },
         waitStrategy: (state, _attempt) => ({
           shouldContinue: state.progress < 100,
-          delaySeconds: 2,
+          delay: { seconds: 2 },
         }),
       };
 
@@ -303,7 +303,7 @@ describe("WaitForCondition Handler Timing Tests", () => {
         initialState: { attempts: 0 },
         waitStrategy: (state) => ({
           shouldContinue: state.attempts < 3,
-          delaySeconds: 1,
+          delay: { seconds: 1 },
         }),
       };
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -7,6 +7,7 @@ import {
   WaitForConditionContext,
   Logger,
 } from "../../types";
+import { durationToSeconds } from "../../utils/duration/duration";
 import { terminate } from "../../utils/termination-helper/termination-helper";
 import {
   OperationAction,
@@ -316,7 +317,9 @@ export const executeWaitForCondition = async <T>(
       name,
       currentAttempt: currentAttempt,
       shouldContinue: decision.shouldContinue,
-      delaySeconds: decision.shouldContinue ? decision.delaySeconds : undefined,
+      delaySeconds: decision.shouldContinue
+        ? durationToSeconds(decision.delay)
+        : undefined,
     });
 
     if (!decision.shouldContinue) {
@@ -351,7 +354,7 @@ export const executeWaitForCondition = async <T>(
         Payload: serializedState, // Just the state, not wrapped in an object
         Name: name,
         StepOptions: {
-          NextAttemptDelaySeconds: decision.delaySeconds,
+          NextAttemptDelaySeconds: durationToSeconds(decision.delay),
         },
       });
 

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -238,7 +238,7 @@ export interface DurableContext {
    *       if (state.status === "completed") {
    *         return { shouldContinue: false };
    *       }
-   *       return { shouldContinue: true, delaySeconds: Math.min(attempt * 2, 60) };
+   *       return { shouldContinue: true, delay: { seconds: Math.min(attempt * 2, 60) } };
    *     }
    *   }
    * );
@@ -264,7 +264,7 @@ export interface DurableContext {
    *   {
    *     initialState: { requestId: "req-456", ready: false },
    *     waitStrategy: (state, attempt) =>
-   *       state.ready ? { shouldContinue: false } : { shouldContinue: true, delaySeconds: 10 }
+   *       state.ready ? { shouldContinue: false } : { shouldContinue: true, delay: { seconds: 10 } }
    *   }
    * );
    * ```

--- a/packages/aws-durable-execution-sdk-js/src/types/step.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/step.ts
@@ -1,9 +1,10 @@
 import { Serdes } from "../utils/serdes/serdes";
 import { StepContext } from "./logger";
+import { Duration } from "../types";
 
 export interface RetryDecision {
   shouldRetry: boolean;
-  delaySeconds?: number;
+  delay?: Duration;
 }
 
 export enum StepSemantics {

--- a/packages/aws-durable-execution-sdk-js/src/types/wait-condition.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/wait-condition.ts
@@ -1,5 +1,6 @@
 import { Serdes } from "../utils/serdes/serdes";
 import { WaitForConditionContext } from "./logger";
+import { Duration } from "../types";
 
 /**
  * Function that checks and updates state for waitForCondition operations
@@ -27,7 +28,7 @@ export type WaitForConditionWaitStrategyFunc<T> = (
  * Decision object for waitForCondition wait strategy
  */
 export type WaitForConditionDecision =
-  | { shouldContinue: true; delaySeconds: number }
+  | { shouldContinue: true; delay: Duration }
   | { shouldContinue: false };
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.test.ts
@@ -10,16 +10,18 @@ describe("RetryStrategy", () => {
       const decision1 = strategy(error, 1);
       expect(decision1.shouldRetry).toBe(true);
       if (decision1.shouldRetry) {
-        expect(decision1.delaySeconds).toBeGreaterThanOrEqual(1); // Min 1 second
-        expect(decision1.delaySeconds).toBeLessThanOrEqual(5); // Max 5 seconds (FULL jitter)
+        expect(decision1.delay).not.toBeUndefined();
+        expect(decision1.delay!.seconds).toBeGreaterThanOrEqual(1); // Min 1 second
+        expect(decision1.delay!.seconds).toBeLessThanOrEqual(5); // Max 5 seconds (FULL jitter)
       }
 
       // Second attempt should retry
       const decision2 = strategy(error, 2);
       expect(decision2.shouldRetry).toBe(true);
       if (decision2.shouldRetry) {
-        expect(decision2.delaySeconds).toBeGreaterThanOrEqual(1); // Min 1 second
-        expect(decision2.delaySeconds).toBeLessThanOrEqual(10); // Max 10 seconds (FULL jitter)
+        expect(decision2.delay).not.toBeUndefined();
+        expect(decision2.delay!.seconds).toBeGreaterThanOrEqual(1); // Min 1 second
+        expect(decision2.delay!.seconds).toBeLessThanOrEqual(10); // Max 10 seconds (FULL jitter)
       }
 
       // Third attempt should not retry (maxAttempts = 3)
@@ -42,7 +44,7 @@ describe("RetryStrategy", () => {
 
     it("should respect custom initialDelaySeconds", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.NONE,
       });
       const error = new Error("Test error");
@@ -50,13 +52,14 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBe(10);
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBe(10);
       }
     });
 
     it("should respect custom backoffRate", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 5,
+        initialDelay: { seconds: 5 },
         backoffRate: 3,
         jitter: JitterStrategy.NONE,
       });
@@ -66,21 +69,23 @@ describe("RetryStrategy", () => {
       const decision1 = strategy(error, 1);
       expect(decision1.shouldRetry).toBe(true);
       if (decision1.shouldRetry) {
-        expect(decision1.delaySeconds).toBe(5);
+        expect(decision1.delay).not.toBeUndefined();
+        expect(decision1.delay!.seconds).toBe(5);
       }
 
       // Second attempt: 5 * 3 = 15 seconds
       const decision2 = strategy(error, 2);
       expect(decision2.shouldRetry).toBe(true);
       if (decision2.shouldRetry) {
-        expect(decision2.delaySeconds).toBe(15);
+        expect(decision2.delay).not.toBeUndefined();
+        expect(decision2.delay!.seconds).toBe(15);
       }
     });
 
     it("should respect maxDelaySeconds", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 100,
-        maxDelaySeconds: 150,
+        initialDelay: { seconds: 100 },
+        maxDelay: { seconds: 150 },
         backoffRate: 2,
         jitter: JitterStrategy.NONE,
       });
@@ -90,20 +95,22 @@ describe("RetryStrategy", () => {
       const decision1 = strategy(error, 1);
       expect(decision1.shouldRetry).toBe(true);
       if (decision1.shouldRetry) {
-        expect(decision1.delaySeconds).toBe(100);
+        expect(decision1.delay).not.toBeUndefined();
+        expect(decision1.delay!.seconds).toBe(100);
       }
 
       // Second attempt would be 200 seconds, but capped at 150
       const decision2 = strategy(error, 2);
       expect(decision2.shouldRetry).toBe(true);
       if (decision2.shouldRetry) {
-        expect(decision2.delaySeconds).toBe(150);
+        expect(decision2.delay).not.toBeUndefined();
+        expect(decision2.delay!.seconds).toBe(150);
       }
     });
 
     it("should apply FULL jitter correctly", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.FULL,
       });
       const error = new Error("Test error");
@@ -111,14 +118,16 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBeGreaterThanOrEqual(1); // Min 1 second
-        expect(decision.delaySeconds).toBeLessThanOrEqual(10); // Max delay
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1); // Min 1 second
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBeLessThanOrEqual(10); // Max delay
       }
     });
 
     it("should apply HALF jitter correctly", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.HALF,
       });
       const error = new Error("Test error");
@@ -126,14 +135,16 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBeGreaterThanOrEqual(5); // delay/2
-        expect(decision.delaySeconds).toBeLessThanOrEqual(10); // delay
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBeGreaterThanOrEqual(5); // delay/2
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBeLessThanOrEqual(10); // delay
       }
     });
 
     it("should apply NONE jitter correctly", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.NONE,
       });
       const error = new Error("Test error");
@@ -141,13 +152,14 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBe(10); // Exact delay
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBe(10); // Exact delay
       }
     });
 
     it("should handle invalid jitter strategy by returning delay unchanged", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: "INVALID" as any, // Force invalid value
       });
       const error = new Error("Test error");
@@ -155,7 +167,8 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBe(10); // Should return delay unchanged
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBe(10); // Should return delay unchanged
       }
     });
 
@@ -225,7 +238,7 @@ describe("RetryStrategy", () => {
 
     it("should ensure minimum delay of 1 second", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 2,
+        initialDelay: { seconds: 2 },
         jitter: JitterStrategy.FULL,
       });
       const error = new Error("Test error");
@@ -235,14 +248,15 @@ describe("RetryStrategy", () => {
         const decision = strategy(error, 1);
         expect(decision.shouldRetry).toBe(true);
         if (decision.shouldRetry) {
-          expect(decision.delaySeconds).toBeGreaterThanOrEqual(1);
+          expect(decision.delay).not.toBeUndefined();
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1);
         }
       }
     });
 
     it("should round delay to whole seconds", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 1.7,
+        initialDelay: { seconds: 1.7 },
         jitter: JitterStrategy.NONE,
       });
       const error = new Error("Test error");
@@ -250,13 +264,14 @@ describe("RetryStrategy", () => {
       const decision = strategy(error, 1);
       expect(decision.shouldRetry).toBe(true);
       if (decision.shouldRetry) {
-        expect(decision.delaySeconds).toBe(2); // 1.7 rounded to 2
+        expect(decision.delay).not.toBeUndefined();
+        expect(decision.delay!.seconds).toBe(2); // 1.7 rounded to 2
       }
     });
 
     it("should always return integer delays >= 1", () => {
       const strategy = createRetryStrategy({
-        initialDelaySeconds: 0.3, // Very small delay
+        initialDelay: { seconds: 0.3 }, // Very small delay
         jitter: JitterStrategy.FULL,
       });
       const error = new Error("Test error");
@@ -266,8 +281,9 @@ describe("RetryStrategy", () => {
         const decision = strategy(error, 1);
         expect(decision.shouldRetry).toBe(true);
         if (decision.shouldRetry) {
-          expect(Number.isInteger(decision.delaySeconds)).toBe(true);
-          expect(decision.delaySeconds).toBeGreaterThanOrEqual(1);
+          expect(decision.delay).not.toBeUndefined();
+          expect(Number.isInteger(decision.delay!.seconds)).toBe(true);
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1);
         }
       }
     });

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
@@ -27,8 +27,8 @@ export const retryPresets = {
    */
   default: createRetryStrategy({
     maxAttempts: 6,
-    initialDelaySeconds: 5,
-    maxDelaySeconds: 60,
+    initialDelay: { seconds: 5 },
+    maxDelay: { seconds: 60 },
     backoffRate: 2,
     jitter: JitterStrategy.FULL,
   }),

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.test.ts
@@ -22,7 +22,7 @@ describe("createWaitStrategy", () => {
 
       expect(decision.shouldContinue).toBe(true);
       if (decision.shouldContinue) {
-        expect(decision.delaySeconds).toBeGreaterThan(0);
+        expect(decision.delay.seconds).toBeGreaterThan(0);
       }
     });
   });
@@ -38,8 +38,8 @@ describe("createWaitStrategy", () => {
       expect(decision.shouldContinue).toBe(true);
       if (decision.shouldContinue) {
         // Default initialDelaySeconds is 5 with FULL jitter (0 to 5)
-        expect(decision.delaySeconds).toBeGreaterThanOrEqual(1); // Min 1 second
-        expect(decision.delaySeconds).toBeLessThanOrEqual(5); // Max 5 seconds
+        expect(decision.delay.seconds).toBeGreaterThanOrEqual(1); // Min 1 second
+        expect(decision.delay.seconds).toBeLessThanOrEqual(5); // Max 5 seconds
       }
     });
 
@@ -76,7 +76,7 @@ describe("createWaitStrategy", () => {
 
     it("should use custom initialDelaySeconds", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.NONE, // Remove jitter for predictable testing
         shouldContinuePolling: () => true,
       });
@@ -84,14 +84,14 @@ describe("createWaitStrategy", () => {
       const decision = strategy("test", 1);
 
       if (decision.shouldContinue) {
-        expect(decision.delaySeconds).toBe(10);
+        expect(decision.delay.seconds).toBe(10);
       }
     });
 
     it("should use custom maxDelaySeconds", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 100,
-        maxDelaySeconds: 50,
+        initialDelay: { seconds: 100 },
+        maxDelay: { seconds: 50 },
         backoffRate: 2,
         jitter: JitterStrategy.NONE, // Remove jitter for predictable testing
         shouldContinuePolling: () => true,
@@ -101,13 +101,13 @@ describe("createWaitStrategy", () => {
 
       if (decision.shouldContinue) {
         // Should be capped at maxDelaySeconds
-        expect(decision.delaySeconds).toBe(50);
+        expect(decision.delay.seconds).toBe(50);
       }
     });
 
     it("should use custom backoffRate", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         backoffRate: 3,
         jitter: JitterStrategy.NONE, // Remove jitter for predictable testing
         shouldContinuePolling: () => true,
@@ -122,9 +122,9 @@ describe("createWaitStrategy", () => {
         decision2.shouldContinue &&
         decision3.shouldContinue
       ) {
-        expect(decision1.delaySeconds).toBe(10); // 10 * 3^0 = 10
-        expect(decision2.delaySeconds).toBe(30); // 10 * 3^1 = 30
-        expect(decision3.delaySeconds).toBe(90); // 10 * 3^2 = 90
+        expect(decision1.delay.seconds).toBe(10); // 10 * 3^0 = 10
+        expect(decision2.delay.seconds).toBe(30); // 10 * 3^1 = 30
+        expect(decision3.delay.seconds).toBe(90); // 10 * 3^2 = 90
       }
     });
   });
@@ -132,7 +132,7 @@ describe("createWaitStrategy", () => {
   describe("Exponential backoff", () => {
     it("should implement exponential backoff correctly", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 2,
+        initialDelay: { seconds: 2 },
         backoffRate: 2,
         jitter: JitterStrategy.NONE, // Remove jitter for predictable testing
         shouldContinuePolling: () => true,
@@ -149,17 +149,17 @@ describe("createWaitStrategy", () => {
         decision3.shouldContinue &&
         decision4.shouldContinue
       ) {
-        expect(decision1.delaySeconds).toBe(2); // 2 * 2^0 = 2
-        expect(decision2.delaySeconds).toBe(4); // 2 * 2^1 = 4
-        expect(decision3.delaySeconds).toBe(8); // 2 * 2^2 = 8
-        expect(decision4.delaySeconds).toBe(16); // 2 * 2^3 = 16
+        expect(decision1.delay.seconds).toBe(2); // 2 * 2^0 = 2
+        expect(decision2.delay.seconds).toBe(4); // 2 * 2^1 = 4
+        expect(decision3.delay.seconds).toBe(8); // 2 * 2^2 = 8
+        expect(decision4.delay.seconds).toBe(16); // 2 * 2^3 = 16
       }
     });
 
     it("should cap delay at maxDelaySeconds", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
-        maxDelaySeconds: 25,
+        initialDelay: { seconds: 10 },
+        maxDelay: { seconds: 25 },
         backoffRate: 2,
         jitter: JitterStrategy.NONE, // Remove jitter for predictable testing
         shouldContinuePolling: () => true,
@@ -174,9 +174,9 @@ describe("createWaitStrategy", () => {
         decision2.shouldContinue &&
         decision3.shouldContinue
       ) {
-        expect(decision1.delaySeconds).toBe(10); // 10 * 2^0 = 10
-        expect(decision2.delaySeconds).toBe(20); // 10 * 2^1 = 20
-        expect(decision3.delaySeconds).toBe(25); // 10 * 2^2 = 40, capped at 25
+        expect(decision1.delay.seconds).toBe(10); // 10 * 2^0 = 10
+        expect(decision2.delay.seconds).toBe(20); // 10 * 2^1 = 20
+        expect(decision3.delay.seconds).toBe(25); // 10 * 2^2 = 40, capped at 25
       }
     });
   });
@@ -184,7 +184,7 @@ describe("createWaitStrategy", () => {
   describe("Jitter", () => {
     it("should apply FULL jitter to delay", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.FULL,
         shouldContinuePolling: () => true,
       });
@@ -194,7 +194,7 @@ describe("createWaitStrategy", () => {
       for (let i = 0; i < 10; i++) {
         const decision = strategy("test", 1);
         if (decision.shouldContinue) {
-          delays.push(decision.delaySeconds);
+          delays.push(decision.delay.seconds);
         }
       }
 
@@ -211,7 +211,7 @@ describe("createWaitStrategy", () => {
 
     it("should apply HALF jitter to delay", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.HALF,
         shouldContinuePolling: () => true,
       });
@@ -221,7 +221,7 @@ describe("createWaitStrategy", () => {
       for (let i = 0; i < 10; i++) {
         const decision = strategy("test", 1);
         if (decision.shouldContinue) {
-          delays.push(decision.delaySeconds);
+          delays.push(decision.delay.seconds);
         }
       }
 
@@ -238,7 +238,7 @@ describe("createWaitStrategy", () => {
 
     it("should apply NONE jitter (no randomness)", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         jitter: JitterStrategy.NONE,
         shouldContinuePolling: () => true,
       });
@@ -248,7 +248,7 @@ describe("createWaitStrategy", () => {
       for (let i = 0; i < 10; i++) {
         const decision = strategy("test", 1);
         if (decision.shouldContinue) {
-          delays.push(decision.delaySeconds);
+          delays.push(decision.delay.seconds);
         }
       }
 
@@ -264,7 +264,7 @@ describe("createWaitStrategy", () => {
 
     it("should ensure minimum delay of 1 second even with negative jitter", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 1,
+        initialDelay: { seconds: 1 },
         jitter: JitterStrategy.FULL, // Could make delay negative
         shouldContinuePolling: () => true,
       });
@@ -273,7 +273,7 @@ describe("createWaitStrategy", () => {
       for (let i = 0; i < 20; i++) {
         const decision = strategy("test", 1);
         if (decision.shouldContinue) {
-          expect(decision.delaySeconds).toBeGreaterThanOrEqual(1);
+          expect(decision.delay.seconds).toBeGreaterThanOrEqual(1);
         }
       }
     });
@@ -356,7 +356,7 @@ describe("createWaitStrategy", () => {
   describe("Edge cases", () => {
     it("should handle attempt number 1 correctly", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         backoffRate: 2,
         jitter: JitterStrategy.NONE,
         shouldContinuePolling: () => true,
@@ -366,13 +366,13 @@ describe("createWaitStrategy", () => {
 
       if (decision.shouldContinue) {
         // First attempt should use initialDelaySeconds without backoff
-        expect(decision.delaySeconds).toBe(10);
+        expect(decision.delay.seconds).toBe(10);
       }
     });
 
     it("should handle zero jitter", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 5,
+        initialDelay: { seconds: 5 },
         jitter: JitterStrategy.NONE,
         shouldContinuePolling: () => true,
       });
@@ -380,13 +380,13 @@ describe("createWaitStrategy", () => {
       const decision = strategy("test", 1);
 
       if (decision.shouldContinue) {
-        expect(decision.delaySeconds).toBe(5);
+        expect(decision.delay.seconds).toBe(5);
       }
     });
 
     it("should handle backoffRate of 1 (no exponential growth)", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 10,
+        initialDelay: { seconds: 10 },
         backoffRate: 1,
         jitter: JitterStrategy.NONE,
         shouldContinuePolling: () => true,
@@ -402,15 +402,15 @@ describe("createWaitStrategy", () => {
         decision3.shouldContinue
       ) {
         // All should be the same with backoffRate = 1
-        expect(decision1.delaySeconds).toBe(10);
-        expect(decision2.delaySeconds).toBe(10);
-        expect(decision3.delaySeconds).toBe(10);
+        expect(decision1.delay.seconds).toBe(10);
+        expect(decision2.delay.seconds).toBe(10);
+        expect(decision3.delay.seconds).toBe(10);
       }
     });
 
     it("should round delay to nearest integer", () => {
       const strategy = createWaitStrategy({
-        initialDelaySeconds: 1.7,
+        initialDelay: { seconds: 1.7 },
         backoffRate: 1.5,
         jitter: JitterStrategy.NONE,
         shouldContinuePolling: () => true,
@@ -420,8 +420,8 @@ describe("createWaitStrategy", () => {
 
       if (decision.shouldContinue) {
         // 1.7 * 1.5^1 = 2.55, should be rounded
-        expect(decision.delaySeconds).toBe(3);
-        expect(Number.isInteger(decision.delaySeconds)).toBe(true);
+        expect(decision.delay.seconds).toBe(3);
+        expect(Number.isInteger(decision.delay.seconds)).toBe(true);
       }
     });
   });
@@ -435,8 +435,8 @@ describe("createWaitStrategy", () => {
 
       const strategy = createWaitStrategy({
         maxAttempts: 30,
-        initialDelaySeconds: 15,
-        maxDelaySeconds: 60,
+        initialDelay: { seconds: 15 },
+        maxDelay: { seconds: 60 },
         backoffRate: 1.2,
         shouldContinuePolling: (result: StackStatus) =>
           !["CREATE_COMPLETE", "CREATE_FAILED"].includes(result.status),
@@ -473,8 +473,8 @@ describe("createWaitStrategy", () => {
 
       const strategy = createWaitStrategy({
         maxAttempts: 100,
-        initialDelaySeconds: 5,
-        maxDelaySeconds: 30,
+        initialDelay: { seconds: 5 },
+        maxDelay: { seconds: 30 },
         shouldContinuePolling: (result: JobStatus) =>
           !["COMPLETED", "FAILED"].includes(result.status),
       });
@@ -497,7 +497,7 @@ describe("createWaitStrategy", () => {
     it("should work for simple boolean conditions", () => {
       const strategy = createWaitStrategy({
         maxAttempts: 5,
-        initialDelaySeconds: 2,
+        initialDelay: { seconds: 2 },
         shouldContinuePolling: (isReady: boolean) => !isReady,
       });
 


### PR DESCRIPTION
    - Updated RetryDecision and WaitForConditionDecision interfaces to use Duration
    - use Duration objects instead of delaySeconds in retry config
    - Updated all example files to use new Duration interface format

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
