### PR TITLE
feat(sdk): improve parallel type inference

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/heterogeneous/parallel-heterogeneous.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/heterogeneous/parallel-heterogeneous.test.ts
@@ -1,0 +1,21 @@
+import { handler } from "./parallel-heterogeneous";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  name: "parallel-heterogeneous test",
+  functionName: "parallel-heterogeneous",
+  handler,
+  tests: (runner) => {
+    it("should handle branches with different return types", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult() as Array<
+        { step1: string } | string | number
+      >;
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ step1: "completed" });
+      expect(result[1]).toBe("task 2 completed");
+      expect(result[2]).toBe(42);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/heterogeneous/parallel-heterogeneous.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/heterogeneous/parallel-heterogeneous.ts
@@ -1,0 +1,35 @@
+import {
+  withDurableExecution,
+  DurableContext,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Parallel Heterogeneous",
+  description: "Running parallel branches with different return types",
+};
+
+export const handler = withDurableExecution(
+  async (_event, context: DurableContext) => {
+    // Parallel branches with different return types
+    const results = await context.parallel("parallel-heterogeneous", [
+      async (childContext: DurableContext) => {
+        return await childContext.step(async () => {
+          return { step1: "completed" };
+        });
+      },
+      async (childContext: DurableContext) => {
+        return await childContext.step(async () => {
+          return "task 2 completed";
+        });
+      },
+      async (childContext: DurableContext) => {
+        return await childContext.step(async () => {
+          return 42;
+        });
+      },
+    ]);
+
+    return results.getResults();
+  },
+);


### PR DESCRIPTION
Added new overloads to context.parallel() that automatically infer union types when branches return different types, while preserving strict type checking for homogeneous branches.

Changes:
- Added flexible overloads with automatic type inference using conditional types
- Kept original strict overloads for backward compatibility and type safety
- Used descriptive generic names (Branches, ReturnType) instead of T, R
- Added parallel-heterogeneous example demonstrating mixed return types
- Added test verifying object | string | number union type inference

Users can now choose between:
- Strict: parallel<string>(...) enforces all branches return same type
- Flexible: parallel(...) automatically infers union types for mixed returns

This improves developer experience by eliminating manual type annotations for heterogeneous parallel operations while maintaining type safety.

*Issue #, if available:*
#185 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
