### PR TITLE
fix(testing-sdk): cancel pending timers when execution completes

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/unawaited/wait-unawaited.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/unawaited/wait-unawaited.ts
@@ -1,0 +1,28 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Unawaited Wait",
+  description:
+    "Demonstrates scheduling a wait operation without awaiting it - function completes immediately while wait is scheduled",
+};
+
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    // Schedule a long wait operation without awaiting it
+    // This demonstrates that the function can complete successfully
+    // even when wait operations are scheduled but not awaited
+    void context.wait({ days: 1 });
+
+    // Give a brief moment to ensure the wait operation is scheduled
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+
+    // Function completes immediately, despite the scheduled wait
+    return "result";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1540,3 +1540,27 @@ Resources:
           DURABLE_VERBOSE_MODE: "true"
     Metadata:
       SkipBuild: "True"
+  WaitUnawaited:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WaitUnawaited-TypeScript
+      CodeUri: ./dist
+      Handler: wait-unawaited.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "true"
+    Metadata:
+      SkipBuild: "True"

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/test-execution-state.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/test-execution-state.ts
@@ -1,4 +1,5 @@
 import { ErrorObject, ExecutionStatus } from "@aws-sdk/client-lambda";
+import { defaultLogger } from "../../logger";
 
 export interface TestExecutionResult {
   status?: ExecutionStatus;
@@ -38,6 +39,7 @@ export class TestExecutionState {
    * This should be called when the handler execution fails.
    */
   rejectWith(error: unknown): void {
+    defaultLogger.debug("Rejecting execution with error", error);
     this.rejectExecution?.(error);
   }
 }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/scheduler.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/scheduler.ts
@@ -1,11 +1,13 @@
+import { defaultLogger } from "../../../logger";
+
 export class Scheduler {
-  private hasScheduledFunctionFlag = false;
   private resolveWaitForScheduledFunction: (() => void) | undefined;
   private waitForScheduledFunctionPromise: Promise<void> = new Promise<void>(
     (resolve) => {
       this.resolveWaitForScheduledFunction = resolve;
     },
   );
+  private readonly runningTimers = new Set<NodeJS.Timeout>();
 
   async waitForScheduledFunction(): Promise<void> {
     await this.waitForScheduledFunctionPromise;
@@ -19,17 +21,27 @@ export class Scheduler {
     delayMs: number,
     onError: (err: unknown) => void,
   ): void {
-    this.hasScheduledFunctionFlag = true;
-    setTimeout(() => {
-      this.hasScheduledFunctionFlag = false;
+    const timer = setTimeout(() => {
+      this.runningTimers.delete(timer);
       fn().catch(onError);
     }, delayMs);
+    this.runningTimers.add(timer);
     this.resolveWaitForScheduledFunction?.();
+  }
+
+  flushTimers() {
+    if (this.runningTimers.size) {
+      defaultLogger.debug(`Flushing ${this.runningTimers.size} pending timers`);
+    }
+    this.runningTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
+    this.runningTimers.clear();
   }
 
   // TODO: use this to check if there is a pending function invocation when the invocation status is PENDING
   // if there is no scheduled function and the invocation status is PENDING, the language SDK has a bug
   hasScheduledFunction(): boolean {
-    return this.hasScheduledFunctionFlag;
+    return !!this.runningTimers.size;
   }
 }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
@@ -94,6 +94,8 @@ export class TestExecutionOrchestrator {
         },
       });
       throw err;
+    } finally {
+      this.scheduler.flushTimers();
     }
   }
 
@@ -348,6 +350,11 @@ export class TestExecutionOrchestrator {
       throw new Error("Missing operation id");
     }
 
+    defaultLogger.debug(`Queuing wait in ${waitSeconds}s`, {
+      executionId,
+      operation,
+      update,
+    });
     this.scheduleAsyncFunction(
       waitSeconds,
       async () => {
@@ -362,6 +369,11 @@ export class TestExecutionOrchestrator {
         );
       },
       () => {
+        defaultLogger.debug(`Wait triggered after ${waitSeconds}s`, {
+          executionId,
+          operation,
+          update,
+        });
         return this.checkpointApi.updateCheckpointData({
           executionId,
           operationId,
@@ -401,6 +413,11 @@ export class TestExecutionOrchestrator {
         throw new Error("Missing operation id");
       }
 
+      defaultLogger.debug(`Queuing step retry in ${retryDelaySeconds}s`, {
+        executionId,
+        operation,
+        update,
+      });
       this.scheduleAsyncFunction(
         retryDelaySeconds,
         async () => {
@@ -414,6 +431,11 @@ export class TestExecutionOrchestrator {
           );
         },
         async () => {
+          defaultLogger.debug(`Retry triggered after ${retryDelaySeconds}s`, {
+            executionId,
+            operation,
+            update,
+          });
           await this.checkpointApi.updateCheckpointData({
             executionId,
             operationId,
@@ -463,6 +485,9 @@ export class TestExecutionOrchestrator {
       throw new Error("Could not find status in execution operation");
     }
 
+    defaultLogger.debug("Resolving execution", {
+      update,
+    });
     this.executionState.resolveWith({
       result: update.Payload,
       error: update.Error,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Timers were not being cleared when the execution completed. This change ensure that timers are cleared when the execution completes to prevent tests from hanging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
