### PR TITLE
perf: enable TypeScript incremental compilation across monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.zip
 .DS_Store
 .eslintcache
+*.tsbuildinfo
 
 # VS Code
 .vscode/

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/.gitignore
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/.gitignore
@@ -25,3 +25,6 @@ pids
 
 # ESLint cache
 .eslintcache
+
+# TypeScript incremental build info
+*.tsbuildinfo

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "incremental": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/packages/aws-durable-execution-sdk-js-examples/.gitignore
+++ b/packages/aws-durable-execution-sdk-js-examples/.gitignore
@@ -7,6 +7,7 @@
 *.iml
 .aws-sam/*
 *.zip
+*.tsbuildinfo
 
 src/utils/examples-catalog.json
 src/dur-sdk/

--- a/packages/aws-durable-execution-sdk-js-examples/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-examples/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true
   },
   "include": ["src"]
 }

--- a/packages/aws-durable-execution-sdk-js-testing/.gitignore
+++ b/packages/aws-durable-execution-sdk-js-testing/.gitignore
@@ -6,3 +6,4 @@
 /coverage
 .husky
 *.iml
+*.tsbuildinfo

--- a/packages/aws-durable-execution-sdk-js-testing/tsconfig.build.json
+++ b/packages/aws-durable-execution-sdk-js-testing/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "incremental": true
   },
   "exclude": ["**/__tests__/**", "**/*.test.ts"]
 }

--- a/packages/aws-durable-execution-sdk-js/.gitignore
+++ b/packages/aws-durable-execution-sdk-js/.gitignore
@@ -10,3 +10,4 @@
 *.zip
 .DS_Store
 *.tgz
+*.tsbuildinfo

--- a/packages/aws-durable-execution-sdk-js/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
*Description of changes:*

Enable incremental compilation in all packages that use TypeScript:
- aws-durable-execution-sdk-js: for type declaration generation
- aws-durable-execution-sdk-js-testing: for build-specific type declarations
- aws-durable-execution-sdk-js-eslint-plugin: for full TypeScript compilation
- aws-durable-execution-sdk-js-examples: for TypeScript configuration

This optimization will significantly speed up subsequent builds by reusing type-checking information from previous compilations. Added *.tsbuildinfo to all .gitignore files to exclude build cache files from version control.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
