### PR TITLE
fix(sdk): update UserAgent header format

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -1,14 +1,17 @@
 /**
  * SDK metadata injected by Rollup at build time from package.json.
+ * These values are inserted into UserAgent headers.
  *
- * At build time, Rollup replaces process.env.NPM_PACKAGE_NAME and
- * process.env.NPM_PACKAGE_VERSION with actual values from package.json.
+ * At build time, Rollup replaces process.env.NPM_PACKAGE_VERSION
+ * with actual values from package.json.
+ *
+ * SDK_NAME is a fixed string matching the cross-SDK convention:
+ * aws-durable-execution-sdk-\{language\}
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
-export const SDK_NAME =
-  process.env.NPM_PACKAGE_NAME || "@aws/durable-execution-sdk-js";
+export const SDK_NAME = "aws-durable-execution-sdk-js";
 export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The JS AWS SDK has formatiing rules on values inserted into UserAgent headers.
- The character `@` cannot be used.
- Multiple '/' characters are replaced.

This CR updates the format of the UserAgent header string to follow the above formatting rules, to avoid modifications by the AWS SDK.

Old format: `@aws/durable-execution-sdk-js/{version}`
New format: `aws-durable-execution-sdk-js/{version}`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
