### PR TITLE
feat(sdk): add SDK version to AWS Lambda client user agent

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client-caching.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client-caching.test.ts
@@ -1,5 +1,6 @@
 import { LambdaClient } from "@aws-sdk/client-lambda";
 import { DurableExecutionApiClient } from "./durable-execution-api-client";
+import { SDK_NAME, SDK_VERSION } from "../utils/constants/version";
 
 // Mock the LambdaClient
 jest.mock("@aws-sdk/client-lambda", () => {
@@ -49,6 +50,7 @@ describe("DurableExecutionApiClient Caching", () => {
 
     // Verify the constructor was called with correct configuration
     expect(LambdaClient).toHaveBeenCalledWith({
+      customUserAgent: [[SDK_NAME, SDK_VERSION]],
       requestHandler: {
         connectionTimeout: 5000,
         socketTimeout: 50000,

--- a/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client.test.ts
@@ -10,6 +10,7 @@ import { OperationSubType } from "../types";
 import { log } from "../utils/logger/logger";
 import { DurableExecutionApiClient } from "./durable-execution-api-client";
 import { DurableExecutionClient } from "../types/durable-execution";
+import { SDK_NAME, SDK_VERSION } from "../utils/constants/version";
 
 // Mock the logger
 jest.mock("../utils/logger/logger", () => ({
@@ -46,6 +47,7 @@ describe("ApiStorage", () => {
 
     // Verify that LambdaClient was constructed with the correct default configuration
     expect(LambdaClient).toHaveBeenCalledWith({
+      customUserAgent: [[SDK_NAME, SDK_VERSION]],
       requestHandler: {
         connectionTimeout: 5000,
         socketTimeout: 50000,

--- a/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client.ts
+++ b/packages/aws-durable-execution-sdk-js/src/durable-execution-api-client/durable-execution-api-client.ts
@@ -10,6 +10,7 @@ import {
 import { DurableExecutionClient } from "../types/durable-execution";
 import { log } from "../utils/logger/logger";
 import { DurableLogger } from "../types/durable-logger";
+import { SDK_NAME, SDK_VERSION } from "../utils/constants/version";
 
 let defaultLambdaClient: LambdaClient | undefined;
 
@@ -27,6 +28,7 @@ export class DurableExecutionApiClient implements DurableExecutionClient {
     if (!client) {
       if (!defaultLambdaClient) {
         defaultLambdaClient = new LambdaClient({
+          customUserAgent: [[SDK_NAME, SDK_VERSION]],
           requestHandler: {
             connectionTimeout: 5000,
             socketTimeout: 50000,

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -1,0 +1,14 @@
+/**
+ * SDK metadata injected by Rollup at build time from package.json.
+ *
+ * At build time, Rollup replaces process.env.NPM_PACKAGE_NAME and
+ * process.env.NPM_PACKAGE_VERSION with actual values from package.json.
+ *
+ * Defaults are provided for test environments where Rollup doesn't run
+ * and process.env values are undefined.
+ *
+ * @internal
+ */
+export const SDK_NAME =
+  process.env.NPM_PACKAGE_NAME || "@aws/durable-execution-sdk-js";
+export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,6 +34,7 @@ export function createBuildOptions(options, mode, packageJson) {
         "process.env.IS_ESM": JSON.stringify(mode === "esm"),
         "process.env.NODE_ENV": JSON.stringify("production"),
         "process.env.NPM_PACKAGE_VERSION": JSON.stringify(packageJson.version),
+        "process.env.NPM_PACKAGE_NAME": JSON.stringify(packageJson.name),
       },
     }),
   ];


### PR DESCRIPTION
Include SDK version in the Lambda client's customUserAgent to enable better debugging visibility. This allows cross-referencing SDK versions with API request IDs when troubleshooting issues.
    
    The version is automatically generated from package.json during build time to ensure it stays in sync with the published SDK version.
    
Changes:
    - Add generate-version.js script to create version.ts from package.json
    - Configure LambdaClient with customUserAgent including SDK version
    - Update tests to expect customUserAgent in client configuration
    - Add version.ts to .gitignore (auto-generated file)
    
Fixes #432
    
Before this change:
```
aws-sdk-js/3.943.0 ua/2.0 os/linux#5.10.247-277.989.amzn2.x86_64 md/arch#x86_64 lang/js md/nodejs#22.0.0 api/lambda#3.943.0 exec-env/AWS_Lambda_nodejs22.x cfg/retry-mode#standard
```

After this change:
```
aws-sdk-js/3.943.0 ua/2.0 os/linux#5.10.247-277.989.amzn2.x86_64 md/arch#x86_64 lang/js md/nodejs#22.0.0 api/lambda#3.943.0 exec-env/AWS_Lambda_nodejs22.x cfg/retry-mode#standard @aws/durable-execution-sdk-js/1.0.2
```
