### PR TITLE
chore(examples): remove debug logging statements

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/tenant-target/tenant-target.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/invoke/tenant-target/tenant-target.ts
@@ -18,13 +18,8 @@ export const handler = withDurableExecution(
   async (event: { seconds?: number }, context: DurableContext) => {
     const waitTime = event.seconds || 1;
 
-    context.logger.info("Starting tenant-enabled target function", {
-      waitTime,
-    });
-
     await context.wait("tenant-wait", { seconds: waitTime });
 
-    context.logger.info("Tenant target function completed");
     return "wait finished";
   },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/basic/serde-basic.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/basic/serde-basic.ts
@@ -60,9 +60,6 @@ export const handler = withDurableExecution(
       "create-user",
       async () => {
         const newUser = new User(event.firstName, event.lastName, event.email);
-        context.logger.info("Created user:", {
-          fullName: newUser.getFullName(),
-        });
         return newUser;
       },
       { serdes: userSerdes },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/with-retry/step-with-retry.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/with-retry/step-with-retry.test.ts
@@ -73,8 +73,6 @@ describe("step-with-retry test", () => {
     expect(stepDetails).toBeDefined();
     expect(stepDetails?.result).toEqual(EXPECTED_RESULT);
 
-    execution.print();
-
     // Verify retry attempt tracking (should be 2 attempts before success)
     expect(typeof stepDetails?.attempt).toBe("number");
     expect(stepDetails?.attempt).toBeGreaterThanOrEqual(1);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/submitter-retry-success/wait-for-callback-submitter-retry-success.ts
@@ -17,15 +17,9 @@ export const handler = withDurableExecution(
     const result = await context.waitForCallback(
       "retry-submitter-callback",
       async (callbackId, ctx) => {
-        ctx.logger.info("Submitting callback to external system", {
-          callbackId,
-        });
-
         if (shouldFail) {
           throw new Error("Simulated submitter failure");
         }
-
-        ctx.logger.info("Successfully submitted callback", { callbackId });
       },
       {
         // Retry strategy: up to 4 attempts with exponential backoff


### PR DESCRIPTION
Remove unnecessary logging statements from example files to reduce test output noise:
- Remove tenant function start/completion logs
- Remove user creation debug logs
- Remove callback submission logs
- Remove test execution.print() call

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
