### PR TITLE
fix(testing-sdk): use a better error message when error data is missing

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/result-formatter.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/result-formatter.ts
@@ -53,11 +53,7 @@ export class ResultFormatter<ResultType> {
         if (lambdaResponse.status !== ExecutionStatus.SUCCEEDED) {
           const errorFromResult = this.getErrorFromResult(lambdaResponse);
 
-          const error = new Error(
-            errorFromResult.errorMessage?.trim()
-              ? errorFromResult.errorMessage
-              : "Execution failed",
-          );
+          const error = new Error(errorFromResult.errorMessage?.trim());
 
           if (errorFromResult.stackTrace) {
             error.stack = errorFromResult.stackTrace.join("\n");
@@ -131,6 +127,11 @@ export class ResultFormatter<ResultType> {
       };
     }
 
-    throw new Error("Could not find error result");
+    return {
+      errorMessage: `Execution failed with status "${result.status}"`,
+      errorData: undefined,
+      errorType: undefined,
+      stackTrace: undefined,
+    };
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/361

*Description of changes:*

Currently, the testing SDK throws a generic `Could not find error result` If the execution times out (or fails) with no error message. This PR improves that by saying `Execution failed with status "TIMED_OUT"` in this case instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
