### PR TITLE
chore: use npm CI and update package.json scripts 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 22.x
           cache: "npm"
       - name: Install dependencies
-        run: npm run install-all
+        run: npm ci
       - name: Build project
         run: npm run build
       - name: Upload build artifacts
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm run install-all
+          npm ci
 
       - name: Get AWS Credentials
         id: credentials

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
           path: .
 
       - name: Install dependencies
-        run: npm run install-all
+        run: npm ci
 
       - name: Deploy functions
         id: deploy-functions
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm run install-all
+          npm ci
 
       - name: Run Jest integration tests
         env:

--- a/.github/workflows/sync-package.yml
+++ b/.github/workflows/sync-package.yml
@@ -47,7 +47,7 @@ jobs:
         uses: martinbeentjes/npm-get-version-action@v1.3.1
         with:
           path: packages/${{ inputs.package_name }}
-      - run: npm run install-all
+      - run: npm ci
       - run: npm run build
       - name: Navigate to package and pack
         working-directory: packages/${{ inputs.package_name }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,6 @@ jobs:
           name: built-artifacts
           path: .
       - name: Install dependencies
-        run: npm run install-all
+        run: npm ci
       - name: Run tests
         run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5218,24 +5218,28 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bowser": {
@@ -8273,9 +8277,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8283,6 +8287,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -10542,23 +10550,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-is": {

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rm -rf dist node_modules .tsbuildinfo"
   },
   "keywords": [
     "eslint",

--- a/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
+++ b/packages/aws-durable-execution-sdk-js-examples/jest.config.integration.js
@@ -7,4 +7,6 @@ module.exports = {
   ...defaultPreset,
   testMatch: ["**/src/examples/**/*.test.ts"],
   testTimeout: 90000,
+  testNamePattern: "cloud",
+  bail: true,
 };

--- a/packages/aws-durable-execution-sdk-js-examples/package.json
+++ b/packages/aws-durable-execution-sdk-js-examples/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "clean": "rm -rf build/ build coverage node_modules/ dist/ *.zip",
+    "clean": "rm -rf build/ build coverage node_modules/ dist/ *.zip .tsbuildinfo .rollup.cache",
     "release": "npm run build && mkdir -p build/aws-durable-execution-sdk-js-examples && npm run copy-files",
     "prebuild": "rm -rf build/aws-durable-execution-sdk-js-examples",
     "postbuild": "npm run generate-sam-template",
@@ -38,7 +38,7 @@
     "copy-catalog": "cp examples-catalog.json build/aws-durable-execution-sdk-js-examples/",
     "generate-sam-template": "node scripts/generate-sam-template.js",
     "test": "npm run unit-test",
-    "test:integration": "NODE_ENV=integration jest --config jest.config.integration.js --testNamePattern=cloud",
+    "test:integration": "NODE_ENV=integration jest --config jest.config.integration.js",
     "pretest-with-sdk-coverage": "node scripts/copy-sdk-source.js",
     "test-with-sdk-coverage": "jest --config jest.config.sdk-coverage.js --collectCoverage",
     "coverage-to-csv": "node scripts/coverage-to-csv.js",

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -8,11 +8,14 @@
   "engines": {
     "node": ">=22"
   },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist-types/index.d.ts",
   "bin": {
     "run-durable": "./dist/cli/run-durable.js"
   },
   "scripts": {
-    "clean": "rm -rf dist dist-cjs dist-types node_modules coverage",
+    "clean": "rm -rf dist dist-cjs dist-types node_modules coverage .tsbuildinfo .rollup.cache",
     "build": "concurrently npm:build:esm npm:build:cjs npm:build:types",
     "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
     "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "node": ">=22"
   },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist-types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist-types/index.d.ts",
@@ -38,7 +41,7 @@
     "lint:fix": "eslint src --ext .ts --fix",
     "prepublishOnly": "npm test && npm run lint && npm run build",
     "run-locally": "tsx ./src/run-durable.ts",
-    "clean": "rm -rf node_modules dist dist-cjs dist-types coverage",
+    "clean": "rm -rf node_modules dist dist-cjs dist-types coverage .tsbuildinfo .rollup.cache",
     "prepack": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- `npm ci` should be used which respects all the locked versions in `package-lock.json`
- Updating body-parser version in package-lock.json based on the dependabot alert.
- adding main/module/types for people using legacy typescript configurations with `moduleResolution: node`
- updating clean scripts to clear .tsbuildinfo and .rollup.cache folders
- fail fast when integ tests fail with `bail` option in integ test config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
