### PR TITLE
feat(sdk): add endTimestamp option for context.wait()

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/end-timestamp/wait-end-timestamp.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/end-timestamp/wait-end-timestamp.test.ts
@@ -1,0 +1,36 @@
+import {
+  OperationType,
+  OperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./wait-end-timestamp";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  name: "wait-end-timestamp",
+  functionName: "wait-end-timestamp",
+  handler,
+  tests: (runner) => {
+    it("should wait until the specified timestamp", async () => {
+      const execution = await runner.run();
+
+      // Get operation using runner helper
+      const waitOperation = runner.getOperationByIndex(0);
+
+      // Verify final result
+      expect(execution.getResult()).toBe("Function Completed");
+
+      // Verify operations were tracked
+      const completedOperations = execution.getOperations();
+      expect(completedOperations.length).toEqual(1);
+
+      // Verify operation data can be accessed
+      expect(waitOperation.getType()).toBe(OperationType.WAIT);
+      expect(waitOperation.getStatus()).toBe(OperationStatus.SUCCEEDED);
+      expect(waitOperation.getName()).toBe("scheduled-wait");
+      expect(waitOperation.getWaitDetails()?.waitSeconds).toBe(5);
+      expect(
+        waitOperation.getWaitDetails()?.scheduledEndTimestamp,
+      ).toBeInstanceOf(Date);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/end-timestamp/wait-end-timestamp.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/end-timestamp/wait-end-timestamp.ts
@@ -1,0 +1,24 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Wait Until Timestamp",
+  description:
+    "Usage of context.wait() with endTimestamp to wait until a specific time",
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    console.log("Starting execution at:", new Date().toISOString());
+
+    // Wait until 5 seconds from now
+    const futureTime = new Date(Date.now() + 5000).toISOString();
+    await context.wait("scheduled-wait", { endTimestamp: futureTime });
+
+    console.log("Execution resumed at:", new Date().toISOString());
+    return "Function Completed";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1156,6 +1156,30 @@ Resources:
           DURABLE_VERBOSE_MODE: "true"
     Metadata:
       SkipBuild: "True"
+  WaitEndTimestamp:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WaitEndTimestamp-TypeScript
+      CodeUri: ./dist
+      Handler: wait-end-timestamp.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "true"
+    Metadata:
+      SkipBuild: "True"
   WaitForCallback:
     Type: AWS::Serverless::Function
     Properties:

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -13,7 +13,7 @@ import {
   WaitForConditionConfig,
   MapFunc,
   MapConfig,
-  Duration,
+  WaitOptions,
   ParallelFunc,
   ParallelConfig,
   NamedParallelBranch,
@@ -291,8 +291,8 @@ class DurableContextImpl implements DurableContext {
   }
 
   wait(
-    nameOrDuration: string | Duration,
-    maybeDuration?: Duration,
+    nameOrWaitOptions: string | WaitOptions,
+    maybeWaitOptions?: WaitOptions,
   ): Promise<void> {
     validateContextUsage(
       this._stepPrefix,
@@ -309,9 +309,9 @@ class DurableContextImpl implements DurableContext {
         this._parentId,
       );
       const promise =
-        typeof nameOrDuration === "string"
-          ? waitHandler(nameOrDuration, maybeDuration!)
-          : waitHandler(nameOrDuration);
+        typeof nameOrWaitOptions === "string"
+          ? waitHandler(nameOrWaitOptions, maybeWaitOptions!)
+          : waitHandler(nameOrWaitOptions);
       // Prevent unhandled promise rejections
       promise?.catch(() => {});
       return promise?.finally(() => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, OperationSubType, Duration } from "../../types";
+import { ExecutionContext, OperationSubType, WaitOptions } from "../../types";
 import { terminate } from "../../utils/termination-helper/termination-helper";
 import {
   OperationStatus,
@@ -11,7 +11,7 @@ import { TerminationReason } from "../../termination-manager/types";
 import { waitBeforeContinue } from "../../utils/wait-before-continue/wait-before-continue";
 import { EventEmitter } from "events";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
-import { durationToSeconds } from "../../utils/duration/duration";
+import { waitOptionsToSeconds } from "../../utils/duration/duration";
 
 export const createWaitHandler = (
   context: ExecutionContext,
@@ -21,25 +21,25 @@ export const createWaitHandler = (
   getOperationsEmitter: () => EventEmitter,
   parentId?: string,
 ): {
-  (name: string, duration: Duration): Promise<void>;
-  (duration: Duration): Promise<void>;
+  (name: string, waitOptions: WaitOptions): Promise<void>;
+  (waitOptions: WaitOptions): Promise<void>;
 } => {
-  function waitHandler(name: string, duration: Duration): Promise<void>;
-  function waitHandler(duration: Duration): Promise<void>;
+  function waitHandler(name: string, waitOptions: WaitOptions): Promise<void>;
+  function waitHandler(waitOptions: WaitOptions): Promise<void>;
   async function waitHandler(
-    nameOrDuration: string | Duration,
-    duration?: Duration,
+    nameOrWaitOptions: string | WaitOptions,
+    waitOptions?: WaitOptions,
   ): Promise<void> {
-    const isNameFirst = typeof nameOrDuration === "string";
-    const actualName = isNameFirst ? nameOrDuration : undefined;
-    const actualDuration = isNameFirst ? duration! : nameOrDuration;
-    const actualSeconds = durationToSeconds(actualDuration);
+    const isNameFirst = typeof nameOrWaitOptions === "string";
+    const actualName = isNameFirst ? nameOrWaitOptions : undefined;
+    const actualWaitOptions = isNameFirst ? waitOptions! : nameOrWaitOptions;
+    const actualSeconds = waitOptionsToSeconds(actualWaitOptions);
     const stepId = createStepId();
 
     log("⏲️", "Wait requested:", {
       stepId,
       name: actualName,
-      duration: actualDuration,
+      waitOptions: actualWaitOptions,
       seconds: actualSeconds,
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/types/core.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/core.ts
@@ -75,6 +75,8 @@ export type Duration =
   | { minutes: number; seconds?: number }
   | { seconds: number };
 
+export type WaitOptions = Duration | { endTimestamp: string };
+
 export interface ExecutionContext {
   state: ExecutionState;
   _stepData: Record<string, Operation>; // Private, use getStepData() instead

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -3,7 +3,7 @@ import { Logger, LoggerConfig } from "./logger";
 import { StepFunc, StepConfig } from "./step";
 import { ChildFunc, ChildConfig } from "./child-context";
 import { InvokeConfig } from "./invoke";
-import { Duration } from "./core";
+import { WaitOptions } from "./core";
 import {
   CreateCallbackConfig,
   CreateCallbackResult,
@@ -191,9 +191,9 @@ export interface DurableContext {
   runInChildContext<T>(fn: ChildFunc<T>, config?: ChildConfig<T>): Promise<T>;
 
   /**
-   * Pauses execution for the specified duration
+   * Pauses execution for the specified duration or until a specific timestamp
    * @param name - Step name for tracking and debugging
-   * @param duration - Duration to wait
+   * @param waitOptions - Duration to wait or end timestamp
    * @example
    * ```typescript
    * // Wait 5 seconds before retrying
@@ -201,13 +201,16 @@ export interface DurableContext {
    *
    * // Wait for a longer duration
    * await context.wait("long-delay", { minutes: 5, seconds: 30 });
+   *
+   * // Wait until a specific timestamp
+   * await context.wait("scheduled-task", { endTimestamp: "2024-12-25T00:00:00Z" });
    * ```
    */
-  wait(name: string, duration: Duration): Promise<void>;
+  wait(name: string, waitOptions: WaitOptions): Promise<void>;
 
   /**
-   * Pauses execution for the specified duration
-   * @param duration - Duration to wait
+   * Pauses execution for the specified duration or until a specific timestamp
+   * @param waitOptions - Duration to wait or end timestamp
    * @example
    * ```typescript
    * // Wait 30 seconds for rate limiting
@@ -215,9 +218,12 @@ export interface DurableContext {
    *
    * // Wait using multiple units
    * await context.wait({ hours: 1, minutes: 30 });
+   *
+   * // Wait until a specific timestamp
+   * await context.wait({ endTimestamp: "2024-12-25T00:00:00Z" });
    * ```
    */
-  wait(duration: Duration): Promise<void>;
+  wait(waitOptions: WaitOptions): Promise<void>;
 
   /**
    * Waits for a condition to be met by periodically checking state

--- a/packages/aws-durable-execution-sdk-js/src/utils/duration/duration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/duration/duration.test.ts
@@ -1,4 +1,71 @@
-import { durationToSeconds } from "./duration";
+import { waitOptionsToSeconds, durationToSeconds } from "./duration";
+import { WaitOptions, Duration } from "../../types/core";
+
+describe("waitOptionsToSeconds", () => {
+  beforeEach(() => {
+    // Mock Date.now() to return April 7th, 1999 baseline
+    jest.spyOn(Date, "now").mockReturnValue(923443200000); // April 7, 1999
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("endTimestamp handling", () => {
+    it("should calculate correct seconds for future timestamp", () => {
+      const futureTime = new Date(923443205000).toISOString(); // 5 seconds in the future
+      const waitOptions: WaitOptions = { endTimestamp: futureTime };
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(5);
+    });
+
+    it("should return 0 for past timestamp", () => {
+      const pastTime = new Date(923443195000).toISOString(); // 5 seconds in the past
+      const waitOptions: WaitOptions = { endTimestamp: pastTime };
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(0);
+    });
+
+    it("should return 0 for current timestamp", () => {
+      const currentTime = new Date(923443200000).toISOString(); // exactly now
+      const waitOptions: WaitOptions = { endTimestamp: currentTime };
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(0);
+    });
+
+    it("should round millisecond precision up", () => {
+      const futureTime = new Date(923443201500).toISOString(); // 1.5 seconds in the future
+      const waitOptions: WaitOptions = { endTimestamp: futureTime };
+
+      // Should round up to 2 seconds
+      expect(waitOptionsToSeconds(waitOptions)).toBe(2);
+    });
+
+    it("should handle different ISO timestamp formats", () => {
+      // Test with timezone
+      const futureTime = "1999-04-07T00:00:05-00:00"; // 5 seconds in the future
+      const waitOptions: WaitOptions = { endTimestamp: futureTime };
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(5);
+    });
+  });
+
+  describe("duration handling", () => {
+    it("should delegate to durationToSeconds for duration objects", () => {
+      const duration: Duration = { seconds: 30 };
+      const waitOptions: WaitOptions = duration;
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(30);
+    });
+
+    it("should handle complex duration objects", () => {
+      const duration: Duration = { hours: 1, minutes: 30, seconds: 45 };
+      const waitOptions: WaitOptions = duration;
+
+      expect(waitOptionsToSeconds(waitOptions)).toBe(5445); // 1*3600 + 30*60 + 45
+    });
+  });
+});
 
 describe("durationToSeconds", () => {
   it("converts seconds only", () => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/duration/duration.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/duration/duration.ts
@@ -1,4 +1,4 @@
-import { Duration } from "../../types";
+import { Duration, WaitOptions } from "../../types";
 
 /**
  * Converts a Duration object to total seconds
@@ -12,4 +12,29 @@ export function durationToSeconds(duration: Duration): number {
   const seconds = "seconds" in duration ? (duration.seconds ?? 0) : 0;
 
   return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60 + seconds;
+}
+
+/**
+ * Converts WaitOptions to total seconds
+ * @param waitOptions - WaitOptions object with duration or endTimestamp
+ * @returns Total duration in seconds
+ */
+export function waitOptionsToSeconds(waitOptions: WaitOptions): number {
+  // Handle endTimestamp case
+  if ("endTimestamp" in waitOptions) {
+    const endTime = new Date(waitOptions.endTimestamp).getTime();
+    const currentTime = Date.now();
+    const diffMs = endTime - currentTime;
+
+    // If the timestamp is in the past, return 0
+    if (diffMs <= 0) {
+      return 0;
+    }
+
+    // Convert milliseconds to seconds
+    return Math.ceil(diffMs / 1000);
+  }
+
+  // Handle traditional duration format
+  return durationToSeconds(waitOptions);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Introducing a new flavour of `ctx.wait()` which allows developers to schedule wait states to complete at a given `endTimestamp`. 

I've renamed the internal property name from `duration` back to `waitOptions` using a union type between `Duration` and `{ endTimestamp: string }` - it didn't feel appropriate to include it on the `Duration` class.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
