### PR TITLE
fix(sdk): export SerdesContext type in index.ts

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -50,6 +50,7 @@ export {
   createClassSerdes,
   createClassSerdesWithDates,
   Serdes,
+  SerdesContext,
 } from "./utils/serdes/serdes";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

When implementing the `Serdes` interface, it was annoying to declare the type of the `context` parameter on the `serialize` and `deserialize` functions without an easily importable reference to `SerdesContext`.

This change addresses that by just adding `SerdesContext` to the exports in the `packages/aws-durable-execution-sdk-js/src/index.ts` file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
