### PR TITLE
fix(testing-sdk): only return new data in checkpoint response

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/checkpoint-handlers.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/handlers/checkpoint-handlers.ts
@@ -105,7 +105,7 @@ export function processCheckpointDurableExecution(
     createCheckpointToken(input.CheckpointToken),
   );
 
-  validateCheckpointUpdates(updates, storage.operationDataMap);
+  validateCheckpointUpdates(updates, storage.getAllOperationData());
   storage.registerUpdates(updates);
 
   const output: CheckpointDurableExecutionResponse = {
@@ -115,10 +115,7 @@ export function processCheckpointDurableExecution(
       token: randomUUID(),
     }),
     NewExecutionState: {
-      // TODO: implement pagination
-      Operations: Array.from(storage.operationDataMap.values()).map(
-        (data) => data.operation,
-      ),
+      Operations: storage.getDirtyOperations(),
       NextMarker: undefined,
     },
   };

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-dirty.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-dirty.test.ts
@@ -1,0 +1,404 @@
+import { CheckpointManager } from "../checkpoint-manager";
+import {
+  createExecutionId,
+  createInvocationId,
+} from "../../utils/tagged-strings";
+import {
+  OperationUpdate,
+  OperationType,
+  OperationAction,
+  OperationStatus,
+} from "@aws-sdk/client-lambda";
+import { CompleteCallbackStatus } from "../callback-manager";
+
+// Mock crypto's randomUUID function
+jest.mock("node:crypto", () => ({
+  randomUUID: jest.fn().mockReturnValue("mocked-uuid"),
+}));
+
+describe("CheckpointManager dirty operation tracking", () => {
+  let storage: CheckpointManager;
+
+  beforeEach(() => {
+    storage = new CheckpointManager(createExecutionId("test-execution-id"));
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    storage.cleanup();
+  });
+
+  describe("dirty operation tracking", () => {
+    describe("getDirtyOperations", () => {
+      it("should return empty array when no operations are dirty", () => {
+        storage.initialize();
+
+        const dirtyOperations = storage.getDirtyOperations();
+
+        expect(dirtyOperations).toEqual([]);
+      });
+
+      it("should return dirty operations and clear the dirty set", () => {
+        storage.initialize();
+        const stepUpdate: OperationUpdate = {
+          Id: "dirty-step",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(stepUpdate);
+
+        const firstCall = storage.getDirtyOperations();
+        expect(firstCall).toHaveLength(1);
+        expect(firstCall[0].Id).toBe("dirty-step");
+
+        const secondCall = storage.getDirtyOperations();
+        expect(secondCall).toEqual([]);
+      });
+
+      it("should return multiple dirty operations in correct order", () => {
+        storage.initialize();
+        const updates: OperationUpdate[] = [
+          {
+            Id: "first-op",
+            Type: OperationType.STEP,
+            Action: OperationAction.START,
+          },
+          {
+            Id: "second-op",
+            Type: OperationType.WAIT,
+            Action: OperationAction.START,
+            WaitOptions: { WaitSeconds: 5 },
+          },
+          {
+            Id: "third-op",
+            Type: OperationType.STEP,
+            Action: OperationAction.SUCCEED,
+            Payload: "result",
+          },
+        ];
+        storage.registerUpdates(updates);
+
+        const dirtyOperations = storage.getDirtyOperations();
+
+        expect(dirtyOperations).toHaveLength(3);
+        expect(dirtyOperations.map((op) => op.Id)).toEqual([
+          "first-op",
+          "second-op",
+          "third-op",
+        ]);
+      });
+    });
+
+    describe("startInvocation clears dirty operations", () => {
+      it("should clear dirty operations when starting new invocation", () => {
+        storage.initialize();
+        const stepUpdate: OperationUpdate = {
+          Id: "pre-invocation-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(stepUpdate);
+
+        // Verify operation is dirty before invocation
+        const dirtyBefore = storage.getDirtyOperations();
+        expect(dirtyBefore).toHaveLength(1);
+
+        // Start new invocation should clear dirty set
+        const invocationId = createInvocationId("test-invocation");
+        storage.startInvocation(invocationId);
+
+        // Verify dirty set is cleared after invocation
+        const dirtyAfter = storage.getDirtyOperations();
+        expect(dirtyAfter).toEqual([]);
+      });
+
+      it("should return all operations from startInvocation", () => {
+        const initialOp = storage.initialize();
+        const stepUpdate: OperationUpdate = {
+          Id: "existing-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(stepUpdate);
+
+        const invocationId = createInvocationId("test-invocation");
+        const allOperations = storage.startInvocation(invocationId);
+
+        expect(allOperations).toHaveLength(2);
+        expect(allOperations.map((op) => op.operation.Id)).toContain(
+          initialOp.operation.Id,
+        );
+        expect(allOperations.map((op) => op.operation.Id)).toContain(
+          "existing-op",
+        );
+      });
+    });
+
+    describe("operations marked dirty through different paths", () => {
+      it("should mark operations dirty when registered through registerUpdate", () => {
+        storage.initialize();
+        const stepUpdate: OperationUpdate = {
+          Id: "register-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+
+        storage.registerUpdate(stepUpdate);
+
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(1);
+        expect(dirtyOperations[0].Id).toBe("register-op");
+      });
+
+      it("should mark operations dirty when registered through registerUpdates", () => {
+        storage.initialize();
+        const updates: OperationUpdate[] = [
+          {
+            Id: "batch-op-1",
+            Type: OperationType.STEP,
+            Action: OperationAction.START,
+          },
+          {
+            Id: "batch-op-2",
+            Type: OperationType.WAIT,
+            Action: OperationAction.START,
+            WaitOptions: { WaitSeconds: 3 },
+          },
+        ];
+
+        storage.registerUpdates(updates);
+
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(2);
+        expect(dirtyOperations.map((op) => op.Id)).toEqual([
+          "batch-op-1",
+          "batch-op-2",
+        ]);
+      });
+
+      it("should mark operations dirty when completed through completeCallback", () => {
+        storage.initialize();
+        const callbackUpdate: OperationUpdate = {
+          Id: "callback-to-complete",
+          Type: OperationType.CALLBACK,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(callbackUpdate);
+
+        // Clear the dirty set from registration
+        storage.getDirtyOperations();
+
+        // Create a realistic callback ID that can be decoded
+        const mockCallbackId = Buffer.from(
+          JSON.stringify({
+            executionId: "test-execution-id",
+            operationId: "callback-to-complete",
+            token: "test-token",
+          }),
+        ).toString("base64");
+
+        const callbackDetails = {
+          CallbackId: mockCallbackId,
+          Result: "callback-result",
+        };
+
+        storage.completeCallback(
+          callbackDetails,
+          CompleteCallbackStatus.SUCCEEDED,
+        );
+
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(1);
+        expect(dirtyOperations[0].Id).toBe("callback-to-complete");
+        expect(dirtyOperations[0].Status).toBe(OperationStatus.SUCCEEDED);
+      });
+
+      it("should mark operations dirty when updated through updateOperation", () => {
+        storage.initialize();
+        const waitUpdate: OperationUpdate = {
+          Id: "wait-to-update",
+          Type: OperationType.WAIT,
+          Action: OperationAction.START,
+          WaitOptions: { WaitSeconds: 10 },
+        };
+        storage.registerUpdate(waitUpdate);
+
+        // Clear the dirty set from registration
+        storage.getDirtyOperations();
+
+        // Update the operation
+        storage.updateOperation(
+          "wait-to-update",
+          { Status: OperationStatus.SUCCEEDED },
+          undefined,
+          undefined,
+        );
+
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(1);
+        expect(dirtyOperations[0].Id).toBe("wait-to-update");
+        expect(dirtyOperations[0].Status).toBe(OperationStatus.SUCCEEDED);
+      });
+    });
+
+    describe("sequential checkpoint calls behavior", () => {
+      it("should return only new operations in subsequent calls", () => {
+        storage.initialize();
+
+        // First batch of operations
+        const firstUpdates: OperationUpdate[] = [
+          {
+            Id: "first-batch-1",
+            Type: OperationType.STEP,
+            Action: OperationAction.START,
+          },
+          {
+            Id: "first-batch-2",
+            Type: OperationType.STEP,
+            Action: OperationAction.START,
+          },
+        ];
+        storage.registerUpdates(firstUpdates);
+
+        // First checkpoint call
+        const firstCheckpoint = storage.getDirtyOperations();
+        expect(firstCheckpoint).toHaveLength(2);
+        expect(firstCheckpoint.map((op) => op.Id)).toEqual([
+          "first-batch-1",
+          "first-batch-2",
+        ]);
+
+        // Second batch of operations
+        const secondUpdates: OperationUpdate[] = [
+          {
+            Id: "second-batch-1",
+            Type: OperationType.WAIT,
+            Action: OperationAction.START,
+            WaitOptions: { WaitSeconds: 5 },
+          },
+        ];
+        storage.registerUpdates(secondUpdates);
+
+        // Second checkpoint call should only return new operations
+        const secondCheckpoint = storage.getDirtyOperations();
+        expect(secondCheckpoint).toHaveLength(1);
+        expect(secondCheckpoint[0].Id).toBe("second-batch-1");
+      });
+
+      it("should return empty array when no new operations since last checkpoint", () => {
+        storage.initialize();
+
+        const stepUpdate: OperationUpdate = {
+          Id: "single-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(stepUpdate);
+
+        // First checkpoint call
+        const firstCheckpoint = storage.getDirtyOperations();
+        expect(firstCheckpoint).toHaveLength(1);
+
+        // Second checkpoint call with no new operations
+        const secondCheckpoint = storage.getDirtyOperations();
+        expect(secondCheckpoint).toEqual([]);
+
+        // Third checkpoint call should still be empty
+        const thirdCheckpoint = storage.getDirtyOperations();
+        expect(thirdCheckpoint).toEqual([]);
+      });
+
+      it("should handle mixed operation sources in sequential calls", () => {
+        storage.initialize();
+
+        // First: register operation
+        storage.registerUpdate({
+          Id: "registered-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        });
+
+        const firstCheckpoint = storage.getDirtyOperations();
+        expect(firstCheckpoint).toHaveLength(1);
+        expect(firstCheckpoint[0].Id).toBe("registered-op");
+
+        // Second: update existing operation
+        storage.updateOperation(
+          "registered-op",
+          { Status: OperationStatus.SUCCEEDED },
+          "final-result",
+          undefined,
+        );
+
+        const secondCheckpoint = storage.getDirtyOperations();
+        expect(secondCheckpoint).toHaveLength(1);
+        expect(secondCheckpoint[0].Id).toBe("registered-op");
+        expect(secondCheckpoint[0].Status).toBe(OperationStatus.SUCCEEDED);
+
+        // Third: add new callback operation
+        storage.registerUpdate({
+          Id: "callback-op",
+          Type: OperationType.CALLBACK,
+          Action: OperationAction.START,
+        });
+
+        const thirdCheckpoint = storage.getDirtyOperations();
+        expect(thirdCheckpoint).toHaveLength(1);
+        expect(thirdCheckpoint[0].Id).toBe("callback-op");
+      });
+    });
+
+    describe("edge cases and error handling", () => {
+      it("should handle operations modified multiple times between checkpoints", () => {
+        storage.initialize();
+
+        // Register operation
+        storage.registerUpdate({
+          Id: "multi-modified",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        });
+
+        // Update same operation multiple times
+        storage.updateOperation(
+          "multi-modified",
+          { Status: OperationStatus.PENDING },
+          undefined,
+          undefined,
+        );
+        storage.updateOperation(
+          "multi-modified",
+          { Status: OperationStatus.SUCCEEDED },
+          "result",
+          undefined,
+        );
+
+        // Should only appear once in dirty operations
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(1);
+        expect(dirtyOperations[0].Id).toBe("multi-modified");
+        expect(dirtyOperations[0].Status).toBe(OperationStatus.SUCCEEDED);
+      });
+
+      it("should maintain dirty operations across getPendingCheckpointUpdates calls", async () => {
+        storage.initialize();
+
+        const stepUpdate: OperationUpdate = {
+          Id: "pending-op",
+          Type: OperationType.STEP,
+          Action: OperationAction.START,
+        };
+        storage.registerUpdate(stepUpdate);
+
+        // getPendingCheckpointUpdates should not affect dirty operations
+        const pendingUpdates = await storage.getPendingCheckpointUpdates();
+        expect(pendingUpdates).toHaveLength(1);
+
+        // getDirtyOperations should still return the operation
+        const dirtyOperations = storage.getDirtyOperations();
+        expect(dirtyOperations).toHaveLength(1);
+        expect(dirtyOperations[0].Id).toBe("pending-op");
+      });
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-register.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-register.test.ts
@@ -52,7 +52,7 @@ describe("checkpoint-manager registerUpdate", () => {
     expect(result.operation.StartTimestamp).toBeInstanceOf(Date);
     expect(result.operation.StepDetails).toBeUndefined();
 
-    expect(storage.operationDataMap.get("step-id")).toBe(result);
+    expect(storage.getOperationData("step-id")).toStrictEqual(result);
   });
 
   it("should create and register a new CONTEXT operation", () => {
@@ -77,7 +77,7 @@ describe("checkpoint-manager registerUpdate", () => {
     expect(result.operation.StepDetails).toBeUndefined();
     expect(result.operation.ContextDetails?.ReplayChildren).toBe(true);
 
-    expect(storage.operationDataMap.get("CONTEXT-id")).toBe(result);
+    expect(storage.getOperationData("CONTEXT-id")).toStrictEqual(result);
   });
 
   it("should update operation with new step details", () => {
@@ -190,7 +190,7 @@ describe("checkpoint-manager registerUpdate", () => {
     // Try to register it again
     const secondResult = storage.registerUpdate(waitUpdate);
 
-    expect(secondResult).toBe(firstResult);
+    expect(secondResult).toStrictEqual(firstResult);
   });
 
   it("should add operation to pending updates", async () => {
@@ -239,7 +239,7 @@ describe("checkpoint-manager registerUpdate", () => {
       });
       expect(result.operation.EndTimestamp).toBeInstanceOf(Date);
 
-      expect(storage.operationDataMap.get("step-id")).toBe(result);
+      expect(storage.getOperationData("step-id")).toStrictEqual(result);
     },
   );
 
@@ -282,7 +282,7 @@ describe("checkpoint-manager registerUpdate", () => {
       );
 
       // Verify operation is stored correctly
-      expect(storage.operationDataMap.get("retry-step-id")).toBe(result);
+      expect(storage.getOperationData("retry-step-id")).toStrictEqual(result);
     });
 
     it("should not process retry for START action during registration", () => {
@@ -469,8 +469,8 @@ describe("checkpoint-manager registerUpdate", () => {
       expect(() => storage.registerUpdates(updates)).toThrow(
         "Invalid checkpoint token",
       );
-      expect(storage.operationDataMap.has("step-1")).toBe(false);
-      expect(storage.operationDataMap.has("step-2")).toBe(false);
+      expect(storage.getOperationData("step-1")).toBeUndefined();
+      expect(storage.getOperationData("step-2")).toBeUndefined();
     });
 
     it("should not affect execution completion when updating non-execution operations", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-update.test.ts
@@ -759,10 +759,10 @@ describe("checkpoint-manager updateOperation", () => {
     );
 
     // And the stored operation should be the same as returned
-    const storedOperation = storage.operationDataMap.get(
+    const storedOperation = storage.getOperationData(
       initialOperation.operation.Id,
     );
-    expect(storedOperation).toBe(result);
+    expect(storedOperation).toStrictEqual(result);
     expect(storedOperation?.operation.Status).toBe(OperationStatus.SUCCEEDED);
     expect(storedOperation?.operation.EndTimestamp).toEqual(
       newOperationData.EndTimestamp,
@@ -787,7 +787,7 @@ describe("checkpoint-manager updateOperation", () => {
       undefined,
     );
 
-    const storedOperation = storage.operationDataMap.get(
+    const storedOperation = storage.getOperationData(
       initialOperation.operation.Id,
     );
     expect(storedOperation?.operation.Type).toBe(originalType);
@@ -828,8 +828,8 @@ describe("checkpoint-manager updateOperation", () => {
     expect(result.operation.Status).toBe(OperationStatus.SUCCEEDED); // Updated
 
     // Check stored operation is the same as returned
-    const storedOperation = storage.operationDataMap.get("step-to-update");
-    expect(storedOperation).toBe(result);
+    const storedOperation = storage.getOperationData("step-to-update");
+    expect(storedOperation).toStrictEqual(result);
     expect(storedOperation?.operation.Status).toBe(OperationStatus.SUCCEEDED);
     expect(storedOperation?.operation.Name).toBe("test-step"); // Preserved
     expect(storedOperation?.operation.Type).toBe(OperationType.STEP); // Preserved
@@ -888,8 +888,8 @@ describe("checkpoint-manager updateOperation", () => {
     expect(result.operation.EndTimestamp).toEqual(updateData.EndTimestamp);
 
     // Stored operation should be the same as returned
-    const storedOperation = storage.operationDataMap.get("complex-op");
-    expect(storedOperation).toBe(result);
+    const storedOperation = storage.getOperationData("complex-op");
+    expect(storedOperation).toStrictEqual(result);
     expect(storedOperation?.operation.Status).toBe(OperationStatus.SUCCEEDED);
     expect(storedOperation?.operation.StepDetails).toEqual({
       Result: "final-result",
@@ -916,7 +916,7 @@ describe("checkpoint-manager updateOperation", () => {
       undefined,
     );
 
-    const storedOperation = storage.operationDataMap.get(
+    const storedOperation = storage.getOperationData(
       initialOperation.operation.Id,
     );
     expect(storedOperation?.operation.Status).toBe(OperationStatus.SUCCEEDED);

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/callback-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/callback-manager.ts
@@ -141,8 +141,7 @@ export class CallbackManager {
     const callbackId = createCallbackId(callbackDetails.CallbackId);
     const { operationId } = decodeCallbackId(callbackId);
 
-    const operationData =
-      this.checkpointManager.operationDataMap.get(operationId);
+    const operationData = this.checkpointManager.getOperationData(operationId);
     if (!operationData) {
       throw new InvalidParameterValueException({
         message: "Could not find operation",
@@ -172,7 +171,6 @@ export class CallbackManager {
       ],
     };
 
-    this.checkpointManager.operationDataMap.set(operationId, copied);
     this.callbackIdMap.delete(callbackId);
 
     // Clear timeout timers
@@ -192,8 +190,7 @@ export class CallbackManager {
    */
   heartbeatCallback(callbackId: CallbackId): void {
     const { operationId } = decodeCallbackId(callbackId);
-    const operationData =
-      this.checkpointManager.operationDataMap.get(operationId);
+    const operationData = this.checkpointManager.getOperationData(operationId);
 
     if (!operationData) {
       throw new Error("Could not find operation");

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/execution-manager.ts
@@ -83,7 +83,9 @@ export class ExecutionManager {
       );
     }
 
-    checkpointStorage.startInvocation(params.invocationId);
+    const operationEvents = checkpointStorage.startInvocation(
+      params.invocationId,
+    );
 
     const checkpointToken = encodeCheckpointToken({
       executionId: params.executionId,
@@ -95,7 +97,7 @@ export class ExecutionManager {
       checkpointToken,
       executionId: params.executionId,
       invocationId: params.invocationId,
-      operationEvents: Array.from(checkpointStorage.operationDataMap.values()),
+      operationEvents,
     };
   }
 

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/checkpoint-durable-execution-input-validator.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/validators/checkpoint-durable-execution-input-validator.ts
@@ -26,7 +26,7 @@ const MAX_ERROR_PAYLOAD_SIZE_BYTES = 32768; // 32KB
  */
 export function validateCheckpointUpdates(
   updates: OperationUpdate[] | undefined,
-  checkpointOperations: Map<string, OperationEvents>,
+  checkpointOperations: ReadonlyMap<string, OperationEvents>,
 ): void {
   if (!updates?.length) {
     return;
@@ -79,7 +79,7 @@ function validateConflictingExecutionUpdate(updates: OperationUpdate[]): void {
  */
 function validateOperationUpdate(
   operationUpdate: OperationUpdate,
-  checkpointOperations: Map<string, OperationEvents>,
+  checkpointOperations: ReadonlyMap<string, OperationEvents>,
 ): void {
   // Validates that the operation payload sizes are not too large
   validatePayloadSizes(operationUpdate);
@@ -129,7 +129,7 @@ function validatePayloadSizes(operationUpdate: OperationUpdate): void {
  */
 function validateParentIdAndDuplicateId(
   operationUpdates: OperationUpdate[],
-  checkpointOperations: Map<string, OperationEvents>,
+  checkpointOperations: ReadonlyMap<string, OperationEvents>,
 ): void {
   const operationsStarted = new Map<string, OperationUpdate>();
   const lastUpdatesSeen = new Map<string, OperationUpdate>();
@@ -207,7 +207,7 @@ function isInvalidDuplicateUpdate(
  * @returns true if parent is valid or no parent is specified, false otherwise
  */
 function isValidParentForUpdate(
-  checkpointOperations: Map<string, OperationEvents>,
+  checkpointOperations: ReadonlyMap<string, OperationEvents>,
   operationUpdate: OperationUpdate,
   operationsStarted: Map<string, OperationUpdate>,
 ): boolean {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/384

*Description of changes:*

Currently the testing library local runner checkpoint API returns the entire operation list on each checkpoint, instead of only what changed since the last checkpoint call. Although this typically works correctly, this is not correct behaviour, and can make it harder to debug issues.

This logic is also necessary to ensure that we re-invoke when there is stale data on the language SDK side compared to the backend (i.e. checkpoint data that has not reached the client yet).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
