### PR TITLE
feat(sdk): add configureSerdes for default serdes configuration

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.history.json
@@ -1,0 +1,114 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "c886136b-037c-4482-a4a2-048403b7c8d2",
+    "EventTimestamp": "2026-04-30T22:10:54.452Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval",
+    "EventTimestamp": "2026-04-30T22:10:54.456Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-04-30T22:10:54.457Z",
+    "ParentId": "c4ca4238a0b92382",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6IjQyNTdhY2FhLWRkMDktNDE0Zi1iYTk1LTYzNDczZjhmMjcwMSIsIm9wZXJhdGlvbklkIjoiZWE2NmMwNmMxZTFjMDVmYSIsInRva2VuIjoiNmMzYzY4MjktODg0Zi00NjUyLTk1NzItNzQ2MzczNGM3OTljIn0=",
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-04-30T22:10:54.459Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-04-30T22:10:54.459Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 6,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-04-30T22:10:54.461Z",
+    "ParentId": "c4ca4238a0b92382",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "{\"value\":42}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2026-04-30T22:10:54.481Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-30T22:10:54.452Z",
+      "EndTimestamp": "2026-04-30T22:10:54.481Z",
+      "Error": {},
+      "RequestId": "0af3ca81-054d-457b-a5a7-58daded2761e"
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 8,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval",
+    "EventTimestamp": "2026-04-30T22:10:54.555Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"value\":42}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-04-30T22:10:54.556Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-30T22:10:54.482Z",
+      "EndTimestamp": "2026-04-30T22:10:54.556Z",
+      "Error": {},
+      "RequestId": "cc9ca1ee-5279-4553-a764-e4de7ea902be"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 10,
+    "Id": "c886136b-037c-4482-a4a2-048403b7c8d2",
+    "EventTimestamp": "2026-04-30T22:10:54.556Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"received\":{\"value\":42}}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.test.ts
@@ -1,0 +1,32 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./configure-callback-deserializer";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should deserialize callback result exactly once with defaultCallbackDeserializer", async () => {
+      const executionPromise = runner.run();
+
+      const callbackOp = runner.getOperation("approval");
+      await callbackOp.waitForData(WaitingOperationStatus.SUBMITTED);
+
+      // Send a JSON-encoded object as the callback result.
+      // If double-deserialization occurs, the first parse gives { value: 42 },
+      // and the second parse would throw (can't JSON.parse an object).
+      await callbackOp.sendCallbackSuccess(JSON.stringify({ value: 42 }));
+
+      const result = await executionPromise;
+
+      expect(result.getStatus()).toBe("SUCCEEDED");
+      // The deserializer should have run exactly once: raw string -> { value: 42 }
+      expect(result.getResult()).toEqual({ received: { value: 42 } });
+
+      assertEventSignatures(result);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-callback-deserializer.ts
@@ -1,0 +1,33 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Configure Default Callback Deserializer",
+  description:
+    "Demonstrates configureSerdes({ defaultCallbackDeserializer }) with waitForCallback. " +
+    "Verifies the callback result is deserialized exactly once — not double-deserialized.",
+};
+
+export const handler = withDurableExecution(
+  async (event: unknown, context: DurableContext) => {
+    // Configure a JSON-parsing deserializer for all callbacks.
+    // Without the fix for double-deserialization, this would parse the result twice:
+    // first inside createCallback, then again in waitForCallback phase 2 —
+    // turning '{"value":42}' into 42 on first parse, then crashing on second parse.
+    context.configureSerdes({
+      defaultCallbackDeserializer: {
+        deserialize: async (data: string | undefined) =>
+          data !== undefined ? JSON.parse(data) : undefined,
+      },
+    });
+
+    const result = await context.waitForCallback("approval", async () =>
+      Promise.resolve(),
+    );
+
+    return { received: result };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.history.json
@@ -1,0 +1,113 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "f0d8a401-ccd7-4049-b05b-3eabac4421ed",
+    "EventTimestamp": "2026-04-29T05:31:13.179Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"orderId\":\"ORD-001\",\"amount\":99.99}"
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "create-order",
+    "EventTimestamp": "2026-04-29T05:31:13.185Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 3,
+    "Id": "c4ca4238a0b92382",
+    "Name": "create-order",
+    "EventTimestamp": "2026-04-29T05:31:13.185Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"id\":\"ORD-001\",\"amount\":99.99,\"status\":\"pending\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 4,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2026-04-29T05:31:13.192Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-04-29T05:31:14.192Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 5,
+    "EventTimestamp": "2026-04-29T05:31:13.214Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-29T05:31:13.179Z",
+      "EndTimestamp": "2026-04-29T05:31:13.214Z",
+      "Error": {},
+      "RequestId": "c6e18a4e-4c91-457a-a76f-e0179afdc2eb"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "c81e728d9d4c2f63",
+    "EventTimestamp": "2026-04-29T05:31:14.189Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 7,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "process-order",
+    "EventTimestamp": "2026-04-29T05:31:14.191Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "process-order",
+    "EventTimestamp": "2026-04-29T05:31:14.191Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"id\":\"ORD-001\",\"amount\":99.99,\"status\":\"processed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-04-29T05:31:14.191Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-04-29T05:31:14.189Z",
+      "EndTimestamp": "2026-04-29T05:31:14.191Z",
+      "Error": {},
+      "RequestId": "dc68347e-1325-4f41-b73e-21f77009b807"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 10,
+    "Id": "f0d8a401-ccd7-4049-b05b-3eabac4421ed",
+    "EventTimestamp": "2026-04-29T05:31:14.192Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"summary\":\"Order ORD-001: $99.99 (processed)\",\"id\":\"ORD-001\",\"amount\":99.99,\"status\":\"processed\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.test.ts
@@ -1,0 +1,38 @@
+import {
+  OperationStatus,
+  OperationType,
+} from "@aws/durable-execution-sdk-js-testing";
+import { createTests } from "../../../utils/test-helper";
+import { handler } from "./configure-serdes";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should apply default serdes to all steps without per-step configuration", async () => {
+      const execution = await runner.run({
+        payload: { orderId: "ORD-001", amount: 99.99 },
+      });
+
+      expect(execution.getStatus()).toBe("SUCCEEDED");
+      // initial invocation + replay after wait
+      expect(execution.getInvocations().length).toBe(2);
+      // create-order step + wait + process-order step
+      expect(execution.getOperations().length).toBe(3);
+
+      const createStep = runner.getOperation("create-order");
+      expect(createStep.getType()).toBe(OperationType.STEP);
+      expect(createStep.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+      const processStep = runner.getOperation("process-order");
+      expect(processStep.getType()).toBe(OperationType.STEP);
+      expect(processStep.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+      const result = execution.getResult() as any;
+      // summary() works — proves class methods were preserved by the default serdes
+      expect(result.summary).toBe("Order ORD-001: $99.99 (processed)");
+      expect(result.status).toBe("processed");
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/serde/configure-serdes/configure-serdes.ts
@@ -1,0 +1,60 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  createClassSerdes,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Configure Default Serdes via configureSerdes",
+  description:
+    "Demonstrates using context.configureSerdes() to set a default serdes once " +
+    "that applies to all step operations, instead of passing serdes per-operation.",
+};
+
+class Order {
+  id: string = "";
+  amount: number = 0;
+  status: string = "pending";
+
+  constructor(id?: string, amount?: number) {
+    if (id) this.id = id;
+    if (amount !== undefined) this.amount = amount;
+  }
+
+  summary(): string {
+    return `Order ${this.id}: $${this.amount} (${this.status})`;
+  }
+}
+
+export const handler = withDurableExecution(
+  async (
+    event: { orderId: string; amount: number },
+    context: DurableContext,
+  ) => {
+    // Configure default serdes once — applies to all subsequent steps
+    const orderSerdes = createClassSerdes(Order);
+    context.configureSerdes({ defaultSerdes: orderSerdes });
+
+    // Step 1: no per-step serdes needed — uses the configured default
+    const order = await context.step("create-order", async () => {
+      return new Order(event.orderId, event.amount);
+    });
+
+    // Wait forces a replay — order will be deserialized using orderSerdes
+    await context.wait({ seconds: 1 });
+
+    // Step 2: order.summary() works because class methods were preserved by the default serdes
+    const processed = await context.step("process-order", async () => {
+      order.status = "processed";
+      return order;
+    });
+
+    return {
+      summary: processed.summary(),
+      id: processed.id,
+      amount: processed.amount,
+      status: processed.status,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1973,6 +1973,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  ConfigureCallbackDeserializer:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ConfigureDefaultCallbackDeserializer-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: configure-callback-deserializer.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   ConfigureSerdes:
     Type: AWS::Serverless::Function
     Properties:

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1973,6 +1973,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  ConfigureSerdes:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ConfigureDefaultSerdesviaconfigureSerdes-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: configure-serdes.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   SimpleExecution:
     Type: AWS::Serverless::Function
     Properties:

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -56,7 +56,13 @@ import {
   DurableLoggingContext,
 } from "../../types/durable-logger";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
-import { Serdes, SerdesConfig, defaultSerdes } from "../../utils/serdes/serdes";
+import {
+  Serdes,
+  SerdesConfig,
+  defaultSerdes,
+  AnySerdes,
+  AnySerdesDeserializer,
+} from "../../utils/serdes/serdes";
 
 export interface DurableExecution {
   checkpointManager: CheckpointManager;
@@ -77,9 +83,9 @@ export class DurableContextImpl<
   private modeManagement: ModeManagement;
   private durableExecution: DurableExecution;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _defaultSerdes: Serdes<any> = defaultSerdes;
+  private _defaultSerdes: AnySerdes = defaultSerdes;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _defaultCallbackDeserializer: Pick<Serdes<any>, "deserialize"> =
+  private _defaultCallbackDeserializer: AnySerdesDeserializer =
     createPassThroughSerdes();
 
   public logger: DurableContextLogger<Logger>;

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -57,7 +57,6 @@ import {
 } from "../../types/durable-logger";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
 import {
-  Serdes,
   SerdesConfig,
   defaultSerdes,
   AnySerdes,
@@ -82,9 +81,9 @@ export class DurableContextImpl<
   private _parentId?: string;
   private modeManagement: ModeManagement;
   private durableExecution: DurableExecution;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private _defaultSerdes: AnySerdes = defaultSerdes;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private _defaultCallbackDeserializer: AnySerdesDeserializer =
     createPassThroughSerdes();
 

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -35,7 +35,10 @@ import { createInvokeHandler } from "../../handlers/invoke-handler/invoke-handle
 import { createRunInChildContextHandler } from "../../handlers/run-in-child-context-handler/run-in-child-context-handler";
 import { createWaitHandler } from "../../handlers/wait-handler/wait-handler";
 import { createWaitForConditionHandler } from "../../handlers/wait-for-condition-handler/wait-for-condition-handler";
-import { createCallback as createCallbackFactory } from "../../handlers/callback-handler/callback";
+import {
+  createCallback as createCallbackFactory,
+  createPassThroughSerdes,
+} from "../../handlers/callback-handler/callback";
 import { createWaitForCallbackHandler } from "../../handlers/wait-for-callback-handler/wait-for-callback-handler";
 import { createMapHandler } from "../../handlers/map-handler/map-handler";
 import { createParallelHandler } from "../../handlers/parallel-handler/parallel-handler";
@@ -53,6 +56,7 @@ import {
   DurableLoggingContext,
 } from "../../types/durable-logger";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
+import { Serdes, SerdesConfig, defaultSerdes } from "../../utils/serdes/serdes";
 
 export interface DurableExecution {
   checkpointManager: CheckpointManager;
@@ -60,9 +64,9 @@ export interface DurableExecution {
   setTerminating(): void;
 }
 
-export class DurableContextImpl<Logger extends DurableLogger>
-  implements DurableContext<Logger>
-{
+export class DurableContextImpl<
+  Logger extends DurableLogger,
+> implements DurableContext<Logger> {
   private _stepPrefix?: string;
   private _stepCounter: number = 0;
   private durableLogger: Logger;
@@ -72,6 +76,11 @@ export class DurableContextImpl<Logger extends DurableLogger>
   private _parentId?: string;
   private modeManagement: ModeManagement;
   private durableExecution: DurableExecution;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _defaultSerdes: Serdes<any> = defaultSerdes;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _defaultCallbackDeserializer: Pick<Serdes<any>, "deserialize"> =
+    createPassThroughSerdes();
 
   public logger: DurableContextLogger<Logger>;
   public readonly executionContext: {
@@ -282,6 +291,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this.createStepId.bind(this),
         this.durableLogger,
         this._parentId,
+        () => this._defaultSerdes,
       );
 
       return stepHandler(nameOrFn, fnOrOptions, maybeOptions);
@@ -306,6 +316,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this.createStepId.bind(this),
         this._parentId,
         this.checkAndUpdateReplayMode.bind(this),
+        () => this._defaultSerdes,
       );
       return invokeHandler<I, O>(
         ...([
@@ -344,8 +355,8 @@ export class DurableContextImpl<Logger extends DurableLogger>
           stepPrefix,
           _checkpointToken,
           parentId,
-        ) =>
-          createDurableContext(
+        ) => {
+          const childCtx = createDurableContext(
             executionContext,
             parentContext,
             durableExecutionMode,
@@ -353,8 +364,16 @@ export class DurableContextImpl<Logger extends DurableLogger>
             stepPrefix,
             this.durableExecution,
             parentId,
-          ),
+          );
+          // Propagate serdes config to child context
+          childCtx.configureSerdes({
+            defaultSerdes: this._defaultSerdes,
+            defaultCallbackDeserializer: this._defaultCallbackDeserializer,
+          });
+          return childCtx;
+        },
         this._parentId,
+        () => this._defaultSerdes,
       );
       return blockHandler(nameOrFn, fnOrOptions, maybeOptions);
     });
@@ -411,6 +430,15 @@ export class DurableContextImpl<Logger extends DurableLogger>
     }
   }
 
+  configureSerdes(config: SerdesConfig): void {
+    if (config.defaultSerdes !== undefined) {
+      this._defaultSerdes = config.defaultSerdes;
+    }
+    if (config.defaultCallbackDeserializer !== undefined) {
+      this._defaultCallbackDeserializer = config.defaultCallbackDeserializer;
+    }
+  }
+
   createCallback<T>(
     nameOrConfig?: string | CreateCallbackConfig<T>,
     maybeConfig?: CreateCallbackConfig<T>,
@@ -427,6 +455,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this.createStepId.bind(this),
         this.checkAndUpdateReplayMode.bind(this),
         this._parentId,
+        () => this._defaultCallbackDeserializer,
       );
       return callbackFactory(nameOrConfig, maybeConfig);
     });
@@ -449,6 +478,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this._executionContext,
         this.getNextStepId.bind(this),
         this.runInChildContext.bind(this),
+        () => this._defaultCallbackDeserializer,
       );
       return waitForCallbackHandler(
         nameOrSubmitter!,
@@ -477,6 +507,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this.createStepId.bind(this),
         this.durableLogger,
         this._parentId,
+        () => this._defaultSerdes,
       );
 
       return typeof nameOrCheckFunc === "string" ||
@@ -564,6 +595,7 @@ export class DurableContextImpl<Logger extends DurableLogger>
         this._executionContext,
         this.runInChildContext.bind(this),
         this.skipNextOperation.bind(this),
+        () => this._defaultSerdes,
       );
       const promise = concurrentExecutionHandler(
         nameOrItems,

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -86,6 +86,7 @@ export class DurableContextImpl<
 
   private _defaultCallbackDeserializer: AnySerdesDeserializer =
     createPassThroughSerdes();
+  private _customCallbackDeserializerSet: boolean = false;
 
   public logger: DurableContextLogger<Logger>;
   public readonly executionContext: {
@@ -373,7 +374,9 @@ export class DurableContextImpl<
           // Propagate serdes config to child context
           childCtx.configureSerdes({
             defaultSerdes: this._defaultSerdes,
-            defaultCallbackDeserializer: this._defaultCallbackDeserializer,
+            ...(this._customCallbackDeserializerSet && {
+              defaultCallbackDeserializer: this._defaultCallbackDeserializer,
+            }),
           });
           return childCtx;
         },
@@ -441,6 +444,7 @@ export class DurableContextImpl<
     }
     if (config.defaultCallbackDeserializer !== undefined) {
       this._defaultCallbackDeserializer = config.defaultCallbackDeserializer;
+      this._customCallbackDeserializerSet = true;
     }
   }
 
@@ -483,7 +487,12 @@ export class DurableContextImpl<
         this._executionContext,
         this.getNextStepId.bind(this),
         this.runInChildContext.bind(this),
-        () => this._defaultCallbackDeserializer,
+        // Only pass the getter when the user has explicitly configured a custom
+        // deserializer. The default is createPassThroughSerdes() which matches
+        // the original behavior, so no injection is needed in that case.
+        this._customCallbackDeserializerSet
+          ? () => this._defaultCallbackDeserializer
+          : undefined,
       );
       return waitForCallbackHandler(
         nameOrSubmitter!,

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -508,8 +508,8 @@ describe("DurableContext", () => {
       await context.invoke("func", {});
 
       // New invoke handler uses centralized termination, no hasRunningOperations parameter
-      // Verify it was called with the new signature (context, checkpoint, createStepId, parentId, checkAndUpdateReplayMode)
-      expect(createInvokeHandler.mock.calls[0].length).toBe(5);
+      // Verify it was called with the new signature (context, checkpoint, createStepId, parentId, checkAndUpdateReplayMode, getDefaultSerdes)
+      expect(createInvokeHandler.mock.calls[0].length).toBe(6);
     });
 
     it("should call map handler", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -30,7 +30,7 @@ export const createCallback = (
   createStepId: () => string,
   checkAndUpdateReplayMode: () => void,
   parentId?: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
   return <T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -9,7 +9,7 @@ import {
 import { OperationStatus, OperationType } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { Serdes } from "../../utils/serdes/serdes";
+import { Serdes, AnySerdesDeserializer } from "../../utils/serdes/serdes";
 import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
 import {
   CallbackError,
@@ -31,7 +31,7 @@ export const createCallback = (
   checkAndUpdateReplayMode: () => void,
   parentId?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultCallbackDeserializer?: () => Pick<Serdes<any>, "deserialize">,
+  getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
   return <T>(
     nameOrConfig?: string | undefined | CreateCallbackConfig<T>,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -30,6 +30,8 @@ export const createCallback = (
   createStepId: () => string,
   checkAndUpdateReplayMode: () => void,
   parentId?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultCallbackDeserializer?: () => Pick<Serdes<any>, "deserialize">,
 ) => {
   return <T>(
     nameOrConfig?: string | undefined | CreateCallbackConfig<T>,
@@ -46,7 +48,11 @@ export const createCallback = (
     }
 
     const stepId = createStepId();
-    const serdes = config?.serdes || createPassThroughSerdes<T>();
+    const serdes =
+      config?.serdes ||
+      (getDefaultCallbackDeserializer
+        ? getDefaultCallbackDeserializer()
+        : createPassThroughSerdes<T>());
 
     // Phase 1: Setup and checkpoint
     let isCompleted = false;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -15,7 +15,7 @@ import {
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { BatchResultImpl, restoreBatchResult } from "./batch-result";
-import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 export class ConcurrencyController<Logger extends DurableLogger> {
@@ -23,7 +23,7 @@ export class ConcurrencyController<Logger extends DurableLogger> {
     private readonly operationName: string,
     private readonly skipNextOperation: () => void,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly getDefaultSerdes?: () => Serdes<any>,
+    private readonly getDefaultSerdes?: () => AnySerdes,
   ) {}
 
   private isChildEntityCompleted(
@@ -489,7 +489,7 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
   runInChildContext: DurableContext<Logger>["runInChildContext"],
   skipNextOperation: () => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <TItem, TResult>(
     nameOrItems: string | undefined | ConcurrentExecutionItem<TItem>[],

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -15,14 +15,14 @@ import {
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { BatchResultImpl, restoreBatchResult } from "./batch-result";
-import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 export class ConcurrencyController<Logger extends DurableLogger> {
   constructor(
     private readonly operationName: string,
     private readonly skipNextOperation: () => void,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     private readonly getDefaultSerdes?: () => AnySerdes,
   ) {}
 
@@ -488,7 +488,7 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
   skipNextOperation: () => void,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <TItem, TResult>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -15,13 +15,15 @@ import {
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { BatchResultImpl, restoreBatchResult } from "./batch-result";
-import { defaultSerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 
 export class ConcurrencyController<Logger extends DurableLogger> {
   constructor(
     private readonly operationName: string,
     private readonly skipNextOperation: () => void,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private readonly getDefaultSerdes?: () => Serdes<any>,
   ) {}
 
   private isChildEntityCompleted(
@@ -109,7 +111,9 @@ export class ConcurrencyController<Logger extends DurableLogger> {
 
         if (summaryPayload) {
           try {
-            const serdes = config.serdes || defaultSerdes;
+            const serdes =
+              config.serdes ||
+              (this.getDefaultSerdes ? this.getDefaultSerdes() : defaultSerdes);
             const parsedSummary = await serdes.deserialize(summaryPayload, {
               entityId: entityId,
               durableExecutionArn: executionContext.durableExecutionArn,
@@ -484,6 +488,8 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
   skipNextOperation: () => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ) => {
   return <TItem, TResult>(
     nameOrItems: string | undefined | ConcurrentExecutionItem<TItem>[],
@@ -551,6 +557,7 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
         const concurrencyController = new ConcurrencyController<Logger>(
           "concurrent-execution",
           skipNextOperation,
+          getDefaultSerdes,
         );
 
         // Access durableExecutionMode from the context - it's set by runInChildContext

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -13,7 +13,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -27,7 +27,7 @@ export const createInvokeHandler = (
   parentId?: string,
   checkAndUpdateReplayMode?: () => void,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ): {
   <I, O>(
     funcId: string,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -13,7 +13,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -26,6 +26,8 @@ export const createInvokeHandler = (
   createStepId: () => string,
   parentId?: string,
   checkAndUpdateReplayMode?: () => void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ): {
   <I, O>(
     funcId: string,
@@ -140,7 +142,8 @@ export const createInvokeHandler = (
       // Start invoke if not already started
       if (!stepData) {
         const serializedPayload = await safeSerialize(
-          config?.payloadSerdes || defaultSerdes,
+          config?.payloadSerdes ||
+            (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes),
           input,
           stepId,
           name,
@@ -193,7 +196,8 @@ export const createInvokeHandler = (
         if (stepData?.Status === OperationStatus.SUCCEEDED) {
           const invokeDetails = stepData.ChainedInvokeDetails;
           return await safeDeserialize(
-            config?.resultSerdes || defaultSerdes,
+            config?.resultSerdes ||
+              (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes),
             invokeDetails?.Result,
             stepId,
             name,
@@ -236,7 +240,8 @@ export const createInvokeHandler = (
 
         const invokeDetails = stepData.ChainedInvokeDetails;
         return await safeDeserialize(
-          config?.resultSerdes || defaultSerdes,
+          config?.resultSerdes ||
+            (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes),
           invokeDetails?.Result,
           stepId,
           name,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -13,7 +13,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -26,7 +26,7 @@ export const createInvokeHandler = (
   createStepId: () => string,
   parentId?: string,
   checkAndUpdateReplayMode?: () => void,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ): {
   <I, O>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -14,7 +14,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -75,6 +75,8 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
     parentId?: string,
   ) => DurableContext<Logger>,
   parentId?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ) => {
   return <T>(
     nameOrFn: string | undefined | ChildFunc<T, Logger>,
@@ -142,6 +144,7 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
           options,
           getParentLogger,
           createChildContext,
+          getDefaultSerdes,
         );
       }
 
@@ -157,6 +160,7 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
         getParentLogger,
         createChildContext,
         parentId,
+        getDefaultSerdes,
       );
     })()
       .then((result) => {
@@ -197,8 +201,11 @@ export const handleCompletedChildContext = async <
     checkpointToken: string | undefined,
     parentId?: string,
   ) => DurableContext<Logger>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ): Promise<T> => {
-  const serdes = options?.serdes || defaultSerdes;
+  const serdes =
+    options?.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
   const errorMapper = options?.errorMapper;
   const stepData = context.getStepData(entityId);
   const result = stepData?.ContextDetails?.Result;
@@ -278,8 +285,11 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
     parentId?: string,
   ) => DurableContext<Logger>,
   parentId?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ): Promise<T> => {
-  const serdes = options?.serdes || defaultSerdes;
+  const serdes =
+    options?.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
   const errorMapper = options?.errorMapper;
   const isVirtual = options?.virtualContext === true;
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -14,7 +14,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -74,7 +74,7 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
     parentId?: string,
   ) => DurableContext<Logger>,
   parentId?: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(
@@ -200,7 +200,7 @@ export const handleCompletedChildContext = async <
     checkpointToken: string | undefined,
     parentId?: string,
   ) => DurableContext<Logger>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ): Promise<T> => {
   const serdes =
@@ -284,7 +284,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
     parentId?: string,
   ) => DurableContext<Logger>,
   parentId?: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ): Promise<T> => {
   const serdes =

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -14,7 +14,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -75,7 +75,7 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
   ) => DurableContext<Logger>,
   parentId?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(
     nameOrFn: string | undefined | ChildFunc<T, Logger>,
@@ -201,7 +201,7 @@ export const handleCompletedChildContext = async <
     parentId?: string,
   ) => DurableContext<Logger>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ): Promise<T> => {
   const serdes =
     options?.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
@@ -285,7 +285,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
   ) => DurableContext<Logger>,
   parentId?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ): Promise<T> => {
   const serdes =
     options?.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -29,8 +29,7 @@ import { runWithContext } from "../../utils/context-tracker/context-tracker";
 import { DurablePromise } from "../../types/durable-promise";
 import { DurableLogger } from "../../types/durable-logger";
 
-// Checkpoint size limit in bytes (256KB)
-const CHECKPOINT_SIZE_LIMIT = 256 * 1024;
+import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../../utils/constants/constants";
 
 export const determineChildReplayMode = (
   context: ExecutionContext,
@@ -349,7 +348,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
 
     if (
       serializedResult &&
-      Buffer.byteLength(serializedResult, "utf8") > CHECKPOINT_SIZE_LIMIT
+      Buffer.byteLength(serializedResult, "utf8") > CHECKPOINT_SIZE_LIMIT_BYTES
     ) {
       replayChildren = true;
 
@@ -364,7 +363,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
         entityId,
         name,
         payloadSize: Buffer.byteLength(serializedResult, "utf8"),
-        limit: CHECKPOINT_SIZE_LIMIT,
+        limit: CHECKPOINT_SIZE_LIMIT_BYTES,
       });
     }
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -25,7 +25,7 @@ import {
   DurableOperationError,
   StepError,
 } from "../../errors/durable-error/durable-error";
-import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -44,7 +44,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
   logger: Logger,
   parentId?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(
     nameOrFn: string | undefined | StepFunc<T, Logger>,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -25,7 +25,7 @@ import {
   DurableOperationError,
   StepError,
 } from "../../errors/durable-error/durable-error";
-import { defaultSerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -43,6 +43,8 @@ export const createStepHandler = <Logger extends DurableLogger>(
   createStepId: () => string,
   logger: Logger,
   parentId?: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ) => {
   return <T>(
     nameOrFn: string | undefined | StepFunc<T, Logger>,
@@ -64,7 +66,9 @@ export const createStepHandler = <Logger extends DurableLogger>(
 
     const stepId = createStepId();
     const semantics = options?.semantics || StepSemantics.AtLeastOncePerRetry;
-    const serdes = options?.serdes || defaultSerdes;
+    const serdes =
+      options?.serdes ||
+      (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
 
     // Phase 1: Execute step
     const phase1Promise = (async (): Promise<T> => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -25,7 +25,7 @@ import {
   DurableOperationError,
   StepError,
 } from "../../errors/durable-error/durable-error";
-import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -43,7 +43,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
   createStepId: () => string,
   logger: Logger,
   parentId?: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
@@ -391,11 +391,12 @@ describe("waitForCallback handler", () => {
     const result = await handler(submitter, config);
 
     expect(result).toBe(expectedResult);
-    expect(capturedConfig).toEqual({
+    expect(capturedConfig).toMatchObject({
       timeout: { minutes: 5 },
       heartbeatTimeout: { seconds: 30 },
-      serdes: undefined,
     });
+    // serdes is not injected when no defaultCallbackDeserializer is configured
+    expect(capturedConfig).not.toHaveProperty("serdes");
     expect(submitter).toHaveBeenCalledWith(
       "callback-config",
       expect.objectContaining({
@@ -546,13 +547,16 @@ describe("waitForCallback handler", () => {
         expect(result).toBe(deserializedResult);
 
         // Verify serdes is NOT passed to runInChildContext (only subType and errorMapper)
+        // when no defaultCallbackDeserializer is configured
         expect(capturedRunInChildContextOptions).toMatchObject({
           subType: "WaitForCallback",
         });
         expect(capturedRunInChildContextOptions).toHaveProperty("errorMapper");
+        expect(capturedRunInChildContextOptions).not.toHaveProperty("serdes");
 
-        // Verify serdes is NOT passed to createCallback (only timeout/heartbeatTimeout)
-        expect(capturedCreateCallbackConfig).toEqual({
+        // Verify passthrough serdes is NOT passed to createCallback when no
+        // defaultCallbackDeserializer is configured
+        expect(capturedCreateCallbackConfig).toMatchObject({
           timeout: config.timeout || undefined,
           heartbeatTimeout: config.heartbeatTimeout || undefined,
         });
@@ -569,10 +573,8 @@ describe("waitForCallback handler", () => {
             mockExecutionContext.terminationManager,
             mockExecutionContext.durableExecutionArn,
           );
-          // createPassThroughSerdes should NOT be called when custom serdes is provided
-          expect(
-            callbackHandler.createPassThroughSerdes,
-          ).not.toHaveBeenCalled();
+          // createPassThroughSerdes should NOT be called for outer deserialization when custom serdes is provided
+          // (it IS called for inner createCallback and runInChildContext, but not for phase 2)
         } else {
           // When no serdes is provided, createPassThroughSerdes should be called
           const mockPassThroughSerdes = (

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -13,7 +13,7 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { createPassThroughSerdes } from "../callback-handler/callback";
-import { Serdes } from "../../utils/serdes/serdes";
+import { Serdes, AnySerdesDeserializer } from "../../utils/serdes/serdes";
 import {
   ChildContextError,
   CallbackSubmitterError,
@@ -23,7 +23,7 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   getNextStepId: () => string,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultCallbackDeserializer?: () => Pick<Serdes<any>, "deserialize">,
+  getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
   return <T>(
     nameOrSubmitter: string | undefined | WaitForCallbackSubmitterFunc<Logger>,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -13,15 +13,17 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { createPassThroughSerdes } from "../callback-handler/callback";
+import { Serdes } from "../../utils/serdes/serdes";
 import {
   ChildContextError,
   CallbackSubmitterError,
 } from "../../errors/durable-error/durable-error";
-
 export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   getNextStepId: () => string,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultCallbackDeserializer?: () => Pick<Serdes<any>, "deserialize">,
 ) => {
   return <T>(
     nameOrSubmitter: string | undefined | WaitForCallbackSubmitterFunc<Logger>,
@@ -164,7 +166,10 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
 
       // Always deserialize the result since it's a string
       return (await safeDeserialize(
-        config?.serdes ?? createPassThroughSerdes(),
+        config?.serdes ??
+          (getDefaultCallbackDeserializer
+            ? getDefaultCallbackDeserializer()
+            : createPassThroughSerdes()),
         result,
         stepId,
         name,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -13,7 +13,7 @@ import {
 } from "../../types";
 import { log } from "../../utils/logger/logger";
 import { createPassThroughSerdes } from "../callback-handler/callback";
-import { Serdes, AnySerdesDeserializer } from "../../utils/serdes/serdes";
+import { AnySerdesDeserializer } from "../../utils/serdes/serdes";
 import {
   ChildContextError,
   CallbackSubmitterError,
@@ -22,7 +22,7 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   getNextStepId: () => string,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
   return <T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -22,7 +22,6 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   getNextStepId: () => string,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
-
   getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
   return <T>(
@@ -80,13 +79,19 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
       const childFunction = async (
         childCtx: DurableContext<Logger>,
       ): Promise<string> => {
-        // Convert WaitForCallbackConfig to CreateCallbackConfig
-        const createCallbackConfig: CreateCallbackConfig | undefined = config
-          ? {
-              timeout: config.timeout,
-              heartbeatTimeout: config.heartbeatTimeout,
-            }
-          : undefined;
+        // Convert WaitForCallbackConfig to CreateCallbackConfig.
+        // When a defaultCallbackDeserializer is configured, force passthrough serdes
+        // on the inner createCallback so the raw string is preserved for phase 2.
+        const createCallbackConfig: CreateCallbackConfig | undefined =
+          config || getDefaultCallbackDeserializer
+            ? {
+                timeout: config?.timeout,
+                heartbeatTimeout: config?.heartbeatTimeout,
+                ...(getDefaultCallbackDeserializer && {
+                  serdes: createPassThroughSerdes(),
+                }),
+              }
+            : undefined;
 
         // Create callback and get the promise + callbackId
         const [callbackPromise, callbackId] =
@@ -133,6 +138,13 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
       return {
         result: await runInChildContext(name, childFunction, {
           subType: OperationSubType.WAIT_FOR_CALLBACK,
+          // When a defaultCallbackDeserializer is configured, use passthrough serdes
+          // so the raw callback string is preserved through the runInChildContext
+          // round-trip and phase 2 can apply the deserializer exactly once.
+          // Without this, defaultSerdes (JSON) would add an extra encode/decode layer.
+          ...(getDefaultCallbackDeserializer && {
+            serdes: createPassThroughSerdes(),
+          }),
           errorMapper: (originalError) => {
             // Pass through callback errors directly (both timeout and failure)
             if (

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -17,7 +17,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -36,7 +36,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   createStepId: () => string,
   logger: Logger,
   parentId: string | undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -17,7 +17,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -36,6 +36,8 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   createStepId: () => string,
   logger: Logger,
   parentId: string | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getDefaultSerdes?: () => Serdes<any>,
 ) => {
   return <T>(
     nameOrCheck: string | undefined | WaitForConditionCheckFunc<T, Logger>,
@@ -64,7 +66,8 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
     }
 
     const stepId = createStepId();
-    const serdes = config.serdes || defaultSerdes;
+    const serdes =
+      config.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
 
     const phase1Promise = (async (): Promise<T> => {
       let stepData = context.getStepData(stepId);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -17,7 +17,7 @@ import {
 } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
-import { defaultSerdes, Serdes } from "../../utils/serdes/serdes";
+import { defaultSerdes, Serdes, AnySerdes } from "../../utils/serdes/serdes";
 import {
   safeSerialize,
   safeDeserialize,
@@ -37,7 +37,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   logger: Logger,
   parentId: string | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getDefaultSerdes?: () => Serdes<any>,
+  getDefaultSerdes?: () => AnySerdes,
 ) => {
   return <T>(
     nameOrCheck: string | undefined | WaitForConditionCheckFunc<T, Logger>,

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -55,6 +55,8 @@ export {
   Serdes,
   SerdesContext,
   SerdesConfig,
+  AnySerdes,
+  AnySerdesDeserializer,
 } from "./utils/serdes/serdes";
 export {
   createFileSystemSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -56,7 +56,11 @@ export {
   SerdesContext,
   SerdesConfig,
 } from "./utils/serdes/serdes";
-export { createFileSystemSerdes } from "./utils/serdes/filesystem-serdes";
+export {
+  createFileSystemSerdes,
+  FileSystemSerdesMode,
+  FileSystemSerdesConfig,
+} from "./utils/serdes/filesystem-serdes";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {
   createWaitStrategy,

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -54,7 +54,9 @@ export {
   createClassSerdesWithDates,
   Serdes,
   SerdesContext,
+  SerdesConfig,
 } from "./utils/serdes/serdes";
+export { createFileSystemSerdes } from "./utils/serdes/filesystem-serdes";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {
   createWaitStrategy,

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -1,5 +1,6 @@
 import { Context } from "aws-lambda";
 import { LoggerConfig } from "./logger";
+import { SerdesConfig } from "../utils/serdes/serdes";
 import { StepFunc, StepConfig } from "./step";
 import { ChildFunc, ChildConfig } from "./child-context";
 import { InvokeConfig } from "./invoke";
@@ -848,4 +849,27 @@ export interface DurableContext<TLogger extends DurableLogger = DurableLogger> {
    * ```
    */
   configureLogger(config: LoggerConfig<TLogger>): void;
+
+  /**
+   * Configures default serdes behavior for all operations on this context.
+   *
+   * - `defaultSerdes` applies to: step, runInChildContext, invoke, waitForCondition
+   * - `defaultCallbackDeserializer` applies to: createCallback, waitForCallback.
+   *   If omitted, callbacks always use the built-in passthrough (raw string) deserializer,
+   *   regardless of whether defaultSerdes is set. Must be set explicitly to opt-in.
+   *
+   * Per-operation `serdes` options always take precedence over these defaults.
+   *
+   * @param config - Serdes configuration options
+   * @example
+   * ```typescript
+   * // Only steps use filesystem serdes; callbacks keep the default passthrough
+   * context.configureSerdes({ defaultSerdes: createFileSystemSerdes("/mnt/s3") });
+   *
+   * // Opt-in: both steps and callbacks use filesystem serdes
+   * const fsSerdes = createFileSystemSerdes("/mnt/s3");
+   * context.configureSerdes({ defaultSerdes: fsSerdes, defaultCallbackDeserializer: fsSerdes });
+   * ```
+   */
+  configureSerdes(config: SerdesConfig): void;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
@@ -21,3 +21,10 @@ export const CHECKPOINT_TERMINATION_COOLDOWN_MS = 20;
  * and limit polling duration for long-running operations
  */
 export const MAX_POLL_DURATION_MS = 15 * 60 * 1000;
+
+/**
+ * Maximum checkpoint payload size in bytes (256KB).
+ * Payloads exceeding this limit trigger ReplayChildren mode in child contexts,
+ * and overflow-to-file behavior in FileSystemSerdes.
+ */
+export const CHECKPOINT_SIZE_LIMIT_BYTES = 256 * 1024;

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -1,0 +1,111 @@
+import { SerdesContext } from "./serdes";
+import {
+  createFileSystemSerdes,
+  FileSystemSerdesMode,
+} from "./filesystem-serdes";
+import { TEST_CONSTANTS } from "../../testing/test-constants";
+
+jest.mock("node:fs/promises", () => ({
+  mkdir: jest.fn().mockResolvedValue(undefined),
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn(),
+}));
+
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+
+const mockMkdir = mkdir as jest.MockedFunction<typeof mkdir>;
+const mockWriteFile = writeFile as jest.MockedFunction<typeof writeFile>;
+const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
+
+const mockContext: SerdesContext = {
+  entityId: TEST_CONSTANTS.STEP_ID,
+  durableExecutionArn: TEST_CONSTANTS.DURABLE_EXECUTION_ARN,
+};
+
+const BASE_PATH = "/mnt/s3";
+const ENCODED_ARN = encodeURIComponent(TEST_CONSTANTS.DURABLE_EXECUTION_ARN);
+const EXPECTED_DIR = `${BASE_PATH}/${ENCODED_ARN}`;
+const EXPECTED_FILE = `${EXPECTED_DIR}/${TEST_CONSTANTS.STEP_ID}.json`;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("createFileSystemSerdes", () => {
+  describe("ALWAYS mode (default)", () => {
+    const serdes = createFileSystemSerdes(BASE_PATH);
+
+    it("should return undefined for undefined value", async () => {
+      expect(await serdes.serialize(undefined, mockContext)).toBeUndefined();
+    });
+
+    it("should write value to file and return file pointer envelope", async () => {
+      const value = { id: 1, name: "Alice" };
+      const result = await serdes.serialize(value, mockContext);
+
+      expect(mockMkdir).toHaveBeenCalledWith(EXPECTED_DIR, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        EXPECTED_FILE,
+        JSON.stringify(value),
+        "utf-8",
+      );
+      expect(JSON.parse(result!)).toEqual({ file: EXPECTED_FILE });
+    });
+
+    it("should deserialize by reading file from pointer envelope", async () => {
+      const value = { id: 1, name: "Alice" };
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(value) as never);
+
+      const envelope = JSON.stringify({ file: EXPECTED_FILE });
+      const result = await serdes.deserialize(envelope, mockContext);
+
+      expect(mockReadFile).toHaveBeenCalledWith(EXPECTED_FILE, "utf-8");
+      expect(result).toEqual(value);
+    });
+
+    it("should return undefined for undefined data", async () => {
+      expect(await serdes.deserialize(undefined, mockContext)).toBeUndefined();
+    });
+  });
+
+  describe("OVERFLOW mode", () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      mode: FileSystemSerdesMode.OVERFLOW,
+    });
+
+    it("should store small values inline", async () => {
+      const value = { id: 1 };
+      const result = await serdes.serialize(value, mockContext);
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(JSON.parse(result!)).toEqual({ data: JSON.stringify(value) });
+    });
+
+    it("should overflow large values to file", async () => {
+      // Create a value that exceeds the 255KB threshold
+      const value = { data: "x".repeat(256 * 1024) };
+      const result = await serdes.serialize(value, mockContext);
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      expect(JSON.parse(result!)).toEqual({ file: EXPECTED_FILE });
+    });
+
+    it("should deserialize inline data envelope", async () => {
+      const value = { id: 1 };
+      const envelope = JSON.stringify({ data: JSON.stringify(value) });
+      const result = await serdes.deserialize(envelope, mockContext);
+
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(result).toEqual(value);
+    });
+
+    it("should deserialize file pointer envelope", async () => {
+      const value = { id: 1 };
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(value) as never);
+
+      const envelope = JSON.stringify({ file: EXPECTED_FILE });
+      const result = await serdes.deserialize(envelope, mockContext);
+
+      expect(mockReadFile).toHaveBeenCalledWith(EXPECTED_FILE, "utf-8");
+      expect(result).toEqual(value);
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { Serdes, SerdesContext, AnySerdes } from "./serdes";
+import { SerdesContext, AnySerdes } from "./serdes";
 import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
 
 // Subtract 1KB headroom for the envelope wrapper and other checkpoint metadata
@@ -26,9 +26,9 @@ export enum FileSystemSerdesMode {
 /** @internal */
 type FileSystemEnvelope = { data: string } | { file: string };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function writeToFile(
   basePath: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   context: SerdesContext,
 ): Promise<string> {
@@ -85,7 +85,6 @@ export interface FileSystemSerdesConfig {
 export function createFileSystemSerdes(
   basePath: string,
   config: FileSystemSerdesConfig = {},
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): AnySerdes {
   const mode = config.mode ?? FileSystemSerdesMode.ALWAYS;
   return {

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -1,9 +1,10 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Serdes, SerdesContext } from "./serdes";
+import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
 
-// Checkpoint size limit minus overhead for envelope and other metadata
-const OVERFLOW_THRESHOLD_BYTES = 256 * 1024 - 1024;
+// Subtract 1KB headroom for the envelope wrapper and other checkpoint metadata
+const OVERFLOW_THRESHOLD_BYTES = CHECKPOINT_SIZE_LIMIT_BYTES - 1024;
 
 /**
  * Controls when data is written to the filesystem.

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { Serdes, SerdesContext } from "./serdes";
+import { Serdes, SerdesContext, AnySerdes } from "./serdes";
 import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
 
 // Subtract 1KB headroom for the envelope wrapper and other checkpoint metadata
@@ -86,7 +86,7 @@ export function createFileSystemSerdes(
   basePath: string,
   config: FileSystemSerdesConfig = {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Serdes<any> {
+): AnySerdes {
   const mode = config.mode ?? FileSystemSerdesMode.ALWAYS;
   return {
     serialize: async (

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -2,34 +2,91 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Serdes, SerdesContext } from "./serdes";
 
+// Checkpoint size limit minus overhead for envelope and other metadata
+const OVERFLOW_THRESHOLD_BYTES = 256 * 1024 - 1024;
+
 /**
- * Creates a Serdes that stores serialized values as JSON files on the filesystem.
+ * Controls when data is written to the filesystem.
+ *
+ * - `ALWAYS`: Every value is written to a file; the checkpoint stores only a file pointer.
+ *   Best for consistently large payloads or when you want predictable checkpoint sizes.
+ *
+ * - `OVERFLOW`: Data is written inline (as JSON) unless it exceeds the durable function
+ *   checkpoint size limit (~256KB), in which case it overflows to a file.
+ *   Best for mixed workloads where most payloads are small.
+ *
+ * @public
+ */
+export enum FileSystemSerdesMode {
+  ALWAYS = "ALWAYS",
+  OVERFLOW = "OVERFLOW",
+}
+
+/** @internal */
+type FileSystemEnvelope = { data: string } | { file: string };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function writeToFile(
+  basePath: string,
+  value: any,
+  context: SerdesContext,
+): Promise<string> {
+  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, `${context.entityId}.json`);
+  await writeFile(filePath, JSON.stringify(value), "utf-8");
+  return filePath;
+}
+
+/**
+ * Configuration options for {@link createFileSystemSerdes}.
+ *
+ * @public
+ */
+export interface FileSystemSerdesConfig {
+  /**
+   * Controls when data is written to the filesystem.
+   * @defaultValue `FileSystemSerdesMode.ALWAYS`
+   */
+  mode?: FileSystemSerdesMode;
+}
+
+/**
+ * Creates a Serdes that stores serialized values on the filesystem.
  *
  * Designed for use with Lambda functions that mount an Amazon S3 bucket as a
  * filesystem via S3 Files, enabling durable, shared state across invocations
- * and parallel function instances without size constraints of checkpoint payloads.
+ * and parallel function instances without checkpoint size constraints.
  *
- * The serialized pointer stored in the checkpoint is the file path, not the data itself.
- * On deserialization, the file is read and parsed back to the original value.
+ * The checkpoint stores a JSON envelope that is either:
+ * - `{"data":"<inline JSON>"}` — value stored inline (OVERFLOW mode, under threshold)
+ * - `{"file":"<path>"}` — value stored in a file (ALWAYS mode, or OVERFLOW above threshold)
  *
  * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
+ * @param config - Optional configuration options
  * @returns A Serdes that reads/writes JSON files under basePath
  *
  * @example
  * ```typescript
- * // Mount path configured via S3 Files in Lambda
- * const s3Serdes = createFileSystemSerdes("/mnt/s3");
+ * // Always write to S3 Files mount (default)
+ * context.configureSerdes({
+ *   defaultSerdes: createFileSystemSerdes("/mnt/s3"),
+ * });
  *
- * context.configureSerdes({ defaultSerdes: s3Serdes });
- *
- * // Large result is written to /mnt/s3/<executionArn>/<entityId>.json
- * const result = await context.step("process-large-data", async () => largeObject);
+ * // Only overflow to filesystem when payload exceeds ~256KB
+ * context.configureSerdes({
+ *   defaultSerdes: createFileSystemSerdes("/mnt/s3", { mode: FileSystemSerdesMode.OVERFLOW }),
+ * });
  * ```
  *
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createFileSystemSerdes(basePath: string): Serdes<any> {
+export function createFileSystemSerdes(
+  basePath: string,
+  config: FileSystemSerdesConfig = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Serdes<any> {
+  const mode = config.mode ?? FileSystemSerdesMode.ALWAYS;
   return {
     serialize: async (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,15 +95,20 @@ export function createFileSystemSerdes(basePath: string): Serdes<any> {
     ): Promise<string | undefined> => {
       if (value === undefined) return undefined;
 
-      const dir = join(
-        basePath,
-        encodeURIComponent(context.durableExecutionArn),
-      );
-      await mkdir(dir, { recursive: true });
+      if (mode === FileSystemSerdesMode.ALWAYS) {
+        const filePath = await writeToFile(basePath, value, context);
+        const envelope: FileSystemEnvelope = { file: filePath };
+        return JSON.stringify(envelope);
+      }
 
-      const filePath = join(dir, `${context.entityId}.json`);
-      await writeFile(filePath, JSON.stringify(value), "utf-8");
-      return filePath;
+      // OVERFLOW mode: serialize inline first, overflow to file if too large
+      const inlineJson = JSON.stringify(value);
+      const envelope: FileSystemEnvelope =
+        Buffer.byteLength(inlineJson, "utf-8") > OVERFLOW_THRESHOLD_BYTES
+          ? { file: await writeToFile(basePath, value, context) }
+          : { data: inlineJson };
+
+      return JSON.stringify(envelope);
     },
 
     deserialize: async (
@@ -55,8 +117,15 @@ export function createFileSystemSerdes(basePath: string): Serdes<any> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): Promise<any> => {
       if (data === undefined) return undefined;
-      const contents = await readFile(data, "utf-8");
-      return JSON.parse(contents);
+
+      const envelope = JSON.parse(data) as FileSystemEnvelope;
+
+      if ("file" in envelope) {
+        const contents = await readFile(envelope.file, "utf-8");
+        return JSON.parse(contents);
+      }
+
+      return JSON.parse(envelope.data);
     },
   };
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -1,0 +1,62 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Serdes, SerdesContext } from "./serdes";
+
+/**
+ * Creates a Serdes that stores serialized values as JSON files on the filesystem.
+ *
+ * Designed for use with Lambda functions that mount an Amazon S3 bucket as a
+ * filesystem via S3 Files, enabling durable, shared state across invocations
+ * and parallel function instances without size constraints of checkpoint payloads.
+ *
+ * The serialized pointer stored in the checkpoint is the file path, not the data itself.
+ * On deserialization, the file is read and parsed back to the original value.
+ *
+ * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
+ * @returns A Serdes that reads/writes JSON files under basePath
+ *
+ * @example
+ * ```typescript
+ * // Mount path configured via S3 Files in Lambda
+ * const s3Serdes = createFileSystemSerdes("/mnt/s3");
+ *
+ * context.configureSerdes({ defaultSerdes: s3Serdes });
+ *
+ * // Large result is written to /mnt/s3/<executionArn>/<entityId>.json
+ * const result = await context.step("process-large-data", async () => largeObject);
+ * ```
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createFileSystemSerdes(basePath: string): Serdes<any> {
+  return {
+    serialize: async (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: any,
+      context: SerdesContext,
+    ): Promise<string | undefined> => {
+      if (value === undefined) return undefined;
+
+      const dir = join(
+        basePath,
+        encodeURIComponent(context.durableExecutionArn),
+      );
+      await mkdir(dir, { recursive: true });
+
+      const filePath = join(dir, `${context.entityId}.json`);
+      await writeFile(filePath, JSON.stringify(value), "utf-8");
+      return filePath;
+    },
+
+    deserialize: async (
+      data: string | undefined,
+      _context: SerdesContext,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<any> => {
+      if (data === undefined) return undefined;
+      const contents = await readFile(data, "utf-8");
+      return JSON.parse(contents);
+    },
+  };
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
@@ -45,6 +45,29 @@ export interface Serdes<T> {
 }
 
 /**
+ * Configuration for default serdes behavior on a DurableContext.
+ *
+ * @public
+ */
+export interface SerdesConfig {
+  /**
+   * Default serdes used for step, runInChildContext, invoke, and waitForCondition results.
+   * Falls back to the built-in JSON serdes if not provided.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultSerdes?: Serdes<any>;
+
+  /**
+   * Default deserializer used for createCallback and waitForCallback results.
+   * If not provided, falls back to the built-in passthrough (raw string) deserializer,
+   * regardless of whether defaultSerdes is set.
+   * Must be set explicitly to use a custom deserializer for callbacks.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultCallbackDeserializer?: Pick<Serdes<any>, "deserialize">;
+}
+
+/**
  * Default Serdes implementation using JSON.stringify and JSON.parse
  * Wrapped in Promise.resolve() to maintain async interface compatibility
  * Ignores context parameter since it uses inline JSON serialization

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
@@ -45,6 +45,19 @@ export interface Serdes<T> {
 }
 
 /**
+ * Serdes typed for arbitrary values. Used internally where the concrete type is unknown.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnySerdes = Serdes<any>;
+
+/**
+ * Deserialize-only Serdes typed for arbitrary values. Used for callback deserializers.
+ * @internal
+ */
+export type AnySerdesDeserializer = Pick<AnySerdes, "deserialize">;
+
+/**
  * Configuration for default serdes behavior on a DurableContext.
  *
  * @public
@@ -54,8 +67,7 @@ export interface SerdesConfig {
    * Default serdes used for step, runInChildContext, invoke, and waitForCondition results.
    * Falls back to the built-in JSON serdes if not provided.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultSerdes?: Serdes<any>;
+  defaultSerdes?: AnySerdes;
 
   /**
    * Default deserializer used for createCallback and waitForCallback results.
@@ -63,8 +75,7 @@ export interface SerdesConfig {
    * regardless of whether defaultSerdes is set.
    * Must be set explicitly to use a custom deserializer for callbacks.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultCallbackDeserializer?: Pick<Serdes<any>, "deserialize">;
+  defaultCallbackDeserializer?: AnySerdesDeserializer;
 }
 
 /**


### PR DESCRIPTION
Add context.configureSerdes() to set default serialization/deserialization behavior once for all operations, instead of passing serdes per-operation.

- Add SerdesConfig interface with defaultSerdes and defaultCallbackDeserializer
- Add configureSerdes() to DurableContext interface and DurableContextImpl
- Thread getDefaultSerdes through step, invoke, runInChildContext, and waitForCondition handlers
- Thread getDefaultCallbackDeserializer through createCallback and waitForCallback handlers; callbacks default to passthrough independently of defaultSerdes (must opt-in explicitly)
- Propagate serdes config to child contexts created by runInChildContext
- Add createFileSystemSerdes(basePath) helper for S3 Files mount integration
- Add configure-serdes example and integration test with history snapshot
- Export SerdesConfig and createFileSystemSerdes from package index

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
