### PR TITLE
ci: enable GitHub Actions tests for v1.x branch PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "v1.x"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v1.x"]
 
 permissions:
   contents: read # This is required for actions/checkout


### PR DESCRIPTION
Enable GitHub Actions (unit tests and integration test) to run for both v1.x and main branch PRs
