### PR TITLE
fix(sdk): set requestTimeout to max socketTimeout + connectionTimeout

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
@@ -60,7 +60,8 @@ describe("ApiStorage", () => {
       requestHandler: {
         connectionTimeout: 5000,
         socketTimeout: 50000,
-        requestTimeout: 5000,
+        requestTimeout: 55000,
+        throwOnRequestTimeout: true,
       },
     });
   });

--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.ts
@@ -21,7 +21,8 @@ export class ApiStorage implements ExecutionState {
       requestHandler: {
         connectionTimeout: 5000,
         socketTimeout: 50000,
-        requestTimeout: 5000,
+        requestTimeout: 55000,
+        throwOnRequestTimeout: true,
       },
     });
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

requestTimeout is for the overall request/response roundtrip time
socketTimeout is for idle socket time
connectionTimeout is for connection time

If we set requestTimeout to 5 seconds, it will always time out before the socketTimeout of 50 seconds and/or connectionTimeout of 5 seconds. Each of the timeouts race against each other: https://github.com/smithy-lang/smithy-typescript/blob/a0e0035db609963933ac8499d0117384e7dbc8a2/packages/node-http-handler/src/node-http-handler.ts#L314-L318

I am fixing this to set the timeout to 55 seconds, which is the max socketTimeout + connectionTimeout, so that it will always happen after both timeouts (if they reach their max timeout). Also enabling the throwOnRequestTimeout option, otherwise it would only log an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
