### PR TITLE
feat(testing-sdk) add `getByCallbackId` support for operations

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -75,6 +75,56 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  ConcurrentCallbackSubmitter:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ConcurrentCallbackwithSubmitter-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: concurrent-callback-submitter.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  ConcurrentCallbackWait:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ConcurrentCallbackWait-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: concurrent-callback-wait.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   ConcurrentOperations:
     Type: AWS::Serverless::Function
     Properties:
@@ -725,6 +775,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  MapEmpty:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: EmptyMap-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: map-empty.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   MapFailureThresholdExceededCount:
     Type: AWS::Serverless::Function
     Properties:
@@ -998,6 +1073,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  ParallelEmpty:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: EmptyParallel-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: parallel-empty.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   ParallelFailureThresholdExceededCount:
     Type: AWS::Serverless::Function
     Properties:
@@ -1126,7 +1226,7 @@ Resources:
   MinSuccessfulWithPassingThreshold:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: ParallelminSuccessful-22x-NodeJS-Local
+      FunctionName: ParallelminSuccessfulwithPassingThreshold-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: min-successful-with-passing-threshold.handler
       Runtime: nodejs22.x
@@ -1354,6 +1454,31 @@ Resources:
       FunctionName: PromiseRace-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: promise-race.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  PromiseRaceWait:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: PromiseRaceWithWait-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: promise-race-wait.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64
@@ -2029,6 +2154,31 @@ Resources:
       FunctionName: WaitforCallback-NestedContexts-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: wait-for-callback-nested.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  WaitForCallbackQuickCompletion:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WaitforCallback-QuickCompletion-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: wait-for-callback-quick-completion.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/__tests__/cloud-durable-test-runner.test.ts
@@ -395,6 +395,41 @@ describe("CloudDurableTestRunner", () => {
       expect(operation.getOperationData()?.Id).toBe("op-123");
     });
 
