### PR TITLE
fix(sdk): handle when execution operation is not in the event

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/large-data-test/large-data-test.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/large-data-test/large-data-test.test.ts
@@ -1,0 +1,47 @@
+import {
+  OperationType,
+  OperationStatus,
+  ExecutionStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./large-data-test";
+import { createTests } from "../../utils/test-helper";
+
+createTests({
+  name: "large-data-test",
+  functionName: "large-data-test",
+  handler,
+  tests: (runner) => {
+    it("should execute steps correctly followed by a wait", async () => {
+      const execution = await runner.run();
+
+      // Verify the handler succeeds
+      expect(execution.getStatus()).toBe(ExecutionStatus.SUCCEEDED);
+
+      const operations = execution.getOperations();
+      expect(operations).toHaveLength(101);
+
+      // Verify the initial operations are steps with correct data
+      for (let i = 0; i < 100; i++) {
+        const stepOperation = runner.getOperationByIndex(i);
+        expect(stepOperation.getType()).toBe(OperationType.STEP);
+        expect(stepOperation.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+        // Verify step result contains expected data structure
+        const stepResult = stepOperation.getStepDetails()?.result as any;
+        expect(stepResult).toMatchObject({
+          largeData: expect.any(String),
+        });
+
+        const stepSize = Buffer.byteLength(stepResult.largeData, "utf-8");
+
+        expect(stepSize).toBe(150600);
+      }
+
+      // Verify the last operation is a wait
+      const waitOperation = runner.getOperationByIndex(-1);
+      expect(waitOperation.getType()).toBe(OperationType.WAIT);
+      expect(waitOperation.getStatus()).toBe(OperationStatus.SUCCEEDED);
+      expect(waitOperation.getWaitDetails()?.waitSeconds).toBe(5);
+    }, 120000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/large-data-test/large-data-test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/large-data-test/large-data-test.ts
@@ -1,0 +1,50 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+import { log } from "../../utils/logger";
+
+export const config: ExampleConfig = {
+  name: "Large Data Test",
+  description:
+    "Test that creates and returns large data in each step, followed by a wait.",
+  durableConfig: {
+    RetentionPeriodInDays: 7,
+    ExecutionTimeout: 300, // 5 minutes to handle the large data processing
+  },
+};
+
+function generateLargeString(): string {
+  const chunkSize = 1000;
+  const pattern = "A".repeat(chunkSize);
+  const chunks = [];
+
+  for (let i = 0; i < 150; i++) {
+    chunks.push(`${pattern}${i.toString().padStart(4, "0")}`);
+  }
+
+  return chunks.join("");
+}
+
+export const handler = withDurableExecution(
+  async (_event, context: DurableContext) => {
+    for (let i = 1; i <= 100; i++) {
+      await context.step(async () => {
+        log(`Generating data in step ${i}`);
+        const largeData = generateLargeString();
+        return {
+          largeData,
+        };
+      });
+    }
+
+    log("All steps completed. Starting wait period...");
+
+    await context.wait({ seconds: 5 });
+
+    log("Wait completed. Test finished.");
+
+    return "";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -1,4 +1,4 @@
-import { Operation } from "@aws-sdk/client-lambda";
+import { Operation, OperationType } from "@aws-sdk/client-lambda";
 import { getExecutionState } from "../../storage/storage";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import {
@@ -18,6 +18,7 @@ export const initializeExecutionContext = async (
   executionContext: ExecutionContext;
   durableExecutionMode: DurableExecutionMode;
   checkpointToken: string;
+  executionOperation: Operation;
 }> => {
   log("🔵", "Initializing durable function with event:", event);
   log("📍", "Function Input:", event);
@@ -69,6 +70,14 @@ export const initializeExecutionContext = async (
 
   log("📝", "Loaded step data:", stepData);
 
+  const executionOperation = operationsArray.find(
+    (operation: Operation) => operation.Type === OperationType.EXECUTION,
+  );
+
+  if (!executionOperation) {
+    throw new Error("No execution event found in operations array");
+  }
+
   return {
     executionContext: {
       state,
@@ -82,5 +91,6 @@ export const initializeExecutionContext = async (
     },
     durableExecutionMode,
     checkpointToken,
+    executionOperation,
   };
 };

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./utils/checkpoint/checkpoint";
 import { TEST_CONSTANTS } from "./testing/test-constants";
 import { createErrorObjectFromError } from "./utils/error-object/error-object";
+import { Operation, OperationType } from "@aws-sdk/client-lambda";
 
 // Mock dependencies
 jest.mock("./context/execution-context/execution-context");
@@ -66,10 +67,22 @@ describe("withDurableExecution", () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
 
+    // Setup default execution operation
+    const mockExecutionOperation: Operation = {
+      Id: "execution-id",
+      Type: OperationType.EXECUTION,
+      StartTimestamp: new Date(),
+      Status: "STARTED",
+      ExecutionDetails: {
+        InputPayload: JSON.stringify(mockCustomerHandlerEvent),
+      },
+    };
+
     // Setup default mocks
     (initializeExecutionContext as jest.Mock).mockResolvedValue({
       executionContext: mockExecutionContext,
       checkpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      executionOperation: mockExecutionOperation,
     });
     (createDurableContext as jest.Mock).mockReturnValue(mockDurableContext);
 
@@ -200,9 +213,22 @@ describe("withDurableExecution", () => {
       ...mockExecutionContext,
       isVerbose: true,
     };
+
+    // Create execution operation for this test
+    const mockExecutionOperation: Operation = {
+      Id: "execution-id-verbose",
+      Type: OperationType.EXECUTION,
+      StartTimestamp: new Date(),
+      Status: "STARTED",
+      ExecutionDetails: {
+        InputPayload: JSON.stringify(mockCustomerHandlerEvent),
+      },
+    };
+
     (initializeExecutionContext as jest.Mock).mockResolvedValue({
       executionContext: verboseExecutionContext,
       checkpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      executionOperation: mockExecutionOperation,
     });
 
     const mockResult = { success: true };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Handle if execution operation is not in event, but it can be acquired from the getStepData API instead. This happens when the data is too large from the initial payload and a next marker is returned instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
