### PR TITLE
fix(sdk): measure response size using bytes instead of string length

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
@@ -35,6 +35,7 @@ class CheckpointHandler {
   private readonly MAX_PAYLOAD_SIZE = 750 * 1024; // 750KB in bytes
   private isTerminating = false;
   private pendingCompletions = new Set<string>(); // Track stepIds with pending SUCCEED/FAIL
+  private static textEncoder = new TextEncoder();
 
   constructor(
     private context: ExecutionContext,
@@ -235,7 +236,9 @@ class CheckpointHandler {
 
     while (this.queue.length > 0) {
       const nextItem = this.queue[0];
-      const itemSize = JSON.stringify(nextItem).length;
+      const itemSize = CheckpointHandler.textEncoder.encode(
+        JSON.stringify(nextItem),
+      ).length;
 
       if (currentSize + itemSize > this.MAX_PAYLOAD_SIZE && batch.length > 0) {
         break;

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -127,16 +127,14 @@ async function runHandler<Input, Output>(
 
     // Stringify the result once to avoid multiple JSON.stringify calls
     const serializedResult = JSON.stringify(result);
+    const serializedSize = new TextEncoder().encode(serializedResult).length;
 
     // Check if the response size exceeds the Lambda limit
     // Note: JSON.stringify(undefined) returns undefined, so we need to handle that case
-    if (
-      serializedResult &&
-      serializedResult.length > LAMBDA_RESPONSE_SIZE_LIMIT
-    ) {
+    if (serializedResult && serializedSize > LAMBDA_RESPONSE_SIZE_LIMIT) {
       log(
         "📦",
-        `Response size (${serializedResult.length} bytes) exceeds Lambda limit (${LAMBDA_RESPONSE_SIZE_LIMIT} bytes). Checkpointing result.`,
+        `Response size (${serializedSize} bytes) exceeds Lambda limit (${LAMBDA_RESPONSE_SIZE_LIMIT} bytes). Checkpointing result.`,
       );
 
       // Create a checkpoint handler to save the large result


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/236

*Description of changes:*

These places count with .length, which is inaccurate for unicode. For example \uFFFF has length 1, but byte length 3. This will cause checkpoint errors from passing payloads too large.

These should be using new TextEncoder().encode(string).length to get the proper byte length.

Fixing response size measurement for checkpoint and large payload response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
