### PR TITLE
chore(sdk): simplify ExecutionState interface

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-runner-storage.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-runner-storage.ts
@@ -3,6 +3,7 @@ import {
   CheckpointDurableExecutionRequest,
   CheckpointDurableExecutionResponse,
   GetDurableExecutionStateCommand,
+  GetDurableExecutionStateRequest,
   GetDurableExecutionStateResponse,
   LambdaClient,
 } from "@aws-sdk/client-lambda";
@@ -31,33 +32,20 @@ export class LocalRunnerStorage implements ExecutionState {
   }
 
   async getStepData(
-    checkpointToken: string,
-    durableExecutionArn: string,
-    nextMarker: string,
+    params: GetDurableExecutionStateRequest,
   ): Promise<GetDurableExecutionStateResponse> {
     const response = await this.client.send(
-      new GetDurableExecutionStateCommand({
-        DurableExecutionArn: durableExecutionArn,
-        CheckpointToken: checkpointToken,
-        Marker: nextMarker,
-        MaxItems: 1000,
-      }),
+      new GetDurableExecutionStateCommand(params),
     );
 
     return response;
   }
 
   async checkpoint(
-    checkpointToken: string,
-    data: CheckpointDurableExecutionRequest,
+    params: CheckpointDurableExecutionRequest,
   ): Promise<CheckpointDurableExecutionResponse> {
     const response = await this.client.send(
-      new CheckpointDurableExecutionCommand({
-        DurableExecutionArn: data.DurableExecutionArn,
-        CheckpointToken: checkpointToken,
-        ClientToken: data.ClientToken,
-        Updates: data.Updates,
-      }),
+      new CheckpointDurableExecutionCommand(params),
     );
 
     return response;

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
@@ -246,9 +246,12 @@ describe("initializeExecutionContext", () => {
 
     // Verify
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(result.executionContext._stepData).toEqual({
@@ -305,15 +308,21 @@ describe("initializeExecutionContext", () => {
 
     // Verify
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token2",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token2",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(result.executionContext._stepData).toEqual({
@@ -358,16 +367,22 @@ describe("initializeExecutionContext", () => {
 
     // Verify
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
 
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token2",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token2",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
 
@@ -400,9 +415,12 @@ describe("initializeExecutionContext", () => {
 
     // Verify
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(mockExecutionState.getStepData).toHaveBeenCalledTimes(1); // Should only be called once
@@ -437,9 +455,12 @@ describe("initializeExecutionContext", () => {
 
     // Verify - should handle undefined operations gracefully and get execution event from pagination
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(result.executionContext._stepData).toEqual({});
@@ -482,9 +503,12 @@ describe("initializeExecutionContext", () => {
 
     // Verify
     expect(mockExecutionState.getStepData).toHaveBeenCalledWith(
-      mockCheckpointToken,
-      "test-durable-execution-arn",
-      "token1",
+      {
+        CheckpointToken: mockCheckpointToken,
+        DurableExecutionArn: "test-durable-execution-arn",
+        Marker: "token1",
+        MaxItems: 1000,
+      },
       expectLogger,
     );
     expect(result.executionContext._stepData).toEqual({

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -40,9 +40,12 @@ export const initializeExecutionContext = async (
 
   while (nextMarker) {
     const response = await state.getStepData(
-      checkpointToken,
-      durableExecutionArn,
-      nextMarker,
+      {
+        CheckpointToken: checkpointToken,
+        Marker: nextMarker,
+        DurableExecutionArn: durableExecutionArn,
+        MaxItems: 1000,
+      },
       initLogger,
     );
     operationsArray.push(...(response.Operations || []));

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
@@ -72,13 +72,11 @@ describe("Run In Child Context Integration Tests", () => {
         getStepData: jest.fn().mockResolvedValue({}),
         checkpoint: jest
           .fn()
-          .mockImplementation(
-            (taskToken: string, data: CheckpointDurableExecutionRequest) => {
-              const checkpointToken = data.CheckpointToken;
-              checkpointCalls.push({ checkpointToken, data });
-              return Promise.resolve({ CheckpointToken: "mock-token" });
-            },
-          ),
+          .mockImplementation((data: CheckpointDurableExecutionRequest) => {
+            const checkpointToken = data.CheckpointToken;
+            checkpointCalls.push({ checkpointToken, data });
+            return Promise.resolve({ CheckpointToken: "mock-token" });
+          }),
       },
       _stepData: {},
       terminationManager: mockTerminationManager,

--- a/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/api-storage.test.ts
@@ -72,11 +72,12 @@ describe("ApiStorage", () => {
     mockLambdaClient.send.mockResolvedValue(mockResponse);
 
     // Call getStepData
-    const result = await apiStorage.getStepData(
-      "checkpoint-token",
-      "durable-execution-arn",
-      "next-marker",
-    );
+    const result = await apiStorage.getStepData({
+      CheckpointToken: "checkpoint-token",
+      DurableExecutionArn: "durable-execution-arn",
+      Marker: "next-marker",
+      MaxItems: 1000,
+    });
 
     // Verify that GetDurableExecutionStateCommand was constructed with the correct parameters
     expect(GetDurableExecutionStateCommand).toHaveBeenCalledWith({
@@ -103,7 +104,7 @@ describe("ApiStorage", () => {
     // Create checkpoint data
     const checkpointData: CheckpointDurableExecutionRequest = {
       DurableExecutionArn: "test-durable-execution-arn",
-      CheckpointToken: "",
+      CheckpointToken: "task-token",
       Updates: [
         {
           Id: "test-step-1",
@@ -115,7 +116,7 @@ describe("ApiStorage", () => {
     };
 
     // Call checkpoint
-    const result = await apiStorage.checkpoint("task-token", checkpointData);
+    const result = await apiStorage.checkpoint(checkpointData);
 
     // Verify that CheckpointDurableExecutionCommand was constructed with the correct parameters
     expect(CheckpointDurableExecutionCommand).toHaveBeenCalledWith({
@@ -140,18 +141,18 @@ describe("ApiStorage", () => {
 
     // Call getStepData and expect it to throw
     await expect(
-      apiStorage.getStepData(
-        "task-token",
-        "durable-execution-arn",
-        "next-token",
-      ),
+      apiStorage.getStepData({
+        CheckpointToken: "task-token",
+        DurableExecutionArn: "durable-execution-arn",
+        Marker: "next-token",
+      }),
     ).rejects.toThrow("Lambda client error");
 
     // Call checkpoint and expect it to throw
     await expect(
-      apiStorage.checkpoint("task-token", {
+      apiStorage.checkpoint({
         DurableExecutionArn: "",
-        CheckpointToken: "",
+        CheckpointToken: "task-token",
         Updates: [
           {
             Id: "test-step-2",
@@ -174,11 +175,11 @@ describe("ApiStorage", () => {
 
     // Call getStepData and expect it to throw
     try {
-      await apiStorage.getStepData(
-        "checkpoint-token",
-        "test-execution-arn",
-        "next-marker",
-      );
+      await apiStorage.getStepData({
+        CheckpointToken: "checkpoint-token",
+        DurableExecutionArn: "test-execution-arn",
+        Marker: "next-marker",
+      });
     } catch (_error) {
       // Expected to throw
     }
@@ -204,13 +205,13 @@ describe("ApiStorage", () => {
 
     const checkpointData: CheckpointDurableExecutionRequest = {
       DurableExecutionArn: "test-execution-arn-2",
-      CheckpointToken: "",
+      CheckpointToken: "checkpoint-token",
       Updates: [],
     };
 
     // Call checkpoint and expect it to throw
     try {
-      await apiStorage.checkpoint("checkpoint-token", checkpointData);
+      await apiStorage.checkpoint(checkpointData);
     } catch (_error) {
       // Expected to throw
     }
@@ -233,11 +234,11 @@ describe("ApiStorage", () => {
 
     // Call getStepData and expect it to throw
     await expect(
-      apiStorage.getStepData(
-        "checkpoint-token",
-        "test-execution-arn",
-        "next-marker",
-      ),
+      apiStorage.getStepData({
+        CheckpointToken: "checkpoint-token",
+        DurableExecutionArn: "test-execution-arn",
+        Marker: "next-marker",
+      }),
     ).rejects.toThrow("Network error");
 
     // Verify error was logged
@@ -269,9 +270,11 @@ describe("ApiStorage", () => {
 
     try {
       await apiStorage.getStepData(
-        "checkpoint-token",
-        "test-execution-arn",
-        "next-marker",
+        {
+          CheckpointToken: "checkpoint-token",
+          DurableExecutionArn: "test-execution-arn",
+          Marker: "next-marker",
+        },
         mockLogger,
       );
     } catch (_error) {
@@ -303,16 +306,12 @@ describe("ApiStorage", () => {
 
     const checkpointData: CheckpointDurableExecutionRequest = {
       DurableExecutionArn: "test-execution-arn",
-      CheckpointToken: "",
+      CheckpointToken: "checkpoint-token",
       Updates: [],
     };
 
     try {
-      await apiStorage.checkpoint(
-        "checkpoint-token",
-        checkpointData,
-        mockLogger,
-      );
+      await apiStorage.checkpoint(checkpointData, mockLogger);
     } catch (_error) {
       // Expected to throw
     }

--- a/packages/aws-durable-execution-sdk-js/src/storage/storage.ts
+++ b/packages/aws-durable-execution-sdk-js/src/storage/storage.ts
@@ -1,6 +1,7 @@
 import {
   CheckpointDurableExecutionRequest,
   CheckpointDurableExecutionResponse,
+  GetDurableExecutionStateRequest,
   GetDurableExecutionStateResponse,
 } from "@aws-sdk/client-lambda";
 import { ApiStorage } from "./api-storage";
@@ -8,14 +9,11 @@ import { DurableLogger } from "../types";
 
 export interface ExecutionState {
   getStepData(
-    taskToken: string,
-    durableExecutionArn: string,
-    nextToken: string,
+    params: GetDurableExecutionStateRequest,
     logger?: DurableLogger,
   ): Promise<GetDurableExecutionStateResponse>;
   checkpoint(
-    taskToken: string,
-    data: CheckpointDurableExecutionRequest,
+    params: CheckpointDurableExecutionRequest,
     logger?: DurableLogger,
   ): Promise<CheckpointDurableExecutionResponse>;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-integration.test.ts
@@ -78,7 +78,7 @@ describe("Checkpoint Integration Tests", () => {
 
     // Verify all operations were processed in one batch
     const totalUpdates = mockState.checkpoint.mock.calls.reduce(
-      (sum: number, call: any) => sum + call[1].Updates.length,
+      (sum: number, call: any) => sum + call[0].Updates.length,
       0,
     ) as unknown as CheckpointFunction;
     expect(totalUpdates).toBe(8);
@@ -132,9 +132,10 @@ describe("Checkpoint Integration Tests", () => {
 
     // Should have batched all different operation types together
     expect(mockState.checkpoint).toHaveBeenCalledWith(
-      TEST_CONSTANTS.CHECKPOINT_TOKEN,
-      expect.objectContaining({
-        Updates: expect.arrayContaining([
+      {
+        DurableExecutionArn: "test-arn",
+        CheckpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
+        Updates: [
           expect.objectContaining({
             Id: hashId("step-1"),
             Action: OperationAction.START,
@@ -164,8 +165,8 @@ describe("Checkpoint Integration Tests", () => {
             Payload: "retry reason",
             StepOptions: { NextAttemptDelaySeconds: 10 },
           }),
-        ]),
-      }),
+        ],
+      },
       mockLogger,
     ) as unknown as CheckpointFunction;
   });
@@ -199,14 +200,13 @@ describe("Checkpoint Integration Tests", () => {
 
     expect(mockState.checkpoint).toHaveBeenCalledTimes(1);
     expect(mockState.checkpoint).toHaveBeenCalledWith(
-      TEST_CONSTANTS.CHECKPOINT_TOKEN,
-      expect.objectContaining({
-        Updates: expect.arrayContaining(
-          Array.from({ length: 10 }, (_, i) =>
-            expect.objectContaining({ Id: hashId(`step-${i}`) }),
-          ),
+      {
+        DurableExecutionArn: "test-arn",
+        CheckpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
+        Updates: Array.from({ length: 10 }, (_, i) =>
+          expect.objectContaining({ Id: hashId(`step-${i}`) }),
         ),
-      }),
+      },
       mockLogger,
     ) as unknown as CheckpointFunction;
   });
@@ -239,10 +239,10 @@ describe("Checkpoint Integration Tests", () => {
     await Promise.all(promises);
 
     expect(mockState.checkpoint).toHaveBeenCalledTimes(1);
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(15);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(15);
 
     // Verify all operations were processed
-    const processedIds = mockState.checkpoint.mock.calls[0][1].Updates.map(
+    const processedIds = mockState.checkpoint.mock.calls[0][0].Updates.map(
       (update: any) => update.Id,
     ) as unknown as CheckpointFunction;
     expect(processedIds).toEqual(
@@ -307,7 +307,7 @@ describe("Checkpoint Integration Tests", () => {
     expect(mockState2.checkpoint).toHaveBeenCalledTimes(1);
 
     // Verify each checkpoint was called with its respective operation
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
-    expect(mockState2.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
+    expect(mockState2.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -369,7 +369,6 @@ export class CheckpointManager implements Checkpoint {
     });
 
     const response = await this.storage.checkpoint(
-      this.currentTaskToken,
       checkpointData,
       this.logger,
     );

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -106,7 +106,6 @@ describe("CheckpointManager", () => {
       // Should be processed immediately
       expect(checkpointHandler.getQueueStatus().queueLength).toBe(0);
       expect(mockState.checkpoint).toHaveBeenCalledWith(
-        TEST_CONSTANTS.CHECKPOINT_TOKEN,
         {
           DurableExecutionArn: "test-durable-execution-arn",
           CheckpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
@@ -169,14 +168,14 @@ describe("CheckpointManager", () => {
       expect(mockState.checkpoint).toHaveBeenCalledTimes(1);
 
       // Should have all three updates in the single call
-      expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(3);
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[0].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(3);
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[0].Id).toBe(
         hashId("step-1"),
       ) as unknown as CheckpointFunction;
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[1].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[1].Id).toBe(
         hashId("step-2"),
       ) as unknown as CheckpointFunction;
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[2].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[2].Id).toBe(
         hashId("step-3"),
       ) as unknown as CheckpointFunction;
     });
@@ -211,7 +210,7 @@ describe("CheckpointManager", () => {
 
       // Verify all operations were processed
       const totalUpdates = mockState.checkpoint.mock.calls.reduce(
-        (sum: number, call: any) => sum + call[1].Updates.length,
+        (sum: number, call: any) => sum + call[0].Updates.length,
         0,
       ) as unknown as CheckpointFunction;
       expect(totalUpdates).toBe(10);
@@ -248,7 +247,7 @@ describe("CheckpointManager", () => {
 
       // Verify all operations were processed
       const totalUpdates = mockState.checkpoint.mock.calls.reduce(
-        (sum: number, call: any) => sum + call[1].Updates.length,
+        (sum: number, call: any) => sum + call[0].Updates.length,
         0,
       ) as unknown as CheckpointFunction;
       expect(totalUpdates).toBe(20);
@@ -335,20 +334,20 @@ describe("CheckpointManager", () => {
       expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
 
       // Verify first batch had 2 updates
-      expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(2);
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[0].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(2);
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[0].Id).toBe(
         hashId("step-1"),
       ) as unknown as CheckpointFunction;
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[1].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[1].Id).toBe(
         hashId("step-2"),
       ) as unknown as CheckpointFunction;
 
       // Verify second batch had 2 updates
-      expect(mockState.checkpoint.mock.calls[1][1].Updates).toHaveLength(2);
-      expect(mockState.checkpoint.mock.calls[1][1].Updates[0].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[1][0].Updates).toHaveLength(2);
+      expect(mockState.checkpoint.mock.calls[1][0].Updates[0].Id).toBe(
         hashId("step-3"),
       ) as unknown as CheckpointFunction;
-      expect(mockState.checkpoint.mock.calls[1][1].Updates[1].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[1][0].Updates[1].Id).toBe(
         hashId("step-4"),
       ) as unknown as CheckpointFunction;
 
@@ -405,10 +404,10 @@ describe("CheckpointManager", () => {
 
       // Should have made two separate API calls
       expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
-      expect(mockState.checkpoint.mock.calls[0][1].Updates[0].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[0][0].Updates[0].Id).toBe(
         hashId("step-1"),
       ) as unknown as CheckpointFunction;
-      expect(mockState.checkpoint.mock.calls[1][1].Updates[0].Id).toBe(
+      expect(mockState.checkpoint.mock.calls[1][0].Updates[0].Id).toBe(
         hashId("step-2"),
       ) as unknown as CheckpointFunction;
     });
@@ -619,7 +618,6 @@ describe("CheckpointManager", () => {
       await checkpointHandler.checkpoint("step-1", {});
 
       expect(mockState.checkpoint).toHaveBeenCalledWith(
-        TEST_CONSTANTS.CHECKPOINT_TOKEN,
         {
           DurableExecutionArn: "test-durable-execution-arn",
           CheckpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
@@ -676,7 +674,7 @@ describe("CheckpointManager", () => {
 
       // Should have batched all operations together in a single call
       expect(mockState.checkpoint).toHaveBeenCalledTimes(1);
-      expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(3);
+      expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(3);
     });
   });
 });
@@ -801,8 +799,8 @@ describe("deleteCheckpointHandler", () => {
     expect(mockState1.checkpoint).toHaveBeenCalledTimes(1);
     expect(mockState2.checkpoint).toHaveBeenCalledTimes(1);
     // Each context processes its own operation
-    expect(mockState1.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
-    expect(mockState2.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState1.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
+    expect(mockState2.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
 
     // Delete the handler
 
@@ -849,8 +847,8 @@ describe("deleteCheckpointHandler", () => {
     expect(mockState2.checkpoint).toHaveBeenCalledTimes(1);
 
     // Each context processes its own operation
-    expect(mockState1.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
-    expect(mockState2.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState1.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
+    expect(mockState2.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
 
     // Clean up
   });
@@ -867,7 +865,6 @@ describe("deleteCheckpointHandler", () => {
       await checkpoint.force();
 
       expect(mockState1.checkpoint).toHaveBeenCalledWith(
-        "test-token",
         {
           DurableExecutionArn: "test-durable-execution-arn-1",
           CheckpointToken: "test-token",
@@ -926,7 +923,6 @@ describe("deleteCheckpointHandler", () => {
       // Should still only have made one API call total (the force request piggybacked)
       expect(mockState1.checkpoint).toHaveBeenCalledTimes(1);
       expect(mockState1.checkpoint).toHaveBeenCalledWith(
-        "test-token",
         {
           DurableExecutionArn: "test-durable-execution-arn-1",
           CheckpointToken: "test-token",
@@ -1030,7 +1026,6 @@ describe("createCheckpointHandler", () => {
 
     // Verify
     expect(mockState.checkpoint).toHaveBeenCalledWith(
-      TEST_CONSTANTS.CHECKPOINT_TOKEN,
       expect.objectContaining({
         CheckpointToken: TEST_CONSTANTS.CHECKPOINT_TOKEN,
         Updates: expect.arrayContaining([
@@ -1176,8 +1171,8 @@ describe("createCheckpointHandler", () => {
     expect(mockState2.checkpoint).toHaveBeenCalledTimes(1);
 
     // Each context processes its own operation
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
-    expect(mockState2.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
+    expect(mockState2.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
   });
 
   it("should use the same handler for equivalent execution context ids, but different objects", async () => {
@@ -1219,8 +1214,8 @@ describe("createCheckpointHandler", () => {
     expect(mockState2.checkpoint).toHaveBeenCalledTimes(1);
 
     // Each context processes its own operation
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
-    expect(mockState2.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
+    expect(mockState2.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
   });
 
   it("should split large payloads into multiple API calls when exceeding 750KB limit", async () => {
@@ -1252,9 +1247,9 @@ describe("createCheckpointHandler", () => {
     expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
 
     // First call should have one item
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
     // Second call should have the remaining item
-    expect(mockState.checkpoint.mock.calls[1][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[1][0].Updates).toHaveLength(1);
   });
 
   it("should split large payloads into multiple API calls when exceeding 750KB limit for large unicode characters", async () => {
@@ -1286,9 +1281,9 @@ describe("createCheckpointHandler", () => {
     expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
 
     // First call should have one item
-    expect(mockState.checkpoint.mock.calls[0][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(1);
     // Second call should have the remaining item
-    expect(mockState.checkpoint.mock.calls[1][1].Updates).toHaveLength(1);
+    expect(mockState.checkpoint.mock.calls[1][0].Updates).toHaveLength(1);
   });
 
   it("should process remaining items in queue after size limit is reached", async () => {
@@ -1326,7 +1321,7 @@ describe("createCheckpointHandler", () => {
 
     // Verify all items were processed
     const allUpdates = mockState.checkpoint.mock.calls.flatMap(
-      (call: any) => call[1].Updates,
+      (call: any) => call[0].Updates,
     );
     expect(allUpdates).toHaveLength(3);
     expect(allUpdates.map((u: any) => u.Id)).toEqual([


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The ExecutionState interface has multiple duplicated parameters. Combining them into just the API parameters that are required for the interface.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
