### PR TITLE
refactor(sdk): reduce checkpoint termination cooldown to 20ms

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -5,6 +5,7 @@ import { OperationLifecycleState, OperationSubType } from "../../types";
 import { OperationType } from "@aws-sdk/client-lambda";
 import { EventEmitter } from "events";
 import { hashId } from "../step-id-utils/step-id-utils";
+import { CHECKPOINT_TERMINATION_COOLDOWN_MS } from "../constants/constants";
 
 jest.mock("../logger/logger");
 
@@ -720,7 +721,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       );
 
       // Advance past cooldown
-      jest.advanceTimersByTime(50);
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS);
 
       expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
         reason: TerminationReason.WAIT_SCHEDULED,
@@ -741,7 +742,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       );
 
       // Advance partway through cooldown
-      jest.advanceTimersByTime(25);
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS / 2);
 
       // Start new operation
       checkpointManager.markOperationState(
@@ -757,7 +758,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       );
 
       // Advance past original cooldown
-      jest.advanceTimersByTime(50);
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS);
 
       // Should not have terminated
       expect(mockTerminationManager.terminate).not.toHaveBeenCalled();

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -16,6 +16,7 @@ import {
 } from "../../errors/checkpoint-errors/checkpoint-errors";
 import { DurableLogger } from "../../types/durable-logger";
 import { Checkpoint } from "./checkpoint-helper";
+import { CHECKPOINT_TERMINATION_COOLDOWN_MS } from "../constants/constants";
 import {
   OperationLifecycleState,
   OperationInfo,
@@ -59,7 +60,6 @@ export class CheckpointManager implements Checkpoint {
   // Termination cooldown
   private terminationTimer: NodeJS.Timeout | null = null;
   private terminationReason: TerminationReason | null = null;
-  private readonly TERMINATION_COOLDOWN_MS = 50;
 
   constructor(
     private durableExecutionArn: string,
@@ -702,7 +702,7 @@ export class CheckpointManager implements Checkpoint {
     this.terminationReason = reason;
     log("⏱️", "Scheduling termination", {
       reason,
-      cooldownMs: this.TERMINATION_COOLDOWN_MS,
+      cooldownMs: CHECKPOINT_TERMINATION_COOLDOWN_MS,
     });
 
     this.terminationTimer = setTimeout(() => {
@@ -715,7 +715,7 @@ export class CheckpointManager implements Checkpoint {
         return;
       }
       this.executeTermination(reason);
-    }, this.TERMINATION_COOLDOWN_MS);
+    }, CHECKPOINT_TERMINATION_COOLDOWN_MS);
   }
 
   private executeTermination(reason: TerminationReason): void {

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
@@ -10,6 +10,7 @@ import { EventEmitter } from "events";
 import { createDefaultLogger } from "../logger/default-logger";
 import { OperationType } from "@aws-sdk/client-lambda";
 import { log } from "../logger/logger";
+import { CHECKPOINT_TERMINATION_COOLDOWN_MS } from "../constants/constants";
 
 jest.mock("../logger/logger", () => ({
   log: jest.fn(),
@@ -244,7 +245,7 @@ describe("CheckpointManager Termination Behavior", () => {
         "Scheduling termination",
         expect.objectContaining({
           reason: "CALLBACK_PENDING",
-          cooldownMs: 50,
+          cooldownMs: CHECKPOINT_TERMINATION_COOLDOWN_MS,
         }),
       );
 
@@ -255,8 +256,10 @@ describe("CheckpointManager Termination Behavior", () => {
         Type: "CHAINED_INVOKE",
       });
 
-      // Step 3: Advance time past the termination cooldown (50ms + buffer)
-      await jest.advanceTimersByTimeAsync(60);
+      // Step 3: Advance time past the termination cooldown
+      await jest.advanceTimersByTimeAsync(
+        CHECKPOINT_TERMINATION_COOLDOWN_MS + 10,
+      );
 
       // At this point, the timer callback should execute and re-check shouldTerminate()
       // It should find isProcessing=true and cancel termination

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
@@ -7,3 +7,10 @@
  * TODO: Accept this as configuration parameter in the future
  */
 export const STORE_STACK_TRACES = false;
+
+/**
+ * Checkpoint manager termination cooldown in milliseconds
+ * After the last operation completes, the checkpoint manager waits this duration
+ * before terminating to allow for any final checkpoint operations
+ */
+export const CHECKPOINT_TERMINATION_COOLDOWN_MS = 20;


### PR DESCRIPTION
Changed CHECKPOINT_TERMINATION_COOLDOWN_MS from 50ms to 20ms and moved it to a shared constant for consistency across code and tests.

Changes:
- Add CHECKPOINT_TERMINATION_COOLDOWN_MS constant (20ms) to constants.ts
- Update checkpoint-manager to use the constant
- Update all tests to use the constant instead of hardcoded values
- Adjust test timing to work with the reduced cooldown

*Issue #, if available:*
#437 
