### PR TITLE
test(examples): add map + waitForCallback example and integration test

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback-success.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback-success.history.json
@@ -1,0 +1,279 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "962c69f2-6454-41f9-a12c-8d60c0956b27",
+    "EventTimestamp": "2026-04-26T20:22:34.387Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"items\":[0,1]}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "map-callbacks",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "branch-callback",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 5,
+    "Id": "55998bab939d40e7",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "2f221a18eb863803",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImIxMDIzNmRmLWM2Y2ItNDk1OC1hNzEzLTdhZGUyYjE4ZjY2ZSIsIm9wZXJhdGlvbklkIjoiNTU5OThiYWI5MzlkNDBlNyIsInRva2VuIjoiZmRmODBmNDMtODNmMS00YmQ1LTk3M2MtYzFjNmQ4N2U4YTNkIn0=",
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 6,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 7,
+    "Id": "6151f5ab282d90e4",
+    "Name": "branch-callback",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 8,
+    "Id": "361fe970d1e192e9",
+    "EventTimestamp": "2026-04-26T20:22:34.394Z",
+    "ParentId": "6151f5ab282d90e4",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImIxMDIzNmRmLWM2Y2ItNDk1OC1hNzEzLTdhZGUyYjE4ZjY2ZSIsIm9wZXJhdGlvbklkIjoiMzYxZmU5NzBkMWUxOTJlOSIsInRva2VuIjoiMGY1OTlkMjgtZWIxZi00NGQ0LWFkZGItMjgzMDQ2NGFkYTczIn0=",
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "90ef5a310191970a",
+    "EventTimestamp": "2026-04-26T20:22:34.398Z",
+    "ParentId": "2f221a18eb863803",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "1c573df7b335bdcb",
+    "EventTimestamp": "2026-04-26T20:22:34.398Z",
+    "ParentId": "6151f5ab282d90e4",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "90ef5a310191970a",
+    "EventTimestamp": "2026-04-26T20:22:34.398Z",
+    "ParentId": "2f221a18eb863803",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 12,
+    "Id": "1c573df7b335bdcb",
+    "EventTimestamp": "2026-04-26T20:22:34.398Z",
+    "ParentId": "6151f5ab282d90e4",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 13,
+    "Id": "55998bab939d40e7",
+    "EventTimestamp": "2026-04-26T20:22:34.399Z",
+    "ParentId": "2f221a18eb863803",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "result-0"
+      }
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 14,
+    "Id": "361fe970d1e192e9",
+    "EventTimestamp": "2026-04-26T20:22:34.399Z",
+    "ParentId": "6151f5ab282d90e4",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "result-1"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 15,
+    "EventTimestamp": "2026-04-26T20:22:34.420Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-26T20:22:34.387Z",
+      "EndTimestamp": "2026-04-26T20:22:34.420Z",
+      "Error": {},
+      "RequestId": "c9f96c4e-89af-4cfd-9665-66a3608d0825"
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 16,
+    "Id": "2f221a18eb863803",
+    "Name": "branch-callback",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"result-0\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 17,
+    "Id": "6151f5ab282d90e4",
+    "Name": "branch-callback",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"result-1\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 18,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"result-0\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 19,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"result-1\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 20,
+    "Id": "c4ca4238a0b92382",
+    "Name": "map-callbacks",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":\"result-0\",\"index\":0,\"status\":\"SUCCEEDED\"},{\"result\":\"result-1\",\"index\":1,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 21,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "after-map",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 22,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "after-map",
+    "EventTimestamp": "2026-04-26T20:22:34.424Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"processed 2 items\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 23,
+    "EventTimestamp": "2026-04-26T20:22:34.425Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-26T20:22:34.421Z",
+      "EndTimestamp": "2026-04-26T20:22:34.425Z",
+      "Error": {},
+      "RequestId": "fb64e275-3275-4b09-a6d6-728d7459bb90"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 24,
+    "Id": "962c69f2-6454-41f9-a12c-8d60c0956b27",
+    "EventTimestamp": "2026-04-26T20:22:34.425Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"callbackResults\":[\"result-0\",\"result-1\"],\"afterMap\":\"processed 2 items\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback.test.ts
@@ -1,0 +1,49 @@
+import {
+  InvocationType,
+  OperationStatus,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./map-wait-for-callback";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should progress to next step immediately after all map callbacks signal (issue #510)", async () => {
+      const items = [0, 1];
+      const executionPromise = runner.run({ payload: { items } });
+
+      const mapOp = runner.getOperation("map-callbacks");
+      await mapOp.waitForData(WaitingOperationStatus.STARTED);
+
+      // Each map branch has a waitForCallback child named "branch-callback".
+      const branches = mapOp.getChildOperations();
+      expect(branches).toHaveLength(items.length);
+
+      await Promise.all(
+        branches!.map(async (branch, i) => {
+          const callbackOp = branch
+            .getChildOperations()!
+            .find((op) => op.isWaitForCallback())!;
+          await callbackOp.waitForData(WaitingOperationStatus.SUBMITTED);
+          await callbackOp.sendCallbackSuccess(`result-${i}`);
+        }),
+      );
+
+      const execution = await executionPromise;
+
+      expect(execution.getResult()).toEqual({
+        callbackResults: ["result-0", "result-1"],
+        afterMap: "processed 2 items",
+      });
+
+      // Regression guard: after-map step ran (did not wedge waiting for an unrelated timer).
+      expect(runner.getOperation("after-map").getStatus()).toBe(
+        OperationStatus.SUCCEEDED,
+      );
+
+      assertEventSignatures(execution, "success");
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/map-wait-for-callback.ts
@@ -1,0 +1,44 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map Wait for Callback",
+  description:
+    "Demonstrates context.map where each branch uses waitForCallback - reproduces issue #510",
+};
+
+export const handler = withDurableExecution(
+  async (event: { items?: number[] }, context: DurableContext) => {
+    const items = event.items ?? [0, 1];
+
+    const results = await context.map(
+      "map-callbacks",
+      items,
+      async (branchCtx, item) => {
+        return await branchCtx.waitForCallback<string>(
+          "branch-callback",
+          async () => {
+            // Submitter: in production this would trigger external async work
+            // (e.g. write callbackId to S3, invoke another Lambda)
+            return Promise.resolve();
+          },
+        );
+      },
+      { maxConcurrency: 4 },
+    );
+
+    // This step must execute promptly after all callbacks signal.
+    // Issue #510: in cloud, this wedges ~11-12 min after last callback.
+    const afterMap = await context.step("after-map", async () => {
+      return `processed ${items.length} items`;
+    });
+
+    return {
+      callbackResults: results.getResults(),
+      afterMap,
+    };
+  },
+);


### PR DESCRIPTION
Adds a new example under packages/aws-durable-execution-sdk-js-examples/src/examples/map/wait-for-callback/ that uses context.map where each branch performs a waitForCallback, followed by a context.step that must run once all callbacks signal.

This scenario was previously uncovered by the examples and integration tests. It is the exact pattern reported in issue #510, where, in cloud executions, the orchestrator does not progress to the next step after the last map branch's callback succeeds until an unrelated timer fires.

The integration test signals each branch's callback and asserts that the after-map step ran successfully, acting as a regression guard for the termination re-evaluation path on map + waitForCallback. The test passes locally against LocalDurableTestRunner and will also run against CloudDurableTestRunner via createTests.

Refs: #510

*Issue #, if available:*
#510

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
