### PR TITLE
chore(testing-sdk): remove invocation-operation association

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/__tests__/checkpoint-server.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/__tests__/checkpoint-server.test.ts
@@ -730,10 +730,7 @@ describe("checkpoint-server", () => {
         mockExecutionManager.getCheckpointsByExecution,
       ).toHaveBeenCalledWith(durableExecutionArn);
       // registerUpdates should be called with empty array when no Updates field is provided
-      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(
-        [],
-        "test-invocation-id",
-      );
+      expect(mockStorage.registerUpdates).toHaveBeenCalledWith([]);
       expect(response.body).toEqual({
         CheckpointToken: expect.any(String),
         NewExecutionState: {
@@ -797,10 +794,7 @@ describe("checkpoint-server", () => {
       expect(
         mockExecutionManager.getCheckpointsByExecution,
       ).toHaveBeenCalledWith(durableExecutionArn);
-      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(
-        input.Updates,
-        "test-invocation-id",
-      );
+      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(input.Updates);
       expect(response.body).toEqual({
         CheckpointToken: expect.any(String),
         NewExecutionState: {
@@ -860,10 +854,7 @@ describe("checkpoint-server", () => {
         .send(input);
 
       expect(response.status).toBe(200);
-      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(
-        input.Updates,
-        "test-invocation-id",
-      );
+      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(input.Updates);
       expect(response.body).toEqual({
         CheckpointToken: expect.any(String),
         NewExecutionState: {
@@ -931,10 +922,7 @@ describe("checkpoint-server", () => {
         .send(input);
 
       expect(response.status).toBe(200);
-      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(
-        input.Updates,
-        "test-invocation-id",
-      );
+      expect(mockStorage.registerUpdates).toHaveBeenCalledWith(input.Updates);
     });
 
     it("should return 404 when execution does not exist", async () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/checkpoint-server.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/checkpoint-server.ts
@@ -117,8 +117,6 @@ export async function startCheckpointServer(port: number) {
 
       res.json({
         operations: convertDatesToTimestamps(operations),
-        operationInvocationIdMap:
-          checkpointStorage.getOperationInvocationIdMap(),
       });
     },
   );
@@ -233,7 +231,7 @@ export async function startCheckpointServer(port: number) {
 
       try {
         validateCheckpointUpdates(updates, storage.operationDataMap);
-        storage.registerUpdates(updates, data.invocationId);
+        storage.registerUpdates(updates);
       } catch (err: unknown) {
         if (err instanceof InvalidParameterValueException) {
           res.setHeaders(

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager.test.ts
@@ -5,10 +5,7 @@ import {
   OperationUpdate,
 } from "@aws-sdk/client-lambda";
 import { CheckpointManager } from "../checkpoint-manager";
-import {
-  createExecutionId,
-  createInvocationId,
-} from "../../utils/tagged-strings";
+import { createExecutionId } from "../../utils/tagged-strings";
 import { CompleteCallbackStatus } from "../callback-manager";
 
 // Mock crypto's randomUUID function
@@ -18,8 +15,6 @@ jest.mock("node:crypto", () => ({
 
 describe("CheckpointManager", () => {
   let storage: CheckpointManager;
-
-  const mockInvocationId = createInvocationId();
 
   beforeEach(() => {
     storage = new CheckpointManager(createExecutionId("test-execution-id"));
@@ -113,7 +108,7 @@ describe("CheckpointManager", () => {
         Action: OperationAction.START,
         Payload: "my-payload",
       };
-      storage.registerUpdate(update, mockInvocationId);
+      storage.registerUpdate(update);
 
       const pendingUpdates = await storage.getPendingCheckpointUpdates();
       expect(pendingUpdates).toHaveLength(1);
@@ -134,7 +129,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.START,
         };
-        storage.registerUpdate(update, mockInvocationId);
+        storage.registerUpdate(update);
       }, 10);
 
       // Now await the promise
@@ -149,7 +144,7 @@ describe("CheckpointManager", () => {
         Type: OperationType.STEP,
         Action: OperationAction.START,
       };
-      storage.registerUpdate(update, mockInvocationId);
+      storage.registerUpdate(update);
 
       // Retrieve updates first time
       const firstRetrieval = await storage.getPendingCheckpointUpdates();
@@ -162,7 +157,7 @@ describe("CheckpointManager", () => {
         Type: OperationType.STEP,
         Action: OperationAction.START,
       };
-      storage.registerUpdate(update2, mockInvocationId);
+      storage.registerUpdate(update2);
 
       const secondRetrieval = await secondPromise;
       expect(secondRetrieval).toHaveLength(1);
@@ -192,7 +187,7 @@ describe("CheckpointManager", () => {
         Action: OperationAction.START,
       };
 
-      storage.registerUpdate(update, mockInvocationId);
+      storage.registerUpdate(update);
       expect(storage.hasOperation("registered-op")).toBe(true);
     });
 
@@ -220,7 +215,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.RETRY,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete the operation with RETRY action
         const result = storage.completeOperation({
@@ -243,7 +238,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.RETRY,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete with SUCCEED action (should preserve retry count)
         const result = storage.completeOperation({
@@ -267,7 +262,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.START,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete with RETRY action
         const result = storage.completeOperation({
@@ -291,7 +286,7 @@ describe("CheckpointManager", () => {
           Payload: "retry payload",
         };
 
-        const result = storage.registerUpdate(retryUpdate, mockInvocationId);
+        const result = storage.registerUpdate(retryUpdate);
 
         expect(result.operation.StepDetails?.Attempt).toBe(1);
         // Result should not be populated in registerUpdate, only in completeOperation
@@ -309,7 +304,7 @@ describe("CheckpointManager", () => {
           Payload: "normal payload",
         };
 
-        const result = storage.registerUpdate(normalUpdate, mockInvocationId);
+        const result = storage.registerUpdate(normalUpdate);
 
         expect(result.operation.StepDetails?.Attempt).toBe(1);
         expect(result.operation.StepDetails?.Result).toBe("normal payload");
@@ -324,7 +319,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.RETRY,
         };
-        storage.registerUpdate(firstUpdate, mockInvocationId);
+        storage.registerUpdate(firstUpdate);
 
         // Register again without retry action (simulating subsequent update)
         const secondUpdate: OperationUpdate = {
@@ -333,7 +328,7 @@ describe("CheckpointManager", () => {
           Action: OperationAction.SUCCEED,
           Payload: "final result",
         };
-        const result = storage.registerUpdate(secondUpdate, mockInvocationId);
+        const result = storage.registerUpdate(secondUpdate);
 
         // Should complete the existing operation, preserving retry count
         expect(result.operation.StepDetails?.Attempt).toBe(2);
@@ -350,7 +345,7 @@ describe("CheckpointManager", () => {
           Action: OperationAction.RETRY,
         };
 
-        const result = storage.registerUpdate(retryUpdate, mockInvocationId);
+        const result = storage.registerUpdate(retryUpdate);
 
         expect(result.operation.StepDetails?.Attempt).toBe(1); // Should default to 1 for retry
       });
@@ -366,7 +361,7 @@ describe("CheckpointManager", () => {
           Action: OperationAction.START,
           Type: OperationType.STEP,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete the operation with error
         const result = storage.completeOperation({
@@ -399,7 +394,7 @@ describe("CheckpointManager", () => {
           Action: OperationAction.START,
           Type: OperationType.STEP,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete the operation with both result and error
         const result = storage.completeOperation({
@@ -434,7 +429,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.STEP,
           Action: OperationAction.RETRY,
         };
-        storage.registerUpdate(stepUpdate, mockInvocationId);
+        storage.registerUpdate(stepUpdate);
 
         // Complete the operation with error and another retry
         const result = storage.completeOperation({
@@ -510,7 +505,7 @@ describe("CheckpointManager", () => {
           Payload: '{"userId": 123, "name": "John Doe"}',
         };
 
-        const result = storage.registerUpdate(contextUpdate, mockInvocationId);
+        const result = storage.registerUpdate(contextUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Id).toBe("context-id");
@@ -539,7 +534,7 @@ describe("CheckpointManager", () => {
           },
         };
 
-        const result = storage.registerUpdate(contextUpdate, mockInvocationId);
+        const result = storage.registerUpdate(contextUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CONTEXT);
@@ -563,7 +558,7 @@ describe("CheckpointManager", () => {
           },
         };
 
-        const result = storage.registerUpdate(contextUpdate, mockInvocationId);
+        const result = storage.registerUpdate(contextUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CONTEXT);
@@ -584,7 +579,7 @@ describe("CheckpointManager", () => {
           Error: undefined,
         };
 
-        const result = storage.registerUpdate(contextUpdate, mockInvocationId);
+        const result = storage.registerUpdate(contextUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CONTEXT);
@@ -607,10 +602,7 @@ describe("CheckpointManager", () => {
             Payload: '{"result": "data"}',
           };
 
-          const result = storage.registerUpdate(
-            contextUpdate,
-            mockInvocationId,
-          );
+          const result = storage.registerUpdate(contextUpdate);
 
           expect(result).toBeDefined();
           expect(result.operation.Id).toBe("completed-context");
@@ -645,7 +637,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.CONTEXT,
           Payload: '{"initial": "result"}',
         };
-        storage.registerUpdate(contextUpdate, mockInvocationId);
+        storage.registerUpdate(contextUpdate);
 
         // Complete the operation with new result
         const result = storage.completeOperation({
@@ -674,7 +666,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.CONTEXT,
           Payload: '{"initial": "result"}',
         };
-        storage.registerUpdate(contextUpdate, mockInvocationId);
+        storage.registerUpdate(contextUpdate);
 
         // Complete the operation with error
         const result = storage.completeOperation({
@@ -706,7 +698,7 @@ describe("CheckpointManager", () => {
           Action: OperationAction.START,
           Type: OperationType.CONTEXT,
         };
-        storage.registerUpdate(contextUpdate, mockInvocationId);
+        storage.registerUpdate(contextUpdate);
 
         // Complete the operation with both result and error
         const result = storage.completeOperation({
@@ -784,7 +776,7 @@ describe("CheckpointManager", () => {
           },
         };
 
-        const result = storage.registerUpdate(callbackUpdate, mockInvocationId);
+        const result = storage.registerUpdate(callbackUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Id).toBe("callback-op");
@@ -802,7 +794,7 @@ describe("CheckpointManager", () => {
           Type: OperationType.CALLBACK,
         };
 
-        const result = storage.registerUpdate(callbackUpdate, mockInvocationId);
+        const result = storage.registerUpdate(callbackUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CALLBACK);
@@ -821,7 +813,7 @@ describe("CheckpointManager", () => {
           },
         };
 
-        const result = storage.registerUpdate(callbackUpdate, mockInvocationId);
+        const result = storage.registerUpdate(callbackUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CALLBACK);
@@ -840,7 +832,7 @@ describe("CheckpointManager", () => {
           },
         };
 
-        const result = storage.registerUpdate(callbackUpdate, mockInvocationId);
+        const result = storage.registerUpdate(callbackUpdate);
 
         expect(result).toBeDefined();
         expect(result.operation.Type).toBe(OperationType.CALLBACK);
@@ -1077,7 +1069,7 @@ describe("CheckpointManager", () => {
         },
       ];
 
-      const results = storage.registerUpdates(updates, mockInvocationId);
+      const results = storage.registerUpdates(updates);
 
       expect(results).toHaveLength(3);
       expect(results[0].operation.Id).toBe("batch-op-1");
@@ -1097,7 +1089,7 @@ describe("CheckpointManager", () => {
     it("should handle empty updates array", () => {
       storage.initialize();
 
-      const results = storage.registerUpdates([], mockInvocationId);
+      const results = storage.registerUpdates([]);
 
       expect(results).toHaveLength(0);
       expect(results).toEqual([]);
@@ -1115,7 +1107,7 @@ describe("CheckpointManager", () => {
         },
       ];
 
-      const results = storage.registerUpdates(updates, mockInvocationId);
+      const results = storage.registerUpdates(updates);
 
       expect(results).toHaveLength(1);
       expect(results[0].operation.Id).toBe("single-op");
@@ -1137,7 +1129,7 @@ describe("CheckpointManager", () => {
         { Id: "op-m", Type: OperationType.STEP, Action: OperationAction.START },
       ];
 
-      const results = storage.registerUpdates(updates, mockInvocationId);
+      const results = storage.registerUpdates(updates);
 
       expect(results[0].operation.Id).toBe("op-z");
       expect(results[1].operation.Id).toBe("op-a");
@@ -1176,8 +1168,8 @@ describe("CheckpointManager", () => {
         WaitOptions: { WaitSeconds: 1 },
       };
 
-      storage.registerUpdate(update1, mockInvocationId);
-      storage.registerUpdate(update2, mockInvocationId);
+      storage.registerUpdate(update1);
+      storage.registerUpdate(update2);
 
       const state = storage.getState();
 
@@ -1281,7 +1273,7 @@ describe("CheckpointManager", () => {
         },
       ];
 
-      storage.registerUpdates(updates, mockInvocationId);
+      storage.registerUpdates(updates);
 
       const state = storage.getState();
 
@@ -1314,110 +1306,6 @@ describe("CheckpointManager", () => {
       ];
       prunedOperations.forEach((prunedId) => {
         expect(state.find((op) => op.Id === prunedId)).toBeUndefined();
-      });
-    });
-  });
-
-  describe("invocation tracking", () => {
-    describe("getOperationInvocationIdMap", () => {
-      it("should return empty map initially", () => {
-        const map = storage.getOperationInvocationIdMap();
-        expect(map).toEqual({});
-      });
-
-      it("should return operations associated with invocations", () => {
-        storage.initialize();
-
-        const invocationId1 = createInvocationId("invocation-1");
-        const invocationId2 = createInvocationId("invocation-2");
-
-        // Register operations with invocations
-        const update1: OperationUpdate = {
-          Id: "op1",
-          Type: OperationType.STEP,
-          Action: OperationAction.START,
-        };
-        storage.registerUpdate(update1, invocationId1);
-
-        const update2: OperationUpdate = {
-          Id: "op2",
-          Type: OperationType.WAIT,
-          WaitOptions: { WaitSeconds: 1 },
-          Action: OperationAction.START,
-        };
-        storage.registerUpdate(update2, invocationId2);
-
-        const map = storage.getOperationInvocationIdMap();
-
-        expect(map).toEqual({
-          op1: [invocationId1],
-          op2: [invocationId2],
-        });
-      });
-
-      it("should convert Set to Array for invocation IDs", () => {
-        storage.initialize();
-
-        const invocationId = createInvocationId("test-invocation");
-
-        const update: OperationUpdate = {
-          Id: "test-op",
-          Type: OperationType.STEP,
-          Action: OperationAction.START,
-        };
-        storage.registerUpdate(update, invocationId);
-
-        const map = storage.getOperationInvocationIdMap();
-
-        expect(Array.isArray(map["test-op"])).toBe(true);
-        expect(map["test-op"]).toEqual([invocationId]);
-      });
-    });
-
-    describe("registerUpdate with invocation tracking", () => {
-      it("should track invocation for new operations", () => {
-        storage.initialize();
-
-        const invocationId = createInvocationId("new-op-invocation");
-
-        const update: OperationUpdate = {
-          Id: "new-tracked-op",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-        };
-
-        storage.registerUpdate(update, invocationId);
-
-        const map = storage.getOperationInvocationIdMap();
-        expect(map["new-tracked-op"]).toEqual([invocationId]);
-      });
-
-      it("should add invocation to existing operation", () => {
-        storage.initialize();
-
-        const invocationId1 = createInvocationId("first-invocation");
-        const invocationId2 = createInvocationId("second-invocation");
-
-        const update: OperationUpdate = {
-          Id: "existing-op",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-        };
-
-        // First registration
-        storage.registerUpdate(update, invocationId1);
-
-        // Second registration should add to existing operation
-        const update2: OperationUpdate = {
-          Id: "existing-op",
-          Type: OperationType.STEP,
-          Action: OperationAction.SUCCEED,
-        };
-        storage.registerUpdate(update2, invocationId2);
-
-        const map = storage.getOperationInvocationIdMap();
-        expect(map["existing-op"]).toContain(invocationId1);
-        expect(map["existing-op"]).toContain(invocationId2);
       });
     });
   });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/durable-test-runner.ts
@@ -121,6 +121,4 @@ export interface TestResult<T> {
 // Tracks a single invocation of the handler function
 export interface Invocation {
   id: string;
-  // Get completed steps in this invocation
-  getOperations(params?: { status: OperationStatus }): OperationWithData[];
 }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -113,20 +113,16 @@ describe("LocalDurableTestRunner Integration", () => {
     expect(allOperationIds).toContain(stepOpId);
     expect(allOperationIds).toContain(secondWaitId);
 
-    // For each invocation, get its operations
-    const invocationOperations = invocations.map((inv) =>
-      inv.getOperations().map((op) => op.getOperationData()?.Id),
-    );
-
-    // Verify exact operations in each invocation
-    // Make sure we have the right number of invocations first
-    expect(invocationOperations).toHaveLength(3);
-    // - Invocation 0: first wait operation
-    expect(invocationOperations[0]).toEqual([firstWaitId]);
-    // - Invocation 1: step operation and second wait operation
-    expect(invocationOperations[1]).toEqual([stepOpId, secondWaitId]);
-    // - Invocation 2: no checkpoints performed
-    expect(invocationOperations[2]).toEqual([]);
+    // Ensure each invocation is valid
+    expect(invocations[0]).toEqual({
+      id: expect.any(String),
+    });
+    expect(invocations[1]).toEqual({
+      id: expect.any(String),
+    });
+    expect(invocations[2]).toEqual({
+      id: expect.any(String),
+    });
 
     // Assert history events
     expect(result.getHistoryEvents()).toEqual([

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -228,20 +228,6 @@ describe("WaitForCallback Operations Integration", () => {
       const invocations = result.getInvocations();
       expect(invocations).toHaveLength(4);
 
-      // Verify operations distribution across invocations
-      const invocationOperations = invocations.map(
-        (inv) => inv.getOperations().length,
-      );
-
-      // Invocation 0: wait
-      expect(invocationOperations[0]).toBe(1);
-      // Invocation 1: callback context, callback, submitter, step, wait
-      expect(invocationOperations[1]).toBe(5);
-      // Invocation 3: new callback context, callback, submitter
-      expect(invocationOperations[2]).toBe(3);
-      // Invocation 4: previous callback context
-      expect(invocationOperations[3]).toBe(1);
-
       // Verify callback IDs are unique
       expect(firstCallbackId).toBeDefined();
       expect(secondCallbackId).toBeDefined();

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/__tests__/checkpoint-api-client.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/__tests__/checkpoint-api-client.test.ts
@@ -223,11 +223,9 @@ describe("CheckpointApiClient", () => {
     it("should make a GET request to the correct endpoint", async () => {
       const mockResponseDataSerialized: SerializedPollCheckpointResponse = {
         operations: mockOperationsSerialized,
-        operationInvocationIdMap: { op1: [createInvocationId("invocation-1")] },
       };
       const mockResponseData = {
         operations: mockOperations,
-        operationInvocationIdMap: { op1: ["invocation-1"] },
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -279,7 +277,6 @@ describe("CheckpointApiClient", () => {
             ],
           },
         ],
-        operationInvocationIdMap: {},
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -313,14 +310,12 @@ describe("CheckpointApiClient", () => {
             ],
           },
         ],
-        operationInvocationIdMap: {},
       });
     });
 
     it("should pass the abort signal when provided", async () => {
       const mockResponseData = {
         operations: mockOperationsSerialized,
-        operationInvocationIdMap: { op1: ["invocation-1"] },
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -344,46 +339,6 @@ describe("CheckpointApiClient", () => {
           signal,
         },
       );
-    });
-
-    it("should handle response with operationInvocationIdMap", async () => {
-      const mockResponseData = {
-        operations: mockOperationsSerialized,
-        operationInvocationIdMap: {
-          op1: ["invocation-1", "invocation-2"],
-          op2: ["invocation-3"],
-        },
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockResponseData),
-      });
-
-      const result = await apiClient.pollCheckpointData(mockExecutionId);
-
-      expect(result.operations).toEqual(mockOperations);
-      expect(result.operationInvocationIdMap).toEqual({
-        op1: ["invocation-1", "invocation-2"],
-        op2: ["invocation-3"],
-      });
-    });
-
-    it("should handle response with empty operationInvocationIdMap", async () => {
-      const mockResponseData: SerializedPollCheckpointResponse = {
-        operations: mockOperationsSerialized,
-        operationInvocationIdMap: {},
-      };
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockResponseData),
-      });
-
-      const result = await apiClient.pollCheckpointData(mockExecutionId);
-
-      expect(result.operations).toStrictEqual(mockOperations);
-      expect(result.operationInvocationIdMap).toEqual({});
     });
 
     it("should throw an error when the request fails", async () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/checkpoint-api-client.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/api-client/checkpoint-api-client.ts
@@ -1,7 +1,4 @@
-import {
-  CheckpointOperation,
-  OperationInvocationIdMap,
-} from "../../../checkpoint-server/storage/checkpoint-manager";
+import { CheckpointOperation } from "../../../checkpoint-server/storage/checkpoint-manager";
 import { InvocationResult } from "../../../checkpoint-server/storage/execution-manager";
 import { ErrorObject, Operation } from "@aws-sdk/client-lambda";
 import {
@@ -21,7 +18,6 @@ import {
 
 export interface SerializedPollCheckpointResponse {
   operations: SerializedCheckpointOperation[];
-  operationInvocationIdMap: OperationInvocationIdMap;
 }
 
 /**
@@ -58,7 +54,6 @@ export class CheckpointApiClient {
     signal?: AbortSignal,
   ): Promise<{
     operations: CheckpointOperation[];
-    operationInvocationIdMap: OperationInvocationIdMap;
   }> {
     const result = await this.makeRequest<SerializedPollCheckpointResponse>({
       path: getPollCheckpointDataPath(executionId),
@@ -70,7 +65,6 @@ export class CheckpointApiClient {
       operations: result.operations.map((operationEvents) =>
         deserializeCheckpointOperation(operationEvents),
       ),
-      operationInvocationIdMap: result.operationInvocationIdMap,
     };
   }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/invocation-tracker.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/invocation-tracker.ts
@@ -1,7 +1,4 @@
-import { OperationStatus } from "@aws-sdk/client-lambda";
-import { LocalOperationStorage } from "./local-operation-storage";
 import { Invocation } from "../../durable-test-runner";
-import { OperationWithData } from "../../common/operations/operation-with-data";
 import { InvocationId } from "../../../checkpoint-server/utils/tagged-strings";
 
 /**
@@ -10,17 +7,13 @@ import { InvocationId } from "../../../checkpoint-server/utils/tagged-strings";
  */
 export class InvocationTracker {
   private invocations = new Map<InvocationId, Invocation>();
-  private invocationOperationsMap = new Map<InvocationId, Set<string>>(); // invocationId -> Set of operationIds
   private completedInvocations = new Set<InvocationId>();
-
-  constructor(private operationStorage: LocalOperationStorage) {}
 
   /**
    * Reset all invocation tracking data.
    */
   reset(): void {
     this.invocations = new Map();
-    this.invocationOperationsMap.clear();
     this.completedInvocations.clear();
   }
 
@@ -33,9 +26,6 @@ export class InvocationTracker {
   createInvocation(invocationId: InvocationId): Invocation {
     const invocation: Invocation = {
       id: invocationId,
-      getOperations: (params?) => {
-        return this.getOperationsForInvocation(invocationId, params?.status);
-      },
     };
 
     this.invocations.set(invocationId, invocation);
@@ -54,47 +44,6 @@ export class InvocationTracker {
 
   completeInvocation(invocationId: InvocationId): void {
     this.completedInvocations.add(invocationId);
-  }
-
-  /**
-   * Associate an operation with an invocation.
-   *
-   * @param invocationIds ID of the invocations
-   * @param operationId ID of the operation
-   */
-  associateOperation(invocationIds: InvocationId[], operationId: string): void {
-    for (const invocationId of invocationIds) {
-      if (!this.invocationOperationsMap.has(invocationId)) {
-        this.invocationOperationsMap.set(invocationId, new Set());
-      }
-      this.invocationOperationsMap.get(invocationId)?.add(operationId);
-    }
-  }
-
-  /**
-   * Get all operations associated with an invocation, optionally filtered by status.
-   *
-   * @param invocationId ID of the invocation
-   * @param status Optional status to filter by
-   * @returns Array of operations associated with the invocation
-   */
-  getOperationsForInvocation(
-    invocationId: InvocationId,
-    status?: OperationStatus,
-  ): OperationWithData[] {
-    const opIds = this.invocationOperationsMap.get(invocationId) ?? new Set();
-    // Filter by operation ID (belonging to this invocation)
-    const operations = this.operationStorage.getOperations().filter((op) => {
-      const id = op.getId();
-      return (
-        id !== undefined &&
-        opIds.has(id) &&
-        // Filter by status if provided
-        (status !== undefined ? op.getStatus() === status : true)
-      );
-    });
-
-    return operations;
   }
 
   /**


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/189

*Description of changes:*

Removing invocation-operation association in testing library local runner. Now that the `InvocationCompleted` event is added, we should be getting any sort of operation-invocation association by parsing the history. The local runner will also have this history (coming next), so removing the logic for that here.

If I have time to add back the association, it will be implemented by parsing the history in a cloud/local abstract way instead of through internal invocation tracking.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
