### PR TITLE
fix(examples): prevent duplicate DeleteFunction calls 

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -458,55 +458,48 @@ async function main(): Promise<void> {
       endpoint: env.LAMBDA_ENDPOINT,
     });
 
+    console.log("Checking if function exists...");
+    let functionExists = await checkFunctionExists(lambdaClient, functionName);
+    let currentConfig: GetFunctionConfigurationCommandOutput;
+
+    const zipFile = `${example}.zip`;
+    const selectedRuntime = mapRuntimeToEnum(runtime);
+
+    // Handle function deletion if configuration changes require it (outside retry logic)
+    if (functionExists) {
+      currentConfig = await getCurrentConfiguration(lambdaClient, functionName);
+      if (!!currentConfig.DurableConfig !== !!exampleConfig.durableConfig) {
+        console.log("Deleting function since durability changed");
+        functionExists = false;
+      }
+      if (!!currentConfig.CapacityProviderConfig !== useCapacityProvider) {
+        console.log("Deleting function since capacity provider changed");
+        functionExists = false;
+      }
+
+      // Check if tenancy configuration needs to change
+      const needsTenancy = exampleConfig.handler.includes("tenant-target");
+      const hasTenancy = !!currentConfig.TenancyConfig;
+      if (needsTenancy !== hasTenancy) {
+        console.log("Deleting function since tenancy configuration changed");
+        functionExists = false;
+      }
+
+      if (!functionExists) {
+        await lambdaClient.send(
+          new DeleteFunctionCommand({
+            FunctionName: functionName,
+          }),
+        );
+        // Wait for function to be fully deleted
+        console.log("Waiting for function deletion to complete...");
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+    }
+
+    // Handle function update or creation with retry logic
     await retryOnConflict(
       async () => {
-        console.log("Checking if function exists...");
-        let functionExists = await checkFunctionExists(
-          lambdaClient,
-          functionName,
-        );
-        let currentConfig: GetFunctionConfigurationCommandOutput;
-
-        const zipFile = `${example}.zip`;
-
-        const selectedRuntime = mapRuntimeToEnum(runtime);
-
-        if (functionExists) {
-          currentConfig = await getCurrentConfiguration(
-            lambdaClient,
-            functionName,
-          );
-          if (!!currentConfig.DurableConfig !== !!exampleConfig.durableConfig) {
-            console.log("Deleting function since durability changed");
-            functionExists = false;
-          }
-          if (!!currentConfig.CapacityProviderConfig !== useCapacityProvider) {
-            console.log("Deleting function since capacity provider changed");
-            functionExists = false;
-          }
-
-          // Check if tenancy configuration needs to change
-          const needsTenancy = exampleConfig.handler.includes("tenant-target");
-          const hasTenancy = !!currentConfig.TenancyConfig;
-          if (needsTenancy !== hasTenancy) {
-            console.log(
-              "Deleting function since tenancy configuration changed",
-            );
-            functionExists = false;
-          }
-
-          if (!functionExists) {
-            await lambdaClient.send(
-              new DeleteFunctionCommand({
-                FunctionName: functionName,
-              }),
-            );
-            // Wait for function to be fully deleted
-            console.log("Waiting for function deletion to complete...");
-            await new Promise((resolve) => setTimeout(resolve, 5000));
-          }
-        }
-
         if (functionExists) {
           await updateFunction(
             lambdaClient,


### PR DESCRIPTION
Move function deletion logic outside retryOnConflict to prevent duplicate delete operations. Only retry create/update operations, not delete operations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
