### PR TITLE
feat(sdk): add preview config to createFileSystemSerdes

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -62,6 +62,10 @@ export {
   createFileSystemSerdes,
   FileSystemSerdesMode,
   FileSystemSerdesConfig,
+  FieldMatchMode,
+  PreviewMode,
+  PreviewField,
+  PreviewConfig,
 } from "./utils/serdes/filesystem-serdes";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -2,6 +2,9 @@ import { SerdesContext } from "./serdes";
 import {
   createFileSystemSerdes,
   FileSystemSerdesMode,
+  PreviewMode,
+  FieldMatchMode,
+  buildPreview,
 } from "./filesystem-serdes";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
 
@@ -68,7 +71,7 @@ describe("createFileSystemSerdes", () => {
 
   describe("OVERFLOW mode", () => {
     const serdes = createFileSystemSerdes(BASE_PATH, {
-      mode: FileSystemSerdesMode.OVERFLOW,
+      storageMode: FileSystemSerdesMode.OVERFLOW,
     });
 
     it("should store small values inline", async () => {
@@ -107,5 +110,192 @@ describe("createFileSystemSerdes", () => {
       expect(mockReadFile).toHaveBeenCalledWith(EXPECTED_FILE, "utf-8");
       expect(result).toEqual(value);
     });
+  });
+});
+
+describe("buildPreview", () => {
+  const value = {
+    id: "123",
+    email: "alice@example.com",
+    ssn: "000-00-0000",
+    user: { name: "Alice", role: "admin" },
+  };
+
+  it("INCLUDE_ALL: includes all fields by default", () => {
+    const result = buildPreview(value, { mode: PreviewMode.INCLUDE_ALL });
+    expect(result).toHaveProperty("id", "123");
+    expect(result).toHaveProperty("email", "alice@example.com");
+    expect(result).toHaveProperty("ssn", "000-00-0000");
+  });
+
+  it("INCLUDE_ALL + exclude: omits excluded fields", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "ssn" }],
+    });
+    expect(result).not.toHaveProperty("ssn");
+    expect(result).toHaveProperty("id", "123");
+  });
+
+  it("EXCLUDE_ALL + include: only includes specified fields", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      include: [{ name: "id" }, { name: "email" }],
+    });
+    expect(result).toHaveProperty("id", "123");
+    expect(result).toHaveProperty("email", "alice@example.com");
+    expect(result).not.toHaveProperty("ssn");
+  });
+
+  it("mask: replaces visible field value with maskString", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      mask: [{ name: "ssn" }],
+    });
+    expect(result).toHaveProperty("ssn", "***");
+    expect(result).toHaveProperty("id", "123");
+  });
+
+  it("mask: uses custom maskString", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      mask: [{ name: "ssn" }],
+      maskString: "[REDACTED]",
+    });
+    expect(result).toHaveProperty("ssn", "[REDACTED]");
+  });
+
+  it("PATH match: only matches exact path", () => {
+    const result = buildPreview(
+      { email: "root@example.com", user: { email: "nested@example.com" } },
+      {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "email", match: FieldMatchMode.PATH }],
+      },
+    );
+    expect(result).toHaveProperty("email", "root@example.com");
+    expect(result).not.toHaveProperty("user.email");
+  });
+
+  it("ANYWHERE match: matches field at any depth", () => {
+    const result = buildPreview(
+      { email: "root@example.com", user: { email: "nested@example.com" } },
+      {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "email" }],
+      },
+    );
+    expect(result?.["email"]).toBe("root@example.com");
+    expect(result?.["user.email"]).toBe("nested@example.com");
+  });
+
+  it("respects maxPreviewBytes budget", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      maxPreviewBytes: 20, // very small — only first field fits
+    });
+    expect(Object.keys(result ?? {}).length).toBeLessThan(
+      Object.keys(value).length,
+    );
+  });
+
+  it("returns undefined for non-object values", () => {
+    expect(
+      buildPreview("string", { mode: PreviewMode.INCLUDE_ALL }),
+    ).toBeUndefined();
+    expect(buildPreview(42, { mode: PreviewMode.INCLUDE_ALL })).toBeUndefined();
+  });
+
+  it("mask implies visibility in EXCLUDE_ALL — masked field shown even without include", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      mask: [{ name: "ssn" }], // not in include, but mask implies visible
+    });
+    expect(result).toHaveProperty("ssn", "***");
+    expect(result).not.toHaveProperty("id");
+  });
+
+  it("exclude wins over mask — excluded field is not shown even if in mask", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "ssn" }],
+      mask: [{ name: "ssn" }],
+    });
+    expect(result).not.toHaveProperty("ssn");
+  });
+
+  it("returns undefined when no fields are visible", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      // no include, no mask
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("createFileSystemSerdes with preview", () => {
+  it("stores preview in envelope alongside file pointer", async () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      preview: {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "id" }],
+        mask: [{ name: "secret" }],
+      },
+    });
+
+    const value = { id: "abc", secret: "s3cr3t", other: "ignored" };
+    const result = await serdes.serialize(value, mockContext);
+    const envelope = JSON.parse(result!);
+
+    expect(envelope).toHaveProperty("file");
+    expect(envelope.preview).toEqual({ id: "abc", secret: "***" });
+  });
+
+  it("deserialize ignores preview field and reads from file", async () => {
+    const value = { id: "abc" };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(value) as never);
+
+    const envelope = JSON.stringify({
+      file: EXPECTED_FILE,
+      preview: { id: "abc" },
+    });
+    const result = await createFileSystemSerdes(BASE_PATH).deserialize(
+      envelope,
+      mockContext,
+    );
+
+    expect(result).toEqual(value);
+    expect(mockReadFile).toHaveBeenCalledWith(EXPECTED_FILE, "utf-8");
+  });
+
+  it("OVERFLOW mode: includes preview when payload overflows to file", async () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      storageMode: FileSystemSerdesMode.OVERFLOW,
+      preview: {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "id" }],
+      },
+    });
+
+    const value = { id: "abc", data: "x".repeat(256 * 1024) };
+    const result = await serdes.serialize(value, mockContext);
+    const envelope = JSON.parse(result!);
+
+    expect(envelope).toHaveProperty("file");
+    expect(envelope.preview).toEqual({ id: "abc" });
+  });
+
+  it("OVERFLOW mode: no preview for inline payloads", async () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      storageMode: FileSystemSerdesMode.OVERFLOW,
+      preview: { mode: PreviewMode.INCLUDE_ALL },
+    });
+
+    const value = { id: "abc" }; // small — stays inline
+    const result = await serdes.serialize(value, mockContext);
+    const envelope = JSON.parse(result!);
+
+    expect(envelope).toHaveProperty("data");
+    expect(envelope).not.toHaveProperty("preview");
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -186,7 +186,7 @@ describe("buildPreview", () => {
       },
     );
     expect(result?.["email"]).toBe("root@example.com");
