### PR TITLE
chore(testing-sdk): fix all typescript errors in tests

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build && npm run test",
     "lint": "eslint --fix",
     "prebuild": "npm run lint",
-    "test": "jest --config jest.config.mjs --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}",
+    "test": "tsc --noEmit && jest --config jest.config.mjs --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}",
     "run-durable": "tsx src/cli/run-durable.ts"
   },
   "exports": {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/execution-handlers.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/__tests__/execution-handlers.test.ts
@@ -72,20 +72,20 @@ describe("execution handlers", () => {
       });
     });
 
-    it("should return undefined when execution manager cannot find execution", () => {
+    it("should propagate errors when execution manager cannot find execution", () => {
       const startInvocationSpy = jest
         .spyOn(executionManager, "startInvocation")
-        .mockReturnValue(undefined);
+        .mockImplementation(() => {
+          throw new Error("Execution not found");
+        });
 
-      const result = processStartInvocation(
-        "non-existent-execution",
-        executionManager,
-      );
+      expect(() =>
+        processStartInvocation("non-existent-execution", executionManager),
+      ).toThrow("Execution not found");
 
       expect(startInvocationSpy).toHaveBeenCalledWith(
         createExecutionId("non-existent-execution"),
       );
-      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/callback-manager.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/callback-manager.test.ts
@@ -5,7 +5,7 @@ import {
   OperationType,
 } from "@aws-sdk/client-lambda";
 import { CallbackManager, CompleteCallbackStatus } from "../callback-manager";
-import { CheckpointManager } from "../checkpoint-manager";
+import { CheckpointManager, CheckpointOperation } from "../checkpoint-manager";
 import {
   createExecutionId,
   createCallbackId,
@@ -143,15 +143,17 @@ describe("CallbackManager", () => {
       const timeoutSeconds = 30;
 
       // Setup operation data
-      const mockOperationData = {
+      const mockOperationData: CheckpointOperation = {
         operation: {
           Id: operationId,
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         update: {
           Id: operationId,
           Type: OperationType.CALLBACK,
+          Action: undefined,
         },
         events: [],
       };
@@ -188,15 +190,17 @@ describe("CallbackManager", () => {
   describe("completeCallback", () => {
     beforeEach(() => {
       // Setup mock operation data
-      const mockOperationData = {
+      const mockOperationData: CheckpointOperation = {
         operation: {
           Id: "test-operation-id",
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         update: {
           Id: "test-operation-id",
           Type: OperationType.CALLBACK,
+          Action: undefined,
         },
         events: [],
       };
@@ -343,11 +347,13 @@ describe("CallbackManager", () => {
           Id: "test-operation-id",
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         events: [
           {
             CallbackStartedDetails: {
               HeartbeatTimeout: 60,
+              CallbackId: undefined,
             },
           },
         ],
@@ -373,15 +379,18 @@ describe("CallbackManager", () => {
       const callbackId = createCallbackId("test-callback-id");
 
       // Update operation to not have heartbeat timeout
-      const mockOperationData = {
+      const mockOperationData: CheckpointOperation = {
         operation: {
           Id: "test-operation-id",
           Type: OperationType.CALLBACK,
+          StartTimestamp: undefined,
+          Status: undefined,
         },
         update: {
           Id: "test-operation-id",
           Type: OperationType.CALLBACK,
           CallbackOptions: {},
+          Action: undefined,
         },
         events: [],
       };
@@ -443,27 +452,31 @@ describe("CallbackManager", () => {
       const operationId2 = "operation-2";
 
       // Setup operation data first
-      const mockOperationData1 = {
+      const mockOperationData1: CheckpointOperation = {
         operation: {
           Id: operationId1,
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         update: {
           Id: operationId1,
           Type: OperationType.CALLBACK,
+          Action: undefined,
         },
         events: [],
       };
-      const mockOperationData2 = {
+      const mockOperationData2: CheckpointOperation = {
         operation: {
           Id: operationId2,
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         update: {
           Id: operationId2,
           Type: OperationType.CALLBACK,
+          Action: undefined,
         },
         events: [],
       };
@@ -527,15 +540,17 @@ describe("CallbackManager", () => {
       const operationId = "integration-test-id";
 
       // Setup operation data
-      const mockOperationData = {
+      const mockOperationData: CheckpointOperation = {
         operation: {
           Id: operationId,
           Type: OperationType.CALLBACK,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         update: {
           Id: operationId,
           Type: OperationType.CALLBACK,
+          Action: undefined,
         },
         events: [],
       };
@@ -579,15 +594,17 @@ describe("CallbackManager", () => {
 
       // Setup operation data for all
       operationIds.forEach((id) => {
-        const mockOperationData = {
+        const mockOperationData: CheckpointOperation = {
           operation: {
             Id: id,
             Type: OperationType.CALLBACK,
             Status: OperationStatus.STARTED,
+            StartTimestamp: undefined,
           },
           update: {
             Id: id,
             Type: OperationType.CALLBACK,
+            Action: undefined,
           },
           events: [],
         };

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-complete.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-complete.test.ts
@@ -3,10 +3,7 @@ import {
   OperationType,
   OperationStatus,
 } from "@aws-sdk/client-lambda";
-import {
-  createInvocationId,
-  createExecutionId,
-} from "../../utils/tagged-strings";
+import { createExecutionId } from "../../utils/tagged-strings";
 import { CheckpointManager } from "../checkpoint-manager";
 
 jest.mock("node:crypto", () => ({
@@ -15,8 +12,6 @@ jest.mock("node:crypto", () => ({
 
 describe("checkpoint-manager completeOperation", () => {
   let storage: CheckpointManager;
-
-  const mockInvocationId = createInvocationId();
 
   beforeEach(() => {
     storage = new CheckpointManager(createExecutionId("test-execution-id"));
@@ -48,14 +43,11 @@ describe("checkpoint-manager completeOperation", () => {
     storage.initialize();
 
     // Register a step operation
-    storage.registerUpdate(
-      {
-        Id: "new-id",
-        Action: OperationAction.START,
-        Type: OperationType.STEP,
-      },
-      mockInvocationId,
-    );
+    storage.registerUpdate({
+      Id: "new-id",
+      Action: OperationAction.START,
+      Type: OperationType.STEP,
+    });
 
     // Complete the operation
     const { operation } = storage.completeOperation({
@@ -101,17 +93,14 @@ describe("checkpoint-manager completeOperation", () => {
     storage.initialize();
 
     // Register a step operation
-    storage.registerUpdate(
-      {
-        Id: "new-id",
-        Action: OperationAction.START,
-        Type: OperationType.CONTEXT,
-        ContextOptions: {
-          ReplayChildren: true,
-        },
+    storage.registerUpdate({
+      Id: "new-id",
+      Action: OperationAction.START,
+      Type: OperationType.CONTEXT,
+      ContextOptions: {
+        ReplayChildren: true,
       },
-      mockInvocationId,
-    );
+    });
 
     // Complete the operation
     const { operation } = storage.completeOperation({
@@ -143,15 +132,12 @@ describe("checkpoint-manager completeOperation", () => {
       storage.initialize();
 
       // Register a step operation
-      storage.registerUpdate(
-        {
-          Id: "retry-step-id",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-          Name: "test-step",
-        },
-        mockInvocationId,
-      );
+      storage.registerUpdate({
+        Id: "retry-step-id",
+        Action: OperationAction.START,
+        Type: OperationType.STEP,
+        Name: "test-step",
+      });
 
       // Complete the operation with RETRY action
       const { operation } = storage.completeOperation({
@@ -183,15 +169,12 @@ describe("checkpoint-manager completeOperation", () => {
       storage.initialize();
 
       // Register a step operation with initial attempt
-      storage.registerUpdate(
-        {
-          Id: "retry-step-id",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-          Name: "test-step",
-        },
-        mockInvocationId,
-      );
+      storage.registerUpdate({
+        Id: "retry-step-id",
+        Action: OperationAction.START,
+        Type: OperationType.STEP,
+        Name: "test-step",
+      });
 
       // Set initial attempt to 2
       const operationData = storage.operationDataMap.get("retry-step-id");
@@ -218,15 +201,12 @@ describe("checkpoint-manager completeOperation", () => {
       storage.initialize();
 
       // Register a step operation
-      storage.registerUpdate(
-        {
-          Id: "retry-step-id",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-          Name: "test-step",
-        },
-        mockInvocationId,
-      );
+      storage.registerUpdate({
+        Id: "retry-step-id",
+        Action: OperationAction.START,
+        Type: OperationType.STEP,
+        Name: "test-step",
+      });
 
       // Add some existing step details
       const operationData = storage.operationDataMap.get("retry-step-id");
@@ -270,15 +250,12 @@ describe("checkpoint-manager completeOperation", () => {
       storage.initialize();
 
       // Register a step operation
-      storage.registerUpdate(
-        {
-          Id: "retry-step-id",
-          Action: OperationAction.START,
-          Type: OperationType.STEP,
-          Name: "test-step",
-        },
-        mockInvocationId,
-      );
+      storage.registerUpdate({
+        Id: "retry-step-id",
+        Action: OperationAction.START,
+        Type: OperationType.STEP,
+        Name: "test-step",
+      });
 
       // Ensure no existing StepDetails
       const operationData = storage.operationDataMap.get("retry-step-id");

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-update.test.ts
@@ -4,10 +4,7 @@ import {
   OperationUpdate,
   OperationAction,
 } from "@aws-sdk/client-lambda";
-import {
-  createInvocationId,
-  createExecutionId,
-} from "../../utils/tagged-strings";
+import { createExecutionId } from "../../utils/tagged-strings";
 import { CheckpointManager } from "../checkpoint-manager";
 
 jest.mock("node:crypto", () => ({
@@ -16,8 +13,6 @@ jest.mock("node:crypto", () => ({
 
 describe("checkpoint-manager updateOperation", () => {
   let storage: CheckpointManager;
-
-  const mockInvocationId = createInvocationId();
 
   beforeEach(() => {
     storage = new CheckpointManager(createExecutionId("test-execution-id"));
@@ -92,7 +87,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -142,7 +137,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-fail",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -199,7 +194,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-cancel",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -241,7 +236,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-timeout",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -283,7 +278,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-no-details",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -323,7 +318,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-empty",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -383,7 +378,7 @@ describe("checkpoint-manager updateOperation", () => {
           Action: OperationAction.START,
           Name: "test-invoke-both",
         };
-        storage.registerUpdate(invokeUpdate, mockInvocationId);
+        storage.registerUpdate(invokeUpdate);
 
         const newOperationData = {
           Type: OperationType.CHAINED_INVOKE,
@@ -427,7 +422,7 @@ describe("checkpoint-manager updateOperation", () => {
             Action: OperationAction.START,
             Name: "test-invoke-invalid",
           };
-          storage.registerUpdate(invokeUpdate, mockInvocationId);
+          storage.registerUpdate(invokeUpdate);
 
           const newOperationData = {
             Type: OperationType.CHAINED_INVOKE,
@@ -816,7 +811,7 @@ describe("checkpoint-manager updateOperation", () => {
       Action: OperationAction.START,
       Name: "test-step",
     };
-    storage.registerUpdate(stepUpdate, mockInvocationId);
+    storage.registerUpdate(stepUpdate);
 
     const partialUpdate = {
       Status: OperationStatus.SUCCEEDED,
@@ -866,7 +861,7 @@ describe("checkpoint-manager updateOperation", () => {
       Name: "complex-step",
       Payload: "initial-payload",
     };
-    storage.registerUpdate(complexUpdate, mockInvocationId);
+    storage.registerUpdate(complexUpdate);
 
     const updateData = {
       Status: OperationStatus.SUCCEEDED,
@@ -950,18 +945,15 @@ describe("checkpoint-manager updateOperation", () => {
       storage.initialize();
 
       // Register a STEP operation with RETRY action
-      const result = storage.registerUpdate(
-        {
-          Id: "retry-step-id",
-          Action: OperationAction.RETRY,
-          Type: OperationType.STEP,
-          Name: "test-retry-step",
-          StepOptions: {
-            NextAttemptDelaySeconds: 15,
-          },
+      const result = storage.registerUpdate({
+        Id: "retry-step-id",
+        Action: OperationAction.RETRY,
+        Type: OperationType.STEP,
+        Name: "test-retry-step",
+        StepOptions: {
+          NextAttemptDelaySeconds: 15,
         },
-        mockInvocationId,
-      );
+      });
 
       expect(result.operation.Id).toBe("retry-step-id");
       expect(result.operation.Status).toBe(OperationStatus.PENDING);
@@ -984,15 +976,12 @@ describe("checkpoint-manager updateOperation", () => {
       storage.initialize();
 
       // Register a STEP operation with RETRY action but no delay
-      const result = storage.registerUpdate(
-        {
-          Id: "retry-no-delay-id",
-          Action: OperationAction.RETRY,
-          Type: OperationType.STEP,
-          Name: "test-retry-no-delay",
-        },
-        mockInvocationId,
-      );
+      const result = storage.registerUpdate({
+        Id: "retry-no-delay-id",
+        Action: OperationAction.RETRY,
+        Type: OperationType.STEP,
+        Name: "test-retry-no-delay",
+      });
 
       expect(result.operation.Id).toBe("retry-no-delay-id");
       expect(result.operation.Status).toBe(OperationStatus.PENDING);
@@ -1010,18 +999,15 @@ describe("checkpoint-manager updateOperation", () => {
       storage.initialize();
 
       // Register a STEP operation with RETRY action and explicit zero delay
-      const result = storage.registerUpdate(
-        {
-          Id: "retry-zero-delay-id",
-          Action: OperationAction.RETRY,
-          Type: OperationType.STEP,
-          Name: "test-retry-zero-delay",
-          StepOptions: {
-            NextAttemptDelaySeconds: 0,
-          },
+      const result = storage.registerUpdate({
+        Id: "retry-zero-delay-id",
+        Action: OperationAction.RETRY,
+        Type: OperationType.STEP,
+        Name: "test-retry-zero-delay",
+        StepOptions: {
+          NextAttemptDelaySeconds: 0,
         },
-        mockInvocationId,
-      );
+      });
 
       expect(result.operation.Status).toBe(OperationStatus.PENDING);
       expect(result.operation.StepDetails?.Attempt).toBe(1);

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/event-processor.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/event-processor.test.ts
@@ -36,6 +36,8 @@ describe("EventProcessor", () => {
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
         ParentId: "parent-id",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
       const detailPlace = "ExecutionStartedDetails" as const;
       const details = {
@@ -69,6 +71,8 @@ describe("EventProcessor", () => {
         Name: "test-operation",
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
       const detailPlace = "ExecutionStartedDetails" as const;
       const details = {
@@ -100,6 +104,8 @@ describe("EventProcessor", () => {
         Name: "test-operation",
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
       const detailPlace = "ExecutionFailedDetails" as const;
       const details = {
@@ -145,6 +151,7 @@ describe("EventProcessor", () => {
         SubType: "update-subtype",
         ParentId: "parent-id",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -152,6 +159,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       const result = eventProcessor.processUpdate(update, operation);
@@ -188,6 +197,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -195,6 +205,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       processorWithTimeout.processUpdate(update, operation);
@@ -212,6 +224,8 @@ describe("EventProcessor", () => {
         Name: "update-name",
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
+        Action: undefined,
       };
 
       const operation: Operation = {
@@ -219,6 +233,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       expect(() => eventProcessor.processUpdate(update, operation)).toThrow(
@@ -233,12 +249,16 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       const operation: Operation = {
         Id: "operation-id",
         Name: "operation-name",
         SubType: "operation-subtype",
+        Type: undefined,
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       expect(() => eventProcessor.processUpdate(update, operation)).toThrow(
@@ -253,6 +273,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -260,6 +281,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       const firstResult = eventProcessor.processUpdate(update, operation);
@@ -276,6 +299,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -283,6 +307,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.STEP,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       eventProcessor.processUpdate(update, operation);
@@ -300,6 +326,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.FAIL,
         SubType: "update-subtype",
         Error: { ErrorType: "TestError", ErrorMessage: "Test error" },
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -307,6 +334,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       eventProcessor.processUpdate(update, operation);
@@ -402,20 +431,28 @@ describe("EventProcessor", () => {
         Name: "test-operation",
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       const event1 = processor1.createHistoryEvent(
         EventType.ExecutionStarted,
         operation,
         "ExecutionStartedDetails",
-        { Input: { Payload: "test" } },
+        {
+          Input: { Payload: "test" },
+          ExecutionTimeout: undefined,
+        },
       );
 
       const event2 = processor2.createHistoryEvent(
         EventType.ExecutionStarted,
         operation,
         "ExecutionStartedDetails",
-        { Input: { Payload: "test" } },
+        {
+          Input: { Payload: "test" },
+          ExecutionTimeout: undefined,
+        },
       );
 
       expect(event1.EventId).toBe(1);
@@ -428,6 +465,8 @@ describe("EventProcessor", () => {
         Name: "test-operation",
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       const update: OperationUpdate = {
@@ -436,6 +475,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "update-subtype",
         Payload: "test-payload",
+        Type: undefined,
       };
 
       mockGetHistoryEventDetail.mockReturnValue({
@@ -451,7 +491,10 @@ describe("EventProcessor", () => {
         EventType.ExecutionStarted,
         operation,
         "ExecutionStartedDetails",
-        { Input: { Payload: "test" } },
+        {
+          Input: { Payload: "test" },
+          ExecutionTimeout: undefined,
+        },
       );
 
       // Create event using processUpdate
@@ -479,6 +522,7 @@ describe("EventProcessor", () => {
         Action: OperationAction.START,
         SubType: "",
         Payload: "",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -486,6 +530,8 @@ describe("EventProcessor", () => {
         Name: "",
         Type: OperationType.EXECUTION,
         SubType: "",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       mockGetHistoryEventDetail.mockReturnValue({
@@ -509,6 +555,7 @@ describe("EventProcessor", () => {
         Name: "update-name",
         Action: OperationAction.START,
         SubType: "update-subtype",
+        Type: undefined,
       };
 
       const operation: Operation = {
@@ -516,6 +563,8 @@ describe("EventProcessor", () => {
         Name: "operation-name",
         Type: OperationType.EXECUTION,
         SubType: "operation-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       mockGetHistoryEventDetail.mockReturnValue({
@@ -538,6 +587,8 @@ describe("EventProcessor", () => {
         Name: "test-operation",
         Type: OperationType.EXECUTION,
         SubType: "test-subtype",
+        StartTimestamp: undefined,
+        Status: undefined,
       };
 
       const details = {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/utils/__tests__/history-event-details.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/utils/__tests__/history-event-details.test.ts
@@ -23,6 +23,9 @@ describe("history-event-details", () => {
   const createMockUpdate = (
     overrides: Partial<OperationUpdate> = {},
   ): OperationUpdate => ({
+    Id: undefined,
+    Type: undefined,
+    Action: undefined,
     Payload: "test-payload",
     Error: createMockErrorObject(),
     CallbackOptions: {
@@ -44,6 +47,10 @@ describe("history-event-details", () => {
   const createMockOperation = (
     overrides: Partial<Operation> = {},
   ): Operation => ({
+    Id: undefined,
+    Type: undefined,
+    StartTimestamp: undefined,
+    Status: undefined,
     CallbackDetails: {
       CallbackId: "test-callback-id",
     },

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/__tests__/checkpoint-durable-execution-input-validator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/__tests__/checkpoint-durable-execution-input-validator.test.ts
@@ -24,6 +24,7 @@ describe("validateCheckpointUpdates", () => {
       Type: type,
       Status: status,
       Id: "test-id",
+      StartTimestamp: undefined,
     },
     update: {
       Id: "test-id",
@@ -442,9 +443,10 @@ describe("validateCheckpointUpdates", () => {
 
   describe("operation id validation", () => {
     it("should throw exception when operation update has no id", () => {
-      const update = {
+      const update: OperationUpdate = {
         Type: OperationType.STEP,
         Action: OperationAction.START,
+        Id: undefined,
       };
 
       expect(() => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-callback-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-callback-operation.test.ts
@@ -19,6 +19,7 @@ describe("validateCallbackOperation", () => {
     Status: status,
     Type: OperationType.CALLBACK,
     Id: "test-id",
+    StartTimestamp: undefined,
   });
 
   describe("START action", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-context-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-context-operation.test.ts
@@ -26,6 +26,7 @@ describe("validateContextOperation", () => {
     Status: status,
     Type: OperationType.CONTEXT,
     Id: "test-id",
+    StartTimestamp: undefined,
   });
 
   describe("START action", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-invoke-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-invoke-operation.test.ts
@@ -19,6 +19,7 @@ describe("validateInvokeOperation", () => {
     Status: status,
     Type: OperationType.CHAINED_INVOKE,
     Id: "test-id",
+    StartTimestamp: undefined,
   });
 
   describe("START action", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-step-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-step-operation.test.ts
@@ -29,6 +29,7 @@ describe("validateStepOperation", () => {
     Status: status,
     Type: OperationType.STEP,
     Id: "test-id",
+    StartTimestamp: undefined,
   });
 
   describe("START action", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-wait-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/operation-type/__tests__/validate-wait-operation.test.ts
@@ -19,6 +19,7 @@ describe("validateWaitOperation", () => {
     Status: status,
     Type: OperationType.WAIT,
     Id: "test-id",
+    StartTimestamp: undefined,
   });
 
   describe("START action", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/__tests__/cloud-operation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/operations/__tests__/cloud-operation.test.ts
@@ -4,10 +4,11 @@ import { OperationWaitManager } from "../../../local/operations/operation-wait-m
 import { IndexedOperations } from "../../../common/indexed-operations";
 import { DurableApiClient } from "../../../common/create-durable-api-client";
 import { WaitingOperationStatus } from "../../../types/durable-operation";
+import { OperationEvents } from "../../../common/operations/operation-with-data";
 
 describe("CloudOperation", () => {
-  const waitManager = new OperationWaitManager();
   const mockIndexedOperations = new IndexedOperations([]);
+  const waitManager = new OperationWaitManager(mockIndexedOperations);
   const mockApiClient: jest.Mocked<DurableApiClient> = {
     sendCallbackSuccess: jest.fn(),
     sendCallbackFailure: jest.fn(),
@@ -23,10 +24,12 @@ describe("CloudOperation", () => {
         InvocationType.Event,
       );
 
-      const checkpointData = {
+      const checkpointData: OperationEvents = {
         operation: {
           Id: "test-id",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/event-data-extractors.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/event-data-extractors.test.ts
@@ -18,6 +18,7 @@ describe("getErrorFromEvent", () => {
         Error: {
           Payload: errorPayload,
         },
+        RetryDetails: undefined,
       },
     };
 
@@ -38,6 +39,7 @@ describe("getErrorFromEvent", () => {
         Result: {
           Payload: "success result",
         },
+        RetryDetails: undefined,
       },
     };
 
@@ -49,6 +51,7 @@ describe("getErrorFromEvent", () => {
     const event: Event = {
       StepFailedDetails: {
         Error: {},
+        RetryDetails: undefined,
       },
     };
 
@@ -97,6 +100,7 @@ describe("getPayloadFromEvent", () => {
         Result: {
           Payload: resultPayload,
         },
+        RetryDetails: undefined,
       },
     };
 
@@ -120,6 +124,7 @@ describe("getPayloadFromEvent", () => {
             ErrorMessage: "Test error",
           },
         },
+        RetryDetails: undefined,
       },
     };
 
@@ -142,6 +147,7 @@ describe("getPayloadFromEvent", () => {
     const event: Event = {
       StepSucceededDetails: {
         Result: {},
+        RetryDetails: undefined,
       },
     };
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-details.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-details.test.ts
@@ -6,6 +6,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {
@@ -32,6 +35,9 @@ describe("addOperationDetails", () => {
       StepDetails: {
         Attempt: 1,
       },
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {
@@ -54,6 +60,9 @@ describe("addOperationDetails", () => {
         Result: "old result",
         Attempt: 1,
       },
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {
@@ -73,6 +82,9 @@ describe("addOperationDetails", () => {
       StepDetails: {
         Attempt: 1,
       },
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {
@@ -92,6 +104,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     const originalOperation = { ...operation };
@@ -111,6 +126,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "CallbackDetails", {
@@ -128,6 +146,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     const scheduledEndTimestamp = new Date("2023-01-01T12:00:00Z");
@@ -145,6 +166,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "ChainedInvokeDetails", {
@@ -168,6 +192,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "ContextDetails", {
@@ -191,6 +218,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     // Since ExecutionDetails doesn't have any properties we can add,
@@ -208,6 +238,9 @@ describe("addOperationDetails", () => {
       StepDetails: {
         Attempt: 1,
       },
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {});
@@ -221,6 +254,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     addOperationDetails(operation, "StepDetails", {
@@ -238,6 +274,9 @@ describe("addOperationDetails", () => {
     const operation: Operation = {
       Id: "test-id",
       Name: "test-operation",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
     };
 
     const complexError = {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-factory.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/operation-factory.test.ts
@@ -189,6 +189,7 @@ describe("createOperation", () => {
         Name: "test-operation",
         Type: OperationType.STEP,
         Status: OperationStatus.STARTED,
+        StartTimestamp: undefined,
       },
       events: [],
     };
@@ -225,7 +226,12 @@ describe("populateOperationDetails", () => {
     };
 
     const historyEventType = historyEventTypes.StepStarted;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     expect(() => {
       populateOperationDetails(
@@ -243,11 +249,17 @@ describe("populateOperationDetails", () => {
         Result: {
           Payload: '{"success": true}',
         },
+        RetryDetails: undefined,
       },
     };
 
     const historyEventType = historyEventTypes.StepSucceeded;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 
@@ -266,7 +278,12 @@ describe("populateOperationDetails", () => {
     };
 
     const historyEventType = historyEventTypes.CallbackStarted;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 
@@ -283,11 +300,17 @@ describe("populateOperationDetails", () => {
           CurrentAttempt: 2,
           NextAttemptDelaySeconds: 30,
         },
+        Error: undefined,
       },
     };
 
     const historyEventType = historyEventTypes.StepFailed;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 
@@ -306,11 +329,17 @@ describe("populateOperationDetails", () => {
         RetryDetails: {
           CurrentAttempt: 3,
         },
+        Error: undefined,
       },
     };
 
     const historyEventType = historyEventTypes.StepFailed;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 
@@ -328,11 +357,17 @@ describe("populateOperationDetails", () => {
       ...baseEvent,
       WaitStartedDetails: {
         ScheduledEndTimestamp: scheduledEndTimestamp,
+        Duration: undefined,
       },
     };
 
     const historyEventType = historyEventTypes.WaitStarted;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 
@@ -345,7 +380,12 @@ describe("populateOperationDetails", () => {
 
   it("should populate EXECUTION operation type", () => {
     const historyEventType = historyEventTypes.ExecutionStarted;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(baseEvent, historyEventType, operation);
 
@@ -362,11 +402,17 @@ describe("populateOperationDetails", () => {
             ErrorMessage: "Test failed",
           },
         },
+        RetryDetails: undefined,
       },
     };
 
     const historyEventType = historyEventTypes.StepFailed;
-    const operation: Operation = { Id: "test-id" };
+    const operation: Operation = {
+      Id: "test-id",
+      Type: undefined,
+      StartTimestamp: undefined,
+      Status: undefined,
+    };
 
     populateOperationDetails(event, historyEventType, operation);
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/process-history-events.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/utils/process-history-events/__tests__/process-history-events.test.ts
@@ -62,6 +62,7 @@ describe("historyEventsToOperationEvents", () => {
           Input: {
             Payload: '{"input": "data"}',
           },
+          ExecutionTimeout: undefined,
         },
         EventTimestamp: new Date("2023-01-01T12:00:00Z"),
       },
@@ -116,6 +117,7 @@ describe("historyEventsToOperationEvents", () => {
           Result: {
             Payload: '{"result": "success"}',
           },
+          RetryDetails: undefined,
         },
       },
     ];
@@ -243,6 +245,7 @@ describe("historyEventsToOperationEvents", () => {
         EventTimestamp: new Date("2023-01-01T12:00:00Z"),
         WaitStartedDetails: {
           ScheduledEndTimestamp: scheduledEndTimestamp,
+          Duration: undefined,
         },
       },
       {
@@ -281,6 +284,7 @@ describe("historyEventsToOperationEvents", () => {
         EventTimestamp: new Date("2023-01-01T12:00:00Z"),
         ChainedInvokeStartedDetails: {
           DurableExecutionArn: "my-durable-execution-arn",
+          FunctionName: undefined,
         },
       },
       {
@@ -374,6 +378,7 @@ describe("historyEventsToOperationEvents", () => {
           Result: {
             Payload: '{"step": "result"}',
           },
+          RetryDetails: undefined,
         },
       },
       {
@@ -426,7 +431,10 @@ describe("historyEventsToOperationEvents", () => {
         Id: "execution-id",
         EventType: EventType.ExecutionStarted,
         EventTimestamp: new Date("2023-01-01T12:00:00Z"),
-        ExecutionStartedDetails: {},
+        ExecutionStartedDetails: {
+          Input: undefined,
+          ExecutionTimeout: undefined,
+        },
       },
       {
         Id: "step-id",
@@ -439,7 +447,9 @@ describe("historyEventsToOperationEvents", () => {
         Id: "execution-id",
         EventType: EventType.ExecutionSucceeded,
         EventTimestamp: new Date("2023-01-01T12:02:00Z"),
-        ExecutionSucceededDetails: {},
+        ExecutionSucceededDetails: {
+          Result: undefined,
+        },
       },
       {
         Id: "step-id",
@@ -449,6 +459,7 @@ describe("historyEventsToOperationEvents", () => {
           Result: {
             Payload: '{"step": "result"}',
           },
+          RetryDetails: undefined,
         },
       },
     ];
@@ -480,6 +491,7 @@ describe("historyEventsToOperationEvents", () => {
             CurrentAttempt: 1,
             NextAttemptDelaySeconds: 10,
           },
+          Error: undefined,
         },
       },
       {
@@ -496,6 +508,7 @@ describe("historyEventsToOperationEvents", () => {
           Result: {
             Payload: '{"final": "result"}',
           },
+          RetryDetails: undefined,
         },
       },
     ];
@@ -608,6 +621,7 @@ describe("historyEventsToOperationEvents", () => {
       ChainedInvokeStartedDetails: {
         DurableExecutionArn:
           "arn:aws:lambda:us-east-1:123456789012:durable-execution:test",
+        FunctionName: undefined,
       },
     };
 
@@ -643,6 +657,7 @@ describe("historyEventsToOperationEvents", () => {
         Result: {
           Payload: '{"step": "result"}',
         },
+        RetryDetails: undefined,
       },
     };
 
@@ -675,6 +690,7 @@ describe("historyEventsToOperationEvents", () => {
         Input: {
           Payload: '{"test": "data"}',
         },
+        ExecutionTimeout: undefined,
       },
     };
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
@@ -1,5 +1,10 @@
-import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
+import {
+  Operation,
+  OperationStatus,
+  OperationType,
+} from "@aws-sdk/client-lambda";
 import { IndexedOperations } from "../indexed-operations";
+import { OperationEvents } from "../operations/operation-with-data";
 
 describe("IndexedOperations", () => {
   // Sample operations for testing
@@ -122,10 +127,12 @@ describe("IndexedOperations", () => {
       const indexed = new IndexedOperations([]);
 
       // Add initial operation
-      const initialOperation = {
+      const initialOperation: Operation = {
         Id: "op1",
         Name: "operation1",
         Status: OperationStatus.STARTED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
       indexed.addOperations([
         {
@@ -141,10 +148,12 @@ describe("IndexedOperations", () => {
       );
 
       // Add operation with same ID but different properties
-      const updatedOperation = {
+      const updatedOperation: Operation = {
         Id: "op1",
         Name: "operation1-updated",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
       indexed.addOperations([
         {
@@ -172,12 +181,14 @@ describe("IndexedOperations", () => {
     it("should handle multiple operations with same ID by keeping the last one", () => {
       const indexed = new IndexedOperations([]);
 
-      const operations = [
+      const operations: OperationEvents[] = [
         {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -186,6 +197,8 @@ describe("IndexedOperations", () => {
             Id: "op2",
             Name: "operation2",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -194,6 +207,8 @@ describe("IndexedOperations", () => {
             Id: "op1",
             Name: "operation1-updated",
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         }, // Same ID as first operation
@@ -219,11 +234,13 @@ describe("IndexedOperations", () => {
       const indexed = new IndexedOperations([]);
 
       // Add initial operation
-      const initialOperation = {
+      const initialOperation: OperationEvents = {
         operation: {
           Id: "op1",
           Name: "original-name",
           Status: OperationStatus.STARTED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -236,11 +253,13 @@ describe("IndexedOperations", () => {
       );
 
       // Add operation with same ID but different name
-      const updatedOperation = {
+      const updatedOperation: OperationEvents = {
         operation: {
           Id: "op1",
           Name: "updated-name",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -266,12 +285,14 @@ describe("IndexedOperations", () => {
       const indexed = new IndexedOperations([]);
 
       // Add some operations
-      const operations = [
+      const operations: OperationEvents[] = [
         {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -280,6 +301,8 @@ describe("IndexedOperations", () => {
             Id: "op2",
             Name: "operation2",
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -300,11 +323,13 @@ describe("IndexedOperations", () => {
       ).toBeDefined();
 
       // Add an operation with same ID as existing one
-      const updatedOp1 = {
+      const updatedOp1: OperationEvents = {
         operation: {
           Id: "op1",
           Name: "operation1-updated",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -324,9 +349,12 @@ describe("IndexedOperations", () => {
 
     it("should not handle operations without id", () => {
       const indexed = new IndexedOperations([]);
-      const operationWithoutId = {
+      const operationWithoutId: Operation = {
         Status: OperationStatus.STARTED,
         Name: "my-operation-name",
+        Id: undefined,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       // Add the operation
@@ -342,11 +370,13 @@ describe("IndexedOperations", () => {
 
     it("should handle operations with empty string id", () => {
       const indexed = new IndexedOperations([]);
-      const operationWithEmptyId = {
+      const operationWithEmptyId: OperationEvents = {
         operation: {
           Id: "",
           Name: undefined,
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -359,11 +389,13 @@ describe("IndexedOperations", () => {
 
     it("should handle operations with empty string name", () => {
       const indexed = new IndexedOperations([]);
-      const operationWithEmptyName = {
+      const operationWithEmptyName: OperationEvents = {
         operation: {
           Id: "test-op",
           Name: "",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -394,12 +426,14 @@ describe("IndexedOperations", () => {
       it("should add all events when adding new operations", () => {
         const indexed = new IndexedOperations([]);
 
-        const operations = [
+        const operations: OperationEvents[] = [
           {
             operation: {
               Id: "op1",
               Name: "operation1",
               Status: OperationStatus.STARTED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 1 }, { EventId: 2 }],
           },
@@ -408,6 +442,8 @@ describe("IndexedOperations", () => {
               Id: "op2",
               Name: "operation2",
               Status: OperationStatus.SUCCEEDED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 3 }, { EventId: 4 }],
           },
@@ -424,11 +460,13 @@ describe("IndexedOperations", () => {
         const indexed = new IndexedOperations([]);
 
         // Add initial operation with 2 events
-        const initialOperation = {
+        const initialOperation: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 1 }, { EventId: 2 }],
         };
@@ -439,11 +477,13 @@ describe("IndexedOperations", () => {
         expect(historyEvents.map((e) => e.EventId)).toEqual([1, 2]);
 
         // Update same operation with 2 additional events (4 total)
-        const updatedOperation = {
+        const updatedOperation: OperationEvents = {
           operation: {
             Id: "op1", // Same ID
             Name: "operation1",
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [
             { EventId: 1 }, // Existing
@@ -464,11 +504,13 @@ describe("IndexedOperations", () => {
       it("should not add duplicate events when updating operation with same events", () => {
         const indexed = new IndexedOperations([]);
 
-        const operation = {
+        const operation: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 1 }, { EventId: 2 }],
         };
@@ -487,11 +529,13 @@ describe("IndexedOperations", () => {
       it("should handle operations with no events", () => {
         const indexed = new IndexedOperations([]);
 
-        const operationWithoutEvents = {
+        const operationWithoutEvents: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         };
@@ -501,11 +545,13 @@ describe("IndexedOperations", () => {
         expect(historyEvents).toHaveLength(0);
 
         // Update with events
-        const operationWithEvents = {
+        const operationWithEvents: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 1 }],
         };
@@ -520,12 +566,14 @@ describe("IndexedOperations", () => {
         const indexed = new IndexedOperations([]);
 
         // Initial operations
-        const initialOperations = [
+        const initialOperations: OperationEvents[] = [
           {
             operation: {
               Id: "op1",
               Name: "operation1",
               Status: OperationStatus.STARTED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 1 }],
           },
@@ -534,6 +582,8 @@ describe("IndexedOperations", () => {
               Id: "op2",
               Name: "operation2",
               Status: OperationStatus.STARTED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 2 }, { EventId: 3 }],
           },
@@ -544,12 +594,14 @@ describe("IndexedOperations", () => {
         expect(historyEvents).toHaveLength(3);
 
         // Update both operations with additional events
-        const updatedOperations = [
+        const updatedOperations: OperationEvents[] = [
           {
             operation: {
               Id: "op1",
               Name: "operation1",
               Status: OperationStatus.SUCCEEDED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [
               { EventId: 1 }, // Existing
@@ -561,6 +613,8 @@ describe("IndexedOperations", () => {
               Id: "op2",
               Name: "operation2",
               Status: OperationStatus.SUCCEEDED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [
               { EventId: 2 }, // Existing
@@ -589,6 +643,8 @@ describe("IndexedOperations", () => {
               Id: "op1",
               Name: "operation1",
               Status: OperationStatus.STARTED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 1 }],
           },
@@ -601,6 +657,8 @@ describe("IndexedOperations", () => {
               Id: "op2",
               Name: "operation2",
               Status: OperationStatus.STARTED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 2 }],
           },
@@ -613,6 +671,8 @@ describe("IndexedOperations", () => {
               Id: "op1",
               Name: "operation1",
               Status: OperationStatus.SUCCEEDED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 1 }, { EventId: 3 }],
           },
@@ -629,11 +689,13 @@ describe("IndexedOperations", () => {
         const indexed = new IndexedOperations([]);
 
         // Add operation with multiple events
-        const operationWithManyEvents = {
+        const operationWithManyEvents: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.STARTED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 1 }, { EventId: 2 }, { EventId: 3 }],
         };
@@ -643,11 +705,13 @@ describe("IndexedOperations", () => {
         expect(historyEvents).toHaveLength(3);
 
         // Update with fewer events (this shouldn't normally happen in practice, but testing edge case)
-        const operationWithFewerEvents = {
+        const operationWithFewerEvents: OperationEvents = {
           operation: {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.FAILED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 1 }, { EventId: 2 }],
         };
@@ -737,12 +801,14 @@ describe("IndexedOperations", () => {
   });
 
   describe("getOperationChildren", () => {
-    const parentChildOperations = [
+    const parentChildOperations: OperationEvents[] = [
       {
         operation: {
           Id: "parent1",
           Name: "parent-operation",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       },
@@ -752,6 +818,8 @@ describe("IndexedOperations", () => {
           Name: "child-operation-1",
           ParentId: "parent1",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       },
@@ -761,6 +829,8 @@ describe("IndexedOperations", () => {
           Name: "child-operation-2",
           ParentId: "parent1",
           Status: OperationStatus.FAILED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       },
@@ -769,6 +839,8 @@ describe("IndexedOperations", () => {
           Id: "orphan",
           Name: "orphan-operation",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       },
@@ -778,6 +850,8 @@ describe("IndexedOperations", () => {
           Name: "child-operation-3",
           ParentId: "different-parent",
           Status: OperationStatus.SUCCEEDED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       },
@@ -839,6 +913,8 @@ describe("IndexedOperations", () => {
             Id: "op1",
             Name: "operation1",
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -878,6 +954,8 @@ describe("IndexedOperations", () => {
               Name: "child-operation-1-updated",
               ParentId: "new-parent", // Different parent
               Status: OperationStatus.SUCCEEDED,
+              Type: undefined,
+              StartTimestamp: undefined,
             },
             events: [],
           },
@@ -901,6 +979,8 @@ describe("IndexedOperations", () => {
             Name: "operation1",
             ParentId: undefined,
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -918,6 +998,8 @@ describe("IndexedOperations", () => {
             Name: "child-operation",
             ParentId: "", // Empty string parent ID
             Status: OperationStatus.SUCCEEDED,
+            Type: undefined,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -932,12 +1014,13 @@ describe("IndexedOperations", () => {
 
   describe("executionOperation handling", () => {
     describe("should exclude execution operations from main indexes", () => {
-      const executionOperation = {
+      const executionOperation: OperationEvents = {
         operation: {
           Id: "execution-1",
           Name: "my-execution",
           Type: OperationType.EXECUTION,
           Status: OperationStatus.STARTED,
+          StartTimestamp: undefined,
         },
         events: [
           {
@@ -946,12 +1029,13 @@ describe("IndexedOperations", () => {
         ],
       };
 
-      const regularOperation = {
+      const regularOperation: OperationEvents = {
         operation: {
           Id: "step-1",
           Name: "my-step",
           Type: OperationType.STEP,
           Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
         },
         events: [
           {
@@ -1036,22 +1120,24 @@ describe("IndexedOperations", () => {
       });
 
       it("should handle multiple execution operations by keeping the last one", () => {
-        const firstExecution = {
+        const firstExecution: OperationEvents = {
           operation: {
             Id: "execution-1",
             Name: "first-execution",
             Type: OperationType.EXECUTION,
             Status: OperationStatus.STARTED,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 100 }],
         };
 
-        const secondExecution = {
+        const secondExecution: OperationEvents = {
           operation: {
             Id: "execution-2",
             Name: "second-execution",
             Type: OperationType.EXECUTION,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 200 }],
         };
@@ -1081,12 +1167,13 @@ describe("IndexedOperations", () => {
         ]);
 
         // Add updated execution with same ID but additional events
-        const updatedExecution = {
+        const updatedExecution: OperationEvents = {
           operation: {
             Id: "execution-1", // Same ID
             Name: "my-execution-updated",
             Type: OperationType.EXECUTION,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [
             { EventId: 100 }, // Existing
@@ -1109,23 +1196,25 @@ describe("IndexedOperations", () => {
       });
 
       it("should handle execution operations with parent-child relationships (execution operations cannot have parents but can be parents)", () => {
-        const executionWithChild = {
+        const executionWithChild: OperationEvents = {
           operation: {
             Id: "execution-parent",
             Name: "parent-execution",
             Type: OperationType.EXECUTION,
             Status: OperationStatus.STARTED,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 300 }],
         };
 
-        const childOfExecution = {
+        const childOfExecution: OperationEvents = {
           operation: {
             Id: "child-of-execution",
             Name: "child-step",
             Type: OperationType.STEP,
             ParentId: "execution-parent",
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [{ EventId: 301 }],
         };
@@ -1155,13 +1244,14 @@ describe("IndexedOperations", () => {
       });
 
       it("should handle mixed operations with execution operations", () => {
-        const operations = [
+        const operations: OperationEvents[] = [
           {
             operation: {
               Id: "step-1",
               Name: "first-step",
               Type: OperationType.STEP,
               Status: OperationStatus.SUCCEEDED,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 1 }],
           },
@@ -1171,6 +1261,7 @@ describe("IndexedOperations", () => {
               Name: "execution",
               Type: OperationType.EXECUTION,
               Status: OperationStatus.STARTED,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 2 }],
           },
@@ -1180,6 +1271,7 @@ describe("IndexedOperations", () => {
               Name: "wait-operation",
               Type: OperationType.WAIT,
               Status: OperationStatus.STARTED,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 3 }],
           },
@@ -1189,6 +1281,7 @@ describe("IndexedOperations", () => {
               Name: "context-operation",
               Type: OperationType.CONTEXT,
               Status: OperationStatus.SUCCEEDED,
+              StartTimestamp: undefined,
             },
             events: [{ EventId: 4 }],
           },

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/operation-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/operation-storage.test.ts
@@ -52,8 +52,8 @@ describe("OperationStorage", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockWaitManager = new OperationWaitManager();
     mockIndexedOperations = new IndexedOperations([]);
+    mockWaitManager = new OperationWaitManager(mockIndexedOperations);
     mockApiClient = {} as DurableApiClient;
   });
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/__tests__/operation-with-data.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operations/__tests__/operation-with-data.test.ts
@@ -2,18 +2,19 @@ import {
   OperationStatus,
   OperationType,
   ErrorObject,
+  Operation,
 } from "@aws-sdk/client-lambda";
 import { OperationSubType } from "@aws/durable-execution-sdk-js";
 
 import { WaitingOperationStatus } from "../../../types/durable-operation";
 import { OperationWaitManager } from "../../../local/operations/operation-wait-manager";
-import { OperationWithData } from "../operation-with-data";
+import { OperationEvents, OperationWithData } from "../operation-with-data";
 import { IndexedOperations } from "../../indexed-operations";
 import { DurableApiClient } from "../../create-durable-api-client";
 
 describe("OperationWithData", () => {
-  const waitManager = new OperationWaitManager();
   const mockIndexedOperations = new IndexedOperations([]);
+  const waitManager = new OperationWaitManager(mockIndexedOperations);
   const mockApiClient: jest.Mocked<DurableApiClient> = {
     sendCallbackSuccess: jest.fn(),
     sendCallbackFailure: jest.fn(),
@@ -42,10 +43,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -64,11 +67,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
-        Type: OperationType.STEP, // Not CONTEXT
+        Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -87,7 +91,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-context",
         Status: OperationStatus.SUCCEEDED,
@@ -99,6 +103,7 @@ describe("OperationWithData", () => {
             ErrorType: "ContextWarning",
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -122,7 +127,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-context",
         Status: OperationStatus.SUCCEEDED,
@@ -131,6 +136,7 @@ describe("OperationWithData", () => {
           Result: '{"userId": 123, "name": "John Doe"}',
           Error: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -151,7 +157,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-context",
         Status: OperationStatus.FAILED,
@@ -163,6 +169,7 @@ describe("OperationWithData", () => {
             ErrorType: "ContextExecutionError",
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -186,7 +193,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-context",
         Status: OperationStatus.SUCCEEDED,
@@ -195,6 +202,7 @@ describe("OperationWithData", () => {
           Result: "invalid-json{",
           Error: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -225,12 +233,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-context",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
-        // ContextDetails is missing
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -253,11 +261,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
-        Type: OperationType.CALLBACK, // Not STEP
+        Type: OperationType.CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -276,7 +285,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-step",
         Status: OperationStatus.SUCCEEDED,
@@ -287,6 +296,7 @@ describe("OperationWithData", () => {
           Result: '{"success": true}',
           Error: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -319,7 +329,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "step-op-error",
         Type: OperationType.STEP,
         Status: OperationStatus.FAILED,
@@ -331,6 +341,7 @@ describe("OperationWithData", () => {
             ErrorType: "StepError",
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -357,7 +368,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "step-op-partial",
         Type: OperationType.STEP,
         Status: OperationStatus.FAILED,
@@ -369,6 +380,7 @@ describe("OperationWithData", () => {
             ErrorType: "PartialFailure",
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -395,7 +407,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "step-op-bad-json",
         Type: OperationType.STEP,
         Status: OperationStatus.FAILED,
@@ -407,6 +419,7 @@ describe("OperationWithData", () => {
             ErrorType: "ParseError",
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -433,11 +446,11 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "step-op-no-details",
         Type: OperationType.STEP,
         Status: OperationStatus.STARTED,
-        // StepDetails is missing
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -463,11 +476,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
-        Type: OperationType.STEP, // Not CALLBACK
+        Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -486,7 +500,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-callback",
         Status: OperationStatus.SUCCEEDED,
@@ -494,6 +508,7 @@ describe("OperationWithData", () => {
         CallbackDetails: {
           CallbackId: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -512,7 +527,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-callback",
         Status: OperationStatus.SUCCEEDED,
@@ -522,6 +537,7 @@ describe("OperationWithData", () => {
           Result: '{"data": "test"}',
           Error: { ErrorMessage: "Test error" },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -548,7 +564,7 @@ describe("OperationWithData", () => {
     });
 
     it("should return callback details for WAIT_FOR_CALLBACK context operation with child CALLBACK", () => {
-      const mockChildOperations = [
+      const mockChildOperations: OperationEvents[] = [
         {
           operation: {
             Id: "child-callback",
@@ -559,6 +575,8 @@ describe("OperationWithData", () => {
               Result: '{"waitResult": "success"}',
               Error: { ErrorMessage: "Wait callback error" },
             },
+            StartTimestamp: undefined,
+            Status: undefined,
           },
           events: [],
         },
@@ -574,12 +592,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "wait-for-callback-op",
         Name: "wait-for-callback",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -596,12 +615,14 @@ describe("OperationWithData", () => {
     });
 
     it("should throw error when WAIT_FOR_CALLBACK context has no child CALLBACK operation", () => {
-      const mockChildOperations = [
+      const mockChildOperations: OperationEvents[] = [
         {
           operation: {
             Id: "child-step",
             Name: "child-step-op",
-            Type: OperationType.STEP, // Not CALLBACK
+            Type: OperationType.STEP,
+            StartTimestamp: undefined,
+            Status: undefined,
           },
           events: [],
         },
@@ -617,12 +638,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "wait-for-callback-op",
         Name: "wait-for-callback",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -646,12 +668,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "wait-for-callback-op",
         Name: "wait-for-callback",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -665,7 +688,7 @@ describe("OperationWithData", () => {
     });
 
     it("should throw error when WAIT_FOR_CALLBACK child CALLBACK operation has undefined CallbackId", () => {
-      const mockChildOperations = [
+      const mockChildOperations: OperationEvents[] = [
         {
           operation: {
             Id: "child-callback",
@@ -674,6 +697,8 @@ describe("OperationWithData", () => {
             CallbackDetails: {
               CallbackId: undefined, // Missing CallbackId
             },
+            StartTimestamp: undefined,
+            Status: undefined,
           },
           events: [],
         },
@@ -689,12 +714,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "wait-for-callback-op",
         Name: "wait-for-callback",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -715,11 +741,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
-        Type: OperationType.STEP, // Not INVOKE
+        Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -738,7 +765,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-invoke",
         Status: OperationStatus.SUCCEEDED,
@@ -747,6 +774,7 @@ describe("OperationWithData", () => {
           Result: '{"functionResult": "success", "executionTime": 250}',
           Error: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -767,7 +795,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-invoke",
         Status: OperationStatus.FAILED,
@@ -780,6 +808,7 @@ describe("OperationWithData", () => {
             StackTrace: ["Error at line 1", "Error at line 2"],
           },
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -804,7 +833,7 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-invoke",
         Status: OperationStatus.SUCCEEDED,
@@ -813,6 +842,7 @@ describe("OperationWithData", () => {
           Result: "invalid-json{",
           Error: undefined,
         },
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -841,12 +871,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-invoke",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CHAINED_INVOKE,
-        // ChainedInvokeDetails is missing
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -869,11 +899,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
-        Type: OperationType.STEP, // Not WAIT
+        Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -892,11 +923,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-wait",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.WAIT,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -941,10 +973,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-operation-id",
         Name: "test-operation-name",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -970,10 +1004,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation-name",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -999,11 +1035,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1029,10 +1066,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1059,11 +1098,12 @@ describe("OperationWithData", () => {
         mockApiClient,
       );
       const startTime = new Date("2023-01-01T10:00:00Z");
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         StartTimestamp: startTime,
+        Type: undefined,
       };
 
       operation.populateData({
@@ -1090,11 +1130,13 @@ describe("OperationWithData", () => {
         mockApiClient,
       );
       const endTime = new Date("2023-01-01T11:00:00Z");
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         EndTimestamp: endTime,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1120,11 +1162,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         ParentId: "parent-123",
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1150,12 +1194,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1181,12 +1226,13 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CONTEXT,
         SubType: OperationSubType.WAIT_FOR_CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1203,11 +1249,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1224,11 +1271,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1245,11 +1293,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "test-id",
         Name: "test-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.STEP,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1281,11 +1330,12 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
-          Type: OperationType.STEP, // Not CALLBACK
+          Type: OperationType.STEP,
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1304,12 +1354,12 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
           Type: OperationType.CALLBACK,
-          // CallbackDetails is missing
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1328,7 +1378,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1336,6 +1386,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             // CallbackId is undefined
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1356,7 +1407,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1364,6 +1415,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-123",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1391,7 +1443,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1399,6 +1451,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-123",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1421,7 +1474,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1429,6 +1482,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-456",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1459,7 +1513,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1467,6 +1521,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-123",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1493,7 +1548,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1501,6 +1556,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-heartbeat-123",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1525,7 +1581,7 @@ describe("OperationWithData", () => {
           mockIndexedOperations,
           mockApiClient,
         );
-        const operationData = {
+        const operationData: Operation = {
           Id: "test-id",
           Name: "callback-op",
           Status: OperationStatus.SUCCEEDED,
@@ -1533,6 +1589,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-123",
           },
+          StartTimestamp: undefined,
         };
 
         operation.populateData({
@@ -1561,7 +1618,7 @@ describe("OperationWithData", () => {
           mockApiClient,
         );
 
-        const operationData1 = {
+        const operationData1: Operation = {
           Id: "test-id-1",
           Name: "callback-1",
           Status: OperationStatus.SUCCEEDED,
@@ -1569,9 +1626,10 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-id-1",
           },
+          StartTimestamp: undefined,
         };
 
-        const operationData2 = {
+        const operationData2: Operation = {
           Id: "test-id-2",
           Name: "callback-2",
           Status: OperationStatus.SUCCEEDED,
@@ -1579,6 +1637,7 @@ describe("OperationWithData", () => {
           CallbackDetails: {
             CallbackId: "callback-id-2",
           },
+          StartTimestamp: undefined,
         };
 
         operation1.populateData({
@@ -1619,9 +1678,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.STARTED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1644,9 +1706,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1669,15 +1734,21 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const initialData = {
+      const initialData: OperationEvents = {
         operation: {
-          Status: OperationStatus.STARTED, // Data exists but has STARTED status
+          Status: OperationStatus.STARTED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
-      const finalData = {
+      const finalData: OperationEvents = {
         operation: {
-          Status: OperationStatus.SUCCEEDED, // Final status is SUCCEEDED (COMPLETED)
+          Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1709,19 +1780,23 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const initialData = {
+      const initialData: OperationEvents = {
         operation: {
           Id: "test-id",
           Name: "test-operation",
-          // No Status field - should always wait
+          Type: undefined,
+          StartTimestamp: undefined,
+          Status: undefined,
         },
         events: [],
       };
-      const finalData = {
+      const finalData: OperationEvents = {
         operation: {
           Id: "test-id",
           Name: "test-operation",
           Status: OperationStatus.STARTED,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1757,9 +1832,12 @@ describe("OperationWithData", () => {
         mockOperation,
       );
 
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1789,9 +1867,12 @@ describe("OperationWithData", () => {
       (waitManager.waitForOperation as jest.Mock).mockResolvedValue(
         mockOperation,
       );
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1832,9 +1913,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1879,9 +1963,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const expectedResult = {
+      const expectedResult: OperationEvents = {
         operation: {
           Status: OperationStatus.SUCCEEDED,
+          Id: undefined,
+          Type: undefined,
+          StartTimestamp: undefined,
         },
         events: [],
       };
@@ -1912,13 +1999,25 @@ describe("OperationWithData", () => {
     });
 
     it("should return OperationWithData instances for child operations when data is populated", () => {
-      const mockChildOperations = [
+      const mockChildOperations: OperationEvents[] = [
         {
-          operation: { Id: "child-1", Name: "child-op-1" },
+          operation: {
+            Id: "child-1",
+            Name: "child-op-1",
+            Type: undefined,
+            StartTimestamp: undefined,
+            Status: undefined,
+          },
           events: [],
         },
         {
-          operation: { Id: "child-2", Name: "child-op-2" },
+          operation: {
+            Id: "child-2",
+            Name: "child-op-2",
+            Type: undefined,
+            StartTimestamp: undefined,
+            Status: undefined,
+          },
           events: [],
         },
       ];
@@ -1933,10 +2032,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "parent-id",
         Name: "parent-operation",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -1985,10 +2086,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "parent-with-no-children",
         Name: "parent-operation",
         Status: OperationStatus.SUCCEEDED,
+        Type: undefined,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({
@@ -2005,12 +2108,14 @@ describe("OperationWithData", () => {
     });
 
     it("should work with different operation types", () => {
-      const mockChildOperations = [
+      const mockChildOperations: OperationEvents[] = [
         {
           operation: {
             Id: "step-child",
             Name: "step-child",
             Type: OperationType.STEP,
+            StartTimestamp: undefined,
+            Status: undefined,
           },
           events: [],
         },
@@ -2025,11 +2130,12 @@ describe("OperationWithData", () => {
         mockIndexedOperations,
         mockApiClient,
       );
-      const operationData = {
+      const operationData: Operation = {
         Id: "callback-parent",
         Name: "callback-operation",
         Status: OperationStatus.SUCCEEDED,
         Type: OperationType.CALLBACK,
+        StartTimestamp: undefined,
       };
 
       operation.populateData({

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
@@ -21,7 +21,6 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
 
     const runner = new LocalDurableTestRunner({
       handlerFunction: handler,
-      skipTime: true,
     });
 
     const durableOperation = runner.getOperation("durableOperation");
@@ -151,7 +150,6 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
 
     const runner = new LocalDurableTestRunner({
       handlerFunction: handler,
-      skipTime: true,
     });
 
     runner.registerDurableFunction(

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/invoke-handler.test.ts
@@ -1,5 +1,4 @@
 import { Context } from "aws-lambda";
-import { Operation } from "@aws-sdk/client-lambda";
 import {
   DurableExecutionInvocationInput,
   DurableExecutionInvocationOutput,
@@ -38,7 +37,15 @@ describe("invoke-handler", () => {
 
       const params: HandlerParameters = {
         durableExecutionArn: "test-arn",
-        operations: [{ id: "op1", name: "testOp" } as Operation],
+        operations: [
+          {
+            Id: "op1",
+            Name: "testOp",
+            Type: undefined,
+            StartTimestamp: undefined,
+            Status: undefined,
+          },
+        ],
         checkpointToken: "test-token",
       };
 
@@ -80,7 +87,15 @@ describe("invoke-handler", () => {
 
       const params: HandlerParameters = {
         durableExecutionArn: "test-arn",
-        operations: [{ id: "op1", name: "testOp" } as Operation],
+        operations: [
+          {
+            Id: "op1",
+            Name: "testOp",
+            Type: undefined,
+            StartTimestamp: undefined,
+            Status: undefined,
+          },
+        ],
         checkpointToken: "test-token",
         contextValues: customContextValues,
       };
@@ -133,7 +148,15 @@ describe("invoke-handler", () => {
 
       const params: HandlerParameters = {
         durableExecutionArn: "test-arn",
-        operations: [{ id: "op1", name: "testOp" } as Operation],
+        operations: [
+          {
+            Id: "op1",
+            Name: "testOp",
+            Type: undefined,
+            StartTimestamp: undefined,
+            Status: undefined,
+          },
+        ],
         checkpointToken: "test-token",
       };
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/test-execution-orchestrator.test.ts
@@ -146,10 +146,11 @@ describe("TestExecutionOrchestrator", () => {
       sendCallbackSuccess: jest.fn(),
       sendCallbackHeartbeat: jest.fn(),
     };
+    const indexedOperations = new IndexedOperations([]);
     // Mock OperationStorage
     mockOperationStorage = new LocalOperationStorage(
-      new OperationWaitManager(),
-      new IndexedOperations([]),
+      new OperationWaitManager(indexedOperations),
+      indexedOperations,
       mockDurableApiClient,
       jest.fn(),
     ) as jest.Mocked<LocalOperationStorage>;

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/operations/__tests__/local-operation-storage.test.ts
@@ -29,6 +29,7 @@ describe("LocalOperationStorage", () => {
         Name: "operation1",
         Type: OperationType.STEP,
         Status: OperationStatus.SUCCEEDED,
+        StartTimestamp: undefined,
       },
       events: [
         {
@@ -47,6 +48,7 @@ describe("LocalOperationStorage", () => {
             Result: {
               Payload: "",
             },
+            RetryDetails: undefined,
           },
           Name: "operation1",
           Id: "op1",
@@ -59,6 +61,7 @@ describe("LocalOperationStorage", () => {
         Name: "operation2",
         Type: OperationType.WAIT,
         Status: OperationStatus.SUCCEEDED,
+        StartTimestamp: undefined,
       },
       events: [
         {
@@ -67,6 +70,7 @@ describe("LocalOperationStorage", () => {
           EventTimestamp: new Date("2026-01-01"),
           WaitStartedDetails: {
             Duration: 10,
+            ScheduledEndTimestamp: undefined,
           },
           Name: "operation2",
           Id: "op2",
@@ -87,13 +91,17 @@ describe("LocalOperationStorage", () => {
         Name: "operation1", // Same name as first operation
         Type: OperationType.CALLBACK,
         Status: OperationStatus.FAILED,
+        StartTimestamp: undefined,
       },
       events: [
         {
           EventId: 5,
           EventType: EventType.CallbackStarted,
           EventTimestamp: new Date("2026-01-02"),
-          StepSucceededDetails: {},
+          StepSucceededDetails: {
+            Result: undefined,
+            RetryDetails: undefined,
+          },
           Name: "operation1",
           Id: "op3",
         },
@@ -101,7 +109,10 @@ describe("LocalOperationStorage", () => {
           EventId: 6,
           EventType: EventType.CallbackSucceeded,
           EventTimestamp: new Date("2026-01-03"),
-          StepSucceededDetails: {},
+          StepSucceededDetails: {
+            Result: undefined,
+            RetryDetails: undefined,
+          },
           Name: "operation1",
           Id: "op3",
         },
@@ -111,8 +122,8 @@ describe("LocalOperationStorage", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockWaitManager = new OperationWaitManager();
     mockIndexedOperations = new IndexedOperations([]);
+    mockWaitManager = new OperationWaitManager(mockIndexedOperations);
     mockCallback = jest.fn();
     mockDurableApiClient = {
       sendCallbackSuccess: jest.fn(),
@@ -354,6 +365,7 @@ describe("LocalOperationStorage", () => {
             Name: "test-op",
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -426,6 +438,7 @@ describe("LocalOperationStorage", () => {
             Name: "test-op",
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -468,6 +481,7 @@ describe("LocalOperationStorage", () => {
             Type: OperationType.STEP,
             Name: "", // Empty string name
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -510,6 +524,7 @@ describe("LocalOperationStorage", () => {
             Name: "operation-at-index-0",
             Type: OperationType.STEP,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -519,6 +534,7 @@ describe("LocalOperationStorage", () => {
             Name: "operation-at-index-1",
             Type: OperationType.WAIT,
             Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
           },
           events: [],
         },
@@ -748,6 +764,7 @@ describe("LocalOperationStorage", () => {
             Id: "op4",
             Status: "STARTED",
             Type: "CALLBACK",
+            StartTimestamp: undefined,
           },
           events: [
             {
@@ -755,7 +772,7 @@ describe("LocalOperationStorage", () => {
               EventType: EventType.CallbackStarted,
             },
           ],
-        },
+        } satisfies OperationEvents,
       ]);
 
       storage.populateOperations(populatedOperations);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the tests have a lot of TypeScript errors since TS has not been running on the tests. This PR fixes all the errors and enables running `tsc` when running `npm test`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
