### PR TITLE
fix(sdk): handle empty items in map/parallel

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.history.json
@@ -1,0 +1,89 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "5d2291db-f359-4b1c-8ef2-b144a192b751",
+    "EventTimestamp": "2025-12-19T23:26:24.653Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "empty-map",
+    "EventTimestamp": "2025-12-19T23:26:24.659Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 3,
+    "Id": "c4ca4238a0b92382",
+    "Name": "empty-map",
+    "EventTimestamp": "2025-12-19T23:26:24.659Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 4,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2025-12-19T23:26:24.661Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2025-12-19T23:26:25.661Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 5,
+    "EventTimestamp": "2025-12-19T23:26:24.713Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2025-12-19T23:26:24.653Z",
+      "EndTimestamp": "2025-12-19T23:26:24.713Z",
+      "Error": {},
+      "RequestId": "5711d3b6-2f02-4175-9791-8f98ff53e4f7"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2025-12-19T23:26:25.660Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2025-12-19T23:26:25.663Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2025-12-19T23:26:25.661Z",
+      "EndTimestamp": "2025-12-19T23:26:25.663Z",
+      "Error": {},
+      "RequestId": "fbb3da82-3269-4ad1-8fad-00be9a118a11"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 8,
+    "Id": "5d2291db-f359-4b1c-8ef2-b144a192b751",
+    "EventTimestamp": "2025-12-19T23:26:25.663Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"results\":[],\"errors\":[],\"successCount\":0,\"failureCount\":0,\"totalCount\":0,\"status\":\"SUCCEEDED\",\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.test.ts
@@ -1,0 +1,28 @@
+import { handler } from "./map-empty";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should execute successfully with empty map array and expected result structure", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult() as any;
+
+      expect(result).toBeDefined();
+      expect(result.results).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.successCount).toBe(0);
+      expect(result.failureCount).toBe(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.status).toBe("SUCCEEDED");
+      expect(result.completionReason).toBe("ALL_COMPLETED");
+
+      // Verify the map operation exists but has no child operations
+      const emptyMap = runner.getOperation("empty-map");
+      expect(emptyMap.getChildOperations()).toHaveLength(0);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/empty/map-empty.ts
@@ -1,0 +1,25 @@
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Empty Map",
+  description: "Running map with an empty array of items",
+};
+
+export const handler = withDurableExecution(async (event, context) => {
+  const result = await context.map("empty-map", [], (mapContext, item) => {
+    return item;
+  });
+
+  await context.wait({ seconds: 1 });
+
+  return {
+    results: result.getResults(),
+    errors: result.getErrors(),
+    successCount: result.successCount,
+    failureCount: result.failureCount,
+    totalCount: result.totalCount,
+    status: result.status,
+    completionReason: result.completionReason,
+  };
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.history.json
@@ -1,0 +1,89 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "c7a78a8b-d203-4f2e-a702-efb0585ee131",
+    "EventTimestamp": "2025-12-19T23:26:31.718Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Parallel",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "empty-parallel",
+    "EventTimestamp": "2025-12-19T23:26:31.725Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Parallel",
+    "EventId": 3,
+    "Id": "c4ca4238a0b92382",
+    "Name": "empty-parallel",
+    "EventTimestamp": "2025-12-19T23:26:31.725Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 4,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2025-12-19T23:26:31.728Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2025-12-19T23:26:32.728Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 5,
+    "EventTimestamp": "2025-12-19T23:26:31.779Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2025-12-19T23:26:31.718Z",
+      "EndTimestamp": "2025-12-19T23:26:31.779Z",
+      "Error": {},
+      "RequestId": "c81908f2-5367-45d3-9266-7d4d15272780"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2025-12-19T23:26:32.730Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2025-12-19T23:26:32.732Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2025-12-19T23:26:32.731Z",
+      "EndTimestamp": "2025-12-19T23:26:32.732Z",
+      "Error": {},
+      "RequestId": "fbdbe427-9edc-4769-8a74-3b907d28a442"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 8,
+    "Id": "c7a78a8b-d203-4f2e-a702-efb0585ee131",
+    "EventTimestamp": "2025-12-19T23:26:32.732Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"results\":[],\"errors\":[],\"successCount\":0,\"failureCount\":0,\"totalCount\":0,\"status\":\"SUCCEEDED\",\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.test.ts
@@ -1,0 +1,28 @@
+import { handler } from "./parallel-empty";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should execute successfully with empty parallel array and expected result structure", async () => {
+      const execution = await runner.run();
+
+      const result = execution.getResult() as any;
+
+      expect(result).toBeDefined();
+      expect(result.results).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.successCount).toBe(0);
+      expect(result.failureCount).toBe(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.status).toBe("SUCCEEDED");
+      expect(result.completionReason).toBe("ALL_COMPLETED");
+
+      // Verify the parallel operation exists but has no child operations
+      const parallelOp = runner.getOperation("empty-parallel");
+      expect(parallelOp.getChildOperations()).toHaveLength(0);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/empty/parallel-empty.ts
@@ -1,0 +1,28 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Empty Parallel",
+  description: "Running parallel with an empty array of operations",
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.parallel("empty-parallel", []);
+
+    await context.wait({ seconds: 1 });
+
+    return {
+      results: result.getResults(),
+      errors: result.getErrors(),
+      successCount: result.successCount,
+      failureCount: result.failureCount,
+      totalCount: result.totalCount,
+      status: result.status,
+      completionReason: result.completionReason,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -461,7 +461,12 @@ export class ConcurrencyController<Logger extends DurableLogger> {
         }
       };
 
-      tryStartNext();
+      if (items.length === 0) {
+        log("🎉", `${this.operationName} completed with no items`);
+        resolve(new BatchResultImpl([], getCompletionReason(0)));
+      } else {
+        tryStartNext();
+      }
     });
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

Closes https://github.com/aws/aws-durable-execution-sdk-js/issues/399

*Description of changes:*

The SDK does not properly handle map/parallel with an empty list. It will just wait forever waiting for the next item.

Adding logic to resolve immediately when the lists are empty, and adding integ/unit tests for this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
