### PR TITLE
feat(sdk): replace timeout number fields with Duration interface

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/concurrent/create-callback-concurrent.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/concurrent/create-callback-concurrent.ts
@@ -14,13 +14,13 @@ export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
     // Start multiple callbacks concurrently
     const [promise1] = await context.createCallback("api-call-1", {
-      timeout: 300,
+      timeout: { minutes: 5 },
     });
     const [promise2] = await context.createCallback("api-call-2", {
-      timeout: 300,
+      timeout: { minutes: 5 },
     });
     const [promise3] = await context.createCallback("api-call-3", {
-      timeout: 300,
+      timeout: { minutes: 5 },
     });
 
     const [result1, result2, result3] = await Promise.all([

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.ts
@@ -18,7 +18,7 @@ export const handler = withDurableExecution(
         const [callbackPromise] = await context.createCallback(
           "failing-operation",
           {
-            timeout: 60,
+            timeout: { seconds: 60 },
           },
         );
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/heartbeat/create-callback-heartbeat.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/heartbeat/create-callback-heartbeat.ts
@@ -20,7 +20,7 @@ export const handler = withDurableExecution(
     const [callbackPromise] = await context.createCallback(
       "long-running-task",
       {
-        heartbeatTimeout: event.isCloud ? 30 : 1,
+        heartbeatTimeout: event.isCloud ? { seconds: 30 } : { seconds: 1 },
       },
     );
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/mixed-ops/create-callback-mixed-ops.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/mixed-ops/create-callback-mixed-ops.ts
@@ -17,7 +17,7 @@ export const handler = withDurableExecution(
     });
 
     const [callbackPromise] = await context.createCallback("process-user", {
-      timeout: 300,
+      timeout: { minutes: 5 },
     });
 
     // Mix callback with step and wait operations

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/serdes/create-callback-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/serdes/create-callback-serdes.ts
@@ -49,7 +49,7 @@ export const handler = withDurableExecution(
     const [callbackPromise] = await context.createCallback<CustomData>(
       "custom-serdes-callback",
       {
-        timeout: 300,
+        timeout: { minutes: 5 },
         serdes: customSerdes,
       },
     );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/timeout/create-callback-timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/timeout/create-callback-timeout.ts
@@ -20,8 +20,8 @@ export const handler = withDurableExecution(
     const [callbackPromise] = await context.createCallback(
       "long-running-task",
       event.timeoutType === "heartbeat"
-        ? { heartbeatTimeout: 1 }
-        : { timeout: 1 },
+        ? { heartbeatTimeout: { seconds: 1 } }
+        : { timeout: { seconds: 1 } },
     );
 
     const result = await callbackPromise;

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/basic/wait-for-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/basic/wait-for-callback.ts
@@ -20,7 +20,7 @@ export const handler = withDurableExecution(
       "my callback function",
       mySubmitterFunction,
       {
-        timeout: 5,
+        timeout: { seconds: 5 },
       },
     );
     console.log("Hello world after callback!");

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/heartbeat-sends/wait-for-callback-heartbeat-sends.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/heartbeat-sends/wait-for-callback-heartbeat-sends.ts
@@ -26,7 +26,7 @@ export const handler = withDurableExecution(
         return Promise.resolve();
       },
       {
-        heartbeatTimeout: event.isCloud ? 15 : 1,
+        heartbeatTimeout: event.isCloud ? { seconds: 15 } : { seconds: 1 },
       },
     );
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/serdes/wait-for-callback-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/serdes/wait-for-callback-serdes.ts
@@ -66,7 +66,7 @@ export const handler = withDurableExecution(
       },
       {
         serdes: customSerdes,
-        timeout: 300,
+        timeout: { minutes: 5 },
       },
     );
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/timeout/wait-for-callback-timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/timeout/wait-for-callback-timeout.ts
@@ -18,7 +18,7 @@ export const handler = withDurableExecution(
           return Promise.resolve();
         },
         {
-          timeout: 1, // 1 second timeout
+          timeout: { seconds: 1 }, // 1 second timeout
         },
       );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -303,7 +303,7 @@ describe("Callback Handler", () => {
 
       const config: CreateCallbackConfig<string> = {
         serdes: customSerdes,
-        timeout: 300,
+        timeout: { minutes: 5 },
       };
 
       const [promise, callbackId] = await callbackHandler<string>(
@@ -717,8 +717,8 @@ describe("Callback Handler", () => {
       });
 
       const config: CreateCallbackConfig<string> = {
-        timeout: 300,
-        heartbeatTimeout: 60,
+        timeout: { minutes: 5 },
+        heartbeatTimeout: { seconds: 60 },
       };
 
       const [, callbackId] = await callbackHandler<string>(
@@ -826,7 +826,7 @@ describe("Callback Handler", () => {
       });
 
       const config: CreateCallbackConfig<string> = {
-        timeout: 120,
+        timeout: { minutes: 2 },
       };
 
       const [, callbackId] = await callbackHandler<string>(
@@ -862,8 +862,8 @@ describe("Callback Handler", () => {
       });
 
       const config: CreateCallbackConfig<string> = {
-        timeout: 180,
-        heartbeatTimeout: 30,
+        timeout: { minutes: 3 },
+        heartbeatTimeout: { seconds: 30 },
       };
 
       const [, callbackId] = await callbackHandler<string>(config);
@@ -884,7 +884,7 @@ describe("Callback Handler", () => {
     });
 
     test("should accept undefined as name parameter", async () => {
-      const config: CreateCallbackConfig<string> = { timeout: 300 };
+      const config: CreateCallbackConfig<string> = { timeout: { minutes: 5 } };
 
       mockExecutionContext._stepData = {};
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -15,6 +15,7 @@ import { CallbackError } from "../../errors/durable-error/durable-error";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
+import { durationToSeconds } from "../../utils/duration/duration";
 
 const createPassThroughSerdes = <T>(): Serdes<T> => ({
   serialize: async (value: T | undefined) => value as string | undefined,
@@ -354,8 +355,12 @@ const createNewCallback = async <T>(
     Type: OperationType.CALLBACK,
     Name: name,
     CallbackOptions: {
-      TimeoutSeconds: config?.timeout,
-      HeartbeatTimeoutSeconds: config?.heartbeatTimeout,
+      TimeoutSeconds: config?.timeout
+        ? durationToSeconds(config.timeout)
+        : undefined,
+      HeartbeatTimeoutSeconds: config?.heartbeatTimeout
+        ? durationToSeconds(config.heartbeatTimeout)
+        : undefined,
     },
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
@@ -160,7 +160,7 @@ describe("waitForCallback handler", () => {
       mockRunInChildContext,
     );
 
-    const config = { timeout: 300 };
+    const config = { timeout: { minutes: 5 } };
 
     // Should throw error when name is provided but second parameter is not a function
     await expect(handler("test-name", config as any)).rejects.toThrow(
@@ -309,8 +309,8 @@ describe("waitForCallback handler", () => {
 
   it("should pass config to createCallback when submitter and config are provided", async () => {
     const config: WaitForCallbackConfig<string> = {
-      timeout: 300,
-      heartbeatTimeout: 30,
+      timeout: { minutes: 5 },
+      heartbeatTimeout: { seconds: 30 },
     };
     const submitter = jest.fn().mockResolvedValue(undefined);
     const expectedResult = "config result";
@@ -367,8 +367,8 @@ describe("waitForCallback handler", () => {
 
     expect(result).toBe(expectedResult);
     expect(capturedConfig).toEqual({
-      timeout: 300,
-      heartbeatTimeout: 30,
+      timeout: { minutes: 5 },
+      heartbeatTimeout: { seconds: 30 },
       serdes: undefined,
     });
     expect(submitter).toHaveBeenCalledWith(

--- a/packages/aws-durable-execution-sdk-js/src/types/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/callback.ts
@@ -1,15 +1,16 @@
 import { Serdes } from "../utils/serdes/serdes";
 import { RetryDecision } from "./step";
 import { WaitForCallbackContext } from "./logger";
+import { Duration } from "./core";
 
 /**
  * Configuration options for createCallback operations
  */
 export interface CreateCallbackConfig<T> {
-  /** Maximum time to wait for callback submission in seconds */
-  timeout?: number;
-  /** Heartbeat timeout in seconds to detect stalled callback operations */
-  heartbeatTimeout?: number;
+  /** Maximum time to wait for callback submission */
+  timeout?: Duration;
+  /** Heartbeat timeout to detect stalled callback operations */
+  heartbeatTimeout?: Duration;
   /** Serialization/deserialization configuration for callback data */
   serdes?: Serdes<T>;
 }
@@ -18,10 +19,10 @@ export interface CreateCallbackConfig<T> {
  * Configuration options for waitForCallback operations
  */
 export interface WaitForCallbackConfig<T> {
-  /** Maximum time to wait for callback in seconds */
-  timeout?: number;
-  /** Heartbeat timeout in seconds to detect stalled operations */
-  heartbeatTimeout?: number;
+  /** Maximum time to wait for callback */
+  timeout?: Duration;
+  /** Heartbeat timeout to detect stalled operations */
+  heartbeatTimeout?: Duration;
   /** Strategy for retrying failed callback submissions */
   retryStrategy?: (error: Error, attemptCount: number) => RetryDecision;
   /** Serialization/deserialization configuration for callback data */

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -284,7 +284,7 @@ export interface DurableContext {
    * ```typescript
    * const [callbackPromise, callbackId] = await context.createCallback(
    *   "external-approval",
-   *   { timeout: 3600 } // 1 hour timeout
+   *   { timeout: { hours: 1 } } // 1 hour timeout
    * );
    *
    * // Send callback ID to external system
@@ -307,7 +307,7 @@ export interface DurableContext {
    * @example
    * ```typescript
    * const [promise, callbackId] = await context.createCallback({
-   *   timeout: 1800 // 30 minutes
+   *   timeout: { minutes: 30 } // 30 minutes
    * });
    * await notifyExternalSystem(callbackId);
    * const result = await promise;
@@ -331,7 +331,7 @@ export interface DurableContext {
    *     // Submit callback ID to external system
    *     await submitToExternalAPI(callbackId);
    *   },
-   *   { timeout: 300 }
+   *   { timeout: { minutes: 5 } }
    * );
    * ```
    */


### PR DESCRIPTION
    - Update CreateCallbackConfig and WaitForCallbackConfig to use Duration instead of number for timeout and heartbeatTimeout fields
    - Add durationToSeconds conversion in callback handlers to maintain AWS API compatibility
    - Update all examples to use Duration objects (e.g., {minutes: 5} instead of 300)
    - Update documentation and JSDoc examples to reflect new Duration usage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
