### PR TITLE
perf(sdk): reuse LambdaClient instance across invocations

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/storage/storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/storage.ts
@@ -18,11 +18,18 @@ export interface ExecutionState {
 }
 
 let customStorage: ExecutionState | undefined;
+let defaultStorage: ExecutionState | undefined;
 
 export function setCustomStorage(storage: ExecutionState): void {
   customStorage = storage;
 }
 
 export function getExecutionState(): ExecutionState {
-  return customStorage || new ApiStorage();
+  if (customStorage) {
+    return customStorage;
+  }
+  if (!defaultStorage) {
+    defaultStorage = new ApiStorage();
+  }
+  return defaultStorage;
 }


### PR DESCRIPTION
Implement singleton pattern for ApiStorage to prevent creating a new LambdaClient on every call to getExecutionState(). This improves performance by reusing the same client instance and its connection pool.

Changes:
- Added defaultStorage variable to cache ApiStorage instance
- Modified getExecutionState() to lazily create and reuse ApiStorage
- Custom storage behavior remains unchanged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
