### PR TITLE
docs: add language sdk specification

### DIFF
--- a/LANGUAGE_SDK_SPECIFICATION.md
+++ b/LANGUAGE_SDK_SPECIFICATION.md
@@ -302,12 +302,13 @@ The SDK MUST:
 
 ```mermaid
 flowchart LR
-    New[Customer calls operation] --> START
-    START --> |Started| SUCCEED
+    STARTED[Execution starts] --> |Started| SUCCEED
     SUCCEED --> |Succeeded| Success[Completes successfully]
-    START --> |Started| FAIL
+    STARTED --> |Started| FAIL
     FAIL --> |Failed| Failure[Completes with error]
 ```
+
+Note: The EXECUTION operation is always in STARTED status when the handler begins. It does not have a START action.
 
 ### 4.4 STEP Operation
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Provide a language SDK specification for developers to build their own SDKs and establish conformance testing. This is just a first start to iterate on the SDK and provide builders guidance given the large interest in additional SDKs (Go, Rust, Java, Swift, .NET). The file should then be extracted into its own repository to create conformance tests for officially supported SDKs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
