### PR TITLE
feat(sdk): improve error handling determinism and add examples

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.test.ts
@@ -32,7 +32,7 @@ createTests({
       expect(result.getError()).toEqual({
         errorMessage: "External API failure",
         errorType: "CallbackError",
-        stackTrace: expect.any(Array),
+        stackTrace: undefined,
       });
     });
   },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/timeout/create-callback-timeout.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/timeout/create-callback-timeout.test.ts
@@ -12,9 +12,10 @@ createTests({
       });
 
       expect(result.getError()).toEqual({
+        errorData: undefined,
         errorMessage: "Callback timed out on heartbeat",
         errorType: "CallbackError",
-        stackTrace: expect.any(Array),
+        stackTrace: undefined,
       });
     });
 
@@ -24,9 +25,10 @@ createTests({
       });
 
       expect(result.getError()).toEqual({
+        errorData: undefined,
         errorMessage: "Callback timed out",
         errorType: "CallbackError",
-        stackTrace: expect.any(Array),
+        stackTrace: undefined,
       });
     });
   },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/error-determinism/error-determinism.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/error-determinism/error-determinism.ts
@@ -1,0 +1,88 @@
+import {
+  DurableContext,
+  StepError,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+
+export const config: ExampleConfig = {
+  name: "Error Determinism",
+  description:
+    "Demonstrates deterministic error handling behavior between initial execution and replay",
+};
+
+class CustomBusinessError extends Error {
+  readonly errorCode: string;
+
+  constructor(message: string, errorCode: string) {
+    super(message);
+    this.name = "CustomBusinessError";
+    this.errorCode = errorCode;
+  }
+}
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    let stepError: StepError | null = null;
+
+    // Step throws custom error
+    try {
+      await context.step("failing-step", async () => {
+        throw new CustomBusinessError(
+          "Business validation failed",
+          "VALIDATION_ERROR",
+        );
+      });
+    } catch (error) {
+      stepError = error as StepError;
+    }
+
+    // Check error properties before replay
+    const errorPropsBeforeReplay = await context.step(
+      "check-before-replay",
+      async () => {
+        return {
+          isStepError: stepError instanceof StepError,
+          message: stepError?.message,
+          causeName: stepError?.cause?.name,
+          causeMessage: stepError?.cause?.message,
+          // Note: Custom properties like errorCode are lost during serialization
+          // but error handling is now deterministic between runs
+        };
+      },
+    );
+
+    // Force replay by waiting
+    await context.wait({ seconds: 1 });
+
+    // Check error properties after replay
+    const errorPropsAfterReplay = await context.step(
+      "check-after-replay",
+      async () => {
+        return {
+          isStepError: stepError instanceof StepError,
+          message: stepError?.message,
+          causeName: stepError?.cause?.name,
+          causeMessage: stepError?.cause?.message,
+        };
+      },
+    );
+
+    // Verify deterministic behavior
+    const isDeterministic = await context.step(
+      "verify-determinism",
+      async () => {
+        return (
+          JSON.stringify(errorPropsBeforeReplay) ===
+          JSON.stringify(errorPropsAfterReplay)
+        );
+      },
+    );
+
+    return {
+      isDeterministic,
+      errorPropsBeforeReplay,
+      errorPropsAfterReplay,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/handler-error/handler-error.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/handler-error/handler-error.test.ts
@@ -15,13 +15,7 @@ createTests({
       expect(error).toEqual({
         errorMessage: "Intentional handler failure",
         errorType: "Error",
-        stackTrace: expect.any(Array),
-      });
-
-      // Verify stack trace structure
-      expect(error.stackTrace?.length).toBeGreaterThan(1);
-      error.stackTrace?.forEach((value) => {
-        expect(typeof value).toBe("string");
+        stackTrace: undefined,
       });
 
       // Verify no operations were completed due to early error

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/any/promise-any.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/any/promise-any.test.ts
@@ -29,7 +29,7 @@ createTests<string>({
         errorMessage: "All promises were rejected",
         errorType: "StepError",
         errorData: undefined,
-        stackTrace: expect.any(Array),
+        stackTrace: undefined,
       });
       expect(execution.getOperations()).toHaveLength(4);
     }, 30000);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/retry-exhaustion/retry-exhaustion.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/retry-exhaustion/retry-exhaustion.test.ts
@@ -22,11 +22,7 @@ createTests({
       expect(error).toMatchObject({
         errorType: "StepError",
         errorMessage: "There was an error",
-        stackTrace: expect.any(Array),
-      });
-      expect(error.stackTrace?.length).toBeGreaterThan(1);
-      error.stackTrace?.forEach((value) => {
-        expect(typeof value).toBe("string");
+        stackTrace: undefined,
       });
 
       // Verify operations were tracked

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/with-failing-step/run-in-child-context-failing-step.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/with-failing-step/run-in-child-context-failing-step.ts
@@ -1,6 +1,7 @@
 import {
   ChildContextError,
   DurableContext,
+  StepError,
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 import { ExampleConfig } from "../../../types";
@@ -31,7 +32,10 @@ export const handler = withDurableExecution(
         );
       });
     } catch (error) {
-      if (!(error instanceof ChildContextError)) {
+      if (
+        !(error instanceof ChildContextError) &&
+        !(error instanceof StepError)
+      ) {
         throw error;
       }
     }

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/step-error-determinism/step-error-determinism.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/step-error-determinism/step-error-determinism.test.ts
@@ -1,0 +1,17 @@
+import { handler } from "./step-error-determinism";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  name: "step-error-determinism test",
+  functionName: "step-error-determinism",
+  handler,
+  tests: (runner) => {
+    it("should have deterministic error handling behavior through replay", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult();
+
+      expect(result).toBe(true);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/step-error-determinism/step-error-determinism.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/step-error-determinism/step-error-determinism.ts
@@ -1,0 +1,83 @@
+import {
+  DurableContext,
+  StepError,
+  withDurableExecution,
+  retryPresets,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Step Error Determinism",
+  description:
+    "Tests that error handling behavior is deterministic between initial execution and replay",
+};
+
+class CustomBusinessError extends Error {
+  readonly errorCode: string;
+
+  constructor(message: string, errorCode: string) {
+    super(message);
+    this.name = "CustomBusinessError";
+    this.errorCode = errorCode;
+  }
+}
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    let stepError: StepError | null = null;
+
+    // Step throws custom error
+    try {
+      await context.step(
+        "failing-step",
+        async () => {
+          throw new CustomBusinessError(
+            "Business validation failed",
+            "VALIDATION_ERROR",
+          );
+        },
+        { retryStrategy: retryPresets.noRetry },
+      );
+    } catch (error) {
+      stepError = error as StepError;
+    }
+
+    // Check error properties before replay
+    const errorPropsBeforeReplay = await context.step(
+      "check-before-replay",
+      async () => {
+        return {
+          hasError: stepError !== null,
+          errorMessage: stepError?.message,
+          causeMessage: stepError?.cause?.message,
+          causeName: stepError?.cause?.name,
+          // Note: Custom properties like errorCode are lost during serialization
+          // but error handling is now deterministic between runs
+        };
+      },
+      { retryStrategy: retryPresets.noRetry },
+    );
+
+    await context.wait({ seconds: 1 });
+
+    // Check error properties after replay
+    const errorPropsAfterReplay = await context.step(
+      "check-after-replay",
+      async () => {
+        return {
+          hasError: stepError !== null,
+          errorMessage: stepError?.message,
+          causeMessage: stepError?.cause?.message,
+          causeName: stepError?.cause?.name,
+        };
+      },
+      { retryStrategy: retryPresets.noRetry },
+    );
+
+    // Verify deterministic behavior - error properties should be the same
+    return (
+      JSON.stringify(errorPropsBeforeReplay) ===
+      JSON.stringify(errorPropsAfterReplay)
+    );
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.test.ts
@@ -111,20 +111,19 @@ describe("steps-with-retry", () => {
       errorMessage: "Persistent failure",
       errorType: "StepError",
       errorData: undefined,
-      stackTrace: expect.any(Array),
+      stackTrace: undefined,
     };
 
     // Step details contain original Error
     const expectedStepError = {
       errorMessage: "Persistent failure",
       errorType: "Error",
-      stackTrace: expect.any(Array),
+      stackTrace: undefined,
     };
 
     const result = await durableTestRunner.run();
     const error = result.getError();
     expect(error).toEqual(expectedExecutionError);
-    expect(error.stackTrace?.length).toBeGreaterThan(1);
 
     // Verify that step operations were attempted
     const stepOp = durableTestRunner.getOperationByIndex(0);
@@ -141,9 +140,8 @@ describe("steps-with-retry", () => {
     expect(error).toEqual({
       errorMessage: "Item Not Found",
       errorType: "Error",
-      stackTrace: expect.any(Array),
+      stackTrace: undefined,
     });
-    expect(error.stackTrace?.length).toBeGreaterThan(1);
 
     // Verify that multiple operations were created for polling
     const firstStepOp = durableTestRunner.getOperationByIndex(0);

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -43,7 +43,7 @@ import { createContextLoggerFactory } from "../../utils/logger/context-logger";
 import { createDefaultLogger } from "../../utils/logger/default-logger";
 import { createModeAwareLogger } from "../../utils/logger/mode-aware-logger";
 import { EventEmitter } from "events";
-import { OPERATIONS_COMPLETE_EVENT } from "../../utils/constants";
+import { OPERATIONS_COMPLETE_EVENT } from "../../utils/constants/constants";
 
 class DurableContextImpl implements DurableContext {
   private _stepPrefix?: string;

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.test.ts
@@ -41,7 +41,7 @@ describe("DurableOperationError", () => {
         ErrorType: "StepError",
         ErrorMessage: "Step failed",
         ErrorData: "error-data",
-        StackTrace: ["line1", "line2", "line3"],
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/error-determinism.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/error-determinism.integration.test.ts
@@ -120,12 +120,8 @@ describe("Error Determinism Integration Tests", () => {
 
       // Should be serializable for storage
       const errorObject = stepError.toErrorObject();
-      expect(errorObject.StackTrace).toContain(
-        "Error: Database connection failed",
-      );
-      expect(errorObject.StackTrace).toContain(
-        "    at db.connect(db.js:45:12)",
-      );
+      // Stack traces are disabled by default, so StackTrace should be undefined
+      expect(errorObject.StackTrace).toBeUndefined();
     });
 
     it("should handle callback errors with complete error information", () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -296,7 +296,7 @@ describe("Run In Child Context Handler", () => {
 
     await expect(
       runInChildContextHandler(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn, {}),
-    ).rejects.toThrow("Child context failed");
+    ).rejects.toThrow("Unknown error"); // After reconstruction, non-Error objects become "Unknown error"
 
     expect(mockCheckpoint).toHaveBeenCalledTimes(2);
     expect(mockCheckpoint).toHaveBeenNthCalledWith(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -343,9 +343,10 @@ export const executeChildContext = async <T>(
       Name: name,
     });
 
-    throw new ChildContextError(
-      error instanceof Error ? error.message : "Child context failed",
-      error instanceof Error ? error : undefined,
-    );
+    // Reconstruct error from ErrorObject for deterministic behavior
+    const errorObject = createErrorObjectFromError(error);
+    const reconstructedError =
+      DurableOperationError.fromErrorObject(errorObject);
+    throw new ChildContextError(reconstructedError.message, reconstructedError);
   }
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -210,7 +210,7 @@ describe("Step Handler", () => {
         ErrorMessage:
           "The step execution process was initiated but failed to reach completion due to an interruption.",
         ErrorType: "StepInterruptedError",
-        StackTrace: expect.any(Array),
+        StackTrace: undefined, // Stack traces are disabled by default
       }),
       StepOptions: {
         NextAttemptDelaySeconds: 10,
@@ -252,9 +252,10 @@ describe("Step Handler", () => {
       thrownError = error;
     }
 
-    // Verify the final error is StepError wrapping StepInterruptedError
+    // Verify the final error is StepError with reconstructed cause
     expect(thrownError).toBeInstanceOf(StepError);
-    expect(thrownError.cause).toBeInstanceOf(StepInterruptedError);
+    expect(thrownError.cause).toBeInstanceOf(Error);
+    expect(thrownError.cause?.name).toBe("StepInterruptedError");
     expect(thrownError.message).toBe(
       "The step execution process was initiated but failed to reach completion due to an interruption.",
     );
@@ -278,7 +279,7 @@ describe("Step Handler", () => {
         ErrorMessage:
           "The step execution process was initiated but failed to reach completion due to an interruption.",
         ErrorType: "StepInterruptedError",
-        StackTrace: expect.any(Array),
+        StackTrace: undefined, // Stack traces are disabled by default
       }),
     });
   });
@@ -454,7 +455,10 @@ describe("Step Handler", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(StepError);
       expect((error as StepError).message).toBe("original-step-error");
-      expect((error as StepError).cause).toBe(originalError);
+      // After error reconstruction, cause is a new Error instance with same properties
+      expect((error as StepError).cause).toBeInstanceOf(Error);
+      expect((error as StepError).cause?.message).toBe("original-step-error");
+      expect((error as StepError).cause?.name).toBe("Error");
     }
   });
 
@@ -587,7 +591,7 @@ describe("Step Handler", () => {
         ErrorMessage:
           "The step execution process was initiated but failed to reach completion due to an interruption.",
         ErrorType: "StepInterruptedError",
-        StackTrace: expect.any(Array),
+        StackTrace: undefined, // Stack traces are disabled by default
       }),
       StepOptions: {
         NextAttemptDelaySeconds: 5,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -212,8 +212,9 @@ export const createStepHandler = (
                 Name: name,
               });
 
-              // Wrap StepInterruptedError in StepError when retry is exhausted
-              throw new StepError(error.message, error);
+              // Reconstruct error from ErrorObject for deterministic behavior
+              const errorObject = createErrorObjectFromError(error);
+              throw DurableOperationError.fromErrorObject(errorObject);
             } else {
               // Retry
               await checkpoint(stepId, {
@@ -468,10 +469,9 @@ export const executeStep = async <T>(
         Name: name,
       });
 
-      throw new StepError(
-        error instanceof Error ? error.message : "Unknown error",
-        error instanceof Error ? error : undefined,
-      );
+      // Reconstruct error from ErrorObject for deterministic behavior
+      const errorObject = createErrorObjectFromError(error);
+      throw DurableOperationError.fromErrorObject(errorObject);
     } else {
       // Retry
       await checkpoint(stepId, {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
@@ -14,7 +14,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { TerminationReason } from "../../termination-manager/types";
 import { hashId, getStepData } from "../../utils/step-id-utils/step-id-utils";
 import { EventEmitter } from "events";
-import { OPERATIONS_COMPLETE_EVENT } from "../../utils/constants";
+import { OPERATIONS_COMPLETE_EVENT } from "../../utils/constants/constants";
 
 // Mock the logger to avoid console output during tests
 jest.mock("../../utils/logger/logger", () => ({

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -31,6 +31,7 @@ export {
   CallbackError,
   InvokeError,
   ChildContextError,
+  WaitForConditionError,
 } from "./errors/durable-error/durable-error";
 export {
   defaultSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants.ts
@@ -1,5 +1,0 @@
-/**
- * Shared constants to avoid circular dependencies
- */
-
-export const OPERATIONS_COMPLETE_EVENT = "allOperationsComplete";

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared constants to avoid circular dependencies
+ */
+
+export const OPERATIONS_COMPLETE_EVENT = "allOperationsComplete";
+
+/**
+ * Controls whether stack traces are stored in error objects
+ * TODO: Accept this as configuration parameter in the future
+ */
+export const STORE_STACK_TRACES = false;

--- a/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.test.ts
@@ -10,7 +10,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Test error message",
         ErrorType: "Error",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -24,7 +24,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Custom error message",
         ErrorType: "CustomError",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -52,7 +52,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Empty stack error",
         ErrorType: "Error",
-        StackTrace: [""],
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -71,7 +71,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Custom subclass error",
         ErrorType: "CustomError",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -83,7 +83,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Type error message",
         ErrorType: "TypeError",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -95,7 +95,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Reference error message",
         ErrorType: "ReferenceError",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
   });
@@ -111,7 +111,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: "test-data",
         ErrorMessage: "Error with data",
         ErrorType: "Error",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -125,7 +125,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: '{"key": "value", "number": 42}',
         ErrorMessage: "Error with JSON data",
         ErrorType: "Error",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -139,7 +139,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: "",
         ErrorMessage: "Error with empty data",
         ErrorType: "Error",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 
@@ -152,7 +152,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "Error with undefined data",
         ErrorType: "Error",
-        StackTrace: error.stack?.split(/\r?\n/),
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
   });
@@ -239,11 +239,8 @@ describe("createErrorObjectFromError", () => {
 
       const result = createErrorObjectFromError(error);
 
-      expect(result.StackTrace).toEqual([
-        "Error: Multi-line stack error",
-        "    at test (test.js:1:1)",
-        "    at main (main.js:5:5)",
-      ]);
+      // Stack traces are disabled by default
+      expect(result.StackTrace).toBeUndefined();
     });
 
     it("should handle single line stack traces", () => {
@@ -252,7 +249,7 @@ describe("createErrorObjectFromError", () => {
 
       const result = createErrorObjectFromError(error);
 
-      expect(result.StackTrace).toEqual(["Error: Single line error"]);
+      expect(result.StackTrace).toBeUndefined(); // Stack traces are disabled by default
     });
 
     it("should handle stack traces with Windows line endings", () => {
@@ -262,11 +259,8 @@ describe("createErrorObjectFromError", () => {
 
       const result = createErrorObjectFromError(error);
 
-      expect(result.StackTrace).toEqual([
-        "Error: Windows line endings",
-        "    at test (test.js:1:1)",
-        "    at main (main.js:5:5)",
-      ]);
+      // Stack traces are disabled by default
+      expect(result.StackTrace).toBeUndefined();
     });
 
     it("should handle stack traces with mixed line endings", () => {
@@ -276,11 +270,8 @@ describe("createErrorObjectFromError", () => {
 
       const result = createErrorObjectFromError(error);
 
-      expect(result.StackTrace).toEqual([
-        "Error: Mixed line endings",
-        "    at test (test.js:1:1)",
-        "    at main (main.js:5:5)",
-      ]);
+      // Stack traces are disabled by default
+      expect(result.StackTrace).toBeUndefined();
     });
   });
 
@@ -298,10 +289,7 @@ describe("createErrorObjectFromError", () => {
         ErrorData: undefined,
         ErrorMessage: "I look like an error",
         ErrorType: "FakeError",
-        StackTrace: [
-          "FakeError: I look like an error",
-          "    at fake (fake.js:1:1)",
-        ],
+        StackTrace: undefined, // Stack traces are disabled by default
       });
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.ts
@@ -1,5 +1,6 @@
 import { ErrorObject } from "@aws-sdk/client-lambda";
 import { DurableOperationError } from "../../errors/durable-error/durable-error";
+import { STORE_STACK_TRACES } from "../constants/constants";
 
 function isErrorLike(obj: unknown): obj is Error {
   return (
@@ -29,7 +30,7 @@ export function createErrorObjectFromError(
       ErrorData: data,
       ErrorMessage: error.message,
       ErrorType: error.name,
-      StackTrace: error.stack?.split(/\r?\n/),
+      StackTrace: STORE_STACK_TRACES ? error.stack?.split(/\r?\n/) : undefined,
     };
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.test.ts
@@ -2,7 +2,7 @@ import { waitBeforeContinue } from "./wait-before-continue";
 import { ExecutionContext } from "../../types";
 import { OperationStatus, Operation } from "@aws-sdk/client-lambda";
 import { EventEmitter } from "events";
-import { OPERATIONS_COMPLETE_EVENT } from "../constants";
+import { OPERATIONS_COMPLETE_EVENT } from "../constants/constants";
 import { STEP_DATA_UPDATED_EVENT } from "../checkpoint/checkpoint";
 import { hashId } from "../step-id-utils/step-id-utils";
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/wait-before-continue/wait-before-continue.ts
@@ -4,7 +4,7 @@ import {
   STEP_DATA_UPDATED_EVENT,
 } from "../checkpoint/checkpoint";
 import { EventEmitter } from "events";
-import { OPERATIONS_COMPLETE_EVENT } from "../constants";
+import { OPERATIONS_COMPLETE_EVENT } from "../constants/constants";
 import { hashId } from "../step-id-utils/step-id-utils";
 
 export interface WaitBeforeContinueOptions {


### PR DESCRIPTION
- Add WaitForConditionError for proper error type handling
- Fix wait-for-condition-handler to reconstruct errors from ErrorObject
- Add STORE_STACK_TRACES constant to control stack trace storage
- Move constants to dedicated directory structure
- Update all error handling to use proper DurableOperationError reconstruction
- Add comprehensive unit tests for new error handling behavior

This ensures consistent error handling across all durable operations and provides configurable stack trace storage for performance optimization.

*Issue #, if available:*
#219 
#213
#209 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
