### PR TITLE
feat(sdk): treat KMS exceptions as non-retryable customer errors

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/non-retryable-errors.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/non-retryable-errors.ts
@@ -1,0 +1,16 @@
+// KMS errors from Lambda that indicate customer-caused key misconfiguration.
+// These arrive as 502 errors but are non-retryable.
+const NON_RETRYABLE_CUSTOMER_ERRORS = new Set([
+  "KMSAccessDeniedException",
+  "KMSDisabledException",
+  "KMSInvalidStateException",
+  "KMSNotFoundException",
+]);
+
+/**
+ * Returns true if the error is a non-retryable customer error (e.g., KMS key misconfiguration).
+ */
+export function isNonRetryableCustomerError(error: unknown): boolean {
+  const name = (error as { name?: string })?.name;
+  return !!name && NON_RETRYABLE_CUSTOMER_ERRORS.has(name);
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-error-classification.test.ts
@@ -111,6 +111,70 @@ describe("Checkpoint Error Classification", () => {
     expect(result.message).toContain("Network timeout");
   });
 
+  it("should classify KMSAccessDeniedException as execution error", () => {
+    const awsError = {
+      name: "KMSAccessDeniedException",
+      message:
+        "Lambda was unable to decrypt the environment variables because KMS access was denied.",
+      $metadata: { httpStatusCode: 502 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+    expect(result.message).toContain("KMS access was denied");
+  });
+
+  it("should classify KMSDisabledException as execution error", () => {
+    const awsError = {
+      name: "KMSDisabledException",
+      message:
+        "Lambda was unable to decrypt the environment variables because the KMS key used is disabled.",
+      $metadata: { httpStatusCode: 502 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+  });
+
+  it("should classify KMSInvalidStateException as execution error", () => {
+    const awsError = {
+      name: "KMSInvalidStateException",
+      message: "KMS key state is not valid for Decrypt.",
+      $metadata: { httpStatusCode: 502 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+  });
+
+  it("should classify KMSNotFoundException as execution error", () => {
+    const awsError = {
+      name: "KMSNotFoundException",
+      message: "KMS key was not found.",
+      $metadata: { httpStatusCode: 502 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableExecutionError);
+  });
+
+  it("should classify 502 without KMS error name as invocation error", () => {
+    const awsError = {
+      name: "ServiceException",
+      message: "Service unavailable",
+      $metadata: { httpStatusCode: 502 },
+    };
+
+    const result = (handler as any).classifyCheckpointError(awsError);
+
+    expect(result).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(result.message).toContain("Service unavailable");
+  });
+
   it("should preserve original error in classified error", () => {
     const originalError = new Error("Original error");
     const result = (handler as any).classifyCheckpointError(originalError);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -14,6 +14,7 @@ import {
   CheckpointUnrecoverableInvocationError,
   CheckpointUnrecoverableExecutionError,
 } from "../../errors/checkpoint-errors/checkpoint-errors";
+import { isNonRetryableCustomerError } from "../../errors/non-retryable-errors";
 import { DurableLogger } from "../../types/durable-logger";
 import { Checkpoint } from "./checkpoint-helper";
 import {
@@ -243,6 +244,15 @@ export class CheckpointManager implements Checkpoint {
       statusCode < 500 &&
       statusCode !== 429
     ) {
+      return new CheckpointUnrecoverableExecutionError(
+        `Checkpoint failed: ${errorMessage}`,
+        originalError,
+      );
+    }
+
+    // For example: KMS errors from Lambda arrive as 502 errors. These indicate customer-caused
+    // KMS key misconfiguration and should not be retried — treat as execution error.
+    if (isNonRetryableCustomerError(error)) {
       return new CheckpointUnrecoverableExecutionError(
         `Checkpoint failed: ${errorMessage}`,
         originalError,

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -552,4 +552,36 @@ describe("withDurableExecution", () => {
       mockDurableContext,
     );
   });
+
+  it("should return FAILED status when initializeExecutionContext throws a non-retryable KMS error", async () => {
+    const kmsError = Object.assign(new Error("KMS access was denied"), {
+      name: "KMSAccessDeniedException",
+      $metadata: { httpStatusCode: 502 },
+    });
+    (initializeExecutionContext as jest.Mock).mockRejectedValue(kmsError);
+
+    const mockHandler = jest.fn();
+    const wrappedHandler = withDurableExecution(mockHandler);
+    const result = await wrappedHandler(mockEvent, mockContext);
+
+    expect(result.Status).toBe(InvocationStatus.FAILED);
+    expect(result).toHaveProperty("Error");
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it("should re-throw non-KMS errors from initializeExecutionContext", async () => {
+    const serviceError = Object.assign(new Error("Service unavailable"), {
+      name: "ServiceException",
+      $metadata: { httpStatusCode: 500 },
+    });
+    (initializeExecutionContext as jest.Mock).mockRejectedValue(serviceError);
+
+    const mockHandler = jest.fn();
+    const wrappedHandler = withDurableExecution(mockHandler);
+
+    await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
+      "Service unavailable",
+    );
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
 });

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -7,6 +7,7 @@ import { CheckpointManager } from "./utils/checkpoint/checkpoint-manager";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { SerdesFailedError } from "./errors/serdes-errors/serdes-errors";
 import { isUnrecoverableInvocationError } from "./errors/unrecoverable-error/unrecoverable-error";
+import { isNonRetryableCustomerError } from "./errors/non-retryable-errors";
 import { TerminationReason } from "./termination-manager/types";
 
 import {
@@ -365,15 +366,27 @@ export const withDurableExecution = <
     context: Context,
   ): Promise<DurableExecutionInvocationOutput> => {
     validateDurableExecutionEvent(event);
-    const { executionContext, durableExecutionMode, checkpointToken } =
-      await initializeExecutionContext(event, context, config?.client);
-    return runHandler(
-      event,
-      context,
-      executionContext,
-      durableExecutionMode,
-      checkpointToken,
-      handler,
-    );
+    try {
+      const { executionContext, durableExecutionMode, checkpointToken } =
+        await initializeExecutionContext(event, context, config?.client);
+      return await runHandler(
+        event,
+        context,
+        executionContext,
+        durableExecutionMode,
+        checkpointToken,
+        handler,
+      );
+    } catch (error) {
+      // Non-retryable customer errors (e.g., KMS key misconfiguration) should
+      // fail the execution immediately rather than retrying the invocation.
+      if (isNonRetryableCustomerError(error)) {
+        return {
+          Status: InvocationStatus.FAILED,
+          Error: createErrorObjectFromError(error),
+        };
+      }
+      throw error;
+    }
   };
 };


### PR DESCRIPTION
*Description of changes:*

KMS exceptions from Lambda (e.g., KMSAccessDeniedException,
KMSDisabledException) will arrive as 502 errors during
CheckpointDurableExecution and GetDurableExecutionState API calls.
Without this change, all 502s are classified as retryable invocation
errors, causing Durable Functions to retry invocations for errors that
could never self-resolve.

Extract a shared NON_RETRYABLE_CUSTOMER_ERRORS set and
isNonRetryableCustomerError helper into errors/non-retryable-errors.ts.
Use it in both classifyCheckpointError (checkpoint-manager.ts) and the
outer try/catch in withDurableExecution (with-durable-execution.ts) so
that KMS errors from both CheckpointDurableExecution and
GetDurableExecutionState return Status: FAILED immediately.

Testing - unit tests for all four KMS exceptions in checkpoint error
classification, plus tests for KMS and non-KMS errors during
initialization in withDurableExecution.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.