### PR TITLE
fix(sdk): resolve ESLint warnings in build process

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/steps-with-retry/steps-with-retry.ts
@@ -65,12 +65,10 @@ export const handler = withDurableExecution(
         await context.wait({ seconds: 1 });
       }
     } catch (e) {
-      console.error("Failing - DDB Retries Exhausted. ", e);
       throw e;
     }
 
     if (!item) {
-      console.error("Failing - DDB Item Not Found.");
       throw new Error("Item Not Found");
     }
 

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -650,6 +650,56 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  InvokeTenantId:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: InvokeTenantId-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: invoke-tenant-id.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  TenantTarget:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: TenantTarget-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: tenant-target.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 300
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   LargePayload:
     Type: AWS::Serverless::Function
     Properties:

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/invoke.integration.test.ts
@@ -141,6 +141,7 @@ describe("LocalDurableTestRunner Invoke operations integration", () => {
   });
 
   // TODO: handling errors for callback and checkpoint updates
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("should fail execution if invoking a function that does not exist", async () => {
     const handler = withDurableExecution(async (_, ctx) => {
       await ctx.invoke("durableOperation", "nonExistentFunction", {

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/local-durable-test-runner.integration.test.ts
@@ -311,6 +311,7 @@ describe("LocalDurableTestRunner Integration", () => {
   });
 
   // enable when language SDK supports concurrent waits
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip("should prevent scheduled function interference in parallel wait scenario", async () => {
     // This test creates a scenario where multiple wait operations could create
     // scheduled functions that fire while invocations are still active.

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/wait-for-callback-operations.integration.test.ts
@@ -21,6 +21,7 @@ describe("WaitForCallback Operations Integration", () => {
   // Concurrent and Complex Workflow Tests Category
   describe("Concurrent and Complex Workflow Tests", () => {
     // todo: add test when language SDK adds concurrency support
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip("should handle multiple concurrent waitForCallback operations with different submitters", async () => {
       let callback1Id: string | undefined;
       let callback2Id: string | undefined;

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -5,10 +5,7 @@ import { OperationLifecycleState, OperationSubType } from "../../types";
 import { OperationType } from "@aws-sdk/client-lambda";
 import { EventEmitter } from "events";
 import { hashId } from "../step-id-utils/step-id-utils";
-import {
-  CHECKPOINT_TERMINATION_COOLDOWN_MS,
-  MAX_POLL_DURATION_MS,
-} from "../constants/constants";
+import { CHECKPOINT_TERMINATION_COOLDOWN_MS } from "../constants/constants";
 
 jest.mock("../logger/logger");
 


### PR DESCRIPTION
- Remove unused MAX_POLL_DURATION_MS import from checkpoint test
- Add ESLint disable comments for intentionally skipped tests
- Tests are skipped pending future SDK concurrency features
- Removed console.log from noisy test!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
