### PR TITLE
fix(sdk): preserve error types  in BatchResult serialization

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -4,6 +4,7 @@ import {
 } from "./concurrent-execution-handler";
 import { ExecutionContext, DurableContext, BatchItemStatus } from "../../types";
 import { MockBatchResult } from "../../testing/mock-batch-result";
+import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 describe("Concurrent Execution Handler", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
@@ -206,7 +207,7 @@ describe("Concurrent Execution Handler", () => {
         { index: 0, result: "success1", status: BatchItemStatus.SUCCEEDED },
         {
           index: 1,
-          error: new Error("failure"),
+          error: new ChildContextError("failure"),
           status: BatchItemStatus.FAILED,
         },
       ]);
@@ -457,7 +458,7 @@ describe("ConcurrencyController", () => {
         { id: "item-1", data: "data2", index: 1 },
       ];
       const executor = jest.fn();
-      const error = new Error("test error");
+      const error = new ChildContextError("test error");
 
       mockParentContext.runInChildContext
         .mockResolvedValueOnce("result1")

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -13,6 +13,7 @@ import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { BatchResultImpl, restoreBatchResult } from "./batch-result";
 import { defaultSerdes } from "../../utils/serdes/serdes";
+import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 export class ConcurrencyController {
   constructor(
@@ -180,7 +181,13 @@ export class ConcurrencyController {
           completedCount,
         });
       } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
+        const err =
+          error instanceof ChildContextError
+            ? error
+            : new ChildContextError(
+                error instanceof Error ? error.message : String(error),
+                error instanceof Error ? error : undefined,
+              );
         resultItems.push({
           error: err,
           index: item.index,
@@ -349,7 +356,12 @@ export class ConcurrencyController {
               },
               (error) => {
                 const err =
-                  error instanceof Error ? error : new Error(String(error));
+                  error instanceof ChildContextError
+                    ? error
+                    : new ChildContextError(
+                        error instanceof Error ? error.message : String(error),
+                        error instanceof Error ? error : undefined,
+                      );
                 resultItems[index] = {
                   error: err,
                   index,

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-batch-result.ts
@@ -1,4 +1,5 @@
 import { BatchResult, BatchItem, BatchItemStatus } from "../types";
+import { ChildContextError } from "../errors/durable-error/durable-error";
 
 export class MockBatchResult<R> implements BatchResult<R> {
   constructor(
@@ -16,9 +17,9 @@ export class MockBatchResult<R> implements BatchResult<R> {
     );
   }
 
-  failed(): Array<BatchItem<R> & { error: Error }> {
+  failed(): Array<BatchItem<R> & { error: ChildContextError }> {
     return this.all.filter(
-      (item): item is BatchItem<R> & { error: Error } =>
+      (item): item is BatchItem<R> & { error: ChildContextError } =>
         item.status === BatchItemStatus.FAILED && item.error !== undefined,
     );
   }
@@ -51,7 +52,7 @@ export class MockBatchResult<R> implements BatchResult<R> {
     return this.succeeded().map((item) => item.result);
   }
 
-  getErrors(): Array<Error> {
+  getErrors(): Array<ChildContextError> {
     return this.failed().map((item) => item.error);
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/types/batch.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/batch.ts
@@ -1,5 +1,6 @@
 import { Serdes } from "../utils/serdes/serdes";
 import { DurableContext } from "./durable-context";
+import { ChildContextError } from "../errors/durable-error/durable-error";
 
 export enum BatchItemStatus {
   SUCCEEDED = "SUCCEEDED",
@@ -13,8 +14,8 @@ export enum BatchItemStatus {
 export interface BatchItem<R> {
   /** The result value if the item succeeded */
   result?: R;
-  /** The error if the item failed */
-  error?: Error;
+  /** The error if the item failed (always ChildContextError since batch items run in child contexts) */
+  error?: ChildContextError;
   /** Index of the item in the original array */
   index: number;
   /** Status of the item execution */
@@ -30,7 +31,7 @@ export interface BatchResult<R> {
   /** Returns only the items that succeeded */
   succeeded(): Array<BatchItem<R> & { result: R }>;
   /** Returns only the items that failed */
-  failed(): Array<BatchItem<R> & { error: Error }>;
+  failed(): Array<BatchItem<R> & { error: ChildContextError }>;
   /** Returns only the items that are still in progress */
   started(): Array<BatchItem<R> & { status: BatchItemStatus.STARTED }>;
   /** Overall status of the batch (SUCCEEDED if no failures, FAILED otherwise) */
@@ -47,7 +48,7 @@ export interface BatchResult<R> {
   /** Returns array of all successful results */
   getResults(): Array<R>;
   /** Returns array of all errors */
-  getErrors(): Array<Error>;
+  getErrors(): Array<ChildContextError>;
   /** Number of successful items */
   successCount: number;
   /** Number of failed items */

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
@@ -4,6 +4,7 @@ import {
 } from "./summary-generators";
 import { BatchResultImpl } from "../../handlers/concurrent-execution-handler/batch-result";
 import { BatchItemStatus } from "../../types";
+import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 describe("Summary Generators", () => {
   describe("createParallelSummaryGenerator", () => {
@@ -32,7 +33,7 @@ describe("Summary Generators", () => {
     });
 
     it("should generate summary for failed parallel result", () => {
-      const error = new Error("Test error");
+      const error = new ChildContextError("Test error");
       const batchResult = new BatchResultImpl(
         [
           { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
@@ -107,7 +108,7 @@ describe("Summary Generators", () => {
     });
 
     it("should generate summary for failed map result", () => {
-      const error = new Error("Mapping failed");
+      const error = new ChildContextError("Mapping failed");
       const batchResult = new BatchResultImpl(
         [
           { index: 0, result: "mapped1", status: BatchItemStatus.SUCCEEDED },
@@ -132,8 +133,8 @@ describe("Summary Generators", () => {
     });
 
     it("should generate summary for failure tolerance exceeded", () => {
-      const error1 = new Error("Error 1");
-      const error2 = new Error("Error 2");
+      const error1 = new ChildContextError("Error 1");
+      const error2 = new ChildContextError("Error 2");
       const batchResult = new BatchResultImpl(
         [
           { index: 0, error: error1, status: BatchItemStatus.FAILED },


### PR DESCRIPTION
BatchResult errors were not deterministic across serialization cycles. On initial execution, errors had proper ChildContextError instances with custom error causes, but on replay they became plain objects losing type information and custom properties.

Changes:
- Created createBatchResultSerdes() for proper error serialization using ErrorObject format
- Updated BatchItem.error type from Error to ChildContextError for type accuracy
- Modified restoreBatchResult() to use DurableOperationError.fromErrorObject()
- Added defensive error wrapping in concurrent execution handler
- Updated all tests and mocks to use ChildContextError

The fix ensures errors maintain their full structure (type, cause chain, custom properties) across serialization/deserialization cycles, making them deterministic between initial execution and replay.

*Issue #, if available:*
#238 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
