### PR TITLE
feat(sdk): add executionContext.durableExecutionArn to context object

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -1,0 +1,62 @@
+import { DurableContextImpl } from "./durable-context";
+import { ExecutionContext, DurableExecutionMode } from "../../types/core";
+import { Context } from "aws-lambda";
+
+describe("DurableContext executionContext property", () => {
+  it("should expose durableExecutionArn in executionContext property", () => {
+    const DurableExecutionArn =
+      "arn:aws:lambda:us-east-1:123456789012:function:f1:$LATEST/durable-execution/execution-name";
+
+    const mockExecutionContext: ExecutionContext = {
+      durableExecutionArn: DurableExecutionArn,
+      durableExecutionClient: {} as any,
+      _stepData: {},
+      terminationManager: {} as any,
+      requestId: "test-request-id",
+      tenantId: undefined,
+      pendingCompletions: new Set(),
+      getStepData: jest.fn(),
+    };
+
+    const mockLambdaContext: Context = {
+      callbackWaitsForEmptyEventLoop: false,
+      functionName: "test-function",
+      functionVersion: "1",
+      invokedFunctionArn:
+        "arn:aws:lambda:us-east-1:123456789012:function:test-function:1",
+      memoryLimitInMB: "128",
+      awsRequestId: "test-request-id",
+      logGroupName: "/aws/lambda/test-function",
+      logStreamName: "2024/01/01/[$LATEST]abcdef123456",
+      getRemainingTimeInMillis: () => 30000,
+      done: jest.fn(),
+      fail: jest.fn(),
+      succeed: jest.fn(),
+    };
+
+    const mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    const mockDurableExecution = {
+      checkpointManager: {} as any,
+    };
+
+    const context = new DurableContextImpl(
+      mockExecutionContext,
+      mockLambdaContext,
+      DurableExecutionMode.ExecutionMode,
+      mockLogger as any,
+      undefined,
+      mockDurableExecution as any,
+    );
+
+    expect(context.executionContext).toBeDefined();
+    expect(context.executionContext.durableExecutionArn).toBe(
+      DurableExecutionArn,
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -74,9 +74,12 @@ export class DurableContextImpl<Logger extends DurableLogger>
   private durableExecution: DurableExecution;
 
   public logger: DurableContextLogger<Logger>;
+  public readonly executionContext: {
+    readonly durableExecutionArn: string;
+  };
 
   constructor(
-    private executionContext: ExecutionContext,
+    private _executionContext: ExecutionContext,
     public lambdaContext: Context,
     durableExecutionMode: DurableExecutionMode,
     inheritedLogger: Logger,
@@ -92,6 +95,10 @@ export class DurableContextImpl<Logger extends DurableLogger>
       this.getDurableLoggingContext(),
     );
     this.logger = this.createModeAwareLogger(inheritedLogger);
+
+    this.executionContext = {
+      durableExecutionArn: _executionContext.durableExecutionArn,
+    };
 
     this.durableExecutionMode = durableExecutionMode;
 
@@ -114,9 +121,9 @@ export class DurableContextImpl<Logger extends DurableLogger>
         const activeContext = getActiveContext();
 
         const result: DurableLogData = {
-          executionArn: this.executionContext.durableExecutionArn,
-          requestId: this.executionContext.requestId,
-          tenantId: this.executionContext.tenantId,
+          executionArn: this._executionContext.durableExecutionArn,
+          requestId: this._executionContext.requestId,
+          tenantId: this._executionContext.tenantId,
           operationId:
             !activeContext || activeContext?.contextId === "root"
               ? undefined
@@ -209,7 +216,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
   private checkAndUpdateReplayMode(): void {
     if (this.durableExecutionMode === DurableExecutionMode.ReplayMode) {
       const nextStepId = this.getNextStepId();
-      const nextStepData = this.executionContext.getStepData(nextStepId);
+      const nextStepData = this._executionContext.getStepData(nextStepId);
       if (!nextStepData) {
         this.durableExecutionMode = DurableExecutionMode.ExecutionMode;
       }
@@ -220,7 +227,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
     const wasInReplayMode =
       this.durableExecutionMode === DurableExecutionMode.ReplayMode;
     const nextStepId = this.getNextStepId();
-    const stepData = this.executionContext.getStepData(nextStepId);
+    const stepData = this._executionContext.getStepData(nextStepId);
     const wasNotFinished = !!(
       stepData &&
       stepData.Status !== OperationStatus.SUCCEEDED &&
@@ -234,7 +241,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
       this.durableExecutionMode === DurableExecutionMode.ReplaySucceededContext
     ) {
       const nextStepId = this.getNextStepId();
-      const nextStepData = this.executionContext.getStepData(nextStepId);
+      const nextStepData = this._executionContext.getStepData(nextStepId);
       if (
         nextStepData &&
         nextStepData.Status !== OperationStatus.SUCCEEDED &&
@@ -264,12 +271,12 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "step",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
 
     return this.withDurableModeManagement(() => {
       const stepHandler = createStepHandler(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.lambdaContext,
         this.createStepId.bind(this),
@@ -290,11 +297,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "invoke",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const invokeHandler = createInvokeHandler(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.createStepId.bind(this),
         this._parentId,
@@ -319,11 +326,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "runInChildContext",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const blockHandler = createRunInChildContextHandler(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.lambdaContext,
         this.createStepId.bind(this),
@@ -360,11 +367,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "wait",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const waitHandler = createWaitHandler(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.createStepId.bind(this),
         this._parentId,
@@ -411,11 +418,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "createCallback",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const callbackFactory = createCallbackFactory(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.createStepId.bind(this),
         this.checkAndUpdateReplayMode.bind(this),
@@ -435,11 +442,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "waitForCallback",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const waitForCallbackHandler = createWaitForCallbackHandler(
-        this.executionContext,
+        this._executionContext,
         this.getNextStepId.bind(this),
         this.runInChildContext.bind(this),
       );
@@ -461,11 +468,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "waitForCondition",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const waitForConditionHandler = createWaitForConditionHandler(
-        this.executionContext,
+        this._executionContext,
         this.checkpoint,
         this.createStepId.bind(this),
         this.durableLogger,
@@ -497,11 +504,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "map",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const mapHandler = createMapHandler(
-        this.executionContext,
+        this._executionContext,
         this._executeConcurrently.bind(this),
       );
       return mapHandler(
@@ -526,11 +533,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "parallel",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const parallelHandler = createParallelHandler(
-        this.executionContext,
+        this._executionContext,
         this._executeConcurrently.bind(this),
       );
       return parallelHandler(nameOrBranches, branchesOrConfig, maybeConfig);
@@ -550,11 +557,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
     validateContextUsage(
       this._stepPrefix,
       "_executeConcurrently",
-      this.executionContext.terminationManager,
+      this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
       const concurrentExecutionHandler = createConcurrentExecutionHandler(
-        this.executionContext,
+        this._executionContext,
         this.runInChildContext.bind(this),
         this.skipNextOperation.bind(this),
       );

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -66,6 +66,16 @@ export interface DurableContext<TLogger extends DurableLogger = DurableLogger> {
   logger: DurableContextLogger<TLogger>;
 
   /**
+   * Readonly metadata about the current execution context
+   */
+  executionContext: {
+    /**
+     * The ARN of the current durable execution
+     */
+    readonly durableExecutionArn: string;
+  };
+
+  /**
    * Executes a function as a durable step with automatic retry and state persistence
    *
    * @remarks


### PR DESCRIPTION
*Description of changes:*
Introduces a new `executionCotext` property to the `DurableContext` interface that provides readonly access to execution metadata including `durableExecutionArn`. This approach consolidates all readonly execution properties under a single namespace rather than adding individual fields directly to the context interface, maintaining a cleaner API surface.
