### PR TITLE
fix(sdk): retryStrategy for waitForCallback submitter and fix error handling

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.test.ts
@@ -1,0 +1,34 @@
+import { InvocationType } from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./wait-for-callback-submitter-failure-catchable";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  name: "wait-for-callback-submitter-failure-catchable test",
+  functionName: "wait-for-callback-submitter-failure-catchable",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should catch submitter failure in try-catch block", async () => {
+      const execution = await runner.run();
+
+      // The handler catches the error, so execution succeeds with error in result
+      const result = execution.getResult();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("Submitter failed"),
+      });
+    });
+
+    it("should handle submitter failure gracefully after retries", async () => {
+      const execution = await runner.run();
+
+      // Verify error is caught and returned in response
+      const result = execution.getResult() as any;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Submitter failed");
+
+      // Execution completes successfully (doesn't hang or throw unhandled error)
+      expect(execution.getResult()).toBeDefined();
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
@@ -1,0 +1,44 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Submitter Failure Catchable",
+  description:
+    "Demonstrates that submitter failures can be caught with try-catch after retries are exhausted",
+};
+
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    try {
+      const result = await context.waitForCallback<{ data: string }>(
+        "failing-submitter-callback",
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+
+          // Submitter fails
+          throw new Error("Submitter failed");
+        },
+        {
+          retryStrategy: (_, attemptCount) => ({
+            shouldRetry: attemptCount < 3,
+            delaySeconds: 1,
+          }),
+        },
+      );
+
+      return {
+        callbackResult: result,
+        success: true,
+      };
+    } catch (error) {
+      // Submitter error is caught here after retries are exhausted
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.test.ts
@@ -1,0 +1,39 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./wait-for-callback-submitter-retry-success";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  name: "wait-for-callback-submitter-retry-success test",
+  functionName: "wait-for-callback-submitter-retry-success",
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner) => {
+    it("should complete successfully when submitter succeeds", async () => {
+      const executionPromise = runner.run({ payload: { shouldFail: false } });
+
+      const waitForCallbackOp = runner.getOperationByIndex(0);
+      await waitForCallbackOp.waitForData(WaitingOperationStatus.STARTED);
+      await waitForCallbackOp.sendCallbackSuccess(
+        JSON.stringify({ data: "completed" }),
+      );
+
+      const execution = await executionPromise;
+
+      expect(execution.getResult()).toEqual({
+        result: JSON.stringify({ data: "completed" }),
+        success: true,
+      });
+    });
+
+    it("should fail after exhausting retries when submitter always fails", async () => {
+      const execution = await runner.run({ payload: { shouldFail: true } });
+
+      const error = execution.getError();
+      expect(error).toBeDefined();
+      expect(error?.errorMessage).toContain("Simulated submitter failure");
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
@@ -1,0 +1,45 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Wait for Callback - Submitter Retry Success",
+  description:
+    "Demonstrates waitForCallback with submitter retry strategy using exponential backoff (0.5s, 1s, 2s)",
+};
+
+export const handler = withDurableExecution(
+  async (event: { shouldFail?: boolean }, context: DurableContext) => {
+    const shouldFail = event.shouldFail ?? false;
+
+    const result = await context.waitForCallback<{ data: string }>(
+      "retry-submitter-callback",
+      async (callbackId, ctx) => {
+        ctx.logger.info("Submitting callback to external system", {
+          callbackId,
+        });
+
+        if (shouldFail) {
+          throw new Error("Simulated submitter failure");
+        }
+
+        ctx.logger.info("Successfully submitted callback", { callbackId });
+      },
+      {
+        // Retry strategy: up to 4 attempts with exponential backoff
+        // Delays: 0.5s, 1s, 2s between retries
+        retryStrategy: (error, attempt) => ({
+          shouldRetry: attempt < 4,
+          delaySeconds: Math.pow(2, attempt - 1) * 0.5,
+        }),
+      },
+    );
+
+    return {
+      result,
+      success: true,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -398,14 +398,14 @@ describe("WaitForCallback Operations Integration", () => {
       expect(result.getResult()).toEqual({
         success: false,
         error: "Complex submitter failed at step 3",
-        // Retries 6 times (default maxAttempts)
-        sideEffects: 18,
+        // 3 attempts (initial + 2 retries) × 3 side effects per attempt = 9
+        sideEffects: 9,
         callbackId: expect.any(String),
       });
 
       // Verify that callback ID was generated before failure
       expect(callbackId).toBeDefined();
-      expect(sideEffectCounter).toBe(18);
+      expect(sideEffectCounter).toBe(9);
 
       // Should have no succeeded operations since submitter failed
       const completedOperations = result.getOperations({

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -70,22 +70,27 @@ export const createWaitForCallbackHandler = (
       });
 
       // Execute the submitter step (submitter is now mandatory)
-      await childCtx.step(async (stepContext: StepContext) => {
-        // Use the step's built-in logger instead of creating a new one
-        const callbackContext: WaitForCallbackContext = {
-          logger: stepContext.logger,
-        };
+      await childCtx.step(
+        async (stepContext: StepContext) => {
+          // Use the step's built-in logger instead of creating a new one
+          const callbackContext: WaitForCallbackContext = {
+            logger: stepContext.logger,
+          };
 
-        log("📤", "Executing submitter:", {
-          callbackId,
-          name,
-        });
-        await submitter(callbackId, callbackContext);
-        log("✅", "Submitter completed:", {
-          callbackId,
-          name,
-        });
-      });
+          log("📤", "Executing submitter:", {
+            callbackId,
+            name,
+          });
+          await submitter(callbackId, callbackContext);
+          log("✅", "Submitter completed:", {
+            callbackId,
+            name,
+          });
+        },
+        config?.retryStrategy
+          ? { retryStrategy: config.retryStrategy }
+          : undefined,
+      );
 
       log("⏳", "Waiting for callback completion:", {
         callbackId,
@@ -93,8 +98,6 @@ export const createWaitForCallbackHandler = (
       });
 
       // Return just the callback promise result
-      // This will terminate the invocation as right now we are not handdling cuncurrency
-      // Ideally all termination will wait for in-progress steps to finish before terminatiing the process
       return await callbackPromise;
     };
 


### PR DESCRIPTION
- Pass retryStrategy config to submitter step for proper retry behavior
- Wrap callback promise to properly reject on submitter failures
- Add cleanup to prevent unhandled promise rejection warnings
- Add test to verify retryStrategy is passed to submitter step
- Add examples demonstrating submitter retry with exponential backoff
- Add example showing submitter errors are catchable with try-catch
- Fixes issue where submitter failures would create orphaned callbacks

*Issue #, if available:*
#199 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
