### PR TITLE
feat(sdk): make Logger.log() method optional for external logger compatibility

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/types/logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/logger.ts
@@ -3,8 +3,8 @@
  * Provides structured logging capabilities for durable execution contexts
  */
 export interface Logger {
-  /** Generic log method with configurable level */
-  log(level: string, message?: string, data?: unknown, error?: Error): void;
+  /** Generic log method with configurable level (optional for compatibility with popular loggers) */
+  log?(level: string, message?: string, data?: unknown, error?: Error): void;
   /** Log error messages with optional error object and additional data */
   error(message?: string, error?: Error, data?: unknown): void;
   /** Log warning messages with optional additional data */

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.test.ts
@@ -122,7 +122,7 @@ describe("Context Logger", () => {
     const logger = factory("generic-step");
     const testError = new Error("generic error");
 
-    logger.log("custom", "custom message", { custom: "data" }, testError);
+    logger.log?.("custom", "custom message", { custom: "data" }, testError);
 
     expect(mockBaseLogger.log).toHaveBeenCalledWith(
       "custom",
@@ -173,7 +173,7 @@ describe("Context Logger", () => {
     const logger = factory("test-step");
 
     // Test all logger methods to ensure coverage
-    logger.log(
+    logger.log?.(
       "custom",
       "log message",
       { data: "test" },

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/context-logger.ts
@@ -36,19 +36,21 @@ export const createContextLoggerFactory = (
     };
 
     return {
-      log: (
-        level: string,
-        message?: string,
-        data?: unknown,
-        error?: Error,
-      ): void => {
-        baseLogger.log(
-          level,
-          message,
-          createLogEntry(level, message, data, error),
-          error,
-        );
-      },
+      log: baseLogger.log
+        ? (
+            level: string,
+            message?: string,
+            data?: unknown,
+            error?: Error,
+          ): void => {
+            baseLogger.log!(
+              level,
+              message,
+              createLogEntry(level, message, data, error),
+              error,
+            );
+          }
+        : undefined,
       info: (message?: string, data?: unknown): void => {
         baseLogger.info(message, createLogEntry("info", message, data));
       },

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.test.ts
@@ -26,7 +26,7 @@ describe("Default Logger", () => {
     const testData = { key: "value" };
     const testError = new Error("test error");
 
-    logger.log("custom", "test message", testData, testError);
+    logger.log?.("custom", "test message", testData, testError);
 
     expect(consoleSpy).toHaveBeenCalledWith(
       "custom",

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.test.ts
@@ -100,7 +100,7 @@ describe("Mode-Aware Logger", () => {
       false,
     );
 
-    logger.log("custom", "log message", { data: "test" }, new Error("test"));
+    logger.log?.("custom", "log message", { data: "test" }, new Error("test"));
     logger.error("error message", new Error("test"), { data: "test" });
     logger.warn("warn message", { data: "test" });
     logger.debug("debug message", { data: "test" });
@@ -131,7 +131,7 @@ describe("Mode-Aware Logger", () => {
       true,
     );
 
-    logger.log("custom", "log message");
+    logger.log?.("custom", "log message");
     logger.error("error message", new Error("test"));
     logger.warn("warn message");
     logger.debug("debug message");

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/mode-aware-logger.ts
@@ -15,14 +15,16 @@ export const createModeAwareLogger = (
     durableExecutionMode === DurableExecutionMode.ExecutionMode;
 
   return {
-    log: (
-      level: string,
-      message?: string,
-      data?: unknown,
-      error?: Error,
-    ): void => {
-      if (shouldLog()) enrichedLogger.log(level, message, data, error);
-    },
+    log: enrichedLogger.log
+      ? (
+          level: string,
+          message?: string,
+          data?: unknown,
+          error?: Error,
+        ): void => {
+          if (shouldLog()) enrichedLogger.log!(level, message, data, error);
+        }
+      : undefined,
     info: (message?: string, data?: unknown): void => {
       if (shouldLog()) enrichedLogger.info(message, data);
     },


### PR DESCRIPTION
Make the log() method optional in the Logger interface to enable compatibility with popular TypeScript logging libraries like AWS Powertools Logger, Pino, and Winston, which don't implement a generic log() method.

Changes:
- Made Logger.log() optional in interface definition
- Updated context-logger to conditionally create log method
- Updated mode-aware-logger to handle optional log method
- Fixed all tests to use optional chaining for log() calls

This is a non-breaking change that maintains backward compatibility with existing custom loggers while enabling easier integration with external logging libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
