### PR TITLE
chore(testing-sdk): remove verbose debugging console.log statements

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map-completion-config-issue/map-completion-config-issue.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map-completion-config-issue/map-completion-config-issue.test.ts
@@ -32,20 +32,6 @@ createTests({
         }>;
       };
 
-      // Print actual results for debugging
-      console.log("=== ACTUAL RESULTS ===");
-      console.log("Total items processed:", result.totalItems);
-      console.log("Successful count:", result.successfulCount);
-      console.log("Failed count:", result.failedCount);
-      console.log("Has failures:", result.hasFailures);
-      console.log("Batch status:", result.batchStatus);
-      console.log("Completion reason:", result.completionReason);
-      console.log(
-        "Successful items:",
-        JSON.stringify(result.successfulItems, null, 2),
-      );
-      console.log("Failed items:", JSON.stringify(result.failedItems, null, 2));
-
       // Verify the correct behavior after the fix
       expect(result).toMatchObject({
         totalItems: 4,
@@ -54,23 +40,6 @@ createTests({
         hasFailures: false,
         batchStatus: "SUCCEEDED",
         completionReason: "MIN_SUCCESSFUL_REACHED",
-      });
-
-      // Print execution details for debugging
-      console.log("=== EXECUTION DETAILS ===");
-      const operations = execution.getOperations();
-      console.log("Total operations:", operations.length);
-
-      const mapOp = runner.getOperation("completion-config-items");
-      console.log(
-        "Map operation child count:",
-        mapOp.getChildOperations()?.length || 0,
-      );
-
-      // List all operations that were created
-      console.log("=== ALL OPERATIONS ===");
-      operations.forEach((op: any, index: number) => {
-        console.log(`${index}: ${op.getName()} - ${op.getType()}`);
       });
 
       assertEventSignatures(execution);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/child-context/wait-for-callback-child-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/child-context/wait-for-callback-child-context.test.ts
@@ -30,7 +30,6 @@ createTests({
       // Wait for child callback to start
       await childCallbackOp.waitForData(WaitingOperationStatus.SUBMITTED);
       const childCallbackResult = JSON.stringify({ childData: 42 });
-      console.log("child callback op", childCallbackOp.getOperationData());
       await childCallbackOp.sendCallbackSuccess(childCallbackResult);
 
       const result = await executionPromise;

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -252,7 +252,7 @@ describe("LocalDurableTestRunner Integration", () => {
     const handler = withDurableExecution(
       async (_event: unknown, context: DurableContext) => {
         expect(context.lambdaContext.getRemainingTimeInMillis()).toBe(900_000);
-        
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         const mock1: string = await context.step(() => mockedFunction());
 
@@ -349,7 +349,6 @@ describe("LocalDurableTestRunner Integration", () => {
 
     // Verify all operations completed successfully
     const operations = result.getOperations();
-    console.log(operations.map((operation) => operation.getOperationData()));
     expect(operations).toHaveLength(8); // 3 parallel waits + 3 parallel contexts + 1 parallel operation + 1 step
 
     // Check that parallel wait operations all succeeded


### PR DESCRIPTION
Remove debugging console.log statements that were cluttering test output:
- map-completion-config-issue.test.ts: removed 14 debug logs for execution results
- wait-for-callback-child-context.test.ts: removed 1 debug log for callback operation data
- local-durable-test-runner.integration.test.ts: removed 1 debug log for operations data

Preserved legitimate console statements used for test infrastructure and error logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
