### PR TITLE
fix(examples): removed hardcoded import paths in logger examples (#509)

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/powertools-logger/powertools-logger.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/powertools-logger/powertools-logger.ts
@@ -2,6 +2,8 @@ import {
   DurableLogData,
   withDurableExecution,
   DurableLogger,
+  DurableContext,
+  DurableLoggingContext,
 } from "@aws/durable-execution-sdk-js";
 import { ExampleConfig } from "../../../types";
 import { Logger, LogLevel } from "@aws-lambda-powertools/logger";
@@ -9,10 +11,6 @@ import {
   LogItemExtraInput,
   LogItemMessage,
 } from "@aws-lambda-powertools/logger/types";
-import {
-  DurableContext,
-  DurableLoggingContext,
-} from "../../../../../aws-durable-execution-sdk-js/dist-types/types";
 
 export const config: ExampleConfig = {
   name: "Powertools Logger",

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/simple-powertools-logger/simple-powertools-logger.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/simple-powertools-logger/simple-powertools-logger.ts
@@ -1,7 +1,9 @@
-import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+import {
+  withDurableExecution,
+  DurableContext,
+} from "@aws/durable-execution-sdk-js";
 import { ExampleConfig } from "../../../types";
 import { Logger, LogLevel } from "@aws-lambda-powertools/logger";
-import { DurableContext } from "../../../../../aws-durable-execution-sdk-js/dist-types/types";
 
 export const config: ExampleConfig = {
   name: "Simple Powertools Logger",


### PR DESCRIPTION
Issue #, if available:

N/A

Description of changes:

Two tests in the examples pacakge, powertools-logger and simple-powertools-logger, use hardcoded paths to import from the external SDK package.

This PR removes those hardcoded paths.

(This fix has already been merged to the main branch (PR [here](https://github.com/aws/aws-durable-execution-sdk-js/pull/509)). This PR is merging the same fix to the v1.X branch so it can be included in a new release.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.