### PR TITLE
feat(sdk): add retryOperation helper for durable operations

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.history.json
@@ -1,0 +1,387 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "7b0bd406-b8c4-4d89-9b9d-2ccdced3f0c8",
+    "EventTimestamp": "2026-04-23T18:39:46.949Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"maxAttempts\":3}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval",
+    "EventTimestamp": "2026-04-23T18:39:46.955Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "approval-1",
+    "EventTimestamp": "2026-04-23T18:39:46.955Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "EventTimestamp": "2026-04-23T18:39:46.955Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImQ5MTZlODNmLWNiY2ItNDdjMy1hMWViLTRhNDYxNTAyNzMyNSIsIm9wZXJhdGlvbklkIjoiMmYyMjFhMThlYjg2MzgwMyIsInRva2VuIjoiYmY0OWRkMGQtNTdmZC00MWZmLTliOWItMmQyOTIzNTk2NDJhIn0=",
+      "Timeout": 30,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "4f57d0ecf9622a0b",
+    "EventTimestamp": "2026-04-23T18:39:46.958Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "4f57d0ecf9622a0b",
+    "EventTimestamp": "2026-04-23T18:39:46.958Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackFailed",
+    "SubType": "Callback",
+    "EventId": 7,
+    "Id": "2f221a18eb863803",
+    "EventTimestamp": "2026-04-23T18:39:46.959Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "CallbackFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Attempt 1 rejected",
+          "ErrorType": "RetryableError"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 8,
+    "EventTimestamp": "2026-04-23T18:39:46.980Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:46.949Z",
+      "EndTimestamp": "2026-04-23T18:39:46.980Z",
+      "Error": {},
+      "RequestId": "69acbf6c-2363-4242-92f4-05f0c89927f9"
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "WaitForCallback",
+    "EventId": 9,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "approval-1",
+    "EventTimestamp": "2026-04-23T18:39:46.984Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Attempt 1 rejected"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 10,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "approval-backoff-1",
+    "EventTimestamp": "2026-04-23T18:39:46.986Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-04-23T18:39:47.986Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 11,
+    "EventTimestamp": "2026-04-23T18:39:47.008Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:46.982Z",
+      "EndTimestamp": "2026-04-23T18:39:47.008Z",
+      "Error": {},
+      "RequestId": "0ef91475-666f-421d-b745-66f08a12b656"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 12,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "approval-backoff-1",
+    "EventTimestamp": "2026-04-23T18:39:47.985Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 13,
+    "Id": "13cee27a2bd93915",
+    "Name": "approval-2",
+    "EventTimestamp": "2026-04-23T18:39:47.989Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 14,
+    "Id": "b425e0c75591aa8f",
+    "EventTimestamp": "2026-04-23T18:39:47.989Z",
+    "ParentId": "13cee27a2bd93915",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImQ5MTZlODNmLWNiY2ItNDdjMy1hMWViLTRhNDYxNTAyNzMyNSIsIm9wZXJhdGlvbklkIjoiYjQyNWUwYzc1NTkxYWE4ZiIsInRva2VuIjoiMmQyYmQ4ZjgtMzAyZS00NzU3LTk1ZWEtODMxMThlMzhmNmVkIn0=",
+      "Timeout": 30,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 15,
+    "Id": "bc5861c5c13a0b06",
+    "EventTimestamp": "2026-04-23T18:39:47.991Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 16,
+    "Id": "bc5861c5c13a0b06",
+    "EventTimestamp": "2026-04-23T18:39:47.991Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackFailed",
+    "SubType": "Callback",
+    "EventId": 17,
+    "Id": "b425e0c75591aa8f",
+    "EventTimestamp": "2026-04-23T18:39:47.991Z",
+    "ParentId": "13cee27a2bd93915",
+    "CallbackFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Attempt 2 rejected",
+          "ErrorType": "RetryableError"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 18,
+    "EventTimestamp": "2026-04-23T18:39:48.012Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:47.986Z",
+      "EndTimestamp": "2026-04-23T18:39:48.012Z",
+      "Error": {},
+      "RequestId": "6db922cd-e4cd-447c-8767-5f3bbaabc873"
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "WaitForCallback",
+    "EventId": 19,
+    "Id": "13cee27a2bd93915",
+    "Name": "approval-2",
+    "EventTimestamp": "2026-04-23T18:39:48.016Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Attempt 2 rejected"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 20,
+    "Id": "3a170a9fe4f47efa",
+    "Name": "approval-backoff-2",
+    "EventTimestamp": "2026-04-23T18:39:48.016Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-04-23T18:39:49.016Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 21,
+    "EventTimestamp": "2026-04-23T18:39:48.037Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:48.014Z",
+      "EndTimestamp": "2026-04-23T18:39:48.037Z",
+      "Error": {},
+      "RequestId": "d0839a2c-c393-4e25-9c64-dbdc061826d7"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 22,
+    "Id": "3a170a9fe4f47efa",
+    "Name": "approval-backoff-2",
+    "EventTimestamp": "2026-04-23T18:39:49.016Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 23,
+    "Id": "12426c956d1bc501",
+    "Name": "approval-3",
+    "EventTimestamp": "2026-04-23T18:39:49.019Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 24,
+    "Id": "0f42756e5788f9b0",
+    "EventTimestamp": "2026-04-23T18:39:49.019Z",
+    "ParentId": "12426c956d1bc501",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImQ5MTZlODNmLWNiY2ItNDdjMy1hMWViLTRhNDYxNTAyNzMyNSIsIm9wZXJhdGlvbklkIjoiMGY0Mjc1NmU1Nzg4ZjliMCIsInRva2VuIjoiMzgyNWNhOTctY2IwOC00YmQxLTg1MjEtZmU5NjU4N2JmZjg0In0=",
+      "Timeout": 30,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 25,
+    "Id": "79cef6701281790d",
+    "EventTimestamp": "2026-04-23T18:39:49.021Z",
+    "ParentId": "12426c956d1bc501",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 26,
+    "Id": "79cef6701281790d",
+    "EventTimestamp": "2026-04-23T18:39:49.021Z",
+    "ParentId": "12426c956d1bc501",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 27,
+    "Id": "0f42756e5788f9b0",
+    "EventTimestamp": "2026-04-23T18:39:49.021Z",
+    "ParentId": "12426c956d1bc501",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "{\"approved\":true}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 28,
+    "EventTimestamp": "2026-04-23T18:39:49.042Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:49.017Z",
+      "EndTimestamp": "2026-04-23T18:39:49.042Z",
+      "Error": {},
+      "RequestId": "fc456a57-e60a-457d-b9ee-0ede0ab5768e"
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 29,
+    "Id": "12426c956d1bc501",
+    "Name": "approval-3",
+    "EventTimestamp": "2026-04-23T18:39:49.047Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"{\\\"approved\\\":true}\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "RunInChildContext",
+    "EventId": 30,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval",
+    "EventTimestamp": "2026-04-23T18:39:49.047Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"{\\\"approved\\\":true}\""
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 31,
+    "EventTimestamp": "2026-04-23T18:39:49.047Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:49.044Z",
+      "EndTimestamp": "2026-04-23T18:39:49.047Z",
+      "Error": {},
+      "RequestId": "96f73833-bf2f-434b-8a3a-1f604c97a7d7"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 32,
+    "Id": "7b0bd406-b8c4-4d89-9b9d-2ccdced3f0c8",
+    "EventTimestamp": "2026-04-23T18:39:49.047Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"result\":\"{\\\"approved\\\":true}\",\"attempts\":3}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.test.ts
@@ -1,0 +1,40 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./with-retry-callback";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should retry the callback until it succeeds on the final attempt", async () => {
+      const maxAttempts = 3;
+      const executionPromise = runner.run({ payload: { maxAttempts } });
+
+      // Fail the first (maxAttempts - 1) attempts, then succeed on the last.
+      for (let attempt = 1; attempt < maxAttempts; attempt++) {
+        const op = runner.getOperation(`approval-${attempt}`);
+        await op.waitForData(WaitingOperationStatus.SUBMITTED);
+        await op.sendCallbackFailure({
+          ErrorMessage: `Attempt ${attempt} rejected`,
+          ErrorType: "RetryableError",
+        });
+      }
+
+      const finalOp = runner.getOperation(`approval-${maxAttempts}`);
+      await finalOp.waitForData(WaitingOperationStatus.SUBMITTED);
+      await finalOp.sendCallbackSuccess(JSON.stringify({ approved: true }));
+
+      const execution = await executionPromise;
+
+      expect(execution.getResult()).toEqual({
+        result: JSON.stringify({ approved: true }),
+        attempts: maxAttempts,
+      });
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/callback/with-retry-callback.ts
@@ -1,0 +1,45 @@
+import {
+  DurableContext,
+  withRetry,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "With Retry - Callback",
+  description:
+    "Demonstrates retrying waitForCallback end-to-end (new callbackId per attempt) via the withRetry helper",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: { maxAttempts?: number },
+    context: DurableContext,
+  ): Promise<{ result: string; attempts: number }> => {
+    const maxAttempts = event.maxAttempts ?? 3;
+    let attempts = 0;
+
+    const result = await withRetry<string>(
+      context,
+      "approval",
+      async (ctx, attempt) => {
+        attempts = attempt;
+        return await ctx.waitForCallback<string>(
+          `approval-${attempt}`,
+          async () => {
+            // External system would be notified with the callbackId here
+          },
+          { timeout: { seconds: 30 } },
+        );
+      },
+      {
+        retryStrategy: (_error, attempt) => ({
+          shouldRetry: attempt < maxAttempts,
+          delay: { seconds: 1 },
+        }),
+      },
+    );
+
+    return { result, attempts };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke-target.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke-target.ts
@@ -1,0 +1,23 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "With Retry - Invoke Target",
+  description:
+    "Target function for with-retry-invoke example. Fails when the provided attempt is below failUntilAttempt.",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: { attempt: number; failUntilAttempt: number },
+    _context: DurableContext,
+  ): Promise<{ attempt: number; success: true }> => {
+    if (event.attempt < event.failUntilAttempt) {
+      throw new Error(`Intentional failure on attempt ${event.attempt}`);
+    }
+    return { attempt: event.attempt, success: true };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.history.json
@@ -1,0 +1,258 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "e256ac42-7f23-456f-9263-5a095bda5b51",
+    "EventTimestamp": "2026-04-23T18:39:46.949Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"functionName\":\"with-retry-invoke-target\",\"failUntilAttempt\":3,\"maxAttempts\":3}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "invoke-target",
+    "EventTimestamp": "2026-04-23T18:39:46.955Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "invoke-1",
+    "EventTimestamp": "2026-04-23T18:39:46.955Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 4,
+    "EventTimestamp": "2026-04-23T18:39:46.976Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:46.949Z",
+      "EndTimestamp": "2026-04-23T18:39:46.976Z",
+      "Error": {},
+      "RequestId": "54e6ef96-e8e5-4209-bd7c-283efd6aaf22"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeFailed",
+    "SubType": "ChainedInvoke",
+    "EventId": 5,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "invoke-1",
+    "EventTimestamp": "2026-04-23T18:39:47.060Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Intentional failure on attempt 1",
+          "ErrorType": "Error"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "invoke-target-backoff-1",
+    "EventTimestamp": "2026-04-23T18:39:47.065Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-04-23T18:39:48.065Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2026-04-23T18:39:47.087Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:47.060Z",
+      "EndTimestamp": "2026-04-23T18:39:47.087Z",
+      "Error": {},
+      "RequestId": "170afe0c-3d67-43a9-8d11-e1a11e324215"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 8,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "invoke-target-backoff-1",
+    "EventTimestamp": "2026-04-23T18:39:48.063Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 9,
+    "Id": "13cee27a2bd93915",
+    "Name": "invoke-2",
+    "EventTimestamp": "2026-04-23T18:39:48.065Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-04-23T18:39:48.086Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:48.063Z",
+      "EndTimestamp": "2026-04-23T18:39:48.086Z",
+      "Error": {},
+      "RequestId": "483a8f54-0ff0-4a83-a3a7-27d8be35fd0c"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeFailed",
+    "SubType": "ChainedInvoke",
+    "EventId": 11,
+    "Id": "13cee27a2bd93915",
+    "Name": "invoke-2",
+    "EventTimestamp": "2026-04-23T18:39:48.168Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Intentional failure on attempt 2",
+          "ErrorType": "Error"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 12,
+    "Id": "3a170a9fe4f47efa",
+    "Name": "invoke-target-backoff-2",
+    "EventTimestamp": "2026-04-23T18:39:48.172Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-04-23T18:39:49.172Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 13,
+    "EventTimestamp": "2026-04-23T18:39:48.194Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:48.170Z",
+      "EndTimestamp": "2026-04-23T18:39:48.194Z",
+      "Error": {},
+      "RequestId": "0b8dc9ce-ec96-4546-8a50-5f5ec6d7c972"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 14,
+    "Id": "3a170a9fe4f47efa",
+    "Name": "invoke-target-backoff-2",
+    "EventTimestamp": "2026-04-23T18:39:49.173Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "ChainedInvokeStarted",
+    "SubType": "ChainedInvoke",
+    "EventId": 15,
+    "Id": "12426c956d1bc501",
+    "Name": "invoke-3",
+    "EventTimestamp": "2026-04-23T18:39:49.176Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeStartedDetails": {
+      "FunctionName": "",
+      "Input": {
+        "Payload": ""
+      },
+      "DurableExecutionArn": ""
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 16,
+    "EventTimestamp": "2026-04-23T18:39:49.197Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:49.173Z",
+      "EndTimestamp": "2026-04-23T18:39:49.197Z",
+      "Error": {},
+      "RequestId": "b07ed8e0-9bb8-48ef-aea5-78782b05f62b"
+    }
+  },
+  {
+    "EventType": "ChainedInvokeSucceeded",
+    "SubType": "ChainedInvoke",
+    "EventId": 17,
+    "Id": "12426c956d1bc501",
+    "Name": "invoke-3",
+    "EventTimestamp": "2026-04-23T18:39:49.279Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ChainedInvokeSucceededDetails": {
+      "Result": {
+        "Payload": "{\"attempt\":3,\"success\":true}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "RunInChildContext",
+    "EventId": 18,
+    "Id": "c4ca4238a0b92382",
+    "Name": "invoke-target",
+    "EventTimestamp": "2026-04-23T18:39:49.284Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"attempt\":3,\"success\":true}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 19,
+    "EventTimestamp": "2026-04-23T18:39:49.284Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-23T18:39:49.281Z",
+      "EndTimestamp": "2026-04-23T18:39:49.284Z",
+      "Error": {},
+      "RequestId": "ff1009da-eccb-44b9-ba85-9e204ee21f00"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 20,
+    "Id": "e256ac42-7f23-456f-9263-5a095bda5b51",
+    "EventTimestamp": "2026-04-23T18:39:49.284Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"result\":{\"attempt\":3,\"success\":true},\"attempts\":3}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.test.ts
@@ -1,0 +1,38 @@
+import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./with-retry-invoke";
+import { handler as targetHandler } from "./with-retry-invoke-target";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { functionNameMap, assertEventSignatures }) => {
+    it("should retry the invoke until the target succeeds on the final attempt", async () => {
+      const maxAttempts = 3;
+      const failUntilAttempt = 3;
+
+      if (runner instanceof LocalDurableTestRunner) {
+        runner.registerDurableFunction(
+          functionNameMap.getFunctionName("with-retry-invoke-target"),
+          targetHandler,
+        );
+      }
+
+      const execution = await runner.run({
+        payload: {
+          functionName: functionNameMap.getFunctionName(
+            "with-retry-invoke-target",
+          ),
+          failUntilAttempt,
+          maxAttempts,
+        },
+      });
+
+      expect(execution.getResult()).toEqual({
+        result: { attempt: maxAttempts, success: true },
+        attempts: maxAttempts,
+      });
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/invoke/with-retry-invoke.ts
@@ -1,0 +1,47 @@
+import {
+  DurableContext,
+  withRetry,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "With Retry - Invoke",
+  description:
+    "Demonstrates retrying context.invoke end-to-end via the withRetry helper",
+};
+
+export const handler = withDurableExecution(
+  async (
+    event: {
+      functionName: string;
+      failUntilAttempt?: number;
+      maxAttempts?: number;
+    },
+    context: DurableContext,
+  ): Promise<{ result: unknown; attempts: number }> => {
+    const failUntilAttempt = event.failUntilAttempt ?? 3;
+    const maxAttempts = event.maxAttempts ?? 3;
+    let attempts = 0;
+
+    const result = await withRetry<unknown>(
+      context,
+      "invoke-target",
+      async (ctx, attempt) => {
+        attempts = attempt;
+        return await ctx.invoke(`invoke-${attempt}`, event.functionName, {
+          attempt,
+          failUntilAttempt,
+        });
+      },
+      {
+        retryStrategy: (_error, attempt) => ({
+          shouldRetry: attempt < maxAttempts,
+          delay: { seconds: 1 },
+        }),
+      },
+    );
+
+    return { result, attempts };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1373,6 +1373,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  ParallelInvoke:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ParallelInvoke-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: parallel-invoke.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   ParallelMinSuccessful:
     Type: AWS::Serverless::Function
     Properties:
@@ -2148,6 +2173,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  WaitConfigurable:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ConfigurableWait-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: wait-configurable.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   WaitNamed:
     Type: AWS::Serverless::Function
     Properties:
@@ -2629,6 +2679,81 @@ Resources:
       FunctionName: WaitforCondition-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: wait-for-condition.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  WithRetryCallback:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WithRetry-Callback-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: with-retry-callback.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  WithRetryInvokeTarget:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WithRetry-InvokeTarget-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: with-retry-invoke-target.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  WithRetryInvoke:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WithRetry-Invoke-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: with-retry-invoke.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -65,4 +65,5 @@ export {
   RetryStrategyConfig,
 } from "./utils/retry/retry-config";
 export { retryPresets } from "./utils/retry/retry-presets/retry-presets";
+export { withRetry, WithRetryConfig, RetryableFunc } from "./utils/with-retry";
 export { DurableExecutionInvocationInputWithClient } from "./utils/durable-execution-invocation-input/durable-execution-invocation-input";

--- a/packages/aws-durable-execution-sdk-js/src/utils/with-retry/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/with-retry/index.test.ts
@@ -1,0 +1,264 @@
+import { DurableContext } from "../../types/durable-context";
+import { Duration } from "../../types";
+import { withRetry } from ".";
+
+/**
+ * Minimal `DurableContext` stub that records `wait` / `runInChildContext`
+ * invocations. Only the methods used by `withRetry` are implemented.
+ */
+function createMockContext(): {
+  context: DurableContext;
+  waits: Array<{ name: string | undefined; duration: Duration }>;
+  childContextCalls: Array<{ name: string | undefined; config: unknown }>;
+  childContextNames: Array<string | undefined>;
+} {
+  const waits: Array<{ name: string | undefined; duration: Duration }> = [];
+  const childContextCalls: Array<{
+    name: string | undefined;
+    config: unknown;
+  }> = [];
+  const childContextNames: Array<string | undefined> = [];
+
+  const context = {
+    wait: jest.fn(
+      async (nameOrDuration: string | Duration, maybeDuration?: Duration) => {
+        if (typeof nameOrDuration === "string") {
+          waits.push({ name: nameOrDuration, duration: maybeDuration! });
+        } else {
+          waits.push({ name: undefined, duration: nameOrDuration });
+        }
+      },
+    ),
+    runInChildContext: jest.fn(
+      async (
+        nameOrFn: string | ((childCtx: DurableContext) => Promise<unknown>),
+        fnOrConfig?: ((childCtx: DurableContext) => Promise<unknown>) | unknown,
+        maybeConfig?: unknown,
+      ) => {
+        if (typeof nameOrFn === "string") {
+          const fn = fnOrConfig as (
+            childCtx: DurableContext,
+          ) => Promise<unknown>;
+          childContextCalls.push({ name: nameOrFn, config: maybeConfig });
+          childContextNames.push(nameOrFn);
+          return fn(context);
+        } else {
+          childContextCalls.push({ name: undefined, config: fnOrConfig });
+          childContextNames.push(undefined);
+          return nameOrFn(context);
+        }
+      },
+    ),
+  } as unknown as DurableContext;
+
+  return { context, waits, childContextCalls, childContextNames };
+}
+
+describe("withRetry", () => {
+  it("returns the result on the first attempt without retrying", async () => {
+    const { context, waits, childContextNames } = createMockContext();
+    const operation = jest.fn(async () => "success");
+
+    const result = await withRetry(context, "op", operation, {
+      retryStrategy: () => ({ shouldRetry: true, delay: { seconds: 1 } }),
+    });
+
+    expect(result).toBe("success");
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(operation).toHaveBeenCalledWith(context, 1);
+    expect(waits).toHaveLength(0);
+    expect(childContextNames).toEqual(["op"]);
+  });
+
+  it("retries until the operation succeeds", async () => {
+    const { context, waits } = createMockContext();
+    const operation = jest
+      .fn<Promise<string>, [DurableContext, number]>()
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withRetry(context, "op", operation, {
+      retryStrategy: (_err, attempt) => ({
+        shouldRetry: attempt < 3,
+        delay: { seconds: 2 ** attempt },
+      }),
+    });
+
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([
+      { name: "op-backoff-1", duration: { seconds: 2 } },
+      { name: "op-backoff-2", duration: { seconds: 4 } },
+    ]);
+  });
+
+  it("throws the last error when retries are exhausted", async () => {
+    const { context } = createMockContext();
+    const finalError = new Error("final");
+    const operation = jest
+      .fn<Promise<string>, [DurableContext, number]>()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(finalError);
+
+    await expect(
+      withRetry(context, "op", operation, {
+        retryStrategy: (_err, attempt) => ({ shouldRetry: attempt < 2 }),
+      }),
+    ).rejects.toBe(finalError);
+
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately when the strategy returns shouldRetry=false", async () => {
+    const { context, waits } = createMockContext();
+    const error = new Error("nope");
+    const operation = jest
+      .fn<Promise<string>, [DurableContext, number]>()
+      .mockRejectedValueOnce(error);
+    const retryStrategy = jest.fn(() => ({ shouldRetry: false }));
+
+    await expect(
+      withRetry(context, "op", operation, { retryStrategy }),
+    ).rejects.toBe(error);
+
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(retryStrategy).toHaveBeenCalledWith(error, 1);
+    expect(waits).toHaveLength(0);
+  });
+
+  it("defaults the backoff delay to 1 second when none is provided", async () => {
+    const { context, waits } = createMockContext();
+    const operation = jest
+      .fn<Promise<string>, [DurableContext, number]>()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce("ok");
+
+    await withRetry(context, "op", operation, {
+      retryStrategy: () => ({ shouldRetry: true }),
+    });
+
+    expect(waits).toEqual([{ name: "op-backoff-1", duration: { seconds: 1 } }]);
+  });
+
+  it("wraps the retry loop in runInChildContext by default", async () => {
+    const { context, childContextNames } = createMockContext();
+    const operation = jest.fn(async () => "ok");
+
+    await withRetry(context, "my-op", operation, {
+      retryStrategy: () => ({ shouldRetry: false }),
+    });
+
+    expect(childContextNames).toEqual(["my-op"]);
+    expect(context.runInChildContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips runInChildContext when wrapWithRunInChildContext is false", async () => {
+    const { context, childContextNames } = createMockContext();
+    const operation = jest.fn(async () => "ok");
+
+    await withRetry(context, "my-op", operation, {
+      retryStrategy: () => ({ shouldRetry: false }),
+      wrapWithRunInChildContext: false,
+    });
+
+    expect(childContextNames).toEqual([]);
+    expect(context.runInChildContext).not.toHaveBeenCalled();
+  });
+
+  it("passes the 1-based attempt number to the operation", async () => {
+    const { context } = createMockContext();
+    const attempts: number[] = [];
+    const operation = jest.fn(async (_ctx: DurableContext, attempt: number) => {
+      attempts.push(attempt);
+      if (attempt < 3) throw new Error("retry");
+      return "done";
+    });
+
+    await withRetry(context, "op", operation, {
+      retryStrategy: (_err, attempt) => ({ shouldRetry: attempt < 3 }),
+    });
+
+    expect(attempts).toEqual([1, 2, 3]);
+  });
+
+  describe("anonymous (no name)", () => {
+    it("wraps the loop in an anonymous runInChildContext and waits anonymously during backoff", async () => {
+      const { context, waits, childContextNames } = createMockContext();
+      const operation = jest
+        .fn<Promise<string>, [DurableContext, number]>()
+        .mockRejectedValueOnce(new Error("fail"))
+        .mockResolvedValueOnce("ok");
+
+      const result = await withRetry(context, operation, {
+        retryStrategy: (_err, attempt) => ({
+          shouldRetry: attempt < 2,
+          delay: { seconds: 3 },
+        }),
+      });
+
+      expect(result).toBe("ok");
+      expect(childContextNames).toEqual([undefined]);
+      expect(context.runInChildContext).toHaveBeenCalledTimes(1);
+      expect(waits).toEqual([{ name: undefined, duration: { seconds: 3 } }]);
+    });
+
+    it("skips runInChildContext when wrapWithRunInChildContext is false (anonymous overload)", async () => {
+      const { context, childContextNames } = createMockContext();
+      const operation = jest.fn(async () => "ok");
+
+      await withRetry(context, operation, {
+        retryStrategy: () => ({ shouldRetry: false }),
+        wrapWithRunInChildContext: false,
+      });
+
+      expect(childContextNames).toEqual([]);
+      expect(context.runInChildContext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("childContextConfig", () => {
+    it("forwards childContextConfig to runInChildContext in the named form", async () => {
+      const { context, childContextCalls } = createMockContext();
+      const operation = jest.fn(async () => "ok");
+      const childContextConfig = { subType: "approval-flow" };
+
+      await withRetry(context, "op", operation, {
+        retryStrategy: () => ({ shouldRetry: false }),
+        childContextConfig,
+      });
+
+      expect(childContextCalls).toEqual([
+        { name: "op", config: childContextConfig },
+      ]);
+    });
+
+    it("forwards childContextConfig to runInChildContext in the anonymous form", async () => {
+      const { context, childContextCalls } = createMockContext();
+      const operation = jest.fn(async () => "ok");
+      const childContextConfig = { subType: "approval-flow" };
+
+      await withRetry(context, operation, {
+        retryStrategy: () => ({ shouldRetry: false }),
+        childContextConfig,
+      });
+
+      expect(childContextCalls).toEqual([
+        { name: undefined, config: childContextConfig },
+      ]);
+    });
+
+    it("is ignored when wrapWithRunInChildContext is false", async () => {
+      const { context } = createMockContext();
+      const operation = jest.fn(async () => "ok");
+
+      await withRetry(context, "op", operation, {
+        retryStrategy: () => ({ shouldRetry: false }),
+        wrapWithRunInChildContext: false,
+        childContextConfig: { subType: "should-not-be-used" },
+      });
+
+      expect(context.runInChildContext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/with-retry/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/with-retry/index.ts
@@ -1,0 +1,251 @@
+import { DurableContext } from "../../types/durable-context";
+import { RetryDecision } from "../../types";
+import { ChildConfig } from "../../types/child-context";
+
+/**
+ * Configuration for {@link withRetry}.
+ *
+ * @typeParam T - The resolved value type of a successful attempt. Used to
+ * type {@link WithRetryConfig.childContextConfig}. Inferred automatically
+ * from the function passed to {@link withRetry}; callers rarely need to
+ * specify it explicitly.
+ *
+ * @public
+ */
+export interface WithRetryConfig<T> {
+  /**
+   * Strategy for retrying failed attempts. Uses the same signature as
+   * {@link StepConfig.retryStrategy}, so values produced by
+   * {@link createRetryStrategy} or entries of {@link retryPresets} can be
+   * passed directly.
+   *
+   * @param error - The error thrown by the most recent attempt.
+   * @param attemptCount - The 1-based attempt number that just failed.
+   * @returns A {@link RetryDecision} describing whether to retry and the
+   * backoff delay to use before the next attempt.
+   *
+   * @example
+   * ```typescript
+   * retryStrategy: (error, attempt) => ({
+   *   shouldRetry: attempt < 3,
+   *   delay: { seconds: 2 ** attempt },
+   * })
+   * ```
+   */
+  retryStrategy: (error: Error, attemptCount: number) => RetryDecision;
+
+  /**
+   * Wrap the retry loop (attempts + backoff waits) in `runInChildContext`
+   * so attempts are grouped under a single operation in the execution
+   * history. When a `name` is provided it's used as the child context's
+   * name; otherwise the child context is anonymous.
+   *
+   * @remarks
+   * Changing this flag changes the shape of thrown errors:
+   * - When `true` (default), a final failure is rethrown as a
+   *   {@link ChildContextError} that wraps the original error on its `cause`
+   *   property (standard `runInChildContext` behavior).
+   * - When `false`, the original error from the final failed attempt is
+   *   rethrown unchanged.
+   *
+   * Code that uses `instanceof` to branch on error type should account for
+   * this, or always inspect `error.cause`.
+   *
+   * @defaultValue true
+   */
+  wrapWithRunInChildContext?: boolean;
+
+  /**
+   * Optional {@link ChildConfig} forwarded to the wrapping
+   * `context.runInChildContext` call (e.g. `serdes`, `subType`,
+   * `errorMapper`, `virtualContext`).
+   *
+   * @remarks
+   * Ignored when {@link WithRetryConfig.wrapWithRunInChildContext} is
+   * `false`.
+   *
+   * If `errorMapper` is provided it runs on errors produced by the child
+   * context (i.e. after retries are exhausted), not on per-attempt errors
+   * handed to {@link WithRetryConfig.retryStrategy}.
+   */
+  childContextConfig?: ChildConfig<T>;
+}
+
+/**
+ * A function executed by {@link withRetry} on each attempt.
+ *
+ * @remarks
+ * The body can contain any chunk of durable-execution logic — multiple
+ * steps, waits, callbacks, invokes, etc. — not just a single durable
+ * operation.
+ *
+ * @typeParam T - The resolved value type of a successful attempt.
+ * @param context - The {@link DurableContext} to use for durable operations.
+ * When {@link WithRetryConfig.wrapWithRunInChildContext} is enabled this is
+ * the child context.
+ * @param attempt - The 1-based attempt number. Provided as metadata; useful
+ * for logging or for incorporating into operation names to improve execution
+ * history readability. Not required for correctness — the SDK disambiguates
+ * operations by call-site position.
+ * @returns A promise for the successful result. If it rejects, the error is
+ * passed to {@link WithRetryConfig.retryStrategy} to decide whether to
+ * retry.
+ *
+ * @public
+ */
+export type RetryableFunc<T> = (
+  context: DurableContext,
+  attempt: number,
+) => Promise<T>;
+
+/**
+ * Runs a chunk of durable-execution logic with retries. Semantically a
+ * `runInChildContext` with a retry policy wrapped around it — on failure the
+ * whole function body is re-run from the beginning with configurable
+ * backoff, using the same `retryStrategy` shape as {@link StepConfig}.
+ *
+ * @remarks
+ * Unlike `context.step()`, durable operations such as `waitForCallback` and
+ * `invoke` cannot be nested inside a step. `withRetry` runs the function at
+ * the top level and uses `context.wait` between attempts for backoff. By
+ * default the whole loop is wrapped in `context.runInChildContext` for
+ * isolation (opt out with `wrapWithRunInChildContext: false`); the child
+ * context is named when `name` is provided and anonymous otherwise.
+ *
+ * The function body can contain multiple durable operations — this is
+ * effectively "retry this block of logic," not "retry one operation."
+ *
+ * Because the SDK identifies durable operations by call-site position,
+ * unique per-attempt names are not required for correctness. Callers may
+ * still incorporate `attempt` into operation names (e.g.
+ * "`my-callback-${attempt}`") to make execution history easier to read.
+ * Backoff waits are named automatically as `${name}-backoff-${attempt}`
+ * when `name` is provided; otherwise they are anonymous.
+ *
+ * @typeParam T - The resolved value type of a successful attempt.
+ * @param context - The parent {@link DurableContext}.
+ * @param name - Optional name used for the enclosing child context and
+ * backoff wait operations. Omit to run the retry loop directly in `context`.
+ * @param func - The function to execute on each attempt.
+ * @param config - Retry configuration.
+ * @returns The result of the first successful attempt.
+ * @throws \{ChildContextError\} When `wrapWithRunInChildContext` is `true`
+ * (default) and retries are exhausted or `retryStrategy` returns
+ * `shouldRetry: false`. The original error from the final failed attempt is
+ * available on the `cause` property.
+ * @throws When `wrapWithRunInChildContext` is `false`, the original error
+ * from the final failed attempt is rethrown unchanged.
+ *
+ * @example Named (wrapped in a child context by default)
+ * ```typescript
+ * import {
+ *   withRetry,
+ *   createRetryStrategy,
+ * } from "@aws/durable-execution-sdk-js";
+ *
+ * const decision = await withRetry(
+ *   context,
+ *   "approval",
+ *   (ctx, attempt) =>
+ *     ctx.waitForCallback(`approval-${attempt}`, submitter, {
+ *       timeout: { hours: 24 },
+ *     }),
+ *   {
+ *     retryStrategy: createRetryStrategy({
+ *       maxAttempts: 3,
+ *       initialDelay: { seconds: 2 },
+ *       backoffRate: 2,
+ *     }),
+ *   },
+ * );
+ * ```
+ *
+ * @example Anonymous (no child-context name)
+ * ```typescript
+ * const result = await withRetry(
+ *   context,
+ *   (ctx, attempt) =>
+ *     ctx.invoke(`charge-${attempt}`, paymentFnArn, { orderId }),
+ *   {
+ *     retryStrategy: (_err, attempt) => ({
+ *       shouldRetry: attempt < 3,
+ *       delay: { seconds: 1 },
+ *     }),
+ *   },
+ * );
+ * ```
+ *
+ * @see {@link createRetryStrategy}
+ * @see {@link retryPresets}
+ * @see {@link StepConfig}
+ *
+ * @public
+ */
+export function withRetry<T>(
+  context: DurableContext,
+  name: string,
+  func: RetryableFunc<T>,
+  config: WithRetryConfig<T>,
+): Promise<T>;
+/**
+ * Anonymous overload of {@link withRetry}.
+ *
+ * @remarks
+ * Same behavior as the named overload, but the enclosing
+ * `runInChildContext` (when `wrapWithRunInChildContext` is enabled) and the
+ * backoff waits are anonymous.
+ *
+ * @public
+ */
+export function withRetry<T>(
+  context: DurableContext,
+  func: RetryableFunc<T>,
+  config: WithRetryConfig<T>,
+): Promise<T>;
+export async function withRetry<T>(
+  context: DurableContext,
+  nameOrFunc: string | RetryableFunc<T>,
+  funcOrConfig: RetryableFunc<T> | WithRetryConfig<T>,
+  maybeConfig?: WithRetryConfig<T>,
+): Promise<T> {
+  const hasName = typeof nameOrFunc === "string";
+  const name = hasName ? nameOrFunc : undefined;
+  const func = (hasName ? funcOrConfig : nameOrFunc) as RetryableFunc<T>;
+  const config = (hasName ? maybeConfig : funcOrConfig) as
+    | WithRetryConfig<T>
+    | undefined;
+
+  if (!config) {
+    throw new TypeError("withRetry: config is required");
+  }
+  const {
+    retryStrategy,
+    wrapWithRunInChildContext = true,
+    childContextConfig,
+  } = config;
+
+  const runLoop = async (ctx: DurableContext): Promise<T> => {
+    let attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        return await func(ctx, attempt);
+      } catch (err) {
+        const decision = retryStrategy(err as Error, attempt);
+        if (!decision.shouldRetry) throw err;
+        const delay = decision.delay ?? { seconds: 1 };
+        if (name) {
+          await ctx.wait(`${name}-backoff-${attempt}`, delay);
+        } else {
+          await ctx.wait(delay);
+        }
+      }
+    }
+  };
+
+  return wrapWithRunInChildContext
+    ? name
+      ? await context.runInChildContext(name, runLoop, childContextConfig)
+      : await context.runInChildContext(runLoop, childContextConfig)
+    : await runLoop(context);
+}


### PR DESCRIPTION
**What**

Adds a new withRetry helper to @aws/durable-execution-sdk-js that runs a chunk of durable-execution logic with automatic retries and configurable backoff. Semantically it's runInChildContext with a retry policy
   wrapped around it — on failure the whole function body is re-run from the beginning until it succeeds, retries are exhausted, or the strategy decides to stop.

**Why**
context.step() has first-class retry support via StepConfig.retryStrategy, but other durable primitives (waitForCallback, invoke, waitForCondition, etc.) don't — and they can't be nested inside a step. Today
   every team hand-rolls the same pattern:
```
   let attempt = 0;
   while (attempt < 3) {
     attempt++;
     try {
       return await context.waitForCallback(`approval-${attempt}`, submitter, {
         timeout: { hours: 24 },
       });
     } catch (err) {
       if (attempt >= 3) throw err;
       await context.wait(`backoff-${attempt}`, { seconds: 2 ** attempt });
     }
   }
```
   It's easy to get subtly wrong (forgetting context.wait for backoff, using setTimeout, accidentally nesting durable ops inside a step). withRetry turns it into a one-liner and reuses the exact same retryStrategy
    shape as StepConfig — so createRetryStrategy and retryPresets work out of the box.

**Usage**
```
   import { withRetry, createRetryStrategy } from "@aws/durable-execution-sdk-js";

   const decision = await withRetry(
     context,
     "approval",
     (ctx, attempt) =>
       ctx.waitForCallback<"APPROVED" | "REJECTED">(
         `approval-${attempt}`,
         (callbackId) => sendApprovalEmail(event.email, callbackId),
         { timeout: { hours: 24 } },
       ),
     {
       retryStrategy: createRetryStrategy({
         maxAttempts: 3,
         initialDelay: { seconds: 2 },
         backoffRate: 2,
       }),
     },
   );
```
   Anonymous overload (no name, no child-context grouping name) is also supported. The body can contain multiple durable operations — it's not limited to a single op.

**Behavior**

   - Runs func(ctx, attempt) starting at attempt = 1.
   - On rejection → calls retryStrategy. If shouldRetry: true, context.waits for the returned delay, then re-runs the whole function.
   - On fulfillment → returns the value.
   - On the final failure → rethrows (see "Error shape" below).
   - By default wraps the loop in context.runInChildContext for isolation and so all attempts + backoff waits appear as a single grouped operation in execution history. Opt out via wrapWithRunInChildContext: false.
   - Optional `childContextConfig` is forwarded to the wrapping runInChildContext (e.g. serdes, subType, errorMapper, virtualContext).

**Public API**

Three new exports from the SDK barrel:
```
   export function withRetry<T>(context, name, func, config): Promise<T>;
   export function withRetry<T>(context, func, config): Promise<T>;

   export interface WithRetryConfig<T> {
     retryStrategy: (error: Error, attemptCount: number) => RetryDecision;
     wrapWithRunInChildContext?: boolean;         // default: true
     childContextConfig?: ChildConfig<T>;
   }

   export type RetryableFunc<T> = (
     context: DurableContext,
     attempt: number, // 1-based
   ) => Promise<T>;
```
**Error shape**

   Because the loop is wrapped in runInChildContext by default, the final failure is rethrown as a ChildContextError with the original error on .cause. If you're doing instanceof checks on the error, either inspect
   error.cause or set wrapWithRunInChildContext: false to get the raw error.

   