### PR TITLE
fix(sdk): migrate remaining delaySeconds fields to Duration interface

### DIFF
--- a/docs/wait-for-condition-handler-flowchart.md
+++ b/docs/wait-for-condition-handler-flowchart.md
@@ -117,7 +117,7 @@ The waitForCondition handler now implements the same main loop pattern as the st
 **4. Wait Strategy Decision**:
 
 - Calls `config.waitStrategy(newState, attemptNumber)`
-- Returns `{ shouldContinue: boolean, delaySeconds?: number }`
+- Returns `{ shouldContinue: boolean, delay?: Duration }`
 - **shouldContinue = false**: Condition met, complete successfully
 - **shouldContinue = true**: Schedule retry with delay, return CONTINUE_MAIN_LOOP
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
@@ -24,7 +24,7 @@ export const handler = withDurableExecution(
         {
           retryStrategy: (_, attemptCount) => ({
             shouldRetry: attemptCount < 3,
-            delaySeconds: 1,
+            delay: { seconds: 1 },
           }),
         },
       );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
@@ -29,10 +29,10 @@ export const handler = withDurableExecution(
       },
       {
         // Retry strategy: up to 4 attempts with exponential backoff
-        // Delays: 0.5s, 1s, 2s between retries
+        // Delays: 1s, 2s, 4s between retries
         retryStrategy: (error, attempt) => ({
           shouldRetry: attempt < 4,
-          delaySeconds: Math.pow(2, attempt - 1) * 0.5,
+          delay: { seconds: Math.pow(2, attempt - 1) },
         }),
       },
     );

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -366,7 +366,7 @@ describe("WaitForCallback Operations Integration", () => {
               {
                 retryStrategy: (_, attemptCount) => ({
                   shouldRetry: attemptCount < 3,
-                  delaySeconds: 1,
+                  delay: { seconds: 1 },
                 }),
               },
             );

--- a/packages/aws-durable-execution-sdk-js/README.md
+++ b/packages/aws-durable-execution-sdk-js/README.md
@@ -72,7 +72,7 @@ const result = await context.step(
   {
     retryStrategy: (error, attempt) => ({
       shouldRetry: attempt < 3,
-      delaySeconds: Math.pow(2, attempt),
+      delay: { seconds: Math.pow(2, attempt) },
     }),
   },
 );
@@ -147,7 +147,7 @@ const finalState = await context.waitForCondition(
       }
       return {
         shouldContinue: true,
-        delaySeconds: Math.min(attempt * 2, 60),
+        delay: { seconds: Math.min(attempt * 2, 60) },
       };
     },
   },
@@ -301,7 +301,7 @@ Custom retry strategy:
 await context.step("custom-retry", async () => riskyOperation(), {
   retryStrategy: (error, attempt) => ({
     shouldRetry: attempt < 5 && error.message.includes("timeout"),
-    delaySeconds: attempt * 2,
+    delay: { seconds: attempt * 2 },
   }),
 });
 ```
@@ -362,8 +362,8 @@ import {
 
 const retryStrategy = createRetryStrategy({
   maxAttempts: 5,
-  initialDelaySeconds: 1,
-  maxDelaySeconds: 60,
+  initialDelay: { seconds: 1 },
+  maxDelay: { seconds: 60 },
   exponentialDelayFactor: 2,
   jitterStrategy: JitterStrategy.FULL,
 });

--- a/packages/aws-durable-execution-sdk-js/src/documents/API_SPECIFICATION.md
+++ b/packages/aws-durable-execution-sdk-js/src/documents/API_SPECIFICATION.md
@@ -225,7 +225,7 @@ type ConcurrentExecutor<TItem, TResult> = (
  */
 export interface RetryDecision {
   shouldRetry: boolean;
-  delaySeconds?: number;
+  delay?: Duration;
 }
 
 /**
@@ -350,7 +350,7 @@ export interface ConcurrencyConfig<TResult> {
  * Decision object for waitForCondition wait strategy
  */
 export type WaitForConditionDecision =
-  | { shouldContinue: true; delaySeconds: number }
+  | { shouldContinue: true; delay: Duration }
   | { shouldContinue: false };
 
 /**
@@ -552,10 +552,10 @@ const result = await context.step(async () => callMyApi(event.value), {
 ```typescript
 const customRetryStrategy = createRetryStrategy({
   maxAttempts: 5,
-  initialDelaySeconds: 1,
-  maxDelaySeconds: 60,
+  initialDelay: { seconds: 1 },
+  maxDelay: { seconds: 60 },
   backoffRate: 2,
-  jitterSeconds: 0.5,
+  jitter: JitterStrategy.FULL,
   retryableErrors: ["Intentional failure", /Network error/],
   retryableErrorTypes: [NetworkError, TimeoutError],
 });
@@ -574,7 +574,7 @@ const myCustomStrategy = (error: Error, attempt: number) => {
   if (attempt >= 5) {
     return { shouldRetry: false };
   }
-  return { shouldRetry: true, delaySeconds: 1 + attempt };
+  return { shouldRetry: true, delay: { seconds: 1 + attempt } };
 };
 
 const result = await context.step(async () => callMyApi(event.value), {
@@ -752,10 +752,10 @@ waitForCondition<T>(check: WaitForConditionCheckFunc<T>, config?: WaitForConditi
 ```typescript
 const customWaitStrategy = createWaitStrategy({
   maxAttempts: 60,
-  initialDelaySeconds: 5,
-  maxDelaySeconds: 30,
+  initialDelay: { seconds: 5 },
+  maxDelay: { seconds: 30 },
   backoffRate: 1.5,
-  jitterSeconds: 1,
+  jitter: JitterStrategy.FULL,
   shouldContinuePolling: (result) => result.status !== "CURRENT",
   timeoutSeconds: 600,
 });
@@ -777,7 +777,7 @@ const myCustomWaitStrategy = (result: StackInstance, attempt: number) => {
   } else {
     return {
       shouldContinue: true,
-      delaySeconds: Math.min(5 * attempt, 30),
+      delay: { seconds: Math.min(5 * attempt, 30) },
     };
   }
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -194,7 +194,7 @@ export const createStepHandler = (
               name,
               currentAttempt,
               shouldRetry: retryDecision.shouldRetry,
-              delaySeconds: retryDecision.shouldRetry
+              delayInSeconds: retryDecision.shouldRetry
                 ? retryDecision.delay
                   ? durationToSeconds(retryDecision.delay)
                   : undefined
@@ -450,7 +450,7 @@ export const executeStep = async <T>(
       name,
       currentAttempt,
       shouldRetry: retryDecision.shouldRetry,
-      delaySeconds: retryDecision.shouldRetry
+      delayInSeconds: retryDecision.shouldRetry
         ? retryDecision.delay
           ? durationToSeconds(retryDecision.delay)
           : undefined

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -334,7 +334,7 @@ export const executeWaitForCondition = async <T>(
       name,
       currentAttempt: currentAttempt,
       shouldContinue: decision.shouldContinue,
-      delaySeconds: decision.shouldContinue
+      delayInSeconds: decision.shouldContinue
         ? durationToSeconds(decision.delay)
         : undefined,
     });


### PR DESCRIPTION
Complete migration from delaySeconds (number) to delay (Duration) interface across codebase, documentation, and examples. This ensures type safety and consistency with the Duration interface introduced in previous commits.

Changes:
- Updated 2 example files to use delay: { seconds: X }
- Updated 1 integration test to use Duration interface
- Fixed type definitions in API_SPECIFICATION.md
- Updated all code examples in README.md and documentation
- Renamed log fields from delaySeconds to delayInSeconds for clarity
- Updated flowchart documentation

No breaking changes to public API as the Duration interface was already the correct type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
