### PR TITLE
feat(sdk): configure Lambda client timeouts

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
@@ -56,7 +56,13 @@ describe("ApiStorage", () => {
 
   test("should initialize with correct endpoint and region", () => {
     // Verify that LambdaClient was constructed with the correct parameters
-    expect(LambdaClient).toHaveBeenCalledWith();
+    expect(LambdaClient).toHaveBeenCalledWith({
+      requestHandler: {
+        connectionTimeout: 5000,
+        socketTimeout: 50000,
+        requestTimeout: 5000,
+      },
+    });
   });
 
   test("should call getStepData with correct parameters", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
@@ -17,7 +17,13 @@ export class ApiStorage implements ExecutionState {
   protected client: LambdaClient;
 
   constructor() {
-    this.client = new LambdaClient();
+    this.client = new LambdaClient({
+      requestHandler: {
+        connectionTimeout: 5000,
+        socketTimeout: 50000,
+        requestTimeout: 5000,
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
Add connection and socket timeout configurations to LambdaClient:
- connectionTimeout: 5000ms (5 seconds)
- socketTimeout: 50000ms (50 seconds)

This helps prevent hanging requests and provides better error handling for Lambda API calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
