### PR TITLE
refactor(testing-sdk): move server handlers to separate files

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/__tests__/checkpoint-server.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/__tests__/checkpoint-server.test.ts
@@ -410,7 +410,7 @@ describe("checkpoint-server", () => {
       });
     });
 
-    it("should return 404 when execution does not exist", async () => {
+    it("should return 500 when execution does not exist", async () => {
       const executionId = "non-existent-id";
 
       mockExecutionManager.getCheckpointsByExecution.mockReturnValueOnce(
@@ -421,7 +421,7 @@ describe("checkpoint-server", () => {
         `${API_PATHS.POLL_CHECKPOINT_DATA}/${executionId}`,
       );
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(500);
       expect(response.body).toEqual({ message: "Execution not found" });
     });
   });
@@ -479,7 +479,7 @@ describe("checkpoint-server", () => {
       );
     });
 
-    it("should return 404 when execution does not exist", async () => {
+    it("should return 500 when execution does not exist", async () => {
       const executionId = "non-existent-id";
       const operationId = "test-operation-id";
 
@@ -500,11 +500,11 @@ describe("checkpoint-server", () => {
           },
         });
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(500);
       expect(response.body).toEqual({ message: "Execution not found" });
     });
 
-    it("should return 404 when operation does not exist", async () => {
+    it("should return 500 when operation does not exist", async () => {
       const executionId = "test-execution-id";
       const operationId = "non-existent-op-id";
       const mockOperationData = {
@@ -532,7 +532,7 @@ describe("checkpoint-server", () => {
         });
 
       expect(response.body).toEqual({ message: "Operation not found" });
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(500);
     });
 
     it("should pass payload parameter to updateOperation when provided", async () => {
@@ -778,7 +778,7 @@ describe("checkpoint-server", () => {
       });
     });
 
-    it("should return 404 when execution does not exist", async () => {
+    it("should return 500 when execution does not exist", async () => {
       const invalidExecutionId = "invalid-id" as ExecutionId;
 
       mockExecutionManager.getCheckpointsByExecution.mockReturnValueOnce(
@@ -789,7 +789,7 @@ describe("checkpoint-server", () => {
         `${API_PATHS.GET_STATE}/${invalidExecutionId}/state`,
       );
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(500);
       expect(response.body).toEqual({ message: "Execution not found" });
     });
   });
@@ -1030,7 +1030,7 @@ describe("checkpoint-server", () => {
       expect(mockStorage.registerUpdates).toHaveBeenCalledWith(input.Updates);
     });
 
-    it("should return 404 when execution does not exist", async () => {
+    it("should return 500 when execution does not exist", async () => {
       const invalidExecutionId = "invalid-id" as ExecutionId;
 
       mockExecutionManager.getCheckpointsByExecution.mockReturnValueOnce(
@@ -1041,11 +1041,11 @@ describe("checkpoint-server", () => {
         .post(`${API_PATHS.CHECKPOINT}/${invalidExecutionId}/checkpoint`)
         .send({});
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(500);
       expect(response.body).toEqual({ message: "Execution not found" });
     });
 
-    it("should return 400 when checkpoint update is invalid", async () => {
+    it("should return 500 when checkpoint update is invalid", async () => {
       const tokenData: CheckpointTokenData = {
         executionId: createExecutionId("test-execution-id"),
         invocationId: createInvocationId("test-invocation-id"),
@@ -1096,12 +1096,8 @@ describe("checkpoint-server", () => {
         .post(`${API_PATHS.CHECKPOINT}/${durableExecutionArn}/checkpoint`)
         .send(input);
 
-      expect(response.status).toBe(400);
-      expect(response.headers["x-amzn-errortype"]).toEqual(
-        "InvalidParameterValueException",
-      );
+      expect(response.status).toBe(500);
       expect(response.body).toEqual({
-        Type: "InvalidParameterValueException",
         message: "Invalid current STEP state to start.",
       });
     });
@@ -1193,7 +1189,7 @@ describe("checkpoint-server", () => {
         );
       });
 
-      it("should return 404 when execution not found", async () => {
+      it("should return 500 when execution not found", async () => {
         const callbackId = "test-callback-id";
         mockExecutionManager.getCheckpointsByCallbackId.mockReturnValue(
           undefined,
@@ -1204,13 +1200,13 @@ describe("checkpoint-server", () => {
           .set("Content-Type", "application/octet-stream")
           .send("result");
 
-        expect(response.status).toBe(404);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Execution not found",
         });
       });
 
-      it("should return 400 when parameter is not a buffer", async () => {
+      it("should return 500 when parameter is not a buffer", async () => {
         const callbackId = "test-callback-id";
         const mockCheckpointManager = {
           completeCallback: jest.fn(),
@@ -1223,13 +1219,13 @@ describe("checkpoint-server", () => {
           .post(`${API_PATHS.CALLBACKS}/${callbackId}/succeed`)
           .send("result");
 
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Invalid buffer input",
         });
       });
 
-      it("should return 400 for InvalidParameterValueException", async () => {
+      it("should return 500 for InvalidParameterValueException", async () => {
         const callbackId = "test-callback-id";
         const mockCheckpointManager = {
           completeCallback: jest.fn().mockImplementation(() => {
@@ -1249,7 +1245,7 @@ describe("checkpoint-server", () => {
           .set("Content-Type", "application/octet-stream")
           .send("result");
 
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Invalid callback parameters",
         });
@@ -1320,7 +1316,7 @@ describe("checkpoint-server", () => {
         );
       });
 
-      it("should return 404 when execution not found", async () => {
+      it("should return 500 when execution not found", async () => {
         const callbackId = "test-callback-id";
         mockExecutionManager.getCheckpointsByCallbackId.mockReturnValue(
           undefined,
@@ -1330,13 +1326,13 @@ describe("checkpoint-server", () => {
           .post(`${API_PATHS.CALLBACKS}/${callbackId}/fail`)
           .send({ CallbackId: callbackId, Error: "error" });
 
-        expect(response.status).toBe(404);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Execution not found",
         });
       });
 
-      it("should return 400 for InvalidParameterValueException", async () => {
+      it("should return 500 for InvalidParameterValueException", async () => {
         const callbackId = "test-callback-id";
         const mockCheckpointManager = {
           completeCallback: jest.fn().mockImplementation(() => {
@@ -1355,7 +1351,7 @@ describe("checkpoint-server", () => {
           .post(`${API_PATHS.CALLBACKS}/${callbackId}/fail`)
           .send({ ErrorMessage: "test error" });
 
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Invalid callback parameters",
         });
@@ -1391,7 +1387,7 @@ describe("checkpoint-server", () => {
         );
       });
 
-      it("should return 404 when execution not found", async () => {
+      it("should return 500 when execution not found", async () => {
         const callbackId = "test-callback-id";
         mockExecutionManager.getCheckpointsByCallbackId.mockReturnValue(
           undefined,
@@ -1401,13 +1397,13 @@ describe("checkpoint-server", () => {
           .post(`${API_PATHS.CALLBACKS}/${callbackId}/heartbeat`)
           .send({ CallbackId: callbackId });
 
-        expect(response.status).toBe(404);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Execution not found",
         });
       });
 
-      it("should return 400 for InvalidParameterValueException", async () => {
+      it("should return 500 for InvalidParameterValueException", async () => {
         const callbackId = "test-callback-id";
         const mockCheckpointManager = {
           heartbeatCallback: jest.fn().mockImplementation(() => {
@@ -1426,7 +1422,7 @@ describe("checkpoint-server", () => {
           .post(`${API_PATHS.CALLBACKS}/${callbackId}/heartbeat`)
           .send({ CallbackId: callbackId });
 
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(500);
         expect(response.body).toEqual({
           message: "Invalid callback parameters",
         });

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/callbacks.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/callbacks.test.ts
@@ -1,0 +1,276 @@
+import {
+  ErrorObject,
+  OperationType,
+  OperationAction,
+} from "@aws-sdk/client-lambda";
+import {
+  processCallbackFailure,
+  processCallbackSuccess,
+  processCallbackHeartbeat,
+} from "../callbacks";
+import { ExecutionManager } from "../../storage/execution-manager";
+import { CompleteCallbackStatus } from "../../storage/callback-manager";
+import { CheckpointManager } from "../../storage/checkpoint-manager";
+import {
+  createExecutionId,
+  createCallbackId,
+} from "../../utils/tagged-strings";
+
+describe("callbacks handlers", () => {
+  let executionManager: ExecutionManager;
+  let mockExecutionId: ReturnType<typeof createExecutionId>;
+
+  // Helper to create execution with callback
+  const createExecutionWithCallback = (options?: {
+    timeoutSeconds?: number;
+    heartbeatTimeoutSeconds?: number;
+  }) => {
+    executionManager.startExecution({
+      executionId: mockExecutionId,
+      payload: '{"test": "data"}',
+    });
+
+    const storage = executionManager.getCheckpointsByExecution(mockExecutionId);
+    const operationId = `callback-${Date.now()}-${Math.random()}`;
+    const callbackUpdate = {
+      Id: operationId,
+      Type: OperationType.CALLBACK,
+      Action: OperationAction.START,
+      CallbackOptions: {
+        TimeoutSeconds: options?.timeoutSeconds,
+        HeartbeatTimeoutSeconds: options?.heartbeatTimeoutSeconds,
+      },
+    };
+    const operationEvents = storage!.registerUpdate(callbackUpdate);
+    const callbackId = operationEvents.operation.CallbackDetails?.CallbackId;
+    if (!callbackId) {
+      throw new Error("Failed to create callback ID");
+    }
+
+    return { storage: storage!, callbackId, operationId };
+  };
+
+  beforeEach(() => {
+    executionManager = new ExecutionManager();
+    mockExecutionId = createExecutionId("test-execution-id");
+  });
+
+  afterEach(() => {
+    executionManager.cleanup();
+  });
+
+  describe("processCallbackFailure", () => {
+    it("should look up storage by callback ID and complete callback with error", () => {
+      const { storage, callbackId } = createExecutionWithCallback();
+
+      // Spy on the key side effects
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByCallbackId",
+      );
+      const completeCallbackSpy = jest.spyOn(storage, "completeCallback");
+
+      const errorObject: ErrorObject = {
+        ErrorType: "TestError",
+        ErrorMessage: "Test error message",
+        StackTrace: ["line1", "line2"],
+      };
+
+      const result = processCallbackFailure(
+        callbackId,
+        errorObject,
+        executionManager,
+      );
+
+      // Verify the execution manager was asked to look up storage by callback ID
+      expect(getStorageSpy).toHaveBeenCalledWith(createCallbackId(callbackId));
+
+      // Verify storage was told to complete the callback with failure status
+      expect(completeCallbackSpy).toHaveBeenCalledWith(
+        {
+          CallbackId: createCallbackId(callbackId),
+          Error: errorObject,
+        },
+        CompleteCallbackStatus.FAILED,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it("should default to empty error object when input is undefined", () => {
+      const { storage, callbackId } = createExecutionWithCallback();
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByCallbackId",
+      );
+      const completeCallbackSpy = jest.spyOn(storage, "completeCallback");
+
+      const result = processCallbackFailure(
+        callbackId,
+        undefined,
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(createCallbackId(callbackId));
+      expect(completeCallbackSpy).toHaveBeenCalledWith(
+        {
+          CallbackId: createCallbackId(callbackId),
+          Error: {},
+        },
+        CompleteCallbackStatus.FAILED,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it("should throw error when execution manager cannot find storage", () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByCallbackId")
+        .mockReturnValue(undefined);
+
+      const callbackIdParam = "non-existent-callback-id";
+
+      expect(() => {
+        processCallbackFailure(callbackIdParam, undefined, executionManager);
+      }).toThrow("Execution not found");
+
+      // Verify it attempted the lookup
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createCallbackId(callbackIdParam),
+      );
+    });
+  });
+
+  describe("processCallbackSuccess", () => {
+    it("should look up storage and complete callback with converted buffer result", () => {
+      const { storage, callbackId } = createExecutionWithCallback();
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByCallbackId",
+      );
+      const completeCallbackSpy = jest.spyOn(storage, "completeCallback");
+
+      const result = processCallbackSuccess(
+        callbackId,
+        Buffer.from("test result data", "utf-8"),
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(createCallbackId(callbackId));
+      expect(completeCallbackSpy).toHaveBeenCalledWith(
+        {
+          CallbackId: createCallbackId(callbackId),
+          Result: "test result data",
+        },
+        CompleteCallbackStatus.SUCCEEDED,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it.each([
+      {
+        name: "empty buffer",
+        buffer: Buffer.alloc(0),
+        expected: undefined,
+      },
+      {
+        name: "Unicode characters",
+        buffer: Buffer.from("Hello 🌍 World! 特殊文字", "utf-8"),
+        expected: "Hello 🌍 World! 特殊文字",
+      },
+    ])("should handle $name in buffer conversion", ({ buffer, expected }) => {
+      const { storage, callbackId } = createExecutionWithCallback();
+      const completeCallbackSpy = jest.spyOn(storage, "completeCallback");
+
+      const result = processCallbackSuccess(
+        callbackId,
+        buffer,
+        executionManager,
+      );
+
+      expect(completeCallbackSpy).toHaveBeenCalledWith(
+        { CallbackId: createCallbackId(callbackId), Result: expected },
+        CompleteCallbackStatus.SUCCEEDED,
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it("should validate buffer input and execution existence", () => {
+      // Test execution manager lookup behavior for invalid buffer
+      const mockStorage = {
+        completeCallback: jest.fn(),
+        heartbeatCallback: jest.fn(),
+      } as Partial<CheckpointManager> as CheckpointManager;
+
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByCallbackId")
+        .mockReturnValue(mockStorage);
+
+      expect(() => {
+        processCallbackSuccess(
+          "test-id",
+          "not a buffer" as unknown as Buffer,
+          executionManager,
+        );
+      }).toThrow("Invalid buffer input");
+
+      // Should still attempt storage lookup even for invalid input
+      expect(getStorageSpy).toHaveBeenCalledWith(createCallbackId("test-id"));
+
+      // Test execution manager lookup behavior for non-existent execution
+      getStorageSpy.mockReturnValue(undefined);
+      expect(() => {
+        processCallbackSuccess(
+          "non-existent",
+          Buffer.from("test"),
+          executionManager,
+        );
+      }).toThrow("Execution not found");
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createCallbackId("non-existent"),
+      );
+    });
+  });
+
+  describe("processCallbackHeartbeat", () => {
+    it("should look up storage and delegate heartbeat to storage", () => {
+      const { storage, callbackId } = createExecutionWithCallback({
+        heartbeatTimeoutSeconds: 60,
+      });
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByCallbackId",
+      );
+      const heartbeatSpy = jest.spyOn(storage, "heartbeatCallback");
+
+      const result = processCallbackHeartbeat(callbackId, executionManager);
+
+      expect(getStorageSpy).toHaveBeenCalledWith(createCallbackId(callbackId));
+      expect(heartbeatSpy).toHaveBeenCalledWith(createCallbackId(callbackId));
+
+      expect(result).toEqual({});
+    });
+
+    it("should throw error when execution manager cannot find storage", () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByCallbackId")
+        .mockReturnValue(undefined);
+
+      const callbackIdParam = "non-existent-callback-id";
+
+      expect(() => {
+        processCallbackHeartbeat(callbackIdParam, executionManager);
+      }).toThrow("Execution not found");
+
+      // Verify it attempted the lookup
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createCallbackId(callbackIdParam),
+      );
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/checkpoint-handlers.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/checkpoint-handlers.test.ts
@@ -1,0 +1,450 @@
+import {
+  CheckpointDurableExecutionRequest,
+  InvalidParameterValueException,
+  OperationType,
+  OperationAction,
+  OperationStatus,
+  ErrorObject,
+} from "@aws-sdk/client-lambda";
+import {
+  processPollCheckpointData,
+  processUpdateCheckpointData,
+  processCheckpointDurableExecution,
+} from "../checkpoint-handlers";
+import { ExecutionManager } from "../../storage/execution-manager";
+import { createExecutionId } from "../../utils/tagged-strings";
+import { encodeCheckpointToken } from "../../utils/checkpoint-token";
+
+// Mock only external dependencies we can't control
+jest.mock("crypto", () => ({
+  randomUUID: jest.fn().mockReturnValue("mocked-uuid-token"),
+}));
+
+describe("checkpoint handlers", () => {
+  let executionManager: ExecutionManager;
+  let mockExecutionId: ReturnType<typeof createExecutionId>;
+
+  const createExecutionWithOperations = (executionId = mockExecutionId) => {
+    const invocationResult = executionManager.startExecution({
+      executionId,
+      payload: '{"test": "data"}',
+    });
+
+    const storage = executionManager.getCheckpointsByExecution(executionId);
+
+    // Add some test operations
+    const stepUpdate = {
+      Id: "test-step-op",
+      Type: OperationType.STEP,
+      Action: OperationAction.START,
+      Name: "TestStep",
+    };
+    storage!.registerUpdate(stepUpdate);
+
+    return { storage: storage!, invocationResult };
+  };
+
+  beforeEach(() => {
+    executionManager = new ExecutionManager();
+    mockExecutionId = createExecutionId("test-execution-id");
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    executionManager.cleanup();
+  });
+
+  describe("processPollCheckpointData", () => {
+    it("should look up storage and return pending checkpoint updates", async () => {
+      const { storage } = createExecutionWithOperations();
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByExecution",
+      );
+      const getPendingSpy = jest.spyOn(storage, "getPendingCheckpointUpdates");
+
+      // Mock getPendingCheckpointUpdates to resolve immediately with test data
+      const mockOperations = [
+        {
+          operation: {
+            Id: "test-op-1",
+            Type: OperationType.STEP,
+            Status: OperationStatus.STARTED,
+            StartTimestamp: new Date(),
+          },
+          events: [],
+          update: undefined,
+        },
+      ];
+      getPendingSpy.mockResolvedValue(mockOperations);
+
+      const result = await processPollCheckpointData(
+        "test-execution-id",
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("test-execution-id"),
+      );
+      expect(getPendingSpy).toHaveBeenCalled();
+      expect(result).toEqual({ operations: mockOperations });
+    });
+
+    it("should throw error when execution manager cannot find storage", async () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByExecution")
+        .mockReturnValue(undefined);
+
+      await expect(
+        processPollCheckpointData("non-existent-execution", executionManager),
+      ).rejects.toThrow("Execution not found");
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("non-existent-execution"),
+      );
+    });
+  });
+
+  describe("processUpdateCheckpointData", () => {
+    it("should look up storage and update specific operation", () => {
+      const { storage } = createExecutionWithOperations();
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByExecution",
+      );
+      const hasOperationSpy = jest.spyOn(storage, "hasOperation");
+      const updateOperationSpy = jest.spyOn(storage, "updateOperation");
+
+      const operationData = { Status: OperationStatus.SUCCEEDED };
+      const payload = '{"result": "success"}';
+      const error: ErrorObject = { ErrorType: "TestError" };
+
+      const mockResult = {
+        operation: {
+          Id: "test-step-op",
+          Type: OperationType.STEP,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: new Date(),
+        },
+        events: [],
+      };
+      hasOperationSpy.mockReturnValue(true);
+      updateOperationSpy.mockReturnValue(mockResult);
+
+      const result = processUpdateCheckpointData(
+        "test-execution-id",
+        "test-step-op",
+        operationData,
+        payload,
+        error,
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("test-execution-id"),
+      );
+      expect(hasOperationSpy).toHaveBeenCalledWith("test-step-op");
+      expect(updateOperationSpy).toHaveBeenCalledWith(
+        "test-step-op",
+        operationData,
+        payload,
+        error,
+      );
+      expect(result).toEqual({
+        operation: {
+          Id: "test-step-op",
+          Type: OperationType.STEP,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: expect.any(Date),
+        },
+        events: [],
+      });
+    });
+
+    it("should throw error when execution not found", () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByExecution")
+        .mockReturnValue(undefined);
+
+      expect(() => {
+        processUpdateCheckpointData(
+          "non-existent-execution",
+          "test-op",
+          { Status: OperationStatus.SUCCEEDED },
+          undefined,
+          undefined,
+          executionManager,
+        );
+      }).toThrow("Execution not found");
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("non-existent-execution"),
+      );
+    });
+
+    it("should throw error when operation not found in storage", () => {
+      const { storage } = createExecutionWithOperations();
+
+      const hasOperationSpy = jest
+        .spyOn(storage, "hasOperation")
+        .mockReturnValue(false);
+
+      expect(() => {
+        processUpdateCheckpointData(
+          "test-execution-id",
+          "non-existent-operation",
+          { Status: OperationStatus.SUCCEEDED },
+          undefined,
+          undefined,
+          executionManager,
+        );
+      }).toThrow("Operation not found");
+
+      expect(hasOperationSpy).toHaveBeenCalledWith("non-existent-operation");
+    });
+  });
+
+  describe("processCheckpointDurableExecution", () => {
+    it("should look up storage, validate, process updates, and return new checkpoint token", () => {
+      const executionArn = "test-execution-arn";
+      const executionId = createExecutionId(executionArn);
+      const { storage, invocationResult } =
+        createExecutionWithOperations(executionId);
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByExecution",
+      );
+      const registerUpdatesSpy = jest.spyOn(storage, "registerUpdates");
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: executionArn,
+        CheckpointToken: encodeCheckpointToken({
+          executionId,
+          invocationId: invocationResult.invocationId,
+          token: "test-token",
+        }),
+        Updates: [
+          {
+            Id: "test-update-op",
+            Type: OperationType.STEP,
+            Action: OperationAction.SUCCEED,
+            Payload: "test result",
+          },
+        ],
+      };
+
+      const result = processCheckpointDurableExecution(
+        executionArn,
+        input,
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(executionId);
+      expect(registerUpdatesSpy).toHaveBeenCalledWith(input.Updates);
+
+      expect(result.CheckpointToken).toBeDefined();
+      expect(result.NewExecutionState?.Operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          }),
+          expect.objectContaining({
+            Id: "test-step-op",
+            Type: OperationType.STEP,
+            Status: OperationStatus.STARTED,
+            Name: "TestStep",
+          }),
+        ]),
+      );
+      expect(result.NewExecutionState?.NextMarker).toBeUndefined();
+    });
+
+    it("should throw error when execution not found", () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByExecution")
+        .mockReturnValue(undefined);
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: "non-existent-arn",
+        CheckpointToken: "valid-token",
+        Updates: [],
+      };
+
+      expect(() => {
+        processCheckpointDurableExecution(
+          "non-existent-arn",
+          input,
+          executionManager,
+        );
+      }).toThrow("Execution not found");
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("non-existent-arn"),
+      );
+    });
+
+    it("should throw error when checkpoint token is missing", () => {
+      const executionArn = "test-execution-arn";
+      const executionId = createExecutionId(executionArn);
+      createExecutionWithOperations(executionId);
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: executionArn,
+        CheckpointToken: undefined,
+        Updates: [],
+      };
+
+      expect(() => {
+        processCheckpointDurableExecution(
+          executionArn,
+          input,
+          executionManager,
+        );
+      }).toThrow(InvalidParameterValueException);
+    });
+
+    it("should handle empty updates gracefully", () => {
+      const executionArn = "test-execution-arn";
+      const executionId = createExecutionId(executionArn);
+      const { storage, invocationResult } =
+        createExecutionWithOperations(executionId);
+
+      const registerUpdatesSpy = jest.spyOn(storage, "registerUpdates");
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: executionArn,
+        CheckpointToken: encodeCheckpointToken({
+          executionId,
+          invocationId: invocationResult.invocationId,
+          token: "test-token",
+        }),
+        Updates: [],
+      };
+
+      const result = processCheckpointDurableExecution(
+        executionArn,
+        input,
+        executionManager,
+      );
+
+      expect(registerUpdatesSpy).toHaveBeenCalledWith([]);
+      expect(result.CheckpointToken).toBeDefined();
+      expect(result.NewExecutionState?.Operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          }),
+          expect.objectContaining({
+            Id: "test-step-op",
+            Type: OperationType.STEP,
+            Status: OperationStatus.STARTED,
+            Name: "TestStep",
+          }),
+        ]),
+      );
+    });
+
+    it("should generate new checkpoint token with different UUID", () => {
+      const executionArn = "test-execution-arn";
+      const executionId = createExecutionId(executionArn);
+      const { invocationResult } = createExecutionWithOperations(executionId);
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: executionArn,
+        CheckpointToken: encodeCheckpointToken({
+          executionId,
+          invocationId: invocationResult.invocationId,
+          token: "original-token",
+        }),
+        Updates: [],
+      };
+
+      const result = processCheckpointDurableExecution(
+        executionArn,
+        input,
+        executionManager,
+      );
+
+      // Should have a new token (mocked to "mocked-uuid-token")
+      const expectedNewToken = encodeCheckpointToken({
+        executionId,
+        invocationId: invocationResult.invocationId,
+        token: "mocked-uuid-token",
+      });
+
+      expect(result.CheckpointToken).toEqual(expectedNewToken);
+      expect(result.NewExecutionState?.Operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          }),
+          expect.objectContaining({
+            Id: "test-step-op",
+            Type: OperationType.STEP,
+            Status: OperationStatus.STARTED,
+            Name: "TestStep",
+          }),
+        ]),
+      );
+    });
+
+    it("should include all operations from storage in response", () => {
+      const executionArn = "test-execution-arn";
+      const executionId = createExecutionId(executionArn);
+      const { storage, invocationResult } =
+        createExecutionWithOperations(executionId);
+
+      // Add more operations to verify they're all included
+      storage.registerUpdate({
+        Id: "another-op",
+        Type: OperationType.WAIT,
+        Action: OperationAction.START,
+        WaitOptions: { WaitSeconds: 30 },
+      });
+
+      const input: CheckpointDurableExecutionRequest = {
+        DurableExecutionArn: executionArn,
+        CheckpointToken: encodeCheckpointToken({
+          executionId,
+          invocationId: invocationResult.invocationId,
+          token: "test-token",
+        }),
+        Updates: [],
+      };
+
+      const result = processCheckpointDurableExecution(
+        executionArn,
+        input,
+        executionManager,
+      );
+
+      expect(result.CheckpointToken).toBeDefined();
+      expect(result.NewExecutionState?.Operations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            Type: OperationType.EXECUTION,
+            Status: OperationStatus.STARTED,
+          }),
+          expect.objectContaining({
+            Id: "test-step-op",
+            Type: OperationType.STEP,
+            Status: OperationStatus.STARTED,
+            Name: "TestStep",
+          }),
+          expect.objectContaining({
+            Id: "another-op",
+            Type: OperationType.WAIT,
+            Status: OperationStatus.STARTED,
+          }),
+        ]),
+      );
+      expect(result.NewExecutionState?.NextMarker).toBeUndefined();
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/execution-handlers.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/execution-handlers.test.ts
@@ -1,0 +1,137 @@
+import { ErrorObject, EventType } from "@aws-sdk/client-lambda";
+import {
+  processStartDurableExecution,
+  processStartInvocation,
+  processCompleteInvocation,
+} from "../execution-handlers";
+import { ExecutionManager } from "../../storage/execution-manager";
+import {
+  createExecutionId,
+  createInvocationId,
+} from "../../utils/tagged-strings";
+
+describe("execution handlers", () => {
+  let executionManager: ExecutionManager;
+
+  beforeEach(() => {
+    executionManager = new ExecutionManager();
+  });
+
+  afterEach(() => {
+    executionManager.cleanup();
+  });
+
+  describe("processStartDurableExecution", () => {
+    it("should delegate to execution manager startExecution with generated execution ID", () => {
+      const startExecutionSpy = jest.spyOn(executionManager, "startExecution");
+
+      const payload = '{"test": "execution data"}';
+      const result = processStartDurableExecution(payload, executionManager);
+
+      expect(startExecutionSpy).toHaveBeenCalledWith({
+        payload,
+        executionId: expect.any(String),
+      });
+
+      expect(result).toEqual({
+        checkpointToken: expect.any(String),
+        executionId: expect.any(String),
+        invocationId: expect.any(String),
+        operationEvents: expect.any(Array),
+      });
+    });
+  });
+
+  describe("processStartInvocation", () => {
+    it("should delegate to execution manager startInvocation with converted execution ID", () => {
+      // First create an execution
+      const payload = '{"test": "data"}';
+      executionManager.startExecution({
+        executionId: createExecutionId("test-execution-id"),
+        payload,
+      });
+
+      const startInvocationSpy = jest.spyOn(
+        executionManager,
+        "startInvocation",
+      );
+
+      const result = processStartInvocation(
+        "test-execution-id",
+        executionManager,
+      );
+
+      expect(startInvocationSpy).toHaveBeenCalledWith(
+        createExecutionId("test-execution-id"),
+      );
+      expect(result).toEqual({
+        checkpointToken: expect.any(String),
+        executionId: createExecutionId("test-execution-id"),
+        invocationId: expect.any(String),
+        operationEvents: expect.any(Array),
+      });
+    });
+
+    it("should return undefined when execution manager cannot find execution", () => {
+      const startInvocationSpy = jest
+        .spyOn(executionManager, "startInvocation")
+        .mockReturnValue(undefined);
+
+      const result = processStartInvocation(
+        "non-existent-execution",
+        executionManager,
+      );
+
+      expect(startInvocationSpy).toHaveBeenCalledWith(
+        createExecutionId("non-existent-execution"),
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("processCompleteInvocation", () => {
+    it("should delegate to execution manager completeInvocation with all parameters", () => {
+      // First create an execution and invocation
+      const executionId = createExecutionId("test-execution-id");
+      const invocationId = createInvocationId("test-invocation-id");
+      executionManager.startExecution({ executionId, payload: "{}" });
+
+      const completeInvocationSpy = jest.spyOn(
+        executionManager,
+        "completeInvocation",
+      );
+
+      // Mock the return value
+      const mockEvent = {
+        EventType: EventType.InvocationCompleted,
+        Timestamp: new Date(),
+        InvocationCompletedDetails: {
+          StartTimestamp: new Date(),
+          EndTimestamp: new Date(),
+          RequestId: invocationId,
+          Error: { Payload: undefined },
+        },
+      };
+      completeInvocationSpy.mockReturnValue(mockEvent);
+
+      const errorObject: ErrorObject = {
+        ErrorType: "TestError",
+        ErrorMessage: "Test invocation error",
+      };
+
+      const result = processCompleteInvocation(
+        executionId,
+        invocationId,
+        errorObject,
+        executionManager,
+      );
+
+      expect(completeInvocationSpy).toHaveBeenCalledWith(
+        executionId,
+        invocationId,
+        errorObject,
+      );
+      expect(result).toEqual(mockEvent);
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/state-handlers.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/state-handlers.test.ts
@@ -1,0 +1,70 @@
+import { OperationType, OperationAction } from "@aws-sdk/client-lambda";
+import { processGetDurableExecutionState } from "../state-handlers";
+import { ExecutionManager } from "../../storage/execution-manager";
+import { createExecutionId } from "../../utils/tagged-strings";
+
+describe("state handlers", () => {
+  let executionManager: ExecutionManager;
+
+  beforeEach(() => {
+    executionManager = new ExecutionManager();
+  });
+
+  afterEach(() => {
+    executionManager.cleanup();
+  });
+
+  describe("processGetDurableExecutionState", () => {
+    it("should look up storage and return execution state", () => {
+      // Create an execution with some operations
+      const executionId = createExecutionId("test-execution-arn");
+      executionManager.startExecution({
+        executionId,
+        payload: '{"test": "data"}',
+      });
+
+      const storage = executionManager.getCheckpointsByExecution(executionId);
+      storage!.registerUpdate({
+        Id: "test-step",
+        Type: OperationType.STEP,
+        Action: OperationAction.START,
+        Name: "TestStep",
+      });
+
+      const getStorageSpy = jest.spyOn(
+        executionManager,
+        "getCheckpointsByExecution",
+      );
+      const getStateSpy = jest.spyOn(storage!, "getState");
+
+      const result = processGetDurableExecutionState(
+        "test-execution-arn",
+        executionManager,
+      );
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("test-execution-arn"),
+      );
+      expect(getStateSpy).toHaveBeenCalled();
+      expect(result).toEqual({
+        Operations: expect.any(Array),
+        NextMarker: undefined,
+      });
+      expect(result.Operations?.length).toBeGreaterThan(0);
+    });
+
+    it("should throw error when execution manager cannot find storage", () => {
+      const getStorageSpy = jest
+        .spyOn(executionManager, "getCheckpointsByExecution")
+        .mockReturnValue(undefined);
+
+      expect(() => {
+        processGetDurableExecutionState("non-existent-arn", executionManager);
+      }).toThrow("Execution not found");
+
+      expect(getStorageSpy).toHaveBeenCalledWith(
+        createExecutionId("non-existent-arn"),
+      );
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/checkpoint-handlers.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/checkpoint-handlers.ts
@@ -1,0 +1,127 @@
+import {
+  CheckpointDurableExecutionRequest,
+  CheckpointDurableExecutionResponse,
+  InvalidParameterValueException,
+  Operation,
+  ErrorObject,
+} from "@aws-sdk/client-lambda";
+import {
+  createExecutionId,
+  createCheckpointToken,
+} from "../utils/tagged-strings";
+import {
+  decodeCheckpointToken,
+  encodeCheckpointToken,
+} from "../utils/checkpoint-token";
+import { validateCheckpointUpdates } from "../validators/checkpoint-durable-execution-input-validator";
+import { randomUUID } from "crypto";
+import { ExecutionManager } from "../storage/execution-manager";
+import { CheckpointOperation } from "../storage/checkpoint-manager";
+import { OperationEvents } from "../../test-runner/common/operations/operation-with-data";
+
+/**
+ * Long polls for checkpoint data for an execution. The API will return data once checkpoint data
+ * is available. It will store data until the next API call for this execution ID.
+ */
+export async function processPollCheckpointData(
+  executionIdParam: string,
+  executionManager: ExecutionManager,
+): Promise<{ operations: CheckpointOperation[] }> {
+  const executionId = createExecutionId(executionIdParam);
+
+  const checkpointStorage =
+    executionManager.getCheckpointsByExecution(executionId);
+
+  if (!checkpointStorage) {
+    throw new Error("Execution not found");
+  }
+
+  const operations = await checkpointStorage.getPendingCheckpointUpdates();
+
+  return {
+    operations,
+  };
+}
+
+/**
+ * Updates the checkpoint data for a particular execution and operation ID with the intended status.
+ *
+ * Used for resolving operations like wait steps, retries, and status transitions, and also for resolving the execution itself.
+ */
+export function processUpdateCheckpointData(
+  executionIdParam: string,
+  operationId: string,
+  operationData: Partial<Operation>,
+  payload: string | undefined,
+  error: ErrorObject | undefined,
+  executionManager: ExecutionManager,
+): OperationEvents {
+  const executionId = createExecutionId(executionIdParam);
+
+  const checkpointStorage =
+    executionManager.getCheckpointsByExecution(executionId);
+
+  if (!checkpointStorage) {
+    throw new Error("Execution not found");
+  }
+
+  if (!checkpointStorage.hasOperation(operationId)) {
+    throw new Error("Operation not found");
+  }
+
+  return checkpointStorage.updateOperation(
+    operationId,
+    operationData,
+    payload,
+    error,
+  );
+}
+
+/**
+ * The API for CheckpointDurableExecution used by the Language SDK and DEX service model.
+ */
+export function processCheckpointDurableExecution(
+  durableExecutionArn: string,
+  input: CheckpointDurableExecutionRequest,
+  executionManager: ExecutionManager,
+): CheckpointDurableExecutionResponse {
+  const storage = executionManager.getCheckpointsByExecution(
+    createExecutionId(durableExecutionArn),
+  );
+  if (!storage) {
+    throw new Error("Execution not found");
+  }
+
+  const updates = input.Updates ?? [];
+
+  if (!input.CheckpointToken) {
+    throw new InvalidParameterValueException({
+      message: "Checkpoint token is required",
+      $metadata: {},
+    });
+  }
+
+  const data = decodeCheckpointToken(
+    createCheckpointToken(input.CheckpointToken),
+  );
+
+  validateCheckpointUpdates(updates, storage.operationDataMap);
+  storage.registerUpdates(updates);
+
+  const output: CheckpointDurableExecutionResponse = {
+    CheckpointToken: encodeCheckpointToken({
+      executionId: data.executionId,
+      invocationId: data.invocationId,
+      token: randomUUID(),
+    }),
+    NewExecutionState: {
+      // TODO: implement pagination
+      Operations: Array.from(storage.operationDataMap.values()).map(
+        (data) => data.operation,
+      ),
+      NextMarker: undefined,
+    },
+  };
+
+  return output;
+}

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/execution-handlers.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/execution-handlers.ts
@@ -1,0 +1,43 @@
+import { ErrorObject, Event } from "@aws-sdk/client-lambda";
+import {
+  createExecutionId,
+  ExecutionId,
+  InvocationId,
+} from "../utils/tagged-strings";
+import {
+  ExecutionManager,
+  InvocationResult,
+} from "../storage/execution-manager";
+
+/**
+ * Starts a durable execution. Returns the data needed for the handler invocation event.
+ */
+export function processStartDurableExecution(
+  payload: string,
+  executionManager: ExecutionManager,
+): InvocationResult {
+  return executionManager.startExecution({
+    payload,
+    executionId: createExecutionId(),
+  });
+}
+
+/**
+ * Starts an invocation of a durable execution. Returns the data for an individual invocation for an
+ * in-progress execution.
+ */
+export function processStartInvocation(
+  executionIdParam: string,
+  executionManager: ExecutionManager,
+): InvocationResult | undefined {
+  return executionManager.startInvocation(createExecutionId(executionIdParam));
+}
+
+export function processCompleteInvocation(
+  executionId: ExecutionId,
+  invocationId: InvocationId,
+  error: ErrorObject | undefined,
+  executionManager: ExecutionManager,
+): Event {
+  return executionManager.completeInvocation(executionId, invocationId, error);
+}

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/state-handlers.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/state-handlers.ts
@@ -1,0 +1,26 @@
+import { GetDurableExecutionStateResponse } from "@aws-sdk/client-lambda";
+import { createExecutionId } from "../utils/tagged-strings";
+import { ExecutionManager } from "../storage/execution-manager";
+
+/**
+ * The API for GetDurableExecutionState used by the Language SDK and DEX service model.
+ */
+export function processGetDurableExecutionState(
+  durableExecutionArn: string,
+  executionManager: ExecutionManager,
+): GetDurableExecutionStateResponse {
+  const executionData = executionManager.getCheckpointsByExecution(
+    createExecutionId(durableExecutionArn),
+  );
+
+  if (!executionData) {
+    throw new Error("Execution not found");
+  }
+
+  const output: GetDurableExecutionStateResponse = {
+    Operations: executionData.getState(),
+    NextMarker: undefined,
+  };
+
+  return output;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I am working on removing running a full server in the testing library. It's better if the testing library has fewer dependencies, since more dependencies increases the risk of interfering with our local runner implementation from customer mocks, and increasing overhead for the customer.

This refactor will be the first step, as I can follow up with creating a pseudo-server which responds to the data from the worker using postMessage without running a full server.

Also remapping all 4xx errors to 5xx errors for simplification for now. Proper error codes will be added later.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
