### PR TITLE
fix(sdk): dont fail invocations on throttling exceptions

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
@@ -54,6 +54,19 @@ describe("Checkpoint Error Classification", () => {
     expect(result.message).toContain("Invalid parameter value");
   });
 
+  it("should classify 429 errors as invocation error (retryable)", () => {
+    const awsError = {
+      name: "TooManyRequestsException",
+      message: "Rate limit exceeded",
+      $metadata: { httpStatusCode: 429 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(result.message).toContain("Rate limit exceeded");
+  });
+
   it("should classify 4xx InvalidParameterValueException without Invalid Checkpoint Token as execution error", () => {
     const awsError = {
       name: "InvalidParameterValueException",

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.ts
@@ -239,8 +239,13 @@ class CheckpointHandler {
       );
     }
 
-    // Other 4xx errors
-    if (statusCode && statusCode >= 400 && statusCode < 500) {
+    // Non-retryable errors (4xx except 429)
+    if (
+      statusCode &&
+      statusCode >= 400 &&
+      statusCode < 500 &&
+      statusCode !== 429
+    ) {
       return new CheckpointUnrecoverableExecutionError(
         `Checkpoint failed: ${errorMessage}`,
         originalError,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We shouldn't be failing executions on throttling exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
