### PR TITLE
feat(sdk): add MAX_ITEMS_IN_BATCH limit to checkpoint batching

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -49,6 +49,7 @@ export class CheckpointManager implements Checkpoint {
   }> = [];
   private queueCompletionResolver: (() => void) | null = null;
   private readonly MAX_PAYLOAD_SIZE = 750 * 1024; // 750KB in bytes
+  private readonly MAX_ITEMS_IN_BATCH = 250;
   private isTerminating = false;
   private static textEncoder = new TextEncoder();
 
@@ -275,7 +276,11 @@ export class CheckpointManager implements Checkpoint {
         JSON.stringify(nextItem),
       ).length;
 
-      if (currentSize + itemSize > this.MAX_PAYLOAD_SIZE && batch.length > 0) {
+      if (
+        (currentSize + itemSize > this.MAX_PAYLOAD_SIZE ||
+          batch.length >= this.MAX_ITEMS_IN_BATCH) &&
+        batch.length > 0
+      ) {
         break;
       }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -1401,4 +1401,40 @@ describe("createCheckpointHandler", () => {
       mockOperations[0],
     ) as unknown as CheckpointFunction;
   });
+
+  it("should respect MAX_ITEMS_IN_BATCH limit", async () => {
+    const checkpoint = createCheckpoint(
+      mockContext,
+      TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      mockEmitter,
+      mockLogger,
+    ) as unknown as CheckpointFunction;
+
+    // Mock checkpoint to resolve immediately
+    mockState.checkpoint.mockResolvedValue({
+      CheckpointToken: "new-task-token",
+      NewExecutionState: {},
+    });
+
+    // Create 300 small checkpoint requests (exceeds MAX_ITEMS_IN_BATCH of 250)
+    const promises = [];
+    for (let i = 0; i < 300; i++) {
+      promises.push(
+        checkpoint(`step-${i}`, {
+          Action: OperationAction.START,
+          SubType: OperationSubType.STEP,
+          Type: OperationType.STEP,
+        }),
+      );
+    }
+
+    await Promise.all(promises);
+
+    // Should make multiple calls due to item count limit
+    expect(mockState.checkpoint).toHaveBeenCalledTimes(2);
+
+    // First batch should have 250 items, second should have 50
+    expect(mockState.checkpoint.mock.calls[0][0].Updates).toHaveLength(250);
+    expect(mockState.checkpoint.mock.calls[1][0].Updates).toHaveLength(50);
+  });
 });


### PR DESCRIPTION
- Add MAX_ITEMS_IN_BATCH constant set to 250 items
- Update batching logic to respect both size and item count limits
- Add unit test to verify item count batching behavior
- Ensure no queue items are lost during batch processing