### PR TITLE
fix(sdk): re-evaluate termination after checkpoint queue drains

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.history.json
@@ -1,0 +1,252 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "23588ea1-7c59-49f1-88f6-5583f4cafc12",
+    "EventTimestamp": "2026-04-14T22:24:08.163Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"branches\":[{\"functionName\":\"step-named\"},{\"functionName\":\"wait-configurable\",\"payload\":{\"waitSeconds\":2}},{\"functionName\":\"wait-configurable\",\"payload\":{\"waitSeconds\":4}}]}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Parallel",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "parallel-invokes",
+    "EventTimestamp": "2026-04-14T22:24:08.170Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "branch-0",
+    "EventTimestamp": "2026-04-14T22:24:08.170Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 4,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "branch-1",
+    "EventTimestamp": "2026-04-14T22:24:08.170Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 5,
+    "Id": "13cee27a2bd93915",
+    "Name": "branch-2",
+    "EventTimestamp": "2026-04-14T22:24:08.170Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 6,
+    "Id": "2f221a18eb863803",
+    "Name": "invoke-0",
+    "EventTimestamp": "2026-04-14T22:24:08.170Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 7,
+    "Id": "6151f5ab282d90e4",
+    "Name": "invoke-1",
+    "EventTimestamp": "2026-04-14T22:24:08.171Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "invoke-2",
+    "EventTimestamp": "2026-04-14T22:24:08.171Z",
+    "ParentId": "13cee27a2bd93915",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-04-14T22:24:08.192Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-14T22:24:08.163Z",
+      "EndTimestamp": "2026-04-14T22:24:08.192Z",
+      "Error": {},
+      "RequestId": "3d938811-7c01-48a7-adec-a5c93e442213"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeSucceeded",
+    "SubType": "ChainedInvoke",
+    "EventId": 10,
+    "Id": "2f221a18eb863803",
+    "Name": "invoke-0",
+    "EventTimestamp": "2026-04-14T22:24:08.280Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ChainedInvokeSucceededDetails": {
+      "Result": {
+        "Payload": "\"processed: default\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 11,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "branch-0",
+    "EventTimestamp": "2026-04-14T22:24:08.283Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"processed: default\""
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 12,
+    "EventTimestamp": "2026-04-14T22:24:08.303Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-14T22:24:08.281Z",
+      "EndTimestamp": "2026-04-14T22:24:08.303Z",
+      "Error": {},
+      "RequestId": "081c5952-7a0c-467f-a3d3-968907b1a93b"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeSucceeded",
+    "SubType": "ChainedInvoke",
+    "EventId": 13,
+    "Id": "6151f5ab282d90e4",
+    "Name": "invoke-1",
+    "EventTimestamp": "2026-04-14T22:24:10.279Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ChainedInvokeSucceededDetails": {
+      "Result": {
+        "Payload": "\"wait finished\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 14,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "branch-1",
+    "EventTimestamp": "2026-04-14T22:24:10.283Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"wait finished\""
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 15,
+    "EventTimestamp": "2026-04-14T22:24:10.302Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-14T22:24:10.281Z",
+      "EndTimestamp": "2026-04-14T22:24:10.302Z",
+      "Error": {},
+      "RequestId": "30f23694-3c1f-4fd3-9bce-f570da254d0b"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeSucceeded",
+    "SubType": "ChainedInvoke",
+    "EventId": 16,
+    "Id": "b425e0c75591aa8f",
+    "Name": "invoke-2",
+    "EventTimestamp": "2026-04-14T22:24:12.281Z",
+    "ParentId": "13cee27a2bd93915",
+    "ChainedInvokeSucceededDetails": {
+      "Result": {
+        "Payload": "\"wait finished\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 17,
+    "Id": "13cee27a2bd93915",
+    "Name": "branch-2",
+    "EventTimestamp": "2026-04-14T22:24:12.284Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"wait finished\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Parallel",
+    "EventId": 18,
+    "Id": "c4ca4238a0b92382",
+    "Name": "parallel-invokes",
+    "EventTimestamp": "2026-04-14T22:24:12.284Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":\"processed: default\",\"index\":0,\"status\":\"SUCCEEDED\"},{\"result\":\"wait finished\",\"index\":1,\"status\":\"SUCCEEDED\"},{\"result\":\"wait finished\",\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 19,
+    "EventTimestamp": "2026-04-14T22:24:12.284Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-14T22:24:12.282Z",
+      "EndTimestamp": "2026-04-14T22:24:12.284Z",
+      "Error": {},
+      "RequestId": "683e5b92-e4e0-42fe-a6b9-c8433acbfd85"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 20,
+    "Id": "23588ea1-7c59-49f1-88f6-5583f4cafc12",
+    "EventTimestamp": "2026-04-14T22:24:12.284Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"successCount\":3}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.test.ts
@@ -1,0 +1,44 @@
+import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
+import { createTests } from "../../../utils/test-helper";
+import { handler } from "./parallel-invoke";
+import { handler as namedStepHandler } from "../../step/named/step-named";
+import { handler as configurableWaitHandler } from "../../wait/configurable/wait-configurable";
+
+createTests({
+  handler,
+  tests: (runner, { functionNameMap, assertEventSignatures }) => {
+    it("should complete all parallel invoke branches with staggered completions", async () => {
+      const stepTarget = functionNameMap.getFunctionName("step-named");
+      const waitTarget = functionNameMap.getFunctionName("wait-configurable");
+
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerDurableFunction(stepTarget, namedStepHandler);
+        runner.registerDurableFunction(waitTarget, configurableWaitHandler);
+      }
+
+      // Branch 0: instant (step-named)
+      // Branch 1: 2s wait (wait-configurable)
+      // Branch 2: 4s wait (wait-configurable)
+      // Each branch completes at a distinct time, ensuring deterministic
+      // suspend/resume cycles regardless of cloud timing jitter.
+      const execution = await runner.run({
+        payload: {
+          branches: [
+            { functionName: stepTarget },
+            { functionName: waitTarget, payload: { waitSeconds: 2 } },
+            { functionName: waitTarget, payload: { waitSeconds: 4 } },
+          ],
+        },
+      });
+
+      expect(execution.getResult()).toEqual({
+        successCount: 3,
+      });
+
+      const parallelOp = runner.getOperation("parallel-invokes");
+      expect(parallelOp.getChildOperations()).toHaveLength(3);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invoke/parallel-invoke.ts
@@ -1,0 +1,40 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Parallel Invoke",
+  description:
+    "Demonstrates parallel branches that each invoke a child durable function " +
+    "with staggered completion times, verifying correct suspension between " +
+    "branch completions",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: {
+      branches: Array<{ functionName: string; payload?: unknown }>;
+    },
+    context: DurableContext,
+  ) => {
+    const results = await context.parallel(
+      "parallel-invokes",
+      event.branches.map((branch, index) => ({
+        name: `branch-${index}`,
+        func: async (ctx: DurableContext) => {
+          return await ctx.invoke(
+            `invoke-${index}`,
+            branch.functionName,
+            branch.payload ?? {},
+          );
+        },
+      })),
+    );
+
+    return {
+      successCount: results.successCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/configurable/wait-configurable.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait/configurable/wait-configurable.ts
@@ -1,0 +1,18 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Configurable Wait",
+  description: "Wait with a configurable duration passed via the event payload",
+};
+
+export const handler = withDurableExecution(
+  async (event: { waitSeconds?: number }, context: DurableContext) => {
+    const seconds = event.waitSeconds ?? 2;
+    await context.wait("configurable-wait", { seconds });
+    return "wait finished";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -1217,6 +1217,226 @@ describe("CheckpointManager - Centralized Termination", () => {
     });
   });
 
+  describe("processQueue triggers checkAndTerminate after queue drains", () => {
+    it("should call checkAndTerminate when checkpoint queue finishes processing and no termination is scheduled", async () => {
+      // Setup: mock the checkpoint API to succeed
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      // Spy on checkAndTerminate BEFORE any operations that trigger it
+      const checkAndTerminateSpy = jest.spyOn(
+        checkpointManager as any,
+        "checkAndTerminate",
+      );
+
+      // 1. Enqueue a checkpoint FIRST so the queue is non-empty when
+      //    markOperationAwaited calls checkAndTerminate (which will see
+      //    a non-empty queue and NOT schedule termination).
+      const checkpointPromise = checkpointManager.checkpoint("completed-step", {
+        Action: "SUCCEED" as any,
+        SubType: OperationSubType.STEP,
+        Type: OperationType.STEP,
+      });
+      checkpointPromise.catch(() => {});
+
+      // 2. Register an operation in IDLE_NOT_AWAITED (no checkAndTerminate call)
+      checkpointManager.markOperationState(
+        "invoke-1",
+        OperationLifecycleState.IDLE_NOT_AWAITED,
+        {
+          metadata: {
+            stepId: "invoke-1",
+            type: OperationType.CHAINED_INVOKE,
+            subType: OperationSubType.CHAINED_INVOKE,
+          },
+        },
+      );
+
+      // 3. Transition to IDLE_AWAITED — calls checkAndTerminate, but queue
+      //    is non-empty so shouldTerminate returns undefined → no timer set
+      checkpointManager.markOperationAwaited("invoke-1");
+
+      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(1);
+
+      // 4. Let the queue drain — since no terminationTimer is set,
+      //    processQueue should call checkAndTerminate
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should skip checkAndTerminate when queue drains but termination is already scheduled", async () => {
+      // Setup: mock the checkpoint API to succeed
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      const checkAndTerminateSpy = jest.spyOn(
+        checkpointManager as any,
+        "checkAndTerminate",
+      );
+
+      // 1. Register an operation in IDLE_AWAITED — this calls
+      //    checkAndTerminate which schedules termination (timer starts)
+      checkpointManager.markOperationState(
+        "invoke-1",
+        OperationLifecycleState.IDLE_AWAITED,
+        {
+          metadata: {
+            stepId: "invoke-1",
+            type: OperationType.CHAINED_INVOKE,
+            subType: OperationSubType.CHAINED_INVOKE,
+          },
+        },
+      );
+
+      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(1);
+
+      // 2. Enqueue a checkpoint while termination timer is ticking
+      const checkpointPromise = checkpointManager.checkpoint("completed-step", {
+        Action: "SUCCEED" as any,
+        SubType: OperationSubType.STEP,
+        Type: OperationType.STEP,
+      });
+      checkpointPromise.catch(() => {});
+
+      // 3. Let the queue drain — terminationTimer is already set,
+      //    so processQueue should NOT call checkAndTerminate again
+      await jest.advanceTimersByTimeAsync(0);
+
+      // checkAndTerminate should still have been called only once
+      // (from markOperationState), not again from processQueue
+      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(1);
+
+      // 4. Let the cooldown fire — termination should still happen
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS + 1);
+
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: expect.any(String),
+        }),
+      );
+    });
+
+    it("should terminate after queue drains when all operations are IDLE_AWAITED", async () => {
+      // Setup: mock the checkpoint API to succeed
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      // Simulate the parallel invoke race condition:
+      // 1. A completed invoke checkpoints SUCCEED (adds to queue)
+      const checkpointPromise = checkpointManager.checkpoint(
+        "completed-invoke",
+        {
+          Action: "SUCCEED" as any,
+          SubType: OperationSubType.CHAINED_INVOKE,
+          Type: OperationType.CHAINED_INVOKE,
+        },
+      );
+      checkpointPromise.catch(() => {});
+
+      // 2. Pending invokes transition to IDLE_NOT_AWAITED (skips checkAndTerminate)
+      checkpointManager.markOperationState(
+        "pending-invoke-1",
+        OperationLifecycleState.IDLE_NOT_AWAITED,
+        {
+          metadata: {
+            stepId: "pending-invoke-1",
+            type: OperationType.CHAINED_INVOKE,
+            subType: OperationSubType.CHAINED_INVOKE,
+          },
+        },
+      );
+
+      // 3. Pending invokes transition to IDLE_AWAITED (calls checkAndTerminate,
+      //    but queue is non-empty so shouldTerminate returns undefined)
+      checkpointManager.markOperationAwaited("pending-invoke-1");
+
+      // At this point, checkAndTerminate was called but couldn't terminate
+      // because the queue was non-empty.
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
+
+      // 4. Let the queue drain (processQueue runs via setImmediate)
+      await jest.advanceTimersByTimeAsync(0);
+
+      // 5. After queue drains, processQueue should call checkAndTerminate,
+      //    which now sees: queue empty, not processing, all ops IDLE_AWAITED
+      //    → schedules termination → cooldown fires → terminates
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS + 1);
+
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: expect.any(String),
+        }),
+      );
+    });
+
+    it("should terminate after queue drains with multiple pending parallel invoke branches", async () => {
+      // Simulates 4 parallel invoke branches where one completes and checkpoints
+      // SUCCEED while the remaining 3 transition to IDLE_AWAITED. Verifies that
+      // processQueue calls checkAndTerminate after the queue drains, allowing
+      // the function to suspend while remaining branches are pending.
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      // Branch A completed — its child context checkpoints SUCCEED (fire-and-forget)
+      const checkpointPromise = checkpointManager.checkpoint(
+        "branch-a-child-ctx",
+        {
+          Action: "SUCCEED" as any,
+          SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+          Type: OperationType.CONTEXT,
+        },
+      );
+      checkpointPromise.catch(() => {});
+
+      // Branches B, C, D still running — their invokes go through Phase 1 → IDLE_NOT_AWAITED
+      for (const branch of [
+        "branch-b-invoke",
+        "branch-c-invoke",
+        "branch-d-invoke",
+      ]) {
+        checkpointManager.markOperationState(
+          branch,
+          OperationLifecycleState.IDLE_NOT_AWAITED,
+          {
+            metadata: {
+              stepId: branch,
+              type: OperationType.CHAINED_INVOKE,
+              subType: OperationSubType.CHAINED_INVOKE,
+            },
+          },
+        );
+      }
+
+      // Phase 2: all pending invokes transition to IDLE_AWAITED
+      // Each calls checkAndTerminate, but queue is non-empty → no termination
+      for (const branch of [
+        "branch-b-invoke",
+        "branch-c-invoke",
+        "branch-d-invoke",
+      ]) {
+        checkpointManager.markOperationAwaited(branch);
+      }
+
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
+
+      // Queue drains → processQueue finally block → checkAndTerminate
+      await jest.advanceTimersByTimeAsync(0);
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS + 1);
+
+      // Function should suspend with all 3 pending invokes in IDLE_AWAITED
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: expect.any(String),
+        }),
+      );
+    });
+  });
+
   describe("startTimerWithPolling - setTimeout overflow protection", () => {
     it("should skip setTimeout when delay exceeds MAX_POLL_DURATION_MS", () => {
       const stepId = "long-wait-step";

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -344,6 +344,11 @@ export class CheckpointManager implements Checkpoint {
       } else {
         // Queue is empty and processing is done - notify all waiting promises
         this.notifyQueueCompletion();
+        // Re-evaluate termination now that the queue is empty, unless
+        // a termination cooldown is already in progress.
+        if (!this.terminationTimer) {
+          this.checkAndTerminate();
+        }
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/492

*Description of changes:*

When `context.parallel()` dispatches multiple context.invoke() branches, the function correctly suspends after all invokes are dispatched. However, when the first invoke completes and triggers a resume, the runtime stays active polling for remaining branches instead of re-suspending.

Root cause - processQueue()'s finally block notifies queue completion but doesn't call checkAndTerminate(). When a completed branch checkpoints SUCCEED (queued via fire-and-forget), the pending branches' markOperationAwaited→checkAndTerminate()` calls see a non-empty queue and skip termination. After the queue drains, nobody re-evaluates.

Fix - this.checkAndTerminate()afterthis.notifyQueueCompletion()inprocessQueue`'s finally block.

Testing - unit tests and integ tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