+    it("should retrieve operation by callback ID", async () => {
+      const callbackEvent: Event = {
+        EventTimestamp: new Date(),
+        EventType: EventType.CallbackStarted,
+        EventId: 1,
+        Id: "callback-op-123",
+        CallbackStartedDetails: {
+          CallbackId: "callback-abc-123",
+        },
+      };
+
+      setupMockApiResponses(mockSend, {
+        historyResponse: {
+          Events: [callbackEvent, mockSuccessEvent],
+          $metadata: {},
+        },
+      });
+
+      const runner = new CloudDurableTestRunner<{ success: boolean }>({
+        functionName: mockFunctionArn,
+      });
+
+      const operation = runner.getOperationByCallbackId("callback-abc-123");
+
+      const runPromise = runner.run();
+      await jest.advanceTimersByTimeAsync(1000);
+      await runPromise;
+
+      expect(operation).toBeDefined();
+      expect(operation.getOperationData()?.Id).toBe("callback-op-123");
+      expect(operation.getCallbackDetails()?.callbackId).toBe(
+        "callback-abc-123",
+      );
+    });
+
     it("should handle multiple operation retrievals", async () => {
       const stepEvent1: Event = {
         EventTimestamp: new Date(),

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/cloud-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/cloud/cloud-durable-test-runner.ts
@@ -344,6 +344,45 @@ export class CloudDurableTestRunner<
   }
 
   /**
+   * Gets an operation by its callback identifier.
+   *
+   * This method is useful when you have a callback ID but don't know the operation
+   * name or index. It searches through all operations to find the one with the
+   * matching callback ID.
+   *
+   * @typeParam TOperationResult - The expected result type of the operation
+   * @param callbackId - The unique callback identifier
+   * @returns An operation instance for the operation with the specified callback ID
+   *
+   * @example
+   * ```typescript
+   * // Get operation by callback ID and send success
+   * const operation = runner.getOperationByCallbackId('callback-123');
+   * await operation.waitForData();
+   * await operation.sendCallbackSuccess('result');
+   * ```
+   */
+  getOperationByCallbackId<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TOperationResult = any,
+  >(callbackId: string): DurableOperation<TOperationResult> {
+    const operation = new CloudOperation<TOperationResult>(
+      this.waitManager,
+      this.indexedOperations,
+      this.apiClient,
+      this.config.invocationType,
+      this.indexedOperations.getByCallbackId(callbackId),
+    );
+    this.operationStorage.registerOperation({
+      operation,
+      params: {
+        callbackId,
+      },
+    });
+    return operation;
+  }
+
+  /**
    * Resets the test runner state, clearing all cached operations and history.
    *
    * This method should be called between test runs to ensure a clean state.

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/__tests__/indexed-operations.test.ts
@@ -1318,4 +1318,190 @@ describe("IndexedOperations", () => {
       });
     });
   });
+
+  describe("getByCallbackId", () => {
+    it("should retrieve operation by callback ID", () => {
+      const operationWithCallback: OperationEvents = {
+        operation: {
+          Id: "op1",
+          Name: "callback-operation",
+          Type: OperationType.CALLBACK,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+          CallbackDetails: {
+            CallbackId: "callback-123",
+          },
+        },
+        events: [],
+      };
+
+      const indexed = new IndexedOperations([operationWithCallback]);
+      const operation = indexed.getByCallbackId("callback-123");
+
+      expect(operation).toBeDefined();
+      expect(operation?.operation.Id).toBe("op1");
+      expect(operation?.operation.CallbackDetails?.CallbackId).toBe(
+        "callback-123",
+      );
+    });
+
+    it("should return undefined for non-existent callback ID", () => {
+      const indexed = new IndexedOperations(sampleOperations);
+      const operation = indexed.getByCallbackId("non-existent-callback");
+
+      expect(operation).toBeUndefined();
+    });
+
+    it("should find callback in child operations of WAIT_FOR_CALLBACK context", () => {
+      const contextOperation: OperationEvents = {
+        operation: {
+          Id: "context-1",
+          Name: "wait-for-callback-op",
+          Type: OperationType.CONTEXT,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+        },
+        events: [],
+      };
+
+      const callbackOperation: OperationEvents = {
+        operation: {
+          Id: "callback-1",
+          Name: "callback",
+          Type: OperationType.CALLBACK,
+          ParentId: "context-1",
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+          CallbackDetails: {
+            CallbackId: "child-callback-456",
+          },
+        },
+        events: [],
+      };
+
+      const indexed = new IndexedOperations([
+        contextOperation,
+        callbackOperation,
+      ]);
+      const operation = indexed.getByCallbackId("child-callback-456");
+
+      expect(operation).toBeDefined();
+      expect(operation?.operation.Id).toBe("callback-1");
+      expect(operation?.operation.ParentId).toBe("context-1");
+    });
+
+    it("should prioritize direct callback match over child callbacks", () => {
+      const parentWithCallback: OperationEvents = {
+        operation: {
+          Id: "parent-1",
+          Name: "parent-callback",
+          Type: OperationType.CALLBACK,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+          CallbackDetails: {
+            CallbackId: "same-callback-id",
+          },
+        },
+        events: [],
+      };
+
+      const childWithCallback: OperationEvents = {
+        operation: {
+          Id: "child-1",
+          Name: "child-callback",
+          Type: OperationType.CALLBACK,
+          ParentId: "parent-1",
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+          CallbackDetails: {
+            CallbackId: "same-callback-id",
+          },
+        },
+        events: [],
+      };
+
+      const indexed = new IndexedOperations([
+        parentWithCallback,
+        childWithCallback,
+      ]);
+      const operation = indexed.getByCallbackId("same-callback-id");
+
+      // Should return the first match (parent in this case)
+      expect(operation).toBeDefined();
+      expect(operation?.operation.Id).toBe("parent-1");
+    });
+
+    it("should handle operations without CallbackDetails", () => {
+      const indexed = new IndexedOperations(sampleOperations);
+      const operation = indexed.getByCallbackId("any-callback-id");
+
+      expect(operation).toBeUndefined();
+    });
+
+    it("should handle empty callback ID", () => {
+      const operationWithEmptyCallback: OperationEvents = {
+        operation: {
+          Id: "op1",
+          Name: "callback-operation",
+          Type: OperationType.CALLBACK,
+          Status: OperationStatus.SUCCEEDED,
+          StartTimestamp: undefined,
+          CallbackDetails: {
+            CallbackId: "",
+          },
+        },
+        events: [],
+      };
+
+      const indexed = new IndexedOperations([operationWithEmptyCallback]);
+      const operation = indexed.getByCallbackId("");
+
+      expect(operation).toBeDefined();
+      expect(operation?.operation.Id).toBe("op1");
+    });
+
+    it("should find callback among multiple operations", () => {
+      const operations: OperationEvents[] = [
+        {
+          operation: {
+            Id: "step-1",
+            Name: "regular-step",
+            Type: OperationType.STEP,
+            Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
+          },
+          events: [],
+        },
+        {
+          operation: {
+            Id: "callback-1",
+            Name: "callback-op",
+            Type: OperationType.CALLBACK,
+            Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
+            CallbackDetails: {
+              CallbackId: "target-callback",
+            },
+          },
+          events: [],
+        },
+        {
+          operation: {
+            Id: "wait-1",
+            Name: "wait-op",
+            Type: OperationType.WAIT,
+            Status: OperationStatus.SUCCEEDED,
+            StartTimestamp: undefined,
+          },
+          events: [],
+        },
+      ];
+
+      const indexed = new IndexedOperations(operations);
+      const operation = indexed.getByCallbackId("target-callback");
+
+      expect(operation).toBeDefined();
+      expect(operation?.operation.Id).toBe("callback-1");
+    });
+  });
 });

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/indexed-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/indexed-operations.ts
@@ -125,4 +125,27 @@ export class IndexedOperations {
     const operations = this.operationsByName.get(name);
     return operations ? Array.from(operations.values()).at(index) : undefined;
   }
+
+  /**
+   * Get an operation by its callback ID
+   * @param callbackId - The callback ID to search for
+   * @returns The operation with a matching callback ID, or undefined if not found
+   */
+  getByCallbackId(callbackId: string): OperationEvents | undefined {
+    for (const operation of this.operationsById.values()) {
+      const callbackDetails = operation.operation.CallbackDetails;
+      if (callbackDetails?.CallbackId === callbackId) {
+        return operation;
+      }
+
+      // Check child operations for WAIT_FOR_CALLBACK contexts
+      const children = this.getOperationChildren(operation.operation.Id ?? "");
+      for (const child of children) {
+        if (child.operation.CallbackDetails?.CallbackId === callbackId) {
+          return child;
+        }
+      }
+    }
+    return undefined;
+  }
 }

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operation-storage.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/common/operation-storage.ts
@@ -13,6 +13,7 @@ export interface TrackedOperation<Operation extends OperationWithData> {
     id?: string;
     index?: number;
     name?: string;
+    callbackId?: string;
   };
 }
 
