### PR TITLE
fix(sdk): remove termination cooldown

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/multiple-invocations/wait-for-callback-multiple-invocations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/multiple-invocations/wait-for-callback-multiple-invocations.test.ts
@@ -10,6 +10,9 @@ createTests({
   functionName: "wait-for-callback-multiple-invocations",
   handler,
   invocationType: InvocationType.Event,
+  localRunnerConfig: {
+    skipTime: false,
+  },
   tests: (runner) => {
     it("should handle multiple invocations tracking with waitForCallback operations", async () => {
       // Get operations for verification
@@ -41,11 +44,9 @@ createTests({
         invocationCount: "multiple",
       });
 
-      // Verify invocations were tracked - should be 4-5 invocations
-      // Due to update/termination timing, this execution may require 4-5 invocations to complete
+      // Verify invocations were tracked - should be exactly 5 invocations
       const invocations = result.getInvocations();
-      expect(invocations.length).toBeGreaterThanOrEqual(4);
-      expect(invocations.length).toBeLessThanOrEqual(5);
+      expect(invocations.length).toBe(5);
 
       // Verify operations were executed
       const operations = result.getOperations();

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -89,12 +89,9 @@ describe("LocalDurableTestRunner Integration", () => {
     // Verify that operations were tracked
     const operations = result.getOperations();
 
-    // Verify the invocations were tracked - should be exactly 2 invocations
-    // Centralized termination implements a cool-down period prior to termination.
-    // This cool-down phase reduces the total number of invocations needed while increasing
-    // the number of operations performed in each invocation.
+    // Verify the invocations were tracked - should be exactly 3 invocations
     const invocations = result.getInvocations();
-    expect(invocations).toHaveLength(2);
+    expect(invocations).toHaveLength(3);
 
     // We should have 3 operations in total
     expect(operations).toHaveLength(3);
@@ -229,8 +226,19 @@ describe("LocalDurableTestRunner Integration", () => {
         },
       },
       {
-        EventType: "ExecutionSucceeded",
+        EventType: "InvocationCompleted",
         EventId: 10,
+        EventTimestamp: expect.any(Date),
+        InvocationCompletedDetails: {
+          StartTimestamp: expect.any(Date),
+          EndTimestamp: expect.any(Date),
+          Error: {},
+          RequestId: expect.any(String),
+        },
+      },
+      {
+        EventType: "ExecutionSucceeded",
+        EventId: 11,
         Id: expect.any(String),
         EventTimestamp: expect.any(Date),
         ExecutionSucceededDetails: {

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -270,7 +270,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       );
 
       // Advance past cooldown
-      jest.advanceTimersByTime(50);
+      jest.advanceTimersByTime(0);
 
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
         reason: TerminationReason.WAIT_SCHEDULED,
@@ -290,8 +290,8 @@ describe("CheckpointManager - Centralized Termination", () => {
         },
       );
 
-      // Advance partway through cooldown
-      jest.advanceTimersByTime(25);
+      // No time advancement so the setTimeout will get cancelled from synchronous code
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
 
       // Start new operation
       checkpointManager.markOperationState(
@@ -306,10 +306,11 @@ describe("CheckpointManager - Centralized Termination", () => {
         },
       );
 
-      // Advance past original cooldown
-      jest.advanceTimersByTime(50);
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
 
-      // Should not have terminated
+      // Advance past original cooldown
+      jest.advanceTimersByTime(0);
+
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
     });
   });
@@ -340,7 +341,7 @@ describe("CheckpointManager - Centralized Termination", () => {
         },
       );
 
-      jest.advanceTimersByTime(200);
+      jest.advanceTimersByTime(0);
 
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
         reason: TerminationReason.RETRY_SCHEDULED,
@@ -372,7 +373,7 @@ describe("CheckpointManager - Centralized Termination", () => {
         },
       );
 
-      jest.advanceTimersByTime(200);
+      jest.advanceTimersByTime(0);
 
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
         reason: TerminationReason.WAIT_SCHEDULED,
@@ -392,7 +393,7 @@ describe("CheckpointManager - Centralized Termination", () => {
         },
       );
 
-      jest.advanceTimersByTime(200);
+      jest.advanceTimersByTime(0);
 
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
         reason: TerminationReason.CALLBACK_PENDING,
@@ -677,7 +678,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       (checkpointManager as any).checkAndTerminate();
 
       // Should not terminate
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(0);
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
     });
 
@@ -701,7 +702,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       (checkpointManager as any).checkAndTerminate();
 
       // Should not terminate
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(0);
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
     });
 
@@ -725,7 +726,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       (checkpointManager as any).checkAndTerminate();
 
       // Should not terminate
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(0);
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
     });
 
@@ -758,7 +759,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       (checkpointManager as any).checkAndTerminate();
 
       // Should not terminate
-      jest.advanceTimersByTime(300);
+      jest.advanceTimersByTime(0);
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -51,7 +51,6 @@ export class CheckpointManager implements Checkpoint {
   // Termination cooldown
   private terminationTimer: NodeJS.Timeout | null = null;
   private terminationReason: TerminationReason | null = null;
-  private readonly TERMINATION_COOLDOWN_MS = 50;
 
   constructor(
     private durableExecutionArn: string,
@@ -714,12 +713,12 @@ export class CheckpointManager implements Checkpoint {
     this.terminationReason = reason;
     log("⏱️", "Scheduling termination", {
       reason,
-      cooldownMs: this.TERMINATION_COOLDOWN_MS,
     });
 
+    // Schedule termination immediately once event loop is free.
     this.terminationTimer = setTimeout(() => {
       this.executeTermination(reason);
-    }, this.TERMINATION_COOLDOWN_MS);
+    }, 0);
   }
 
   private executeTermination(reason: TerminationReason): void {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing termination cooldown from language SDK. The termination cooldown increases the chance of `invoke` or `callback` updates triggered from the backend not getting registered. For example, if the termination is on cooldown with no further updates, it's possible the backend completes a callback or invoke and the language SDK terminates too early.

Removing the cooldown interval does not break any existing tests, since we are still scheduling it in a setTimeout, so it can still be cancelled by synchronous code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