-    expect(result?.["user.email"]).toBe("nested@example.com");
+    expect((result?.["user"] as any)?.["email"]).toBe("nested@example.com");
   });
 
   it("respects maxPreviewBytes budget", () => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -167,6 +167,23 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
+      current[parts[i]] = {};
+    }
+    current = current[parts[i]] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildPreview(
   value: any,
   config: PreviewConfig,
@@ -204,10 +221,11 @@ export function buildPreview(
       }
 
       if (masked) {
-        const candidate = { ...preview, [path]: maskString };
+        const candidate = JSON.parse(JSON.stringify(preview));
+        setNestedValue(candidate, path, maskString);
         if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
           return;
-        preview[path] = maskString;
+        setNestedValue(preview, path, maskString);
         continue;
       }
 
@@ -221,10 +239,11 @@ export function buildPreview(
         continue;
       }
 
-      const candidate = { ...preview, [path]: obj[key] };
+      const candidate = JSON.parse(JSON.stringify(preview));
+      setNestedValue(candidate, path, obj[key]);
       if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
         return;
-      preview[path] = obj[key];
+      setNestedValue(preview, path, obj[key]);
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -174,18 +174,19 @@ function setNestedValue(
 ): void {
   const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const parts = path.split(".");
+  if (parts.some((p) => DANGEROUS_KEYS.has(p))) return;
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (DANGEROUS_KEYS.has(parts[i])) return;
-    if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
-      current[parts[i]] = {};
+    if (
+      !Object.prototype.hasOwnProperty.call(current, parts[i]) ||
+      typeof current[parts[i]] !== "object" ||
+      current[parts[i]] === null
+    ) {
+      current[parts[i]] = Object.create(null) as Record<string, unknown>;
     }
     current = current[parts[i]] as Record<string, unknown>;
   }
-  const lastKey = parts[parts.length - 1];
-  if (!DANGEROUS_KEYS.has(lastKey)) {
-    current[lastKey] = value;
-  }
+  current[parts[parts.length - 1]] = value;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -23,20 +23,84 @@ export enum FileSystemSerdesMode {
   OVERFLOW = "OVERFLOW",
 }
 
-/** @internal */
-type FileSystemEnvelope = { data: string } | { file: string };
+/**
+ * Controls whether a preview field is matched by name anywhere in the object
+ * tree, or by exact dot-notation path from the root.
+ *
+ * @public
+ */
+export enum FieldMatchMode {
+  /** Match the field name at any depth in the object tree (default). */
+  ANYWHERE = "ANYWHERE",
+  /**
+   * Match by exact dot-notation path from root.
+   * A single segment (e.g. `"email"`) matches only the root-level field.
+   * A dotted path (e.g. `"user.email"`) matches that exact nested location.
+   */
+  PATH = "PATH",
+}
 
-async function writeToFile(
-  basePath: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any,
-  context: SerdesContext,
-): Promise<string> {
-  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
-  await mkdir(dir, { recursive: true });
-  const filePath = join(dir, `${context.entityId}.json`);
-  await writeFile(filePath, JSON.stringify(value), "utf-8");
-  return filePath;
+/**
+ * Controls which fields are included in the preview by default.
+ *
+ * @public
+ */
+export enum PreviewMode {
+  /** Include all fields, then apply `exclude` and `mask` rules. */
+  INCLUDE_ALL = "INCLUDE_ALL",
+  /** Exclude all fields, then apply `include` and `mask` rules. */
+  EXCLUDE_ALL = "EXCLUDE_ALL",
+}
+
+/**
+ * A field selector used in preview include/exclude/mask lists.
+ *
+ * @public
+ */
+export interface PreviewField {
+  /** Field name or dot-notation path. */
+  name: string;
+  /** How to match the field. Defaults to `FieldMatchMode.ANYWHERE`. */
+  match?: FieldMatchMode;
+}
+
+/**
+ * Configuration for the preview feature of {@link createFileSystemSerdes}.
+ *
+ * When configured, a subset of the original value is stored inline in the
+ * checkpoint envelope alongside the file pointer, making it visible in the
+ * console and API without reading the full file.
+ *
+ * @public
+ */
+export interface PreviewConfig {
+  /**
+   * Whether to start with all fields included or all excluded.
+   */
+  mode: PreviewMode;
+  /**
+   * Fields to include (used with `EXCLUDE_ALL` mode, or to override `INCLUDE_ALL`).
+   */
+  include?: PreviewField[];
+  /**
+   * Fields to exclude (used with `INCLUDE_ALL` mode, or to override `EXCLUDE_ALL`).
+   */
+  exclude?: PreviewField[];
+  /**
+   * Fields to mask — if visible, their value is replaced with `maskString`.
+   */
+  mask?: PreviewField[];
+  /**
+   * String used to replace masked field values.
+   * @defaultValue `"***"`
+   */
+  maskString?: string;
+  /**
+   * Maximum size in bytes for the preview object (JSON-serialized).
+   * Fields are added until this limit is reached.
+   * @defaultValue `4096`
+   */
+  maxPreviewBytes?: number;
 }
 
 /**
@@ -49,7 +113,12 @@ export interface FileSystemSerdesConfig {
    * Controls when data is written to the filesystem.
    * @defaultValue `FileSystemSerdesMode.ALWAYS`
    */
-  mode?: FileSystemSerdesMode;
+  storageMode?: FileSystemSerdesMode;
+  /**
+   * When set, a preview of the value is stored inline in the checkpoint
+   * envelope alongside the file pointer.
+   */
+  preview?: PreviewConfig;
 }
 
 /**
@@ -59,9 +128,116 @@ export interface FileSystemSerdesConfig {
  * filesystem via S3 Files, enabling durable, shared state across invocations
  * and parallel function instances without checkpoint size constraints.
  *
+/** @internal */
+type FileSystemEnvelope =
+  | { data: string }
+  | { file: string; preview?: Record<string, unknown> };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function writeToFile(
+  basePath: string,
+  value: any,
+  context: SerdesContext,
+): Promise<string> {
+  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, `${context.entityId}.json`);
+  await writeFile(filePath, JSON.stringify(value), "utf-8");
+  return filePath;
+}
+
+/** Returns true if the field at `path` (dot-notation) matches the given PreviewField rule. */
+function fieldMatches(path: string, field: PreviewField): boolean {
+  const mode = field.match ?? FieldMatchMode.ANYWHERE;
+  if (mode === FieldMatchMode.PATH) {
+    return path === field.name;
+  }
+  // ANYWHERE: match if any segment of the path equals the field name
+  return path.split(".").includes(field.name);
+}
+
+function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
+  return fields?.some((f) => fieldMatches(path, f)) ?? false;
+}
+
+/**
+ * Builds a preview object from `value` according to `config`.
+ * Only top-level and nested scalar/object fields are included (no special array handling).
+ * Fields are added until `maxPreviewBytes` is reached.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildPreview(
+  value: any,
+  config: PreviewConfig,
+): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+
+  const maskString = config.maskString ?? "***";
+  const maxBytes = config.maxPreviewBytes ?? 4096;
+  const preview: Record<string, unknown> = {};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function collect(obj: any, pathPrefix: string): void {
+    if (obj === null || typeof obj !== "object") return;
+    for (const key of Object.keys(obj)) {
+      const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+      const masked = isMatched(path, config.mask);
+      const visible =
+        masked || // mask implies visible, unless explicitly excluded
+        (config.mode === PreviewMode.INCLUDE_ALL
+          ? !isMatched(path, config.exclude)
+          : isMatched(path, config.include));
+      // exclude always wins — even over mask
+      const excluded = isMatched(path, config.exclude);
+
+      if (!visible || excluded) {
+        // Recurse into objects to find nested matches
+        if (
+          obj[key] !== null &&
+          typeof obj[key] === "object" &&
+          !Array.isArray(obj[key])
+        ) {
+          collect(obj[key], path);
+        }
+        continue;
+      }
+
+      if (masked) {
+        const candidate = { ...preview, [path]: maskString };
+        if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
+          return;
+        preview[path] = maskString;
+        continue;
+      }
+
+      // For objects, recurse rather than storing the whole object
+      if (
+        obj[key] !== null &&
+        typeof obj[key] === "object" &&
+        !Array.isArray(obj[key])
+      ) {
+        collect(obj[key], path);
+        continue;
+      }
+
+      const candidate = { ...preview, [path]: obj[key] };
+      if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
+        return;
+      preview[path] = obj[key];
+    }
+  }
+
+  collect(value, "");
+  return Object.keys(preview).length > 0 ? preview : undefined;
+}
+
+/**
+ * Creates a Serdes that stores serialized values on the filesystem.
+ *
  * The checkpoint stores a JSON envelope that is either:
- * - `{"data":"<inline JSON>"}` — value stored inline (OVERFLOW mode, under threshold)
  * - `{"file":"<path>"}` — value stored in a file (ALWAYS mode, or OVERFLOW above threshold)
+ * - `{"file":"<path>","preview":{...}}` — file pointer with inline preview (when preview is configured)
  *
  * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
  * @param config - Optional configuration options
@@ -76,7 +252,18 @@ export interface FileSystemSerdesConfig {
  *
  * // Only overflow to filesystem when payload exceeds ~256KB
  * context.configureSerdes({
- *   defaultSerdes: createFileSystemSerdes("/mnt/s3", { mode: FileSystemSerdesMode.OVERFLOW }),
+ *   defaultSerdes: createFileSystemSerdes("/mnt/s3", { storageMode: FileSystemSerdesMode.OVERFLOW }),
+ * });
+ *
+ * // With preview: show id and masked email in checkpoint
+ * context.configureSerdes({
+ *   defaultSerdes: createFileSystemSerdes("/mnt/s3", {
+ *     preview: {
+ *       mode: PreviewMode.EXCLUDE_ALL,
+ *       include: [{ name: "id" }, { name: "status" }],
+ *       mask: [{ name: "email" }],
+ *     },
+ *   }),
  * });
  * ```
  *
@@ -86,7 +273,7 @@ export function createFileSystemSerdes(
   basePath: string,
   config: FileSystemSerdesConfig = {},
 ): AnySerdes {
-  const mode = config.mode ?? FileSystemSerdesMode.ALWAYS;
+  const storageMode = config.storageMode ?? FileSystemSerdesMode.ALWAYS;
   return {
     serialize: async (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,20 +282,30 @@ export function createFileSystemSerdes(
     ): Promise<string | undefined> => {
       if (value === undefined) return undefined;
 
-      if (mode === FileSystemSerdesMode.ALWAYS) {
+      if (storageMode === FileSystemSerdesMode.ALWAYS) {
         const filePath = await writeToFile(basePath, value, context);
-        const envelope: FileSystemEnvelope = { file: filePath };
+        const preview = config.preview
+          ? buildPreview(value, config.preview)
+          : undefined;
+        const envelope: FileSystemEnvelope = preview
+          ? { file: filePath, preview }
+          : { file: filePath };
         return JSON.stringify(envelope);
       }
 
       // OVERFLOW mode: serialize inline first, overflow to file if too large
       const inlineJson = JSON.stringify(value);
-      const envelope: FileSystemEnvelope =
-        Buffer.byteLength(inlineJson, "utf-8") > OVERFLOW_THRESHOLD_BYTES
-          ? { file: await writeToFile(basePath, value, context) }
-          : { data: inlineJson };
-
-      return JSON.stringify(envelope);
+      if (Buffer.byteLength(inlineJson, "utf-8") > OVERFLOW_THRESHOLD_BYTES) {
+        const filePath = await writeToFile(basePath, value, context);
+        const preview = config.preview
+          ? buildPreview(value, config.preview)
+          : undefined;
+        const envelope: FileSystemEnvelope = preview
+          ? { file: filePath, preview }
+          : { file: filePath };
+        return JSON.stringify(envelope);
+      }
+      return JSON.stringify({ data: inlineJson } as FileSystemEnvelope);
     },
 
     deserialize: async (

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -172,15 +172,20 @@ function setNestedValue(
   path: string,
   value: unknown,
 ): void {
+  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const parts = path.split(".");
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
+    if (DANGEROUS_KEYS.has(parts[i])) return;
     if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
       current[parts[i]] = {};
     }
     current = current[parts[i]] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  if (!DANGEROUS_KEYS.has(lastKey)) {
+    current[lastKey] = value;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -257,13 +257,27 @@ export function buildPreview(
 }
 
 /**
- * Creates a Serdes that stores serialized values on the filesystem.
+ * Creates a Serdes that stores serialized values on a durable filesystem.
+ *
+ * **⚠️ WARNING: Do NOT use with Lambda's ephemeral `/tmp` storage.**
+ * Lambda's `/tmp` filesystem is local to a single execution environment and is
+ * not shared across invocations or function instances. On replay, a different
+ * execution environment may be used and the file will not be found, causing
+ * deserialization to fail.
+ *
+ * **Use only with a durable, shared filesystem such as:**
+ * - **Amazon S3 Files** — mount an S3 bucket as a filesystem via the Lambda console or IaC
+ * - **Amazon EFS** — mount an EFS file system to your Lambda function
+ *
+ * Both options provide persistence across invocations and are accessible from
+ * multiple concurrent function instances, which is required for correct replay behavior.
  *
  * The checkpoint stores a JSON envelope that is either:
- * - `{"file":"<path>"}` — value stored in a file (ALWAYS mode, or OVERFLOW above threshold)
+ * - `{"data":"<inline JSON>"}` — value stored inline (OVERFLOW mode, under threshold)
+ * - `{"file":"<path>"}` — value stored in a file
  * - `{"file":"<path>","preview":{...}}` — file pointer with inline preview (when preview is configured)
  *
- * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
+ * @param basePath - Directory path where data files will be stored (e.g. `/mnt/s3` for S3 Files, `/mnt/efs` for EFS)
  * @param config - Optional configuration options
  * @returns A Serdes that reads/writes JSON files under basePath
  *


### PR DESCRIPTION
Add optional preview configuration that stores a subset of the serialized value inline in the checkpoint envelope alongside the file pointer. This makes data visible in the console and API without reading the full file.

Preview is generated whenever data is written to a file (both ALWAYS mode and OVERFLOW mode when payload exceeds threshold). Inline payloads in OVERFLOW mode do not get a preview since the full data is already in the checkpoint.

New types:
- PreviewMode (INCLUDE_ALL | EXCLUDE_ALL): default visibility strategy
- FieldMatchMode (ANYWHERE | PATH): how field names are matched
- PreviewField: { name, match? } field selector
- PreviewConfig: { mode, include?, exclude?, mask?, maskString?, maxPreviewBytes? }

Priority rules:
- exclude always wins (even over mask)
- mask implies visibility — masked fields are shown (with maskString) unless excluded
- maxPreviewBytes (default 4096) caps the preview size

Also renames FileSystemSerdesConfig.mode to storageMode for clarity and adds full unit test coverage for all preview behaviors.