### PR TITLE
feat(sdk): add linear retry strategy with configurable increment

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -64,6 +64,7 @@ export {
   createRetryStrategy,
   RetryStrategyConfig,
 } from "./utils/retry/retry-config";
+export { createLinearRetryStrategy } from "./utils/retry/linear-retry-strategy/linear-retry-strategy";
 export { retryPresets } from "./utils/retry/retry-presets/retry-presets";
 export { withRetry, WithRetryConfig, RetryableFunc } from "./utils/with-retry";
 export { DurableExecutionInvocationInputWithClient } from "./utils/durable-execution-invocation-input/durable-execution-invocation-input";

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.test.ts
@@ -1,0 +1,44 @@
+import { createLinearRetryStrategy } from "./linear-retry-strategy";
+
+describe("createLinearRetryStrategy", () => {
+  it("should create linear backoff delays", () => {
+    const strategy = createLinearRetryStrategy(5, 2, 3);
+
+    expect(strategy(new Error("test"), 1)).toEqual({
+      shouldRetry: true,
+      delay: { seconds: 2 }, // 2 + (3 * 0)
+    });
+
+    expect(strategy(new Error("test"), 2)).toEqual({
+      shouldRetry: true,
+      delay: { seconds: 5 }, // 2 + (3 * 1)
+    });
+
+    expect(strategy(new Error("test"), 3)).toEqual({
+      shouldRetry: true,
+      delay: { seconds: 8 }, // 2 + (3 * 2)
+    });
+  });
+
+  it("should stop retrying after max attempts", () => {
+    const strategy = createLinearRetryStrategy(3);
+
+    expect(strategy(new Error("test"), 3)).toEqual({
+      shouldRetry: false,
+    });
+  });
+
+  it("should use default values", () => {
+    const strategy = createLinearRetryStrategy();
+
+    expect(strategy(new Error("test"), 1)).toEqual({
+      shouldRetry: true,
+      delay: { seconds: 1 },
+    });
+
+    expect(strategy(new Error("test"), 2)).toEqual({
+      shouldRetry: true,
+      delay: { seconds: 2 },
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.ts
@@ -1,0 +1,25 @@
+import { RetryDecision } from "../../../types";
+
+/**
+ * Creates a linear backoff retry strategy
+ * @param maxAttempts - Maximum number of attempts (default: 6)
+ * @param initialDelay - Initial delay in seconds (default: 1)
+ * @param increment - Linear increment per attempt in seconds (default: 1)
+ * @returns Retry strategy with linear backoff
+ */
+export const createLinearRetryStrategy = (
+  maxAttempts: number = 6,
+  initialDelay: number = 1,
+  increment: number = 1,
+) => {
+  return (error: Error, attemptsMade: number): RetryDecision => {
+    if (attemptsMade >= maxAttempts) {
+      return { shouldRetry: false };
+    }
+
+    return {
+      shouldRetry: true,
+      delay: { seconds: initialDelay + increment * (attemptsMade - 1) },
+    };
+  };
+};

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
@@ -1,13 +1,19 @@
 import { createRetryStrategy, JitterStrategy } from "../retry-config";
+import { createLinearRetryStrategy } from "../linear-retry-strategy/linear-retry-strategy";
 
 /**
  * Pre-configured retry strategies for common use cases
  * @example
  * ```typescript
- * // Use default retry preset (3 attempts with exponential backoff)
+ * // Use default retry preset (6 attempts with exponential backoff)
  * await context.step('my-step', async () => {
  *   return await someOperation();
  * }, { retryStrategy: retryPresets.default });
+ *
+ * // Use linear retry preset (1s, 2s, 3s, 4s, 5s delays)
+ * await context.step('linear-step', async () => {
+ *   return await someOperation();
+ * }, { retryStrategy: retryPresets.linear });
  *
  * // Use no-retry preset (fail immediately on error)
  * await context.step('critical-step', async () => {
@@ -34,6 +40,14 @@ export const retryPresets = {
     backoffRate: 2,
     jitter: JitterStrategy.FULL,
   }),
+
+  /**
+   * Linear retry strategy with fixed increment
+   * - 6 total attempts (1 initial + 5 retries)
+   * - Delays: 1s, 2s, 3s, 4s, 5s
+   * - Total max wait time: 15 seconds
+   */
+  linear: createLinearRetryStrategy(6, 1, 1),
 
   /**
    * No retry strategy - fails immediately on first error


### PR DESCRIPTION
- Add createLinearRetryStrategy function with customizable initial delay and increment
- Add linear preset to retryPresets for 1s, 2s, 3s, 4s, 5s delays
- Export createLinearRetryStrategy from main SDK index
- Include tests for linear backoff functionality