### PR TITLE
ci: Extract capacity provider tests into separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,15 @@ jobs:
     with:
       node-version: ${{ matrix.node-version }}
     secrets: inherit
+
+  capacity-provider-tests:
+    needs: build
+    # Skip for PRs from forked repos (no access to secrets)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+    uses: "./.github/workflows/capacity-provider-tests.yml"
+    with:
+      node-version: "24.x"
+    secrets: inherit

--- a/.github/workflows/capacity-provider-tests.yml
+++ b/.github/workflows/capacity-provider-tests.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Capacity Provider Tests
 
 on:
   workflow_call:
@@ -7,13 +7,8 @@ on:
         required: true
         type: string
 
-# Cancel when pull request is updated for this node version
-concurrency:
-  group: ${{ github.head_ref || github.ref_name || github.run_id }}-${{ inputs.node-version }}-integ
-  cancel-in-progress: true
-
 jobs:
-  deploy:
+  deploy-capacity-provider:
     permissions:
       contents: read
       id-token: write # Required for AWS credentials
@@ -45,19 +40,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Deploy functions
-        id: deploy-functions
+      - name: Deploy all capacity provider functions
+        id: deploy-capacity-providers
         env:
           LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_NUMBER: ${{ github.event.number }}
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-        run: node .github/workflows/scripts/integration-test/integration-test.js --deploy-only --runtime ${{ inputs.node-version }}
+          CAPACITY_PROVIDER_ARN: ${{ secrets.CAPACITY_PROVIDER_ARN }}
+        run: node .github/workflows/scripts/integration-test/integration-test.js --deploy-only --capacity-provider-only --runtime ${{ inputs.node-version }}
 
-  jest-integration-test:
-    needs: deploy
+  test-capacity-provider:
+    needs: deploy-capacity-provider
     runs-on: ubuntu-latest
-    name: Jest Integration Tests
+    name: Test Capacity Provider Functions
     permissions:
       contents: read
       id-token: write # Required for AWS credentials
@@ -87,13 +83,56 @@ jobs:
           path: .
 
       - name: Install dependencies
-        run: |
-          npm ci
+        run: npm ci
 
-      - name: Run Jest integration tests
+      - name: Test all capacity provider functions
         env:
           LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_NUMBER: ${{ github.event.number }}
         run: |
-          node .github/workflows/scripts/integration-test/integration-test.js --test-only --runtime ${{ inputs.node-version }}
+          node .github/workflows/scripts/integration-test/integration-test.js --test-only --capacity-provider-only --runtime ${{ inputs.node-version }}
+
+  cleanup-capacity-provider:
+    if: always()
+    needs: test-capacity-provider
+    runs-on: ubuntu-latest
+    name: Clean up capacity provider functions
+    permissions:
+      contents: read
+      id-token: write # Required for AWS credentials
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: "npm"
+
+      - name: Get AWS Credentials
+        id: credentials
+        if: github.actor != 'nektos/act'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "${{ secrets.ACTIONS_INTEGRATION_ROLE_NAME }}"
+          role-session-name: githubIntegrationTest
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: built-artifacts
+          path: .
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Clean up capacity provider functions
+        env:
+          LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+        run: |
+          node .github/workflows/scripts/integration-test/integration-test.js --cleanup-only --capacity-provider-only --runtime ${{ inputs.node-version }}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/495

*Description of changes:* 
Capacity provider deploy jobs for 22.x and 24.x were running in parallel, exceeding the maxVCpuCount limit on the shared capacity provider. This caused consistent deployment failures requiring manual reruns.

Moved capacity provider deploy/test/cleanup jobs from integration-tests.yml into a new capacity-provider-tests.yml workflow, called once from build.yml with only Node 24.x. Regular integration tests remain parallel for both versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
