### PR TITLE
feat(sdk): implement signal delegation for parallel task termination

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -68,6 +68,8 @@ export class DurableContextImpl<Logger extends DurableLogger>
   private durableExecutionMode: DurableExecutionMode;
   private _parentId?: string;
   private modeManagement: ModeManagement;
+  _onChildSignal?: (childId: string) => void;
+  _parentDurableContext?: DurableContext;
 
   constructor(
     private executionContext: ExecutionContext,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
@@ -15,15 +15,16 @@ describe("ConcurrencyController - Replay Mode", () => {
 
   beforeEach(() => {
     mockSkipNextOperation = jest.fn();
+    mockExecutionContext = {
+      getStepData: jest.fn(),
+    } as any;
     controller = new ConcurrencyController(
       "test-operation",
       mockSkipNextOperation,
+      mockExecutionContext,
     );
     mockParentContext = {
       runInChildContext: jest.fn(),
-    } as any;
-    mockExecutionContext = {
-      getStepData: jest.fn(),
     } as any;
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -2,19 +2,14 @@ import {
   createConcurrentExecutionHandler,
   ConcurrencyController,
 } from "./concurrent-execution-handler";
-import {
-  ExecutionContext,
-  DurableContext,
-  BatchItemStatus,
-  DurableLogger,
-} from "../../types";
+import { ExecutionContext, DurableContext, BatchItemStatus } from "../../types";
 import { MockBatchResult } from "../../testing/mock-batch-result";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 describe("Concurrent Execution Handler", () => {
   let mockExecutionContext: jest.Mocked<ExecutionContext>;
   let mockRunInChildContext: jest.MockedFunction<
-    DurableContext<DurableLogger>["runInChildContext"]
+    DurableContext["runInChildContext"]
   >;
   let concurrentExecutionHandler: ReturnType<
     typeof createConcurrentExecutionHandler
@@ -419,11 +414,17 @@ describe("Concurrent Execution Handler", () => {
 });
 
 describe("ConcurrencyController", () => {
-  let controller: ConcurrencyController<DurableLogger>;
-  let mockParentContext: jest.Mocked<DurableContext<DurableLogger>>;
+  let controller: ConcurrencyController;
+  let mockParentContext: jest.Mocked<DurableContext>;
+  let mockExecutionContext: jest.Mocked<ExecutionContext>;
 
   beforeEach(() => {
-    controller = new ConcurrencyController("test-operation", jest.fn());
+    mockExecutionContext = {} as any;
+    controller = new ConcurrencyController(
+      "test-operation",
+      jest.fn(),
+      mockExecutionContext,
+    );
     mockParentContext = {
       runInChildContext: jest.fn(),
     } as any;
@@ -694,6 +695,7 @@ describe("ConcurrencyController", () => {
       const verboseController = new ConcurrencyController(
         "verbose-test",
         jest.fn(),
+        mockExecutionContext,
       );
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn();
@@ -792,6 +794,7 @@ describe("ConcurrencyController", () => {
       const testController = new ConcurrencyController(
         "test-operation",
         jest.fn(),
+        mockExecutionContext,
       );
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn().mockResolvedValue("test-result");

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -230,8 +230,11 @@ export const handleCompletedChildContext = async <
       entityId, // parentId
     );
 
-    return await runWithContext(entityId, entityId, () =>
-      fn(durableChildContext),
+    return await runWithContext(
+      entityId,
+      entityId,
+      () => fn(durableChildContext),
+      durableChildContext,
     );
   }
 
@@ -302,8 +305,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       entityId,
       parentId,
       () => fn(durableChildContext),
-      undefined,
-      childReplayMode,
+      durableChildContext,
     );
 
     // Serialize the result for consistency

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -818,4 +818,16 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    * ```
    */
   configureLogger(config: LoggerConfig<Logger>): void;
+
+  /**
+   * @internal
+   * Callback for child contexts to signal parent when waiting (e.g., for callback)
+   */
+  _onChildSignal?: (childId: string) => void;
+
+  /**
+   * @internal
+   * Reference to parent DurableContext for signal delegation
+   */
+  _parentDurableContext?: DurableContext;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/context-tracker/context-tracker.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/context-tracker/context-tracker.ts
@@ -1,13 +1,14 @@
 import { AsyncLocalStorage } from "async_hooks";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
-import { DurableExecutionMode } from "../../types";
+import { DurableExecutionMode, DurableContext } from "../../types";
 
 interface ContextInfo {
   contextId: string;
   parentId?: string;
   attempt?: number;
   durableExecutionMode?: DurableExecutionMode;
+  durableContext?: DurableContext;
 }
 
 const asyncLocalStorage = new AsyncLocalStorage<ContextInfo>();
@@ -20,11 +21,12 @@ export const runWithContext = <T>(
   contextId: string,
   parentId: string | undefined,
   fn: () => T,
+  durableContext?: DurableContext,
   attempt?: number,
   durableExecutionMode?: DurableExecutionMode,
 ): T => {
   return asyncLocalStorage.run(
-    { contextId, parentId, attempt, durableExecutionMode },
+    { contextId, parentId, attempt, durableExecutionMode, durableContext },
     fn,
   );
 };

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/active-operations-tracker.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/active-operations-tracker.test.ts
@@ -67,7 +67,7 @@ describe("ActiveOperationsTracker", () => {
     });
 
     it("should track failed async operation", async () => {
-      const operation = async (): Promise<never> => {
+      const operation = async (): Promise<void> => {
         await new Promise((resolve) => setTimeout(resolve, 10));
         throw new Error("operation failed");
       };

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
@@ -77,6 +77,15 @@ export function terminate<T>(
 ): Promise<T> {
   const activeContext = getActiveContext();
 
+  // Check if child should signal parent instead of terminating
+  if (
+    activeContext?.durableContext?._onChildSignal &&
+    activeContext?.contextId
+  ) {
+    activeContext.durableContext._onChildSignal(activeContext.contextId);
+    return new Promise<T>(() => {});
+  }
+
   // If we have a parent context, add delay to let checkpoints process
   if (activeContext?.parentId) {
     return new Promise<T>(async (_resolve, _reject) => {


### PR DESCRIPTION
*Description of changes:*
Implement signal delegation mechanism to properly handle parallel task termination
when all branches are waiting for callbacks, and fix concurrency limit calculation
to include waiting operations.

Key Changes:
- Add signal delegation between child and parent contexts via _onChildSignal callback
- Fix maxConcurrency logic to count both active and waiting operations: (activeCount + waitingCount) < maxConcurrency
- Implement proper termination when all parallel branches are waiting for callbacks
- Add checkCompletion() method for early exit conditions (min successful, failure tolerance)

This resolves issues where:
1. Parallel handlers would complete prematurely when branches were waiting for callbacks
2. MaxConcurrency limits were incorrectly calculated, allowing too many concurrent operations
3. Lambda functions would hang indefinitely when all parallel branches were waiting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
