### PR TITLE
fix(sdk): correct error reconstruction in BatchResult

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/batch-result-error-determinism/batch-result-error-determinism.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/batch-result-error-determinism/batch-result-error-determinism.test.ts
@@ -1,0 +1,31 @@
+import { handler } from "./batch-result-error-determinism";
+import { createTests } from "../../utils/test-helper";
+
+interface TestResult {
+  initialCauseIsCustomError: boolean;
+  replayCauseIsCustomError: boolean;
+  areEqual: boolean;
+}
+
+createTests<TestResult>({
+  name: "batch-result-error-determinism test",
+  functionName: "batch-result-error-determinism",
+  handler,
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  tests: (runner) => {
+    it("should demonstrate proper error reconstruction in BatchResult", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult();
+
+      console.log("Test result:", result);
+
+      expect(result).toBeDefined();
+      expect(result!.areEqual).toBe(true); // Errors are deterministic
+      expect(result!.initialCauseIsCustomError).toBe(false); // CustomError cause becomes generic Error
+      expect(result!.replayCauseIsCustomError).toBe(false); // Both lose CustomError type consistently
+    }, 30000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/batch-result-error-determinism/batch-result-error-determinism.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/batch-result-error-determinism/batch-result-error-determinism.ts
@@ -1,0 +1,66 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+
+class CustomError extends Error {
+  additionalProperty = 1;
+}
+
+export const config: ExampleConfig = {
+  name: "Batch Result Error Determinism",
+  description: "Testing error determinism in BatchResult from map operations",
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items = ["abc"];
+    const result = await context.map("test", items, async (context) => {
+      throw new CustomError("My error");
+    });
+
+    const error0 = result.failed()[0].error;
+
+    console.log("Initial error:", error0);
+    console.log("Error constructor name:", error0?.constructor.name);
+    console.log("Error errorType property:", (error0 as any)?.errorType);
+    console.log("Error cause:", error0?.cause);
+    console.log("Cause constructor name:", error0?.cause?.constructor?.name);
+    console.log(
+      "Additional property:",
+      (error0?.cause as any)?.additionalProperty,
+    );
+
+    await context.wait({ seconds: 1 });
+
+    const error0AfterReplay = result.failed()[0].error;
+
+    console.log("After replay error:", error0AfterReplay);
+    console.log("Error constructor name:", error0AfterReplay?.constructor.name);
+    console.log(
+      "Error errorType property:",
+      (error0AfterReplay as any)?.errorType,
+    );
+    console.log("Error cause:", error0AfterReplay?.cause);
+    console.log(
+      "Cause constructor name:",
+      error0AfterReplay?.cause?.constructor?.name,
+    );
+    console.log(
+      "Additional property:",
+      (error0AfterReplay?.cause as any)?.additionalProperty,
+    );
+
+    // Check if error types are consistent
+    const initialCauseIsCustomError = error0?.cause instanceof CustomError;
+    const replayCauseIsCustomError =
+      error0AfterReplay?.cause instanceof CustomError;
+
+    return {
+      initialCauseIsCustomError,
+      replayCauseIsCustomError,
+      areEqual: initialCauseIsCustomError === replayCauseIsCustomError,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled-error/promise-all-settled-error.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled-error/promise-all-settled-error.test.ts
@@ -1,0 +1,22 @@
+import { handler } from "./promise-all-settled-error";
+import { createTests } from "../../utils/test-helper";
+
+createTests<boolean>({
+  name: "promise-all-settled test",
+  functionName: "promise-all-settled",
+  handler,
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  tests: (runner) => {
+    it("should maintain error determinism - both checks should return the same value", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult();
+
+      // Both error instanceof checks should return the same value (true)
+      // demonstrating that StepError type is preserved through replay
+      expect(result).toBe(true);
+    }, 30000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled-error/promise-all-settled-error.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise-all-settled-error/promise-all-settled-error.ts
@@ -1,0 +1,38 @@
+import {
+  DurableContext,
+  StepError,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+
+export const config: ExampleConfig = {
+  name: "Promise All Settled with Error",
+  description: "Waiting for all promises to settle with failures",
+};
+
+export const handler = withDurableExecution(
+  async (_event, context: DurableContext) => {
+    const error = Promise.reject(new StepError("My step error"));
+
+    const results = await context.promise.allSettled([error]);
+
+    console.log("results", results[0]);
+
+    const errorIsStepError = await context.step(
+      async () =>
+        results[0].status === "rejected" &&
+        results[0].reason instanceof StepError,
+    );
+
+    await context.wait({ seconds: 1 });
+
+    const errorIsStepError2 = await context.step(
+      async () =>
+        results[0].status === "rejected" &&
+        results[0].reason instanceof StepError,
+    );
+
+    // this should be true, but it's false
+    return errorIsStepError === errorIsStepError2;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -31,7 +31,11 @@ export abstract class DurableOperationError extends Error {
     cause.stack = errorObject.StackTrace?.join("\n");
 
     // Determine error type and create appropriate instance
-    switch (errorObject.ErrorType) {
+    // Check both ErrorType (AWS SDK format) and errorType (internal format)
+    const errorType =
+      errorObject.ErrorType ||
+      (errorObject as ErrorObject & { errorType?: string }).errorType;
+    switch (errorType) {
       case "StepError":
         return new StepError(
           errorObject.ErrorMessage || "Step failed",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.test.ts
@@ -87,9 +87,9 @@ describe("BatchResult", () => {
           {
             index: 1,
             error: {
-              name: "Error",
-              message: "test error",
-              stack: "stack trace",
+              ErrorType: "Error",
+              ErrorMessage: "test error",
+              StackTrace: ["stack trace"],
             },
             status: BatchItemStatus.FAILED,
           },

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
@@ -1,4 +1,6 @@
 import { BatchItemStatus, BatchItem, BatchResult } from "../../types";
+import { DurableOperationError } from "../../errors/durable-error/durable-error";
+import { ErrorObject } from "@aws-sdk/client-lambda";
 
 export class BatchResultImpl<R> implements BatchResult<R> {
   constructor(
@@ -107,7 +109,7 @@ export function restoreBatchResult<R>(data: unknown): BatchResult<R> {
         ...item,
         result: item.result as R,
         error: item.error
-          ? Object.assign(new Error(item.error.message), item.error)
+          ? DurableOperationError.fromErrorObject(item.error as ErrorObject)
           : undefined,
       }),
     );


### PR DESCRIPTION
- Replace Object.assign with DurableOperationError.fromErrorObject in batch-result.ts
- Fix fromErrorObject to check both ErrorType and errorType fields for proper case handling
- Ensure ChildContextError is correctly reconstructed instead of falling back to StepError
- Add batch-result-error-determinism example to demonstrate the fix
- Maintain error determinism across initial execution and replay cycles

*Issue #, if available:*
#238 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