@@ -33,6 +34,12 @@ export class OperationStorage {
       () =>
         trackedOperation.params.id !== undefined
           ? this.indexedOperations.getById(trackedOperation.params.id)
+          : null,
+      () =>
+        trackedOperation.params.callbackId !== undefined
+          ? this.indexedOperations.getByCallbackId(
+              trackedOperation.params.callbackId,
+            )
           : null,
       () =>
         trackedOperation.params.name !== undefined &&

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/local-durable-test-runner.test.ts
@@ -321,6 +321,22 @@ describe("LocalDurableTestRunner", () => {
         },
       });
     });
+
+    it("should create and register operation by callback ID", () => {
+      const runner = new LocalDurableTestRunner<{ success: boolean }>({
+        handlerFunction: mockHandlerFunction,
+      });
+
+      const operation = runner.getOperationByCallbackId("callback-123");
+
+      expect(operation).toBeInstanceOf(OperationWithData);
+      expect(mockOperationStorage.registerOperation).toHaveBeenCalledWith({
+        operation,
+        params: {
+          callbackId: "callback-123",
+        },
+      });
+    });
   });
 
   describe("registerFunctions", () => {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/local-durable-test-runner.ts
@@ -415,6 +415,43 @@ export class LocalDurableTestRunner<
   }
 
   /**
+   * Gets an operation by its callback identifier.
+   *
+   * This method is useful when you have a callback ID but don't know the operation
+   * name or index. It searches through all operations to find the one with the
+   * matching callback ID.
+   *
+   * @typeParam TOperationResult - The expected result type of the operation
+   * @param callbackId - The unique callback identifier
+   * @returns An operation instance for the operation with the specified callback ID
+   *
+   * @example
+   * ```typescript
+   * // Get operation by callback ID and send success
+   * const operation = runner.getOperationByCallbackId('callback-123');
+   * await operation.waitForData();
+   * await operation.sendCallbackSuccess('result');
+   * ```
+   */
+  getOperationByCallbackId<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TOperationResult = any,
+  >(callbackId: string): DurableOperation<TOperationResult> {
+    const operation = new OperationWithData<TOperationResult>(
+      this.waitManager,
+      this.operationIndex,
+      this.durableApi,
+    );
+    this.operationStorage.registerOperation({
+      operation,
+      params: {
+        callbackId,
+      },
+    });
+    return operation;
+  }
+
+  /**
    * Resets the test runner state, clearing all cached operations and history.
    *
    * This method should be called between test runs to ensure a clean state.

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/types/durable-test-runner.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/types/durable-test-runner.ts
@@ -69,6 +69,18 @@ export interface DurableTestRunner<
    * @returns An operation instance for the operation with the specified ID
    */
   getOperationById(id: string): TDurableOperation;
+
+  /**
+   * Gets an operation by its callback identifier.
+   *
+   * This method is useful when you have a callback ID but don't know the operation
+   * name or index. It searches through all operations to find the one with the
+   * matching callback ID.
+   *
+   * @param callbackId - The unique callback identifier
+   * @returns An operation instance for the operation with the specified callback ID
+   */
+  getOperationByCallbackId(callbackId: string): TDurableOperation;
 }
 
 /**


### PR DESCRIPTION
#413 

Hey guys, it could be a starting point for an issue #413. 
I've added `getByCallbackId` support so we can invoke a callback without knowing the operation name. 

Note: I haven't tested `CloudDurableTestRunner`. However, LocalDurableTestRunner appears to be working fine. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
