### PR TITLE
fix(sdk): fix default types for waitForCallback to return string 

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/anonymous/wait-for-callback-anonymous.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/anonymous/wait-for-callback-anonymous.ts
@@ -12,7 +12,7 @@ export const config: ExampleConfig = {
 
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
-    const result = await context.waitForCallback<{ data: string }>(async () => {
+    const result = await context.waitForCallback(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       return Promise.resolve();
     });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failing-submitter/wait-for-callback-failing-submitter.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failing-submitter/wait-for-callback-failing-submitter.ts
@@ -13,7 +13,7 @@ export const config: ExampleConfig = {
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
     try {
-      const result = await context.waitForCallback<{ data: string }>(
+      const result = await context.waitForCallback(
         "failing-submitter-callback",
         async () => {
           await new Promise((resolve) => setTimeout(resolve, 500));

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failures/wait-for-callback-failures.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/failures/wait-for-callback-failures.ts
@@ -13,13 +13,11 @@ export const config: ExampleConfig = {
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
     try {
-      const result = await context.waitForCallback<{ data: string }>(
-        async () => {
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-          // Submitter succeeds - simulates successful external API call setup
-          return Promise.resolve();
-        },
-      );
+      const result = await context.waitForCallback(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        // Submitter succeeds - simulates successful external API call setup
+        return Promise.resolve();
+      });
 
       return {
         callbackResult: result,

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/heartbeat-sends/wait-for-callback-heartbeat-sends.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/heartbeat-sends/wait-for-callback-heartbeat-sends.ts
@@ -17,7 +17,7 @@ export const handler = withDurableExecution(
     },
     context: DurableContext,
   ) => {
-    const result = await context.waitForCallback<{ processed: number }>(
+    const result = await context.waitForCallback(
       async () => {
         // Simulate long-running submitter function
         await new Promise((resolve) =>

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/mixed-ops/wait-for-callback-mixed-ops.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/mixed-ops/wait-for-callback-mixed-ops.ts
@@ -19,13 +19,14 @@ export const handler = withDurableExecution(
       return Promise.resolve({ userId: 123, name: "John Doe" });
     });
 
-    const callbackResult = await context.waitForCallback<{
-      processed: boolean;
-    }>("wait-for-callback", async () => {
-      // Submitter uses data from previous step
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      return Promise.resolve();
-    });
+    const callbackResult = await context.waitForCallback(
+      "wait-for-callback",
+      async () => {
+        // Submitter uses data from previous step
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return Promise.resolve();
+      },
+    );
 
     await context.wait("final-wait", { seconds: 2 });
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/nested/wait-for-callback-nested.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/nested/wait-for-callback-nested.ts
@@ -12,7 +12,7 @@ export const config: ExampleConfig = {
 
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
-    const outerResult = await context.waitForCallback<{ level: string }>(
+    const outerResult = await context.waitForCallback(
       "outer-callback-op",
       async () => {
         return Promise.resolve();
@@ -22,11 +22,12 @@ export const handler = withDurableExecution(
     const nestedResult = await context.runInChildContext(
       "outer-child-context",
       async (outerChildContext) => {
-        const innerResult = await outerChildContext.waitForCallback<{
-          level: string;
-        }>("inner-callback-op", async () => {
-          return Promise.resolve();
-        });
+        const innerResult = await outerChildContext.waitForCallback(
+          "inner-callback-op",
+          async () => {
+            return Promise.resolve();
+          },
+        );
 
         // Nested child context with another callback
         const deepNestedResult = await outerChildContext.runInChildContext(
@@ -35,11 +36,12 @@ export const handler = withDurableExecution(
             await innerChildContext.wait("deep-wait", { seconds: 5 });
 
             const nestedCallbackResult =
-              await innerChildContext.waitForCallback<{
-                level: string;
-              }>("nested-callback-op", async () => {
-                return Promise.resolve();
-              });
+              await innerChildContext.waitForCallback(
+                "nested-callback-op",
+                async () => {
+                  return Promise.resolve();
+                },
+              );
 
             return {
               nestedCallback: nestedCallbackResult,

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-failure-catchable/wait-for-callback-submitter-failure-catchable.ts
@@ -13,7 +13,7 @@ export const config: ExampleConfig = {
 export const handler = withDurableExecution(
   async (_event: unknown, context: DurableContext) => {
     try {
-      const result = await context.waitForCallback<{ data: string }>(
+      const result = await context.waitForCallback(
         "failing-submitter-callback",
         async () => {
           await new Promise((resolve) => setTimeout(resolve, 500));

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
@@ -14,7 +14,7 @@ export const handler = withDurableExecution(
   async (event: { shouldFail?: boolean }, context: DurableContext) => {
     const shouldFail = event.shouldFail ?? false;
 
-    const result = await context.waitForCallback<{ data: string }>(
+    const result = await context.waitForCallback(
       "retry-submitter-callback",
       async (callbackId, ctx) => {
         ctx.logger.info("Submitting callback to external system", {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/timeout/wait-for-callback-timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/timeout/wait-for-callback-timeout.ts
@@ -12,7 +12,7 @@ export const config: ExampleConfig = {
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
     try {
-      const result = await context.waitForCallback<{ data: string }>(
+      const result = await context.waitForCallback(
         async () => {
           // Submitter succeeds but callback never completes
           return Promise.resolve();

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -154,11 +154,9 @@ describe("WaitForCallback Operations Integration", () => {
         const handler = withDurableExecution<unknown, unknown>(
           async (_event: unknown, context: DurableContext) => {
             try {
-              const result = await context.waitForCallback<{ data: string }>(
-                () => {
-                  throw new Error("Submitter failed immediately");
-                },
-              );
+              const result = await context.waitForCallback(() => {
+                throw new Error("Submitter failed immediately");
+              });
 
               return {
                 callbackResult: result,
@@ -197,11 +195,9 @@ describe("WaitForCallback Operations Integration", () => {
         const handler = withDurableExecution<unknown, unknown>(
           async (_event: unknown, context: DurableContext) => {
             try {
-              const result = await context.waitForCallback<{ data: string }>(
-                () => {
-                  return Promise.reject(new Error("Async submitter failure"));
-                },
-              );
+              const result = await context.waitForCallback(() => {
+                return Promise.reject(new Error("Async submitter failure"));
+              });
 
               return {
                 callbackResult: result,
@@ -244,7 +240,7 @@ describe("WaitForCallback Operations Integration", () => {
       const handler = withDurableExecution<unknown, unknown>(
         async (_event: unknown, context: DurableContext) => {
           try {
-            const result = await context.waitForCallback<{ data: string }>(
+            const result = await context.waitForCallback(
               async (id) => {
                 callbackId = id;
 

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -334,7 +334,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    * const approvalResult = await callbackPromise;
    * ```
    */
-  createCallback<T>(
+  createCallback<T = string>(
     name: string | undefined,
     config?: CreateCallbackConfig<T>,
   ): DurablePromise<CreateCallbackResult<T>>;
@@ -353,7 +353,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    * const result = await promise;
    * ```
    */
-  createCallback<T>(
+  createCallback<T = string>(
     config?: CreateCallbackConfig<T>,
   ): DurablePromise<CreateCallbackResult<T>>;
 
@@ -375,7 +375,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    * );
    * ```
    */
-  waitForCallback<T>(
+  waitForCallback<T = string>(
     name: string | undefined,
     submitter: WaitForCallbackSubmitterFunc<Logger>,
     config?: WaitForCallbackConfig<T>,
@@ -395,7 +395,7 @@ export interface DurableContext<Logger extends DurableLogger = DurableLogger> {
    * );
    * ```
    */
-  waitForCallback<T>(
+  waitForCallback<T = string>(
     submitter: WaitForCallbackSubmitterFunc<Logger>,
     config?: WaitForCallbackConfig<T>,
   ): DurablePromise<T>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The types for waitForCallback and createCallback defaulted to `unknown`, which makes it seem like it's an object. By default, it's actually `string`.

Our example tests also all passed objects into the type parameter, but all of them are actually returning strings and not objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
