### PR TITLE
chore(sdk): Removes unnecessary throw statements

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -268,15 +268,12 @@ async function runHandler<
  * Validates that the event is a proper durable execution input
  */
 function validateDurableExecutionEvent(event: unknown): void {
-  try {
-    const eventObj = event as Record<string, unknown>;
-    if (!eventObj?.DurableExecutionArn || !eventObj?.CheckpointToken) {
-      throw new Error("Missing required durable execution fields");
-    }
-  } catch {
-    const msg = `Unexpected payload provided to start the durable execution. 
-Check your resource configurations to confirm the durability is set.`;
-    throw new Error(msg);
+  const eventObj = event as Record<string, unknown>;
+  if (!eventObj?.DurableExecutionArn || !eventObj?.CheckpointToken) {
+    throw new Error(
+      "Unexpected payload provided to start the durable execution.\n" +
+        "Check your resource configurations to confirm the durability is set.",
+    );
   }
 }
 
@@ -368,19 +365,13 @@ export const withDurableExecution = <
     validateDurableExecutionEvent(event);
     const { executionContext, durableExecutionMode, checkpointToken } =
       await initializeExecutionContext(event, context, config?.client);
-    let response: DurableExecutionInvocationOutput | null = null;
-    try {
-      response = await runHandler(
-        event,
-        context,
-        executionContext,
-        durableExecutionMode,
-        checkpointToken,
-        handler,
-      );
-      return response;
-    } catch (err) {
-      throw err;
-    }
+    return runHandler(
+      event,
+      context,
+      executionContext,
+      durableExecutionMode,
+      checkpointToken,
+      handler,
+    );
   };
 };


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/discussions/411

*Description of changes:*

Removes unnecessary exception handling patterns in `with-durable-execution.ts`:


## 1. Simplified `validateDurableExecutionEvent`

  The previous implementation threw an error inside a try block and immediately caught all exceptions to replace with a different message:

  ```typescript
  function validateDurableExecutionEvent(event: unknown): void {
    try {
      const eventObj = event as Record<string, unknown>;
      if (!eventObj?.DurableExecutionArn || !eventObj?.CheckpointToken) {
        throw new Error("Missing required durable execution fields");
      }
    } catch {
      const msg = `Unexpected payload provided to start the durable execution...`;
      throw new Error(msg);
    }
  }
```

This was problematic because:

- The specific validation error message was never visible to callers
- Type assertions don't throw at runtime and optional chaining prevents most errors
- The `try/catch` was effectively redundant

Now simplified to directly throw the user-facing error without the wrapper.

## 2. Removed redundant catch block in `withDurableExecution`

The function contained a catch block that simply re-threw the error:

```ts
  try {
    response = await runHandler(...);
    return response;
  } catch (err) {
    throw err;
  }
```

This serves no purpose: errors propagate naturally without it. Replaced with a direct return of `runHandler()`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.