### PR TITLE
fix(sdk): apply default retry regex only when no filters specified

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/types/step.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/step.ts
@@ -2,8 +2,34 @@ import { Serdes } from "../utils/serdes/serdes";
 import { StepContext } from "./logger";
 import { DurableLogger, Duration } from "../types";
 
+/**
+ * Decision returned by a retry strategy function
+ * 
+ * @remarks
+ * Returned by retry strategy functions to indicate whether an operation should be retried
+ * and how long to wait before the next attempt.
+ * 
+ * @example
+ * ```typescript
+ * // Don't retry
+ * { shouldRetry: false }
+ * 
+ * // Retry after 5 seconds
+ * { shouldRetry: true, delay: { seconds: 5 } }
+ * 
+ * // Retry after 2 minutes
+ * { shouldRetry: true, delay: { minutes: 2 } }
+ * ```
+ * 
+ * @see {@link createRetryStrategy} for creating retry strategies
+ */
 export interface RetryDecision {
+  /** Whether the operation should be retried */
   shouldRetry: boolean;
+  /** 
+   * Delay before the next retry attempt
+   * @remarks Only used when `shouldRetry` is true. If not specified, defaults to 1 second.
+   */
   delay?: Duration;
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts
@@ -3,21 +3,104 @@ import { durationToSeconds } from "../../duration/duration";
 
 /**
  * Configuration options for creating a retry strategy
+ * 
+ * @remarks
+ * When neither `retryableErrors` nor `retryableErrorTypes` is specified, all errors are retried by default.
+ * When either is specified, only errors matching the specified criteria are retried.
+ * When both are specified, errors matching either criteria are retried (OR logic).
+ * 
+ * @example
+ * ```typescript
+ * // Retry all errors (default behavior)
+ * createRetryStrategy({ maxAttempts: 5 })
+ * 
+ * // Retry only specific error types
+ * createRetryStrategy({ retryableErrorTypes: [TimeoutError, NetworkError] })
+ * 
+ * // Retry only errors matching message patterns
+ * createRetryStrategy({ retryableErrors: [/timeout/i, /connection/i] })
+ * 
+ * // Retry errors matching either type OR pattern
+ * createRetryStrategy({ 
+ *   retryableErrorTypes: [TimeoutError],
+ *   retryableErrors: [/network/i]
+ * })
+ * ```
  */
 interface RetryStrategyConfig {
-  /** Maximum number of total attempts (including initial attempt). Default: 3 */
+  /** 
+   * Maximum number of total attempts (including initial attempt). 
+   * @defaultValue 3
+   */
   maxAttempts?: number;
-  /** Initial delay before first retry. Default: \{ seconds: 5 \} */
+  
+  /** 
+   * Initial delay before first retry. 
+   * @defaultValue \{ seconds: 5 \}
+   */
   initialDelay?: Duration;
-  /** Maximum delay between retries. Default: \{ minutes: 5 \} */
+  
+  /** 
+   * Maximum delay between retries. 
+   * @defaultValue \{ minutes: 5 \}
+   */
   maxDelay?: Duration;
-  /** Multiplier for exponential backoff on each retry. Default: 2 */
+  
+  /** 
+   * Multiplier for exponential backoff on each retry. 
+   * @defaultValue 2
+   */
   backoffRate?: number;
-  /** Jitter strategy to apply to retry delays. Default: JitterStrategy.FULL */
+  
+  /** 
+   * Jitter strategy to apply to retry delays. 
+   * @defaultValue JitterStrategy.FULL
+   * @see {@link JitterStrategy}
+   */
   jitter?: JitterStrategy;
-  /** List of error message patterns (strings or RegExp) that are retryable. Default: all errors */
+  
+  /** 
+   * List of error message patterns (strings or RegExp) that are retryable.
+   * 
+   * @remarks
+   * - If undefined and `retryableErrorTypes` is also undefined: all errors are retried (default)
+   * - If specified: only errors with messages matching these patterns are retried
+   * - Strings are matched using `includes()`, RegExp patterns use `test()`
+   * - Combined with `retryableErrorTypes` using OR logic
+   * 
+   * @defaultValue All errors when both filters are undefined, otherwise empty array
+   * 
+   * @example
+   * ```typescript
+   * // Retry errors containing "timeout" or "connection"
+   * retryableErrors: ["timeout", "connection"]
+   * 
+   * // Retry errors matching regex patterns (case-insensitive)
+   * retryableErrors: [/timeout/i, /network.*failed/i]
+   * ```
+   */
   retryableErrors?: (string | RegExp)[];
-  /** List of error class types that are retryable. Default: none */
+  
+  /** 
+   * List of error class types that are retryable.
+   * 
+   * @remarks
+   * - If undefined and `retryableErrors` is also undefined: all errors are retried (default)
+   * - If specified: only errors that are instances of these types are retried
+   * - Combined with `retryableErrors` using OR logic
+   * 
+   * @defaultValue Empty array
+   * 
+   * @example
+   * ```typescript
+   * // Define custom error types
+   * class TimeoutError extends Error {}
+   * class NetworkError extends Error {}
+   * 
+   * // Retry only these specific error types
+   * retryableErrorTypes: [TimeoutError, NetworkError]
+   * ```
+   */
   retryableErrorTypes?: (new () => Error)[];
 }
 
@@ -48,29 +131,76 @@ const applyJitter = (delay: number, strategy: JitterStrategy): number => {
 
 /**
  * Creates a retry strategy function with exponential backoff and configurable jitter
+ * 
  * @param config - Configuration options for the retry strategy
  * @returns A function that determines whether to retry and calculates delay based on error and attempt count
+ * 
+ * @remarks
+ * The returned function takes an error and attempt count, and returns a {@link RetryDecision} indicating
+ * whether to retry and the delay before the next attempt.
+ * 
+ * **Delay Calculation:**
+ * - Base delay = `initialDelay × backoffRate^(attemptsMade - 1)`
+ * - Capped at `maxDelay`
+ * - Jitter applied based on `jitter` strategy
+ * - Final delay rounded to nearest second, minimum 1 second
+ * 
+ * **Error Filtering:**
+ * - If neither `retryableErrors` nor `retryableErrorTypes` is specified: all errors are retried
+ * - If either is specified: only matching errors are retried
+ * - If both are specified: errors matching either criteria are retried (OR logic)
+ * 
  * @example
  * ```typescript
- * // Create a custom retry strategy
+ * // Basic usage with defaults (retry all errors, 3 attempts, exponential backoff)
+ * const defaultRetry = createRetryStrategy();
+ * 
+ * // Custom retry with more attempts and specific delays
  * const customRetry = createRetryStrategy({
  *   maxAttempts: 5,
  *   initialDelay: { seconds: 10 },
+ *   maxDelay: { seconds: 60 },
  *   backoffRate: 2,
- *   jitter: JitterStrategy.HALF,
- *   retryableErrors: [/timeout/i, /connection/i]
+ *   jitter: JitterStrategy.HALF
  * });
- *
+ * 
+ * // Retry only specific error types
+ * class TimeoutError extends Error {}
+ * const typeBasedRetry = createRetryStrategy({
+ *   retryableErrorTypes: [TimeoutError]
+ * });
+ * 
+ * // Retry only errors matching message patterns
+ * const patternBasedRetry = createRetryStrategy({
+ *   retryableErrors: [/timeout/i, /connection/i, "rate limit"]
+ * });
+ * 
+ * // Combine error types and patterns
+ * const combinedRetry = createRetryStrategy({
+ *   retryableErrorTypes: [TimeoutError],
+ *   retryableErrors: [/network/i]
+ * });
+ * 
  * // Use in step configuration
  * await context.step('api-call', async () => {
  *   return await callExternalAPI();
  * }, { retryStrategy: customRetry });
  * ```
+ * 
+ * @see {@link RetryStrategyConfig} for configuration options
+ * @see {@link JitterStrategy} for jitter strategies
+ * @see {@link RetryDecision} for return type
  */
 export const createRetryStrategy = (config: RetryStrategyConfig = {}) => {
+  // Only apply default retryableErrors if user didn't specify either filter
+  const shouldUseDefaultErrors =
+    config.retryableErrors === undefined &&
+    config.retryableErrorTypes === undefined;
+
   const finalConfig: Required<RetryStrategyConfig> = {
     ...DEFAULT_CONFIG,
     ...config,
+    retryableErrors: config.retryableErrors ?? (shouldUseDefaultErrors ? [/.*/] : []),
   };
 
   return (error: Error, attemptsMade: number): RetryDecision => {


### PR DESCRIPTION
*Description of changes:*

Fix unintuitive behavior where specifying retryableErrorTypes would still retry all errors due to default retryableErrors regex [/.*/].

Changes:
- Only apply default [/.*/] regex when BOTH retryableErrors and retryableErrorTypes are undefined
- When either filter is specified, only matching errors are retried
- When both filters are specified, errors matching either criteria are retried (OR logic)
- Add TSDoc for RetryStrategyConfig, createRetryStrategy, and RetryDecision
- Add 3 new tests to verify filter behavior

Examples:
- createRetryStrategy({ retryableErrorTypes: [TimeoutError] }) - only retries TimeoutError
- createRetryStrategy({ retryableErrors: [/network/i] }) - only retries matching pattern
- createRetryStrategy({}) - retries all errors (default preserved)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
