### PR TITLE
fix(sdk): Update README.md about invoking other functions

### DIFF
--- a/packages/aws-durable-execution-sdk-js/README.md
+++ b/packages/aws-durable-execution-sdk-js/README.md
@@ -106,7 +106,7 @@ const orderResult = await context.runInChildContext(
 
 ### Invoking Other Functions
 
-Call other durable functions:
+Call another AWS Lambda function and wait for it complete:
 
 ```typescript
 const result = await context.invoke(


### PR DESCRIPTION
*Issue #, if available:* 
None

*Description of changes:*
You can invoke non-durable functions as well as durable functions when using context.invoke().

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
