### PR TITLE
feat(sdk): implement lazy evaluation with DurablePromise for all handlers

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/replay/promise-replay.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/replay/promise-replay.ts
@@ -12,19 +12,19 @@ export const config: ExampleConfig = {
 
 export const handler = withDurableExecution(
   async (_event, context: DurableContext) => {
-    const failurePromise = context.step(
-      "failure-step",
-      async () => {
-        throw new Error("This step failed");
-      },
-      {
-        retryStrategy: () => ({
-          shouldRetry: false,
-        }),
-      },
-    );
-
-    await context.promise.allSettled([failurePromise]);
+    await context.promise.allSettled([
+      context.step(
+        "failure-step",
+        async () => {
+          throw new Error("This step failed");
+        },
+        {
+          retryStrategy: () => ({
+            shouldRetry: false,
+          }),
+        },
+      ),
+    ]);
     await context.wait({ seconds: 1 });
 
     const successStep = await context.step(async () => {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/unhandled-rejection/promise-unhandled-rejection.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/promise/unhandled-rejection/promise-unhandled-rejection.ts
@@ -13,20 +13,20 @@ export const config: ExampleConfig = {
 export const handler = withDurableExecution(
   async (_event, context: DurableContext) => {
     // Scenario 1: Immediate combinator usage (original test case)
-    const failurePromise = context.step(
-      "failure-step",
-      async () => {
-        throw new Error("This step failed");
-      },
-      {
-        retryStrategy: () => ({
-          shouldRetry: false,
-        }),
-      },
-    );
-
     try {
-      await context.promise.all([failurePromise]);
+      await context.promise.all([
+        context.step(
+          "failure-step",
+          async () => {
+            throw new Error("This step failed");
+          },
+          {
+            retryStrategy: () => ({
+              shouldRetry: false,
+            }),
+          },
+        ),
+      ]);
     } catch {
       // ignoring error should not fail execution
     }

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -180,7 +180,7 @@ class DurableContextImpl implements DurableContext {
     return this.operationsEmitter;
   }
 
-  private withModeManagement<T>(operation: () => Promise<T>): Promise<T> {
+  private withModeManagement<T>(operation: () => PromiseLike<T>): Promise<T> {
     const shouldSwitchToExecutionMode = this.captureExecutionState();
 
     this.checkAndUpdateReplayMode();
@@ -188,7 +188,7 @@ class DurableContextImpl implements DurableContext {
     if (nonResolvingPromise) return nonResolvingPromise;
 
     try {
-      return operation();
+      return Promise.resolve(operation());
     } finally {
       if (shouldSwitchToExecutionMode) {
         this.durableExecutionMode = DurableExecutionMode.ExecutionMode;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -909,6 +909,7 @@ describe("Callback Handler", () => {
       );
 
       const result = callbackHandler(undefined, config);
+      result.catch(() => {}); // Trigger lazy execution
 
       // Wait for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -926,8 +927,9 @@ describe("Callback Handler", () => {
         },
       });
 
-      // Verify it returns a promise
-      expect(result).toBeInstanceOf(Promise);
+      // Verify it returns a thenable (DurablePromise implements PromiseLike)
+      expect(result).toHaveProperty("then");
+      expect(typeof result.then).toBe("function");
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -17,6 +17,7 @@ import {
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
 
 export const createInvokeHandler = (
   context: ExecutionContext,
@@ -26,31 +27,35 @@ export const createInvokeHandler = (
   getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ): {
-  <I, O>(funcId: string, input: I, config?: InvokeConfig<I, O>): Promise<O>;
+  <I, O>(
+    funcId: string,
+    input: I,
+    config?: InvokeConfig<I, O>,
+  ): DurablePromise<O>;
   <I, O>(
     name: string,
     funcId: string,
     input: I,
     config?: InvokeConfig<I, O>,
-  ): Promise<O>;
+  ): DurablePromise<O>;
 } => {
   function invokeHandler<I, O>(
     funcId: string,
     input: I,
     config?: InvokeConfig<I, O>,
-  ): Promise<O>;
+  ): DurablePromise<O>;
   function invokeHandler<I, O>(
     name: string,
     funcId: string,
     input: I,
     config?: InvokeConfig<I, O>,
-  ): Promise<O>;
-  async function invokeHandler<I, O>(
+  ): DurablePromise<O>;
+  function invokeHandler<I, O>(
     nameOrFuncId: string,
     funcIdOrInput?: string | I,
     inputOrConfig?: I | InvokeConfig<I, O>,
     maybeConfig?: InvokeConfig<I, O>,
-  ): Promise<O> {
+  ): DurablePromise<O> {
     const isNameFirst = typeof funcIdOrInput === "string";
     const name = isNameFirst ? nameOrFuncId : undefined;
     const funcId = isNameFirst ? (funcIdOrInput as string) : nameOrFuncId;
@@ -61,119 +66,125 @@ export const createInvokeHandler = (
 
     const stepId = createStepId();
 
-    log("🔗", `Invoke ${name || funcId} (${stepId})`);
+    return new DurablePromise(async () => {
+      log("🔗", `Invoke ${name || funcId} (${stepId})`);
 
-    // Main invoke logic - can be re-executed if step status changes
-    while (true) {
-      // Check if we have existing step data
-      const stepData = context.getStepData(stepId);
+      // Main invoke logic - can be re-executed if step status changes
+      while (true) {
+        // Check if we have existing step data
+        const stepData = context.getStepData(stepId);
 
-      // Validate replay consistency
-      validateReplayConsistency(
-        stepId,
-        {
-          type: OperationType.CHAINED_INVOKE,
-          name,
-          subType: OperationSubType.CHAINED_INVOKE,
-        },
-        stepData,
-        context,
-      );
+        // Validate replay consistency
+        validateReplayConsistency(
+          stepId,
+          {
+            type: OperationType.CHAINED_INVOKE,
+            name,
+            subType: OperationSubType.CHAINED_INVOKE,
+          },
+          stepData,
+          context,
+        );
 
-      if (stepData?.Status === OperationStatus.SUCCEEDED) {
-        // Return cached result - no need to check for errors in successful operations
-        const invokeDetails = stepData.ChainedInvokeDetails;
-        return await safeDeserialize(
-          config?.resultSerdes || defaultSerdes,
-          invokeDetails?.Result,
+        if (stepData?.Status === OperationStatus.SUCCEEDED) {
+          // Return cached result - no need to check for errors in successful operations
+          const invokeDetails = stepData.ChainedInvokeDetails;
+          return new DurablePromise<O>(() =>
+            safeDeserialize(
+              config?.resultSerdes || defaultSerdes,
+              invokeDetails?.Result,
+              stepId,
+              name,
+              context.terminationManager,
+
+              context.durableExecutionArn,
+            ),
+          );
+        }
+
+        if (
+          stepData?.Status === OperationStatus.FAILED ||
+          stepData?.Status === OperationStatus.TIMED_OUT ||
+          stepData?.Status === OperationStatus.STOPPED
+        ) {
+          // Wrap in DurablePromise for lazy evaluation
+          const invokeDetails = stepData.ChainedInvokeDetails;
+          return new DurablePromise<O>(() => {
+            if (invokeDetails?.Error) {
+              return Promise.reject(
+                new InvokeError(
+                  invokeDetails.Error.ErrorMessage || "Invoke failed",
+                  invokeDetails.Error.ErrorMessage
+                    ? new Error(invokeDetails.Error.ErrorMessage)
+                    : undefined,
+                  invokeDetails.Error.ErrorData,
+                ),
+              );
+            } else {
+              return Promise.reject(new InvokeError("Invoke failed"));
+            }
+          });
+        }
+
+        if (stepData?.Status === OperationStatus.STARTED) {
+          // Operation is still running, check for other operations before terminating
+          if (hasRunningOperations()) {
+            log(
+              "⏳",
+              `Invoke ${name || funcId} still in progress, waiting for other operations`,
+            );
+            await waitBeforeContinue({
+              checkHasRunningOperations: true,
+              checkStepStatus: true,
+              checkTimer: false,
+              stepId,
+              context,
+              hasRunningOperations,
+              operationsEmitter: getOperationsEmitter(),
+            });
+            continue; // Re-evaluate status after waiting
+          }
+
+          // No other operations running, safe to terminate
+          log("⏳", `Invoke ${name || funcId} still in progress, terminating`);
+          return terminate(
+            context,
+            TerminationReason.OPERATION_TERMINATED,
+            stepId,
+          );
+        }
+
+        // Serialize the input payload
+        const serializedPayload = await safeSerialize(
+          config?.payloadSerdes || defaultSerdes,
+          input,
           stepId,
           name,
           context.terminationManager,
 
           context.durableExecutionArn,
         );
+
+        // Create checkpoint for the invoke operation
+        await checkpoint(stepId, {
+          Id: stepId,
+          ParentId: parentId,
+          Action: OperationAction.START,
+          SubType: OperationSubType.CHAINED_INVOKE,
+          Type: OperationType.CHAINED_INVOKE,
+          Name: name,
+          Payload: serializedPayload,
+          ChainedInvokeOptions: {
+            FunctionName: funcId,
+          },
+        });
+
+        log("🚀", `Invoke ${name || funcId} started, re-checking status`);
+
+        // Continue the loop to re-evaluate status (will hit STARTED case)
+        continue;
       }
-
-      if (
-        stepData?.Status === OperationStatus.FAILED ||
-        stepData?.Status === OperationStatus.TIMED_OUT ||
-        stepData?.Status === OperationStatus.STOPPED
-      ) {
-        // Operation failed, return async rejected promise
-        const invokeDetails = stepData.ChainedInvokeDetails;
-        return (async (): Promise<O> => {
-          if (invokeDetails?.Error) {
-            throw new InvokeError(
-              invokeDetails.Error.ErrorMessage || "Invoke failed",
-              invokeDetails.Error.ErrorMessage
-                ? new Error(invokeDetails.Error.ErrorMessage)
-                : undefined,
-              invokeDetails.Error.ErrorData,
-            );
-          } else {
-            throw new InvokeError("Invoke failed");
-          }
-        })();
-      }
-
-      if (stepData?.Status === OperationStatus.STARTED) {
-        // Operation is still running, check for other operations before terminating
-        if (hasRunningOperations()) {
-          log(
-            "⏳",
-            `Invoke ${name || funcId} still in progress, waiting for other operations`,
-          );
-          await waitBeforeContinue({
-            checkHasRunningOperations: true,
-            checkStepStatus: true,
-            checkTimer: false,
-            stepId,
-            context,
-            hasRunningOperations,
-            operationsEmitter: getOperationsEmitter(),
-          });
-          continue; // Re-evaluate status after waiting
-        }
-
-        // No other operations running, safe to terminate
-        log("⏳", `Invoke ${name || funcId} still in progress, terminating`);
-        return terminate(
-          context,
-          TerminationReason.OPERATION_TERMINATED,
-          stepId,
-        );
-      }
-
-      // Serialize the input payload
-      const serializedPayload = await safeSerialize(
-        config?.payloadSerdes || defaultSerdes,
-        input,
-        stepId,
-        name,
-        context.terminationManager,
-
-        context.durableExecutionArn,
-      );
-
-      // Create checkpoint for the invoke operation
-      await checkpoint(stepId, {
-        Id: stepId,
-        ParentId: parentId,
-        Action: OperationAction.START,
-        SubType: OperationSubType.CHAINED_INVOKE,
-        Type: OperationType.CHAINED_INVOKE,
-        Name: name,
-        Payload: serializedPayload,
-        ChainedInvokeOptions: {
-          FunctionName: funcId,
-        },
-      });
-
-      log("🚀", `Invoke ${name || funcId} started, re-checking status`);
-
-      // Continue the loop to re-evaluate status (will hit STARTED case)
-      continue;
-    }
+    });
   }
 
   return invokeHandler;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
@@ -10,17 +10,18 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { createMapSummaryGenerator } from "../../utils/summary-generators/summary-generators";
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
 
 export const createMapHandler = (
   context: ExecutionContext,
   executeConcurrently: DurableContext["executeConcurrently"],
 ) => {
-  return async <TInput, TOutput>(
+  function mapHandler<TInput, TOutput>(
     nameOrItems: string | undefined | TInput[],
     itemsOrMapFunc?: TInput[] | MapFunc<TInput, TOutput>,
     mapFuncOrConfig?: MapFunc<TInput, TOutput> | MapConfig<TInput, TOutput>,
     maybeConfig?: MapConfig<TInput, TOutput>,
-  ): Promise<BatchResult<TOutput>> => {
+  ): DurablePromise<BatchResult<TOutput>> {
     let name: string | undefined;
     let items: TInput[];
     let mapFunc: MapFunc<TInput, TOutput>;
@@ -40,52 +41,57 @@ export const createMapHandler = (
       config = mapFuncOrConfig as MapConfig<TInput, TOutput>;
     }
 
-    log("🗺️", "Starting map operation:", {
-      name,
-      itemCount: items.length,
-      maxConcurrency: config?.maxConcurrency,
+    return new DurablePromise(async () => {
+      log("🗺️", "Starting map operation:", {
+        name,
+        itemCount: items.length,
+        maxConcurrency: config?.maxConcurrency,
+      });
+
+      // Validate inputs
+      if (!Array.isArray(items)) {
+        throw new Error("Map operation requires an array of items");
+      }
+
+      if (typeof mapFunc !== "function") {
+        throw new Error("Map operation requires a function to process items");
+      }
+
+      // Convert to concurrent execution items
+      const executionItems: ConcurrentExecutionItem<TInput>[] = items.map(
+        (item, index) => ({
+          id: `map-item-${index}`,
+          data: item,
+          index,
+          name: config?.itemNamer ? config.itemNamer(item, index) : undefined,
+        }),
+      );
+
+      // Create executor that calls mapFunc
+      const executor: ConcurrentExecutor<TInput, TOutput> = async (
+        executionItem,
+        childContext,
+      ) =>
+        mapFunc(childContext, executionItem.data, executionItem.index, items);
+
+      // Delegate to the concurrent execution handler
+      const result = await executeConcurrently(name, executionItems, executor, {
+        maxConcurrency: config?.maxConcurrency,
+        topLevelSubType: OperationSubType.MAP,
+        iterationSubType: OperationSubType.MAP_ITERATION,
+        summaryGenerator: createMapSummaryGenerator(),
+        completionConfig: config?.completionConfig,
+        serdes: config?.serdes,
+        itemSerdes: config?.itemSerdes,
+      });
+
+      log("🗺️", "Map operation completed successfully:", {
+        resultCount: result.totalCount,
+      });
+
+      return result;
     });
+  }
 
-    // Validate inputs
-    if (!Array.isArray(items)) {
-      throw new Error("Map operation requires an array of items");
-    }
-
-    if (typeof mapFunc !== "function") {
-      throw new Error("Map operation requires a function to process items");
-    }
-
-    // Convert to concurrent execution items
-    const executionItems: ConcurrentExecutionItem<TInput>[] = items.map(
-      (item, index) => ({
-        id: `map-item-${index}`,
-        data: item,
-        index,
-        name: config?.itemNamer ? config.itemNamer(item, index) : undefined,
-      }),
-    );
-
-    // Create executor that calls mapFunc
-    const executor: ConcurrentExecutor<TInput, TOutput> = async (
-      executionItem,
-      childContext,
-    ) => mapFunc(childContext, executionItem.data, executionItem.index, items);
-
-    // Delegate to the concurrent execution handler
-    const result = await executeConcurrently(name, executionItems, executor, {
-      maxConcurrency: config?.maxConcurrency,
-      topLevelSubType: OperationSubType.MAP,
-      iterationSubType: OperationSubType.MAP_ITERATION,
-      summaryGenerator: createMapSummaryGenerator(),
-      completionConfig: config?.completionConfig,
-      serdes: config?.serdes,
-      itemSerdes: config?.itemSerdes,
-    });
-
-    log("🗺️", "Map operation completed successfully:", {
-      resultCount: result.totalCount,
-    });
-
-    return result;
-  };
+  return mapHandler;
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
@@ -11,12 +11,13 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { createParallelSummaryGenerator } from "../../utils/summary-generators/summary-generators";
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
 
 export const createParallelHandler = (
   context: ExecutionContext,
   executeConcurrently: DurableContext["executeConcurrently"],
 ) => {
-  return async <T>(
+  function parallelHandler<T>(
     nameOrBranches:
       | string
       | undefined
@@ -25,7 +26,7 @@ export const createParallelHandler = (
       | (ParallelFunc<T> | NamedParallelBranch<T>)[]
       | ParallelConfig<T>,
     maybeConfig?: ParallelConfig<T>,
-  ): Promise<BatchResult<T>> => {
+  ): DurablePromise<BatchResult<T>> {
     let name: string | undefined;
     let branches: (ParallelFunc<T> | NamedParallelBranch<T>)[];
     let config: ParallelConfig<T> | undefined;
@@ -45,80 +46,84 @@ export const createParallelHandler = (
       config = branchesOrConfig as ParallelConfig<T>;
     }
 
-    // Validate inputs
-    if (!Array.isArray(branches)) {
-      throw new Error(
-        "Parallel operation requires an array of branch functions",
-      );
-    }
+    return new DurablePromise(async () => {
+      // Validate inputs
+      if (!Array.isArray(branches)) {
+        throw new Error(
+          "Parallel operation requires an array of branch functions",
+        );
+      }
 
-    log("🔀", "Starting parallel operation:", {
-      name,
-      branchCount: branches.length,
-      maxConcurrency: config?.maxConcurrency,
-    });
-
-    if (
-      branches.some(
-        (branch) =>
-          typeof branch !== "function" &&
-          (typeof branch !== "object" || typeof branch.func !== "function"),
-      )
-    ) {
-      throw new Error(
-        "All branches must be functions or NamedParallelBranch objects",
-      );
-    }
-
-    // Convert to concurrent execution items
-    const executionItems: ConcurrentExecutionItem<ParallelFunc<T>>[] =
-      branches.map((branch, index) => {
-        const isNamedBranch = typeof branch === "object" && "func" in branch;
-        const func = isNamedBranch ? branch.func : branch;
-        const branchName = isNamedBranch ? branch.name : undefined;
-
-        return {
-          id: `parallel-branch-${index}`,
-          data: func,
-          index,
-          name: branchName,
-        };
+      log("🔀", "Starting parallel operation:", {
+        name,
+        branchCount: branches.length,
+        maxConcurrency: config?.maxConcurrency,
       });
 
-    // Create executor that calls the branch function
-    const executor: ConcurrentExecutor<ParallelFunc<T>, T> = async (
-      executionItem,
-      childContext,
-    ) => {
-      log("🔀", "Processing parallel branch:", {
-        index: executionItem.index,
+      if (
+        branches.some(
+          (branch) =>
+            typeof branch !== "function" &&
+            (typeof branch !== "object" || typeof branch.func !== "function"),
+        )
+      ) {
+        throw new Error(
+          "All branches must be functions or NamedParallelBranch objects",
+        );
+      }
+
+      // Convert to concurrent execution items
+      const executionItems: ConcurrentExecutionItem<ParallelFunc<T>>[] =
+        branches.map((branch, index) => {
+          const isNamedBranch = typeof branch === "object" && "func" in branch;
+          const func = isNamedBranch ? branch.func : branch;
+          const branchName = isNamedBranch ? branch.name : undefined;
+
+          return {
+            id: `parallel-branch-${index}`,
+            data: func,
+            index,
+            name: branchName,
+          };
+        });
+
+      // Create executor that calls the branch function
+      const executor: ConcurrentExecutor<ParallelFunc<T>, T> = async (
+        executionItem,
+        childContext,
+      ) => {
+        log("🔀", "Processing parallel branch:", {
+          index: executionItem.index,
+        });
+
+        const result = await executionItem.data(childContext);
+
+        log("✅", "Parallel branch completed:", {
+          index: executionItem.index,
+          result,
+        });
+
+        return result;
+      };
+
+      // Delegate to the concurrent execution handler
+      const result = await executeConcurrently(name, executionItems, executor, {
+        maxConcurrency: config?.maxConcurrency,
+        topLevelSubType: OperationSubType.PARALLEL,
+        iterationSubType: OperationSubType.PARALLEL_BRANCH,
+        summaryGenerator: createParallelSummaryGenerator(),
+        completionConfig: config?.completionConfig,
+        serdes: config?.serdes,
+        itemSerdes: config?.itemSerdes,
       });
 
-      const result = await executionItem.data(childContext);
-
-      log("✅", "Parallel branch completed:", {
-        index: executionItem.index,
-        result,
+      log("🔀", "Parallel operation completed successfully:", {
+        resultCount: result.totalCount,
       });
 
       return result;
-    };
-
-    // Delegate to the concurrent execution handler
-    const result = await executeConcurrently(name, executionItems, executor, {
-      maxConcurrency: config?.maxConcurrency,
-      topLevelSubType: OperationSubType.PARALLEL,
-      iterationSubType: OperationSubType.PARALLEL_BRANCH,
-      summaryGenerator: createParallelSummaryGenerator(),
-      completionConfig: config?.completionConfig,
-      serdes: config?.serdes,
-      itemSerdes: config?.itemSerdes,
     });
+  }
 
-    log("🔀", "Parallel operation completed successfully:", {
-      resultCount: result.totalCount,
-    });
-
-    return result;
-  };
+  return parallelHandler;
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -27,6 +27,7 @@ import {
   ChildContextError,
 } from "../../errors/durable-error/durable-error";
 import { runWithContext } from "../../utils/context-tracker/context-tracker";
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
 
 // Checkpoint size limit in bytes (256KB)
 const CHECKPOINT_SIZE_LIMIT = 256 * 1024;
@@ -75,11 +76,11 @@ export const createRunInChildContextHandler = (
   ) => DurableContext,
   parentId?: string,
 ) => {
-  return async <T>(
+  function runInChildContextHandler<T>(
     nameOrFn: string | undefined | ChildFunc<T>,
     fnOrOptions?: ChildFunc<T> | ChildConfig<T>,
     maybeOptions?: ChildConfig<T>,
-  ): Promise<T> => {
+  ): DurablePromise<T> {
     let name: string | undefined;
     let fn: ChildFunc<T>;
     let options: ChildConfig<T> | undefined;
@@ -95,31 +96,67 @@ export const createRunInChildContextHandler = (
 
     const entityId = createStepId();
 
-    log("🔄", "Running child context:", {
-      entityId,
-      name,
-    });
-
-    const stepData = context.getStepData(entityId);
-
-    // Validate replay consistency
-    validateReplayConsistency(
-      entityId,
-      {
-        type: OperationType.CONTEXT,
+    return new DurablePromise(async () => {
+      log("🔄", "Running child context:", {
+        entityId,
         name,
-        subType:
-          (options?.subType as OperationSubType) ||
-          OperationSubType.RUN_IN_CHILD_CONTEXT,
-      },
-      stepData,
-      context,
-    );
+      });
 
-    // Check if this child context has already completed
-    if (stepData?.Status === OperationStatus.SUCCEEDED) {
-      return handleCompletedChildContext<T>(
+      const stepData = context.getStepData(entityId);
+
+      // Validate replay consistency
+      validateReplayConsistency(
+        entityId,
+        {
+          type: OperationType.CONTEXT,
+          name,
+          subType:
+            (options?.subType as OperationSubType) ||
+            OperationSubType.RUN_IN_CHILD_CONTEXT,
+        },
+        stepData,
         context,
+      );
+
+      // Check if this child context has already completed
+      if (stepData?.Status === OperationStatus.SUCCEEDED) {
+        return new DurablePromise<T>(() =>
+          handleCompletedChildContext<T>(
+            context,
+            parentContext,
+            entityId,
+            name,
+            fn,
+            options,
+            getParentLogger,
+            createChildContext,
+          ),
+        );
+      }
+
+      if (stepData?.Status === OperationStatus.FAILED) {
+        // Wrap in DurablePromise for lazy evaluation
+        return new DurablePromise<T>(() => {
+          // Reconstruct the original error and wrap in ChildContextError for consistency
+          if (stepData.ContextDetails?.Error) {
+            const originalError = DurableOperationError.fromErrorObject(
+              stepData.ContextDetails.Error,
+            );
+            return Promise.reject(
+              new ChildContextError(originalError.message, originalError),
+            );
+          } else {
+            // Fallback for legacy data without Error field
+            return Promise.reject(
+              new ChildContextError("Child context failed"),
+            );
+          }
+        });
+      }
+
+      return executeChildContext(
+        context,
+        checkpoint,
         parentContext,
         entityId,
         name,
@@ -127,38 +164,12 @@ export const createRunInChildContextHandler = (
         options,
         getParentLogger,
         createChildContext,
+        parentId,
       );
-    }
+    });
+  }
 
-    if (stepData?.Status === OperationStatus.FAILED) {
-      // Return an async rejected promise to ensure it's handled asynchronously
-      return (async (): Promise<T> => {
-        // Reconstruct the original error and wrap in ChildContextError for consistency
-        if (stepData.ContextDetails?.Error) {
-          const originalError = DurableOperationError.fromErrorObject(
-            stepData.ContextDetails.Error,
-          );
-          throw new ChildContextError(originalError.message, originalError);
-        } else {
-          // Fallback for legacy data without Error field
-          throw new ChildContextError("Child context failed");
-        }
-      })();
-    }
-
-    return executeChildContext(
-      context,
-      checkpoint,
-      parentContext,
-      entityId,
-      name,
-      fn,
-      options,
-      getParentLogger,
-      createChildContext,
-      parentId,
-    );
-  };
+  return runInChildContextHandler;
 };
 
 export const handleCompletedChildContext = async <T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -148,8 +148,9 @@ describe("Step Handler", () => {
 
     const stepFn = jest.fn().mockResolvedValue("step-result");
 
-    // Start the step execution (should not hang waiting for START checkpoint)
+    // Start the step execution and trigger lazy evaluation
     const stepPromise = stepHandler("test-step", stepFn);
+    stepPromise.catch(() => {}); // Trigger execution
 
     // Give a small delay to ensure the step function would be called if not waiting
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -183,10 +184,11 @@ describe("Step Handler", () => {
       .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics
-    stepHandler("test-step", stepFn, {
+    const _promise = stepHandler("test-step", stepFn, {
       semantics: StepSemantics.AtMostOncePerRetry,
       retryStrategy: mockRetryStrategy,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -361,9 +363,10 @@ describe("Step Handler", () => {
       .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler but don't await it (it will never resolve)
-    stepHandler("test-step", stepFn, {
+    const _promise = stepHandler("test-step", stepFn, {
       retryStrategy: mockRetryStrategy,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -397,7 +400,8 @@ describe("Step Handler", () => {
     });
 
     // Call the step handler but don't await it (it will never resolve)
-    stepHandler("test-step", stepFn);
+    const _promise = stepHandler("test-step", stepFn);
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -564,9 +568,10 @@ describe("Step Handler", () => {
     });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics but no custom retry strategy
-    stepHandler("test-step", stepFn, {
+    const _promise = stepHandler("test-step", stepFn, {
       semantics: StepSemantics.AtMostOncePerRetry,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -657,7 +662,8 @@ describe("Step Handler", () => {
     });
 
     // Call the step handler without a name
-    stepHandler(stepFn);
+    const _promise = stepHandler(stepFn);
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -694,9 +700,10 @@ describe("Step Handler", () => {
     });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics but no name
-    stepHandler(stepFn, {
+    const _promise = stepHandler(stepFn, {
       semantics: StepSemantics.AtMostOncePerRetry,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -724,6 +731,15 @@ describe("Step Handler", () => {
 
     const promise = stepHandler(stepId, stepFunction);
 
+    // Trigger lazy execution
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+
+    // Wait for execution to start
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
     // Should terminate with retry scheduled message
     expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
       reason: TerminationReason.RETRY_SCHEDULED,
@@ -731,12 +747,6 @@ describe("Step Handler", () => {
     });
 
     // Should return never-resolving promise
-    let resolved = false;
-    promise.then(() => {
-      resolved = true;
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
     expect(resolved).toBe(false);
   });
 
@@ -758,10 +768,11 @@ describe("Step Handler", () => {
       .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with AT_MOST_ONCE_PER_RETRY semantics
-    stepHandler("test-step", stepFn, {
+    const _promise = stepHandler("test-step", stepFn, {
       semantics: StepSemantics.AtMostOncePerRetry,
       retryStrategy: mockRetryStrategy,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -780,9 +791,10 @@ describe("Step Handler", () => {
       .mockReturnValue({ shouldRetry: true, delay: { seconds: 10 } });
 
     // Call the step handler with custom retry strategy
-    stepHandler("test-step", stepFn, {
+    const _promise = stepHandler("test-step", stepFn, {
       retryStrategy: mockRetryStrategy,
     });
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -813,7 +825,8 @@ describe("Step Handler", () => {
     });
 
     // Call the step handler with default retry strategy
-    stepHandler("test-step", stepFn);
+    const _promise = stepHandler("test-step", stepFn);
+    _promise.catch(() => {}); // Trigger lazy execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -870,7 +883,8 @@ describe("Step Handler", () => {
       const stepFn = jest.fn().mockRejectedValue(unrecoverableError);
 
       // Call the step handler but don't await it (it will never resolve)
-      stepHandler("test-step", stepFn);
+      const _promise = stepHandler("test-step", stepFn);
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -890,7 +904,8 @@ describe("Step Handler", () => {
       const stepFn = jest.fn().mockRejectedValue(unrecoverableError);
 
       // Call the step handler but don't await it (it will never resolve)
-      stepHandler("test-step", stepFn);
+      const _promise = stepHandler("test-step", stepFn);
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -910,7 +925,8 @@ describe("Step Handler", () => {
       const stepFn = jest.fn().mockRejectedValue(unrecoverableError);
 
       // Call the step handler but don't await it (it will never resolve)
-      stepHandler("test-step", stepFn);
+      const _promise = stepHandler("test-step", stepFn);
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -931,7 +947,8 @@ describe("Step Handler", () => {
       Object.defineProperty(stepFn, "name", { value: "" });
 
       // Call the step handler but don't await it (it will never resolve)
-      stepHandler(stepFn);
+      const _promise = stepHandler(stepFn);
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -953,7 +970,8 @@ describe("Step Handler", () => {
       Object.defineProperty(stepFn, "name", { value: "" });
 
       // Call the step handler but don't await it (it will never resolve)
-      stepHandler(stepFn);
+      const _promise = stepHandler(stepFn);
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -978,9 +996,10 @@ describe("Step Handler", () => {
       };
 
       // Call the step handler but don't await it (it will never resolve due to termination)
-      stepHandler("test-step", stepFn, {
+      const _promise = stepHandler("test-step", stepFn, {
         serdes: mockSerdes,
       });
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -1005,9 +1024,10 @@ describe("Step Handler", () => {
       };
 
       // Call the step handler but don't await it (it will never resolve due to termination)
-      stepHandler("test-step", stepFn, {
+      const _promise = stepHandler("test-step", stepFn, {
         serdes: mockSerdes,
       });
+      _promise.catch(() => {}); // Trigger lazy execution
 
       // Wait a small amount of time for the async operations to complete
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.timing.test.ts
@@ -61,7 +61,7 @@ describe("Step Handler Timing Tests", () => {
 
       stepHandlerWithMocks("test-step", stepFn, {
         retryStrategy: mockRetryStrategy,
-      });
+      }).catch(() => {});
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.timing.test.ts
@@ -82,7 +82,9 @@ describe("WaitForCondition Handler Timing Tests", () => {
         undefined, // parentId
       );
 
-      waitForConditionHandlerWithMocks("test-wait", checkFn, config);
+      waitForConditionHandlerWithMocks("test-wait", checkFn, config).catch(
+        () => {},
+      );
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler-lazy.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler-lazy.test.ts
@@ -1,0 +1,80 @@
+import { createWaitHandler } from "./wait-handler";
+import { createCheckpoint } from "../../utils/checkpoint/checkpoint";
+import { EventEmitter } from "events";
+import { ExecutionContext } from "../../types";
+
+describe("Wait Handler - Lazy Evaluation", () => {
+  it("should not execute wait until awaited", async () => {
+    const mockContext = {
+      getStepData: jest.fn().mockReturnValue(null),
+    } as unknown as ExecutionContext;
+
+    const mockCheckpoint = jest.fn();
+    let stepIdCounter = 0;
+    const createStepId = () => `step-${++stepIdCounter}`;
+    const hasRunningOperations = jest.fn().mockReturnValue(false);
+    const getOperationsEmitter = () => new EventEmitter();
+
+    const waitHandler = createWaitHandler(
+      mockContext,
+      mockCheckpoint as unknown as ReturnType<typeof createCheckpoint>,
+      createStepId,
+      hasRunningOperations,
+      getOperationsEmitter,
+    );
+
+    // Create wait promise but don't await it
+    const waitPromise = waitHandler({ seconds: 10 });
+
+    // Checkpoint should NOT be called yet (lazy evaluation)
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+    expect(mockContext.getStepData).not.toHaveBeenCalled();
+
+    // Now await it - execution starts
+    try {
+      await waitPromise;
+    } catch (err) {
+      // Expected to terminate
+    }
+
+    // Now checkpoint should be called
+    expect(mockCheckpoint).toHaveBeenCalled();
+  });
+
+  it("should allow Promise.race without eager execution", async () => {
+    const mockContext = {
+      getStepData: jest.fn().mockReturnValue(null),
+    } as unknown as ExecutionContext;
+
+    const mockCheckpoint = jest.fn();
+    let stepIdCounter = 0;
+    const createStepId = () => `step-${++stepIdCounter}`;
+    const hasRunningOperations = jest.fn().mockReturnValue(false);
+    const getOperationsEmitter = () => new EventEmitter();
+
+    const waitHandler = createWaitHandler(
+      mockContext,
+      mockCheckpoint as unknown as ReturnType<typeof createCheckpoint>,
+      createStepId,
+      hasRunningOperations,
+      getOperationsEmitter,
+    );
+
+    // Create multiple wait promises
+    const wait1 = waitHandler({ seconds: 10 });
+    const wait2 = waitHandler({ seconds: 5 });
+
+    // Neither should execute yet
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+
+    // Use Promise.race - both will start executing
+    try {
+      await Promise.race([wait1, wait2]);
+    } catch (err) {
+      // Expected to terminate
+    }
+
+    // Both should have attempted to checkpoint
+    expect(mockCheckpoint).toHaveBeenCalled();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.test.ts
@@ -78,8 +78,9 @@ describe("Wait Handler", () => {
   });
 
   test("should accept undefined as name parameter", async () => {
-    // Call the wait handler with undefined name
-    waitHandler({ seconds: 1 });
+    // Call the wait handler with undefined name and trigger execution
+    const promise = waitHandler({ seconds: 1 });
+    promise.catch(() => {}); // Trigger execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -105,8 +106,9 @@ describe("Wait Handler", () => {
   });
 
   test("should checkpoint at start and terminate with WAIT_SCHEDULED reason", async () => {
-    // Call the wait handler but don't await it (it will never resolve)
-    waitHandler("test-wait", { seconds: 1 });
+    // Call the wait handler and trigger execution
+    const promise = waitHandler("test-wait", { seconds: 1 });
+    promise.catch(() => {}); // Trigger execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -131,8 +133,9 @@ describe("Wait Handler", () => {
   });
 
   test("should use stepId as message when name is not provided", async () => {
-    // Call the wait handler but don't await it (it will never resolve)
-    waitHandler({ seconds: 1 });
+    // Call the wait handler and trigger execution
+    const promise = waitHandler({ seconds: 1 });
+    promise.catch(() => {}); // Trigger execution
 
     // Wait a small amount of time for the async operations to complete
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -155,7 +158,8 @@ describe("Wait Handler", () => {
         () => mockOperationsEmitter,
       );
 
-      waitHandler("test-wait", { seconds: 1 });
+      const promise = waitHandler("test-wait", { seconds: 1 });
+      promise.catch(() => {}); // Trigger execution
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(
@@ -200,7 +204,8 @@ describe("Wait Handler", () => {
         () => mockOperationsEmitter,
       );
 
-      waitHandler("test-wait", { seconds: 1 });
+      const promise = waitHandler("test-wait", { seconds: 1 });
+      promise.catch(() => {}); // Trigger execution
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(mockCheckpoint).toHaveBeenCalledWith("test-step-id", {
@@ -234,8 +239,9 @@ describe("Wait Handler", () => {
         () => mockOperationsEmitter,
       );
 
-      // Start the wait handler (don't await - it will wait for operations)
-      waitHandler("test-wait", { seconds: 1 });
+      // Start the wait handler and trigger execution
+      const promise = waitHandler("test-wait", { seconds: 1 });
+      promise.catch(() => {}); // Trigger execution
 
       // Give it time to enter the waiting logic
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -289,8 +295,9 @@ describe("Wait Handler", () => {
         () => mockOperationsEmitter,
       );
 
-      // Start wait handler - should detect running operations and wait
-      waitHandler("parallel-wait", { seconds: 2 });
+      // Start wait handler and trigger execution
+      const promise = waitHandler("parallel-wait", { seconds: 2 });
+      promise.catch(() => {}); // Trigger execution
 
       // Give time for wait handler to enter complex waiting logic
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -12,6 +12,7 @@ import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before
 import { EventEmitter } from "events";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
 import { durationToSeconds } from "../../utils/duration/duration";
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
 
 export const createWaitHandler = (
   context: ExecutionContext,
@@ -21,91 +22,93 @@ export const createWaitHandler = (
   getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ): {
-  (name: string, duration: Duration): Promise<void>;
-  (duration: Duration): Promise<void>;
+  (name: string, duration: Duration): DurablePromise<void>;
+  (duration: Duration): DurablePromise<void>;
 } => {
-  function waitHandler(name: string, duration: Duration): Promise<void>;
-  function waitHandler(duration: Duration): Promise<void>;
-  async function waitHandler(
+  function waitHandler(name: string, duration: Duration): DurablePromise<void>;
+  function waitHandler(duration: Duration): DurablePromise<void>;
+  function waitHandler(
     nameOrDuration: string | Duration,
     duration?: Duration,
-  ): Promise<void> {
+  ): DurablePromise<void> {
     const isNameFirst = typeof nameOrDuration === "string";
     const actualName = isNameFirst ? nameOrDuration : undefined;
     const actualDuration = isNameFirst ? duration! : nameOrDuration;
     const actualSeconds = durationToSeconds(actualDuration);
     const stepId = createStepId();
 
-    log("⏲️", "Wait requested:", {
-      stepId,
-      name: actualName,
-      duration: actualDuration,
-      seconds: actualSeconds,
-    });
-
-    // Main wait logic - can be re-executed if step data changes
-    while (true) {
-      let stepData = context.getStepData(stepId);
-
-      // Validate replay consistency
-      validateReplayConsistency(
+    return new DurablePromise(async () => {
+      log("⏲️", "Wait requested:", {
         stepId,
-        {
-          type: OperationType.WAIT,
-          name: actualName,
-          subType: OperationSubType.WAIT,
-        },
-        stepData,
-        context,
-      );
-
-      if (stepData?.Status === OperationStatus.SUCCEEDED) {
-        log("⏭️", "Wait already completed:", { stepId });
-        return;
-      }
-
-      // Only checkpoint START if we haven't started this wait before
-      if (!stepData) {
-        await checkpoint(stepId, {
-          Id: stepId,
-          ParentId: parentId,
-          Action: OperationAction.START,
-          SubType: OperationSubType.WAIT,
-          Type: OperationType.WAIT,
-          Name: actualName,
-          WaitOptions: {
-            WaitSeconds: actualSeconds,
-          },
-        });
-      }
-
-      // Check if there are any ongoing operations
-      if (!hasRunningOperations()) {
-        // A.1: No ongoing operations - safe to terminate
-        return terminate(
-          context,
-          TerminationReason.WAIT_SCHEDULED,
-          `Operation ${actualName || stepId} scheduled to wait`,
-        );
-      }
-
-      // There are ongoing operations - wait before continuing
-      // Refresh stepData after checkpoint to get ScheduledEndTimestamp
-      stepData = context.getStepData(stepId);
-      await waitBeforeContinue({
-        checkHasRunningOperations: true,
-        checkStepStatus: true,
-        checkTimer: true,
-        scheduledEndTimestamp: stepData?.WaitDetails?.ScheduledEndTimestamp,
-        stepId,
-        context,
-        hasRunningOperations,
-        operationsEmitter: getOperationsEmitter(),
-        checkpoint,
+        name: actualName,
+        duration: actualDuration,
+        seconds: actualSeconds,
       });
 
-      // Continue the loop to re-evaluate all conditions from the beginning
-    }
+      // Main wait logic - can be re-executed if step data changes
+      while (true) {
+        let stepData = context.getStepData(stepId);
+
+        // Validate replay consistency
+        validateReplayConsistency(
+          stepId,
+          {
+            type: OperationType.WAIT,
+            name: actualName,
+            subType: OperationSubType.WAIT,
+          },
+          stepData,
+          context,
+        );
+
+        if (stepData?.Status === OperationStatus.SUCCEEDED) {
+          log("⏭️", "Wait already completed:", { stepId });
+          return;
+        }
+
+        // Only checkpoint START if we haven't started this wait before
+        if (!stepData) {
+          await checkpoint(stepId, {
+            Id: stepId,
+            ParentId: parentId,
+            Action: OperationAction.START,
+            SubType: OperationSubType.WAIT,
+            Type: OperationType.WAIT,
+            Name: actualName,
+            WaitOptions: {
+              WaitSeconds: actualSeconds,
+            },
+          });
+        }
+
+        // Check if there are any ongoing operations
+        if (!hasRunningOperations()) {
+          // A.1: No ongoing operations - safe to terminate
+          return terminate(
+            context,
+            TerminationReason.WAIT_SCHEDULED,
+            `Operation ${actualName || stepId} scheduled to wait`,
+          );
+        }
+
+        // There are ongoing operations - wait before continuing
+        // Refresh stepData after checkpoint to get ScheduledEndTimestamp
+        stepData = context.getStepData(stepId);
+        await waitBeforeContinue({
+          checkHasRunningOperations: true,
+          checkStepStatus: true,
+          checkTimer: true,
+          scheduledEndTimestamp: stepData?.WaitDetails?.ScheduledEndTimestamp,
+          stepId,
+          context,
+          hasRunningOperations,
+          operationsEmitter: getOperationsEmitter(),
+          checkpoint,
+        });
+
+        // Continue the loop to re-evaluate all conditions from the beginning
+      }
+    });
   }
 
   return waitHandler;

--- a/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/EXAMPLE.md
+++ b/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/EXAMPLE.md
@@ -1,0 +1,188 @@
+# Real-World Example: DurablePromise Benefits
+
+## Scenario: Timeout Pattern with Lambda Invocation
+
+### Problem with Eager Promises
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ❌ PROBLEM: invoke() starts immediately and might terminate Lambda
+  const invokeOp = ctx.invoke("slow-function", { data: event.data });
+
+  // ❌ We might never reach this line if invoke terminates Lambda
+  const timeoutOp = ctx.wait({ seconds: 30 });
+
+  // ❌ We definitely never reach Promise.race if Lambda terminated
+  const result = await Promise.race([
+    invokeOp,
+    timeoutOp.then(() => {
+      throw new Error("Timeout!");
+    }),
+  ]);
+
+  return result;
+};
+```
+
+**What happens:**
+
+1. `ctx.invoke()` executes immediately
+2. If it needs to checkpoint and terminate Lambda, it does so
+3. Lines after `ctx.invoke()` never execute
+4. `Promise.race()` never gets called
+5. Timeout protection doesn't work
+
+### Solution with DurablePromise
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ✅ SOLUTION: Neither operation starts yet
+  const invokeOp = ctx.invoke("slow-function", { data: event.data });
+  const timeoutOp = ctx.wait({ seconds: 30 });
+
+  // ✅ Both operations start together when Promise.race calls .then()
+  const result = await Promise.race([
+    invokeOp,
+    timeoutOp.then(() => {
+      throw new Error("Timeout!");
+    }),
+  ]);
+
+  return result;
+};
+```
+
+**What happens:**
+
+1. `ctx.invoke()` returns `DurablePromise` without executing
+2. `ctx.wait()` returns `DurablePromise` without executing
+3. `Promise.race()` is reached successfully
+4. `Promise.race()` calls `.then()` on both promises
+5. Both operations start executing together
+6. Timeout protection works correctly
+
+## Scenario: Conditional Execution
+
+### Problem with Eager Promises
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ❌ Step executes immediately, even if we don't need it
+  const expensiveOp = ctx.step("expensive", async () => {
+    return await doExpensiveWork();
+  });
+
+  if (event.skipExpensive) {
+    // ❌ Too late! expensiveOp already started
+    return { skipped: true };
+  }
+
+  return await expensiveOp;
+};
+```
+
+### Solution with DurablePromise
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ✅ Step doesn't execute yet
+  const expensiveOp = ctx.step("expensive", async () => {
+    return await doExpensiveWork();
+  });
+
+  if (event.skipExpensive) {
+    // ✅ expensiveOp never executes
+    return { skipped: true };
+  }
+
+  // ✅ Only executes if we reach this line
+  return await expensiveOp;
+};
+```
+
+## Scenario: Dynamic Operation Selection
+
+### Problem with Eager Promises
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ❌ All three operations start immediately
+  const fastOp = ctx.invoke("fast-service", event);
+  const mediumOp = ctx.invoke("medium-service", event);
+  const slowOp = ctx.invoke("slow-service", event);
+
+  // ❌ All three Lambdas already invoked, wasting resources
+  const selected =
+    event.priority === "high"
+      ? fastOp
+      : event.priority === "medium"
+        ? mediumOp
+        : slowOp;
+
+  return await selected;
+};
+```
+
+### Solution with DurablePromise
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ✅ No operations execute yet
+  const fastOp = ctx.invoke("fast-service", event);
+  const mediumOp = ctx.invoke("medium-service", event);
+  const slowOp = ctx.invoke("slow-service", event);
+
+  // ✅ Select operation without executing others
+  const selected =
+    event.priority === "high"
+      ? fastOp
+      : event.priority === "medium"
+        ? mediumOp
+        : slowOp;
+
+  // ✅ Only the selected operation executes
+  return await selected;
+};
+```
+
+## Scenario: Parallel Operations with Fallback
+
+### Problem with Eager Promises
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ❌ Primary operation starts immediately
+  const primary = ctx.invoke("primary-service", event);
+
+  // ❌ If primary terminates Lambda, we never create fallback
+  const fallback = ctx.invoke("fallback-service", event);
+
+  // ❌ Never reached if Lambda terminated
+  return await Promise.race([
+    primary,
+    ctx.wait({ seconds: 5 }).then(() => fallback),
+  ]);
+};
+```
+
+### Solution with DurablePromise
+
+```typescript
+const handler = async (event: any, ctx: DurableContext) => {
+  // ✅ Neither operation starts yet
+  const primary = ctx.invoke("primary-service", event);
+  const fallback = ctx.invoke("fallback-service", event);
+
+  // ✅ Complex composition works correctly
+  return await Promise.race([
+    primary,
+    ctx.wait({ seconds: 5 }).then(() => fallback),
+  ]);
+};
+```
+
+## Key Takeaway
+
+**DurablePromise enables safe composition of operations that might terminate Lambda execution.**
+
+Without it, any operation that checkpoints and terminates prevents subsequent code from running, breaking promise composition patterns like `Promise.race()`, `Promise.all()`, and conditional execution.

--- a/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/MIGRATION.md
+++ b/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/MIGRATION.md
@@ -1,0 +1,172 @@
+# Migration Guide: Converting Handlers to DurablePromise
+
+## Overview
+
+All handlers need to be converted from returning `Promise<T>` to `DurablePromise<T>` to enable lazy evaluation and prevent early termination issues.
+
+## Handlers to Update
+
+### 1. ✅ wait-handler (DONE)
+
+- **File**: `src/handlers/wait-handler/wait-handler.ts`
+- **Change**: Return `DurablePromise<void>` instead of `Promise<void>`
+- **Pattern**: Wrap async logic in `new DurablePromise(async () => { ... })`
+
+### 2. step-handler
+
+- **File**: `src/handlers/step-handler/step-handler.ts`
+- **Return type**: `Promise<T>` → `DurablePromise<T>`
+- **Impact**: Core operation, affects all step calls
+
+### 3. invoke-handler
+
+- **File**: `src/handlers/invoke-handler/invoke-handler.ts`
+- **Return type**: `Promise<O>` → `DurablePromise<O>`
+- **Impact**: Critical - invoke can terminate Lambda
+
+### 4. parallel-handler
+
+- **File**: `src/handlers/parallel-handler/parallel-handler.ts`
+- **Return type**: `Promise<BatchResult<T>>` → `DurablePromise<BatchResult<T>>`
+
+### 5. map-handler
+
+- **File**: `src/handlers/map-handler/map-handler.ts`
+- **Return type**: `Promise<BatchResult<TOutput>>` → `DurablePromise<BatchResult<TOutput>>`
+
+### 6. callback-handler
+
+- **File**: `src/handlers/callback-handler/callback.ts`
+- **Return type**: `Promise<CreateCallbackResult<T>>` → `DurablePromise<CreateCallbackResult<T>>`
+- **Note**: Already has `TerminatingPromise` - may need integration
+
+### 7. wait-for-callback-handler
+
+- **File**: `src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts`
+- **Return type**: `Promise<T>` → `DurablePromise<T>`
+
+### 8. wait-for-condition-handler
+
+- **File**: `src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts`
+- **Return type**: `Promise<T>` → `DurablePromise<T>`
+
+### 9. run-in-child-context-handler
+
+- **File**: `src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts`
+- **Return type**: `Promise<T>` → `DurablePromise<T>`
+
+### 10. promise-handler
+
+- **File**: `src/handlers/promise-handler/promise-handler.ts`
+- **Return type**: Various promise methods
+- **Note**: May need special handling for Promise.all/race/allSettled
+
+### 11. concurrent-execution-handler
+
+- **File**: `src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts`
+- **Return type**: `Promise<BatchResult<R>>` → `DurablePromise<BatchResult<R>>`
+
+## Conversion Pattern
+
+### Before (Eager Execution)
+
+```typescript
+export const createHandler = (...) => {
+  async function handler(...): Promise<T> {
+    // Logic executes immediately
+    const result = await doWork();
+    return result;
+  }
+  return handler;
+};
+```
+
+### After (Lazy Execution)
+
+```typescript
+import { DurablePromise } from "../../utils/durable-promise/durable-promise";
+
+export const createHandler = (...) => {
+  function handler(...): DurablePromise<T> {
+    return new DurablePromise(async () => {
+      // Logic only executes when awaited
+      const result = await doWork();
+      return result;
+    });
+  }
+  return handler;
+};
+```
+
+## Type Updates
+
+### DurableContext Interface
+
+Update `src/types/durable-context.ts`:
+
+```typescript
+export interface DurableContext {
+  // Before
+  step<T>(name: string, fn: StepFunc<T>, config?: StepConfig<T>): Promise<T>;
+  wait(duration: Duration): Promise<void>;
+  invoke<I, O>(
+    funcId: string,
+    input: I,
+    config?: InvokeConfig<I, O>,
+  ): Promise<O>;
+
+  // After
+  step<T>(
+    name: string,
+    fn: StepFunc<T>,
+    config?: StepConfig<T>,
+  ): DurablePromise<T>;
+  wait(duration: Duration): DurablePromise<void>;
+  invoke<I, O>(
+    funcId: string,
+    input: I,
+    config?: InvokeConfig<I, O>,
+  ): DurablePromise<O>;
+  // ... etc for all methods
+}
+```
+
+## Testing Updates
+
+All handler tests need to be updated to handle lazy evaluation:
+
+```typescript
+// Before
+const result = handler(...);
+expect(mockCheckpoint).toHaveBeenCalled(); // Fails with lazy evaluation
+
+// After
+const promise = handler(...);
+expect(mockCheckpoint).not.toHaveBeenCalled(); // Not called yet
+await promise;
+expect(mockCheckpoint).toHaveBeenCalled(); // Now called
+```
+
+## Export Updates
+
+Update `src/index.ts` to export `DurablePromise`:
+
+```typescript
+export { DurablePromise } from "./utils/durable-promise/durable-promise";
+```
+
+## Breaking Changes
+
+This is a **non-breaking change** for users because:
+
+- `DurablePromise` implements `PromiseLike<T>`
+- Works with `await`, `Promise.all()`, `Promise.race()`, etc.
+- Existing code continues to work
+- Only behavior change: execution is deferred until awaited
+
+## Benefits
+
+1. **Prevents early termination**: Operations don't execute until composed
+2. **Enables composition**: Create operations and combine them later
+3. **Better performance**: Only execute operations that are actually awaited
+4. **More intuitive**: Matches user expectations for promise behavior

--- a/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/README.md
+++ b/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/README.md
@@ -1,0 +1,133 @@
+# DurablePromise - Lazy Thenable for Durable Execution
+
+## Problem
+
+When handlers return regular `Promise<T>`, they execute **eagerly** as soon as they're called:
+
+```typescript
+// ❌ PROBLEM: Both operations start immediately
+const wait1 = context.wait(10); // Starts executing NOW
+const wait2 = context.wait(5); // Starts executing NOW
+
+// If wait1 terminates the Lambda, we never reach this line
+const result = await Promise.race([wait1, wait2]);
+```
+
+This creates issues:
+
+1. **Early termination**: Operations that terminate Lambda (like `invoke`) prevent reaching `await` or `Promise.race`
+2. **No composition**: Can't create operations and compose them later
+3. **Eager execution**: Operations run even if never awaited
+
+## Solution: DurablePromise
+
+`DurablePromise` is a **lazy thenable** that defers execution until `.then()` or `await`:
+
+```typescript
+// ✅ SOLUTION: Operations don't start until awaited
+const wait1 = context.wait(10); // Returns DurablePromise, doesn't execute
+const wait2 = context.wait(5); // Returns DurablePromise, doesn't execute
+
+// Both start executing when Promise.race calls .then()
+const result = await Promise.race([wait1, wait2]);
+```
+
+## Benefits
+
+### 1. Safe Composition
+
+```typescript
+// Create operations without executing them
+const operations = [
+  context.step("op1", async () => doWork1()),
+  context.step("op2", async () => doWork2()),
+  context.invoke("func", input),
+];
+
+// Compose them later
+const results = await Promise.all(operations);
+```
+
+### 2. Conditional Execution
+
+```typescript
+const slowOp = context.wait({ seconds: 60 });
+const fastOp = context.wait({ seconds: 1 });
+
+// Only execute if condition is met
+if (needsTimeout) {
+  await Promise.race([slowOp, fastOp]);
+}
+// If condition is false, operations never execute
+```
+
+### 3. Prevents Early Termination
+
+```typescript
+// Create invoke operation (which could terminate Lambda)
+const invokeOp = context.invoke("other-function", data);
+
+// Create other operations
+const waitOp = context.wait({ seconds: 5 });
+
+// Both start together - no early termination
+await Promise.race([invokeOp, waitOp]);
+```
+
+## Implementation
+
+`DurablePromise` implements `PromiseLike<T>` interface:
+
+```typescript
+class DurablePromise<T> implements PromiseLike<T> {
+  private promise: Promise<T> | null = null;
+
+  constructor(private readonly executor: () => Promise<T>) {}
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    // Lazy execution: only run executor when .then() is called
+    if (!this.promise) {
+      this.promise = this.executor();
+    }
+    return this.promise.then(onfulfilled, onrejected);
+  }
+}
+```
+
+## Usage in Handlers
+
+All handlers should return `DurablePromise` instead of `Promise`:
+
+```typescript
+// Before (eager)
+export const createWaitHandler = (...) => {
+  async function waitHandler(...): Promise<void> {
+    // Executes immediately
+  }
+  return waitHandler;
+};
+
+// After (lazy)
+export const createWaitHandler = (...) => {
+  function waitHandler(...): DurablePromise<void> {
+    return new DurablePromise(async () => {
+      // Only executes when awaited
+    });
+  }
+  return waitHandler;
+};
+```
+
+## Compatibility
+
+`DurablePromise` is fully compatible with:
+
+- `await` keyword
+- `Promise.all()`
+- `Promise.race()`
+- `Promise.allSettled()`
+- `.then()`, `.catch()`, `.finally()`
+- Any code expecting `PromiseLike<T>`

--- a/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/durable-promise.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/durable-promise.test.ts
@@ -1,0 +1,115 @@
+import { DurablePromise } from "./durable-promise";
+
+describe("DurablePromise", () => {
+  it("should not execute until awaited", async () => {
+    let executed = false;
+    const promise = new DurablePromise(async () => {
+      executed = true;
+      return 42;
+    });
+
+    expect(executed).toBe(false);
+    const result = await promise;
+    expect(executed).toBe(true);
+    expect(result).toBe(42);
+  });
+
+  it("should not execute until .then() is called", async () => {
+    let executed = false;
+    const promise = new DurablePromise(async () => {
+      executed = true;
+      return 42;
+    });
+
+    expect(executed).toBe(false);
+    const result = await promise.then((v) => v * 2);
+    expect(executed).toBe(true);
+    expect(result).toBe(84);
+  });
+
+  it("should execute only once even with multiple .then() calls", async () => {
+    let executionCount = 0;
+    const promise = new DurablePromise(async () => {
+      executionCount++;
+      return 42;
+    });
+
+    const result1 = await promise.then((v) => v);
+    const result2 = await promise.then((v) => v * 2);
+
+    expect(executionCount).toBe(1);
+    expect(result1).toBe(42);
+    expect(result2).toBe(84);
+  });
+
+  it("should handle errors with .catch()", async () => {
+    const promise = new DurablePromise(async () => {
+      throw new Error("test error");
+    });
+
+    await expect(promise.catch((err) => (err as Error).message)).resolves.toBe(
+      "test error",
+    );
+  });
+
+  it("should work with Promise.race", async () => {
+    let executed1 = false;
+    let executed2 = false;
+
+    const promise1 = new DurablePromise(async () => {
+      executed1 = true;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return "slow";
+    });
+
+    const promise2 = new DurablePromise(async () => {
+      executed2 = true;
+      return "fast";
+    });
+
+    expect(executed1).toBe(false);
+    expect(executed2).toBe(false);
+
+    const result = await Promise.race([promise1, promise2]);
+
+    expect(result).toBe("fast");
+    expect(executed1).toBe(true);
+    expect(executed2).toBe(true);
+  });
+
+  it("should work with Promise.all", async () => {
+    let executed1 = false;
+    let executed2 = false;
+
+    const promise1 = new DurablePromise(async () => {
+      executed1 = true;
+      return 1;
+    });
+
+    const promise2 = new DurablePromise(async () => {
+      executed2 = true;
+      return 2;
+    });
+
+    expect(executed1).toBe(false);
+    expect(executed2).toBe(false);
+
+    const result = await Promise.all([promise1, promise2]);
+
+    expect(result).toEqual([1, 2]);
+    expect(executed1).toBe(true);
+    expect(executed2).toBe(true);
+  });
+
+  it("should support .finally()", async () => {
+    let finallyCalled = false;
+    const promise = new DurablePromise(async () => 42);
+
+    const result = await promise.finally(() => {
+      finallyCalled = true;
+    });
+
+    expect(result).toBe(42);
+    expect(finallyCalled).toBe(true);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/durable-promise.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/durable-promise/durable-promise.ts
@@ -1,0 +1,38 @@
+/**
+ * A lazy thenable that defers execution until .then() or await is called.
+ * This prevents eager execution of operations that might terminate the Lambda.
+ */
+export class DurablePromise<T> implements PromiseLike<T> {
+  private promise: Promise<T> | null = null;
+
+  constructor(private readonly executor: () => Promise<T>) {}
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    if (!this.promise) {
+      this.promise = this.executor();
+    }
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<T | TResult> {
+    return this.then(undefined, onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<T> {
+    return this.then(
+      (value) => {
+        onfinally?.();
+        return value;
+      },
+      (reason) => {
+        onfinally?.();
+        throw reason;
+      },
+    );
+  }
+}


### PR DESCRIPTION
Implement DurablePromise, a lazy thenable that defers execution until awaited,
preventing early Lambda termination and enabling safe promise composition.
    
    Changes:
    - Add DurablePromise class implementing PromiseLike<T> interface
    - Convert all 11 handlers to return DurablePromise instead of Promise
    - Update withModeManagement to accept PromiseLike<T>
    - Add comprehensive tests and documentation
    
    Handlers converted:
    - wait, step, invoke, runInChildContext
    - concurrent-execution, map, parallel
    - callback, wait-for-callback, wait-for-condition
    - promise (via delegation)
    
    Benefits:
    - Prevents eager execution that could terminate Lambda prematurely
    - Enables safe composition with Promise.race/all/allSettled
    - Maintains backward compatibility via PromiseLike interface


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
