### PR TITLE
fix(sdk): add validation for durable execution not enabled

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-execution-not-enabled-error/durable-execution-not-enabled-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-execution-not-enabled-error/durable-execution-not-enabled-error.ts
@@ -1,0 +1,13 @@
+import { TerminationReason } from "../../termination-manager/types";
+import { UnrecoverableInvocationError } from "../unrecoverable-error/unrecoverable-error";
+
+export class DurableExecutionNotEnabledError extends UnrecoverableInvocationError {
+  readonly terminationReason = TerminationReason.CUSTOM;
+
+  constructor() {
+    super(
+      "This Lambda handler is wrapped with withDurableExecution() but durable executions is not enabled for this function. Recreate the function with durable execution enabled, or remove the withDurableExecution() wrapper",
+    );
+    this.name = "DurableExecutionNotEnabledError";
+  }
+}

--- a/packages/aws-durable-execution-sdk-js/src/types/core.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/core.ts
@@ -30,6 +30,18 @@ export interface DurableExecutionInvocationInput {
   LocalRunner?: boolean;
 }
 
+export function isDurableExecutionInvocationInput(
+  event: unknown,
+): event is DurableExecutionInvocationInput {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "DurableExecutionArn" in event &&
+    "CheckpointToken" in event &&
+    "InitialExecutionState" in event
+  );
+}
+
 export enum InvocationStatus {
   SUCCEEDED = "SUCCEEDED",
   FAILED = "FAILED",

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -2,6 +2,7 @@ import { withDurableExecution } from "./with-durable-execution";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { createDurableContext } from "./context/durable-context/durable-context";
 import { CheckpointUnrecoverableInvocationError } from "./errors/checkpoint-errors/checkpoint-errors";
+import { DurableExecutionNotEnabledError } from "./errors/durable-execution-not-enabled-error/durable-execution-not-enabled-error";
 import {
   UnrecoverableInvocationError,
   UnrecoverableExecutionError,
@@ -26,6 +27,19 @@ const mockCheckpointToken = "test-checkpoint-token";
 const mockDurableExecutionArn = "test-durable-execution-arn";
 
 describe("withDurableExecution", () => {
+  it("should throw DurableExecutionNotEnabledError when event is not a DurableExecutionInvocationInput", async () => {
+    const mockHandler = jest.fn();
+    const nonDurableEvent = { foo: "bar" };
+    const mockContext = {} as Context;
+
+    const wrappedHandler = withDurableExecution(mockHandler);
+    await expect(
+      wrappedHandler(nonDurableEvent as any, mockContext),
+    ).rejects.toThrow(DurableExecutionNotEnabledError);
+
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
   // Setup common test variables
   const mockEvent: DurableExecutionInvocationInput = {
     CheckpointToken: mockCheckpointToken,

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -5,6 +5,7 @@ import { createDurableContext } from "./context/durable-context/durable-context"
 import { CheckpointManager } from "./utils/checkpoint/checkpoint-manager";
 
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
+import { DurableExecutionNotEnabledError } from "./errors/durable-execution-not-enabled-error/durable-execution-not-enabled-error";
 import { SerdesFailedError } from "./errors/serdes-errors/serdes-errors";
 import { isUnrecoverableInvocationError } from "./errors/unrecoverable-error/unrecoverable-error";
 import { TerminationReason } from "./termination-manager/types";
@@ -17,6 +18,7 @@ import {
   DurableExecutionMode,
   ExecutionContext,
   InvocationStatus,
+  isDurableExecutionInvocationInput,
   LambdaHandler,
 } from "./types";
 import { log } from "./utils/logger/logger";
@@ -242,6 +244,10 @@ export const withDurableExecution = <
     event: DurableExecutionInvocationInput,
     context: Context,
   ): Promise<DurableExecutionInvocationOutput> => {
+    if (!isDurableExecutionInvocationInput(event)) {
+      throw new DurableExecutionNotEnabledError();
+    }
+
     const { executionContext, durableExecutionMode, checkpointToken } =
       await initializeExecutionContext(event, context);
     let response: DurableExecutionInvocationOutput | null = null;


### PR DESCRIPTION
*Issue #, if available:* #291

*Description of changes:*

When customers use withDurableExecution() on a Lambda function that does not have durable execution enabled, they receive a cryptic error. This commit adds validation to check if the event is a
DurableExecutionInvocationInput and emits a helpful warning if not.

* I wasn't sure whether to create a new Error type or reuse an existing one. I might have missed an existing type that was appropriate.
* The wording for the error message is up for improvement. If you're creating a function in the console, you "enable" durable executions. If you're using the SDK, CLI or CloudFormation, you set a DurableConfig to "enable" it. Ideally the error message would cover both paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
