### PR TITLE
chore: increase minimum node version to 22.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x", "24.x"]
+        node-version: ["22.x", "24.x"]
     uses: "./.github/workflows/unit-tests.yml"
     with:
       node-version: ${{ matrix.node-version }}
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x", "24.x"]
+        node-version: ["22.x", "24.x"]
     uses: "./.github/workflows/integration-tests.yml"
     with:
       node-version: ${{ matrix.node-version }}
@@ -92,7 +92,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x", "24.x"]
+        node-version: ["22.x", "24.x"]
 
     if: ${{ !failure() }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12429,7 +12429,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/aws-durable-execution-sdk-js-eslint-plugin": {
@@ -12445,7 +12445,7 @@
         "typescript": "^5.8.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "eslint": ">=8.0.0"
@@ -13838,7 +13838,7 @@
         "typescript-eslint": "^8.29.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/aws-durable-execution-sdk-js-examples/node_modules/@jest/console": {
@@ -15025,7 +15025,7 @@
         "typescript-eslint": "^8.34.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@aws/durable-execution-sdk-js": "*"

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/aws-durable-execution-sdk-js-examples/package.json
+++ b/packages/aws-durable-execution-sdk-js-examples/package.json
@@ -5,7 +5,7 @@
   "repository": "ssh:github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js-examples",
   "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js-examples",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "files": [
     "dist"

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -6,7 +6,7 @@
   "repository": "ssh:github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js-testing",
   "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js-testing",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "bin": {
     "run-durable": "./dist/cli/run-durable.js"

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -6,7 +6,7 @@
   "repository": "ssh:github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js",
   "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/development/packages/aws-durable-execution-sdk-js",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increasing minimum node version to 22.x. We can't deploy 20.x functions without creating a container image when running integ tests.

Setting the minimum to 22.x instead will be more of a 2-way door if we decide we want to support 20.x later.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
