### PR TITLE
feat(sdk): add preview config to createFileSystemSerdes

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -62,6 +62,10 @@ export {
   createFileSystemSerdes,
   FileSystemSerdesMode,
   FileSystemSerdesConfig,
+  FieldMatchMode,
+  PreviewMode,
+  PreviewField,
+  PreviewConfig,
 } from "./utils/serdes/filesystem-serdes";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -67,6 +67,7 @@ export {
   PreviewField,
   PreviewConfig,
 } from "./utils/serdes/filesystem-serdes";
+export { buildPreview } from "./utils/serdes/preview";
 export { DurableExecutionApiClient } from "./durable-execution-api-client/durable-execution-api-client";
 export {
   createWaitStrategy,

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -156,6 +156,19 @@ describe("buildPreview", () => {
     expect(result).toHaveProperty("id", "123");
   });
 
+  it("mask: applies to fields nested inside arrays", () => {
+    const result = buildPreview(
+      { items: [{ secret: "xyz" }, { secret: "abc" }] },
+      {
+        mode: PreviewMode.INCLUDE_ALL,
+        mask: [{ name: "secret" }],
+      },
+    );
+    // Array structure is not preserved in preview — fields from array elements
+    // are merged into a plain object at the array's path
+    expect((result?.["items"] as any)?.secret).toBe("***");
+  });
+
   it("mask: uses custom maskString", () => {
     const result = buildPreview(value, {
       mode: PreviewMode.INCLUDE_ALL,

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -2,6 +2,9 @@ import { SerdesContext } from "./serdes";
 import {
   createFileSystemSerdes,
   FileSystemSerdesMode,
+  PreviewMode,
+  FieldMatchMode,
+  buildPreview,
 } from "./filesystem-serdes";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
 
@@ -110,27 +113,142 @@ describe("createFileSystemSerdes", () => {
   });
 });
 
-describe("createFileSystemSerdes with generatePreview", () => {
-  it("stores preview returned by generatePreview in envelope", async () => {
+describe("buildPreview", () => {
+  const value = {
+    id: "123",
+    email: "alice@example.com",
+    ssn: "000-00-0000",
+    user: { name: "Alice", role: "admin" },
+  };
+
+  it("INCLUDE_ALL: includes all fields by default", () => {
+    const result = buildPreview(value, { mode: PreviewMode.INCLUDE_ALL });
+    expect(result).toHaveProperty("id", "123");
+    expect(result).toHaveProperty("email", "alice@example.com");
+    expect(result).toHaveProperty("ssn", "000-00-0000");
+  });
+
+  it("INCLUDE_ALL + exclude: omits excluded fields", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "ssn" }],
+    });
+    expect(result).not.toHaveProperty("ssn");
+    expect(result).toHaveProperty("id", "123");
+  });
+
+  it("EXCLUDE_ALL + include: only includes specified fields", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      include: [{ name: "id" }, { name: "email" }],
+    });
+    expect(result).toHaveProperty("id", "123");
+    expect(result).toHaveProperty("email", "alice@example.com");
+    expect(result).not.toHaveProperty("ssn");
+  });
+
+  it("mask: replaces visible field value with maskString", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      mask: [{ name: "ssn" }],
+    });
+    expect(result).toHaveProperty("ssn", "***");
+    expect(result).toHaveProperty("id", "123");
+  });
+
+  it("mask: uses custom maskString", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      mask: [{ name: "ssn" }],
+      maskString: "[REDACTED]",
+    });
+    expect(result).toHaveProperty("ssn", "[REDACTED]");
+  });
+
+  it("PATH match: only matches exact path", () => {
+    const result = buildPreview(
+      { email: "root@example.com", user: { email: "nested@example.com" } },
+      {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "email", match: FieldMatchMode.PATH }],
+      },
+    );
+    expect(result).toHaveProperty("email", "root@example.com");
+    expect(result).not.toHaveProperty("user.email");
+  });
+
+  it("ANYWHERE match: matches field at any depth", () => {
+    const result = buildPreview(
+      { email: "root@example.com", user: { email: "nested@example.com" } },
+      {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "email" }],
+      },
+    );
+    expect(result?.["email"]).toBe("root@example.com");
+    expect(result?.["user.email"]).toBe("nested@example.com");
+  });
+
+  it("respects maxPreviewBytes budget", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      maxPreviewBytes: 20, // very small — only first field fits
+    });
+    expect(Object.keys(result ?? {}).length).toBeLessThan(
+      Object.keys(value).length,
+    );
+  });
+
+  it("returns undefined for non-object values", () => {
+    expect(
+      buildPreview("string", { mode: PreviewMode.INCLUDE_ALL }),
+    ).toBeUndefined();
+    expect(buildPreview(42, { mode: PreviewMode.INCLUDE_ALL })).toBeUndefined();
+  });
+
+  it("mask implies visibility in EXCLUDE_ALL — masked field shown even without include", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      mask: [{ name: "ssn" }], // not in include, but mask implies visible
+    });
+    expect(result).toHaveProperty("ssn", "***");
+    expect(result).not.toHaveProperty("id");
+  });
+
+  it("exclude wins over mask — excluded field is not shown even if in mask", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "ssn" }],
+      mask: [{ name: "ssn" }],
+    });
+    expect(result).not.toHaveProperty("ssn");
+  });
+
+  it("returns undefined when no fields are visible", () => {
+    const result = buildPreview(value, {
+      mode: PreviewMode.EXCLUDE_ALL,
+      // no include, no mask
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("createFileSystemSerdes with preview", () => {
+  it("stores preview in envelope alongside file pointer", async () => {
     const serdes = createFileSystemSerdes(BASE_PATH, {
-      generatePreview: (value) => ({ id: (value as any).id }),
+      preview: {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "id" }],
+        mask: [{ name: "secret" }],
+      },
     });
 
-    const value = { id: "abc", secret: "s3cr3t" };
+    const value = { id: "abc", secret: "s3cr3t", other: "ignored" };
     const result = await serdes.serialize(value, mockContext);
     const envelope = JSON.parse(result!);
 
     expect(envelope).toHaveProperty("file");
-    expect(envelope.preview).toEqual({ id: "abc" });
-  });
-
-  it("no preview in envelope when generatePreview is not set", async () => {
-    const serdes = createFileSystemSerdes(BASE_PATH);
-    const result = await serdes.serialize({ id: "abc" }, mockContext);
-    const envelope = JSON.parse(result!);
-
-    expect(envelope).toHaveProperty("file");
-    expect(envelope).not.toHaveProperty("preview");
+    expect(envelope.preview).toEqual({ id: "abc", secret: "***" });
   });
 
   it("deserialize ignores preview field and reads from file", async () => {
@@ -147,5 +265,37 @@ describe("createFileSystemSerdes with generatePreview", () => {
     );
 
     expect(result).toEqual(value);
+    expect(mockReadFile).toHaveBeenCalledWith(EXPECTED_FILE, "utf-8");
+  });
+
+  it("OVERFLOW mode: includes preview when payload overflows to file", async () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      storageMode: FileSystemSerdesMode.OVERFLOW,
+      preview: {
+        mode: PreviewMode.EXCLUDE_ALL,
+        include: [{ name: "id" }],
+      },
+    });
+
+    const value = { id: "abc", data: "x".repeat(256 * 1024) };
+    const result = await serdes.serialize(value, mockContext);
+    const envelope = JSON.parse(result!);
+
+    expect(envelope).toHaveProperty("file");
+    expect(envelope.preview).toEqual({ id: "abc" });
+  });
+
+  it("OVERFLOW mode: no preview for inline payloads", async () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      storageMode: FileSystemSerdesMode.OVERFLOW,
+      preview: { mode: PreviewMode.INCLUDE_ALL },
+    });
+
+    const value = { id: "abc" }; // small — stays inline
+    const result = await serdes.serialize(value, mockContext);
+    const envelope = JSON.parse(result!);
+
+    expect(envelope).toHaveProperty("data");
+    expect(envelope).not.toHaveProperty("preview");
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -186,7 +186,7 @@ describe("buildPreview", () => {
       },
     );
     expect(result?.["email"]).toBe("root@example.com");
-    expect(result?.["user.email"]).toBe("nested@example.com");
+    expect((result?.["user"] as any)?.["email"]).toBe("nested@example.com");
   });
 
   it("respects maxPreviewBytes budget", () => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -249,11 +249,12 @@ describe("buildPreview", () => {
 describe("createFileSystemSerdes with preview", () => {
   it("stores preview in envelope alongside file pointer", async () => {
     const serdes = createFileSystemSerdes(BASE_PATH, {
-      preview: {
-        mode: PreviewMode.EXCLUDE_ALL,
-        include: [{ name: "id" }],
-        mask: [{ name: "secret" }],
-      },
+      generatePreview: (value) =>
+        buildPreview(value, {
+          mode: PreviewMode.EXCLUDE_ALL,
+          include: [{ name: "id" }],
+          mask: [{ name: "secret" }],
+        }),
     });
 
     const value = { id: "abc", secret: "s3cr3t", other: "ignored" };
@@ -284,10 +285,11 @@ describe("createFileSystemSerdes with preview", () => {
   it("OVERFLOW mode: includes preview when payload overflows to file", async () => {
     const serdes = createFileSystemSerdes(BASE_PATH, {
       storageMode: FileSystemSerdesMode.OVERFLOW,
-      preview: {
-        mode: PreviewMode.EXCLUDE_ALL,
-        include: [{ name: "id" }],
-      },
+      generatePreview: (value) =>
+        buildPreview(value, {
+          mode: PreviewMode.EXCLUDE_ALL,
+          include: [{ name: "id" }],
+        }),
     });
 
     const value = { id: "abc", data: "x".repeat(256 * 1024) };
@@ -301,7 +303,8 @@ describe("createFileSystemSerdes with preview", () => {
   it("OVERFLOW mode: no preview for inline payloads", async () => {
     const serdes = createFileSystemSerdes(BASE_PATH, {
       storageMode: FileSystemSerdesMode.OVERFLOW,
-      preview: { mode: PreviewMode.INCLUDE_ALL },
+      generatePreview: (value) =>
+        buildPreview(value, { mode: PreviewMode.INCLUDE_ALL }),
     });
 
     const value = { id: "abc" }; // small — stays inline

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -167,6 +167,23 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
+      current[parts[i]] = {};
+    }
+    current = current[parts[i]] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildPreview(
   value: any,
   config: PreviewConfig,
@@ -204,10 +221,11 @@ export function buildPreview(
       }
 
       if (masked) {
-        const candidate = { ...preview, [path]: maskString };
+        const candidate = JSON.parse(JSON.stringify(preview));
+        setNestedValue(candidate, path, maskString);
         if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
           return;
-        preview[path] = maskString;
+        setNestedValue(preview, path, maskString);
         continue;
       }
 
@@ -221,10 +239,11 @@ export function buildPreview(
         continue;
       }
 
-      const candidate = { ...preview, [path]: obj[key] };
+      const candidate = JSON.parse(JSON.stringify(preview));
+      setNestedValue(candidate, path, obj[key]);
       if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
         return;
-      preview[path] = obj[key];
+      setNestedValue(preview, path, obj[key]);
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -174,18 +174,19 @@ function setNestedValue(
 ): void {
   const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const parts = path.split(".");
+  if (parts.some((p) => DANGEROUS_KEYS.has(p))) return;
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (DANGEROUS_KEYS.has(parts[i])) return;
-    if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
-      current[parts[i]] = {};
+    if (
+      !Object.prototype.hasOwnProperty.call(current, parts[i]) ||
+      typeof current[parts[i]] !== "object" ||
+      current[parts[i]] === null
+    ) {
+      current[parts[i]] = Object.create(null) as Record<string, unknown>;
     }
     current = current[parts[i]] as Record<string, unknown>;
   }
-  const lastKey = parts[parts.length - 1];
-  if (!DANGEROUS_KEYS.has(lastKey)) {
-    current[lastKey] = value;
-  }
+  current[parts[parts.length - 1]] = value;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -183,6 +183,15 @@ export function buildPreview(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function collect(obj: any, pathPrefix: string): void {
     if (obj === null || typeof obj !== "object") return;
+
+    // Recurse into arrays transparently (indices are not part of the path)
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        collect(item, pathPrefix);
+      }
+      return;
+    }
+
     for (const key of Object.keys(obj)) {
       if (DANGEROUS_KEYS.has(key)) continue;
       const path = pathPrefix ? `${pathPrefix}.${key}` : key;
@@ -196,13 +205,7 @@ export function buildPreview(
             : isMatched(path, config.include)));
 
       if (!visible) {
-        if (
-          obj[key] !== null &&
-          typeof obj[key] === "object" &&
-          !Array.isArray(obj[key])
-        ) {
-          collect(obj[key], path);
-        }
+        collect(obj[key], path);
         continue;
       }
 
@@ -211,16 +214,12 @@ export function buildPreview(
         continue;
       }
 
-      if (
-        obj[key] !== null &&
-        typeof obj[key] === "object" &&
-        !Array.isArray(obj[key])
-      ) {
+      // Recurse into objects/arrays; push scalars directly
+      if (obj[key] !== null && typeof obj[key] === "object") {
         collect(obj[key], path);
-        continue;
+      } else {
+        pairs.push([path, obj[key]]);
       }
-
-      pairs.push([path, obj[key]]);
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -167,73 +167,35 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function deepMerge(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): void {
-  for (const key of Object.keys(source)) {
-    const sourceVal = source[key];
-    if (
-      sourceVal !== null &&
-      typeof sourceVal === "object" &&
-      !Array.isArray(sourceVal) &&
-      typeof target[key] === "object" &&
-      target[key] !== null
-    ) {
-      deepMerge(
-        target[key] as Record<string, unknown>,
-        sourceVal as Record<string, unknown>,
-      );
-    } else {
-      target[key] = sourceVal;
-    }
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setNestedValue(
-  obj: Record<string, unknown>,
-  path: string,
-  value: unknown,
-): void {
-  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-  const parts = path.split(".");
-  if (parts.some((p) => DANGEROUS_KEYS.has(p))) return;
-  // Build nested structure from inside out, then merge — avoids dynamic traversal
-  const nested = parts.reduceRight<unknown>(
-    (acc, key) => ({ [key]: acc }),
-    value,
-  );
-  deepMerge(obj, nested as Record<string, unknown>);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildPreview(
   value: any,
   config: PreviewConfig,
 ): Record<string, unknown> | undefined {
   if (value === null || typeof value !== "object") return undefined;
 
+  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const maskString = config.maskString ?? "***";
   const maxBytes = config.maxPreviewBytes ?? 4096;
-  const preview: Record<string, unknown> = {};
+
+  // Step 1: collect flat (path, displayValue) pairs
+  const pairs: Array<[string, unknown]> = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function collect(obj: any, pathPrefix: string): void {
     if (obj === null || typeof obj !== "object") return;
     for (const key of Object.keys(obj)) {
+      if (DANGEROUS_KEYS.has(key)) continue;
       const path = pathPrefix ? `${pathPrefix}.${key}` : key;
       const masked = isMatched(path, config.mask);
-      const visible =
-        masked || // mask implies visible, unless explicitly excluded
-        (config.mode === PreviewMode.INCLUDE_ALL
-          ? !isMatched(path, config.exclude)
-          : isMatched(path, config.include));
-      // exclude always wins — even over mask
       const excluded = isMatched(path, config.exclude);
+      const visible =
+        !excluded &&
+        (masked ||
+          (config.mode === PreviewMode.INCLUDE_ALL
+            ? true
+            : isMatched(path, config.include)));
 
-      if (!visible || excluded) {
-        // Recurse into objects to find nested matches
+      if (!visible) {
         if (
           obj[key] !== null &&
           typeof obj[key] === "object" &&
@@ -245,15 +207,10 @@ export function buildPreview(
       }
 
       if (masked) {
-        const candidate = JSON.parse(JSON.stringify(preview));
-        setNestedValue(candidate, path, maskString);
-        if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
-          return;
-        setNestedValue(preview, path, maskString);
+        pairs.push([path, maskString]);
         continue;
       }
 
-      // For objects, recurse rather than storing the whole object
       if (
         obj[key] !== null &&
         typeof obj[key] === "object" &&
@@ -263,16 +220,30 @@ export function buildPreview(
         continue;
       }
 
-      const candidate = JSON.parse(JSON.stringify(preview));
-      setNestedValue(candidate, path, obj[key]);
-      if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
-        return;
-      setNestedValue(preview, path, obj[key]);
+      pairs.push([path, obj[key]]);
     }
   }
 
   collect(value, "");
-  return Object.keys(preview).length > 0 ? preview : undefined;
+  if (pairs.length === 0) return undefined;
+
+  // Step 2: build nested object from flat pairs, respecting maxPreviewBytes
+  let result: Record<string, unknown> = {};
+  for (const [path, val] of pairs) {
+    const nested = path
+      .split(".")
+      .reduceRight<unknown>((acc, k) => ({ [k]: acc }), val) as Record<
+      string,
+      unknown
+    >;
+    const candidate = JSON.parse(
+      JSON.stringify({ ...result, ...nested }),
+    ) as Record<string, unknown>;
+    if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes) break;
+    result = candidate;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -172,15 +172,20 @@ function setNestedValue(
   path: string,
   value: unknown,
 ): void {
+  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const parts = path.split(".");
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
+    if (DANGEROUS_KEYS.has(parts[i])) return;
     if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
       current[parts[i]] = {};
     }
     current = current[parts[i]] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  if (!DANGEROUS_KEYS.has(lastKey)) {
+    current[lastKey] = value;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -121,13 +121,6 @@ export interface FileSystemSerdesConfig {
   preview?: PreviewConfig;
 }
 
-/**
- * Creates a Serdes that stores serialized values on the filesystem.
- *
- * Designed for use with Lambda functions that mount an Amazon S3 bucket as a
- * filesystem via S3 Files, enabling durable, shared state across invocations
- * and parallel function instances without checkpoint size constraints.
- *
 /** @internal */
 type FileSystemEnvelope =
   | { data: string }

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -132,11 +132,11 @@ async function writeToFile(
  * // With preview: show id and masked email in checkpoint
  * context.configureSerdes({
  *   defaultSerdes: createFileSystemSerdes("/mnt/s3", {
- *     preview: {
+ *     generatePreview: (value) => buildPreview(value, {
  *       mode: PreviewMode.EXCLUDE_ALL,
  *       include: [{ name: "id" }, { name: "status" }],
  *       mask: [{ name: "email" }],
- *     },
+ *     }),
  *   }),
  * });
  * ```

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -167,6 +167,30 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): void {
+  for (const key of Object.keys(source)) {
+    const sourceVal = source[key];
+    if (
+      sourceVal !== null &&
+      typeof sourceVal === "object" &&
+      !Array.isArray(sourceVal) &&
+      typeof target[key] === "object" &&
+      target[key] !== null
+    ) {
+      deepMerge(
+        target[key] as Record<string, unknown>,
+        sourceVal as Record<string, unknown>,
+      );
+    } else {
+      target[key] = sourceVal;
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setNestedValue(
   obj: Record<string, unknown>,
   path: string,
@@ -175,18 +199,12 @@ function setNestedValue(
   const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
   const parts = path.split(".");
   if (parts.some((p) => DANGEROUS_KEYS.has(p))) return;
-  let current = obj;
-  for (let i = 0; i < parts.length - 1; i++) {
-    if (
-      !Object.prototype.hasOwnProperty.call(current, parts[i]) ||
-      typeof current[parts[i]] !== "object" ||
-      current[parts[i]] === null
-    ) {
-      current[parts[i]] = Object.create(null) as Record<string, unknown>;
-    }
-    current = current[parts[i]] as Record<string, unknown>;
-  }
-  current[parts[parts.length - 1]] = value;
+  // Build nested structure from inside out, then merge — avoids dynamic traversal
+  const nested = parts.reduceRight<unknown>(
+    (acc, key) => ({ [key]: acc }),
+    value,
+  );
+  deepMerge(obj, nested as Record<string, unknown>);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -245,22 +245,20 @@ export function buildPreview(
 
   if (accepted.length === 0) return undefined;
 
-  // Build nested structure from accepted pairs (no dynamic assignment)
-  const result = accepted.reduce<Record<string, unknown>>(
-    (acc, [path, val]) => {
-      const nested = path
-        .split(".")
-        .reduceRight<unknown>((a, k) => ({ [k]: a }), val) as Record<
-        string,
-        unknown
-      >;
-      return JSON.parse(JSON.stringify({ ...acc, ...nested })) as Record<
-        string,
-        unknown
-      >;
-    },
-    {},
-  );
+  // Build nested structure from accepted pairs in O(n).
+  // Keys are safe at this point — dangerous keys were filtered in collect().
+  const result: Record<string, unknown> = {};
+  for (const [path, val] of accepted) {
+    const parts = path.split(".");
+    let node = result;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (typeof node[parts[i]] !== "object" || node[parts[i]] === null) {
+        node[parts[i]] = {};
+      }
+      node = node[parts[i]] as Record<string, unknown>;
+    }
+    node[parts[parts.length - 1]] = val;
+  }
 
   return Object.keys(result).length > 0 ? result : undefined;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -2,7 +2,6 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { SerdesContext, AnySerdes } from "./serdes";
 import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
-import { buildPreview } from "./preview";
 export {
   FieldMatchMode,
   PreviewMode,

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -2,6 +2,14 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { SerdesContext, AnySerdes } from "./serdes";
 import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
+import { buildPreview } from "./preview";
+export {
+  FieldMatchMode,
+  PreviewMode,
+  PreviewField,
+  PreviewConfig,
+  buildPreview,
+} from "./preview";
 
 // Subtract 1KB headroom for the envelope wrapper and other checkpoint metadata
 const OVERFLOW_THRESHOLD_BYTES = CHECKPOINT_SIZE_LIMIT_BYTES - 1024;
@@ -21,86 +29,6 @@ const OVERFLOW_THRESHOLD_BYTES = CHECKPOINT_SIZE_LIMIT_BYTES - 1024;
 export enum FileSystemSerdesMode {
   ALWAYS = "ALWAYS",
   OVERFLOW = "OVERFLOW",
-}
-
-/**
- * Controls whether a preview field is matched by name anywhere in the object
- * tree, or by exact dot-notation path from the root.
- *
- * @public
- */
-export enum FieldMatchMode {
-  /** Match the field name at any depth in the object tree (default). */
-  ANYWHERE = "ANYWHERE",
-  /**
-   * Match by exact dot-notation path from root.
-   * A single segment (e.g. `"email"`) matches only the root-level field.
-   * A dotted path (e.g. `"user.email"`) matches that exact nested location.
-   */
-  PATH = "PATH",
-}
-
-/**
- * Controls which fields are included in the preview by default.
- *
- * @public
- */
-export enum PreviewMode {
-  /** Include all fields, then apply `exclude` and `mask` rules. */
-  INCLUDE_ALL = "INCLUDE_ALL",
-  /** Exclude all fields, then apply `include` and `mask` rules. */
-  EXCLUDE_ALL = "EXCLUDE_ALL",
-}
-
-/**
- * A field selector used in preview include/exclude/mask lists.
- *
- * @public
- */
-export interface PreviewField {
-  /** Field name or dot-notation path. */
-  name: string;
-  /** How to match the field. Defaults to `FieldMatchMode.ANYWHERE`. */
-  match?: FieldMatchMode;
-}
-
-/**
- * Configuration for the preview feature of {@link createFileSystemSerdes}.
- *
- * When configured, a subset of the original value is stored inline in the
- * checkpoint envelope alongside the file pointer, making it visible in the
- * console and API without reading the full file.
- *
- * @public
- */
-export interface PreviewConfig {
-  /**
-   * Whether to start with all fields included or all excluded.
-   */
-  mode: PreviewMode;
-  /**
-   * Fields to include (used with `EXCLUDE_ALL` mode, or to override `INCLUDE_ALL`).
-   */
-  include?: PreviewField[];
-  /**
-   * Fields to exclude (used with `INCLUDE_ALL` mode, or to override `EXCLUDE_ALL`).
-   */
-  exclude?: PreviewField[];
-  /**
-   * Fields to mask — if visible, their value is replaced with `maskString`.
-   */
-  mask?: PreviewField[];
-  /**
-   * String used to replace masked field values.
-   * @defaultValue `"***"`
-   */
-  maskString?: string;
-  /**
-   * Maximum size in bytes for the preview object (JSON-serialized).
-   * Fields are added until this limit is reached.
-   * @defaultValue `4096`
-   */
-  maxPreviewBytes?: number;
 }
 
 /**
@@ -162,125 +90,6 @@ async function writeToFile(
   const filePath = join(dir, `${context.entityId}.json`);
   await writeFile(filePath, JSON.stringify(value), "utf-8");
   return filePath;
-}
-
-/** Returns true if the field at `path` (dot-notation) matches the given PreviewField rule. */
-function fieldMatches(path: string, field: PreviewField): boolean {
-  const mode = field.match ?? FieldMatchMode.ANYWHERE;
-  if (mode === FieldMatchMode.PATH) {
-    return path === field.name;
-  }
-  // ANYWHERE: match if any segment of the path equals the field name
-  return path.split(".").includes(field.name);
-}
-
-function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
-  return fields?.some((f) => fieldMatches(path, f)) ?? false;
-}
-
-/**
- * Builds a preview object from `value` according to `config`.
- * Only top-level and nested scalar/object fields are included (no special array handling).
- * Fields are added until `maxPreviewBytes` is reached.
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildPreview(
-  value: any,
-  config: PreviewConfig,
-): Record<string, unknown> | undefined {
-  if (value === null || typeof value !== "object") return undefined;
-
-  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-  const maskString = config.maskString ?? "***";
-  const maxBytes = config.maxPreviewBytes ?? 4096;
-
-  // Step 1: collect flat (path, displayValue) pairs
-  const pairs: Array<[string, unknown]> = [];
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function collect(obj: any, pathPrefix: string): void {
-    if (obj === null || typeof obj !== "object") return;
-
-    // Recurse into arrays transparently (indices are not part of the path)
-    if (Array.isArray(obj)) {
-      for (const item of obj) {
-        collect(item, pathPrefix);
-      }
-      return;
-    }
-
-    for (const key of Object.keys(obj)) {
-      if (DANGEROUS_KEYS.has(key)) continue;
-      // Skip keys containing dots — they're indistinguishable from nested paths
-      // in the dot-notation path system used by preview field matching and rebuild.
-      if (key.includes(".")) continue;
-      const path = pathPrefix ? `${pathPrefix}.${key}` : key;
-      const masked = isMatched(path, config.mask);
-      const excluded = isMatched(path, config.exclude);
-      const visible =
-        !excluded &&
-        (masked ||
-          (config.mode === PreviewMode.INCLUDE_ALL
-            ? true
-            : isMatched(path, config.include)));
-
-      if (!visible) {
-        collect(obj[key], path);
-        continue;
-      }
-
-      if (masked) {
-        pairs.push([path, maskString]);
-        continue;
-      }
-
-      // Recurse into objects/arrays; push scalars directly
-      if (obj[key] !== null && typeof obj[key] === "object") {
-        collect(obj[key], path);
-      } else {
-        pairs.push([path, obj[key]]);
-      }
-    }
-  }
-
-  collect(value, "");
-  if (pairs.length === 0) return undefined;
-
-  // Step 2: filter pairs by maxPreviewBytes using incremental size tracking (O(n)),
-  // then build the nested object once from accepted pairs.
-  // Using flat path as key for size estimation — slightly over-estimates for nested
-  // keys but is safe (never under-estimates).
-  const accepted: Array<[string, unknown]> = [];
-  let estimatedSize = 2; // "{}"
-  for (const [path, val] of pairs) {
-    const entrySize = Buffer.byteLength(
-      `"${path}":${JSON.stringify(val)},`,
-      "utf-8",
-    );
-    if (estimatedSize + entrySize > maxBytes) break;
-    accepted.push([path, val]);
-    estimatedSize += entrySize;
-  }
-
-  if (accepted.length === 0) return undefined;
-
-  // Build nested structure from accepted pairs in O(n).
-  // Keys are safe at this point — dangerous keys were filtered in collect().
-  const result: Record<string, unknown> = {};
-  for (const [path, val] of accepted) {
-    const parts = path.split(".");
-    let node = result;
-    for (let i = 0; i < parts.length - 1; i++) {
-      if (typeof node[parts[i]] !== "object" || node[parts[i]] === null) {
-        node[parts[i]] = {};
-      }
-      node = node[parts[i]] as Record<string, unknown>;
-    }
-    node[parts[parts.length - 1]] = val;
-  }
-
-  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -227,21 +227,40 @@ export function buildPreview(
   collect(value, "");
   if (pairs.length === 0) return undefined;
 
-  // Step 2: build nested object from flat pairs, respecting maxPreviewBytes
-  let result: Record<string, unknown> = {};
+  // Step 2: filter pairs by maxPreviewBytes using incremental size tracking (O(n)),
+  // then build the nested object once from accepted pairs.
+  // Using flat path as key for size estimation — slightly over-estimates for nested
+  // keys but is safe (never under-estimates).
+  const accepted: Array<[string, unknown]> = [];
+  let estimatedSize = 2; // "{}"
   for (const [path, val] of pairs) {
-    const nested = path
-      .split(".")
-      .reduceRight<unknown>((acc, k) => ({ [k]: acc }), val) as Record<
-      string,
-      unknown
-    >;
-    const candidate = JSON.parse(
-      JSON.stringify({ ...result, ...nested }),
-    ) as Record<string, unknown>;
-    if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes) break;
-    result = candidate;
+    const entrySize = Buffer.byteLength(
+      `"${path}":${JSON.stringify(val)},`,
+      "utf-8",
+    );
+    if (estimatedSize + entrySize > maxBytes) break;
+    accepted.push([path, val]);
+    estimatedSize += entrySize;
   }
+
+  if (accepted.length === 0) return undefined;
+
+  // Build nested structure from accepted pairs (no dynamic assignment)
+  const result = accepted.reduce<Record<string, unknown>>(
+    (acc, [path, val]) => {
+      const nested = path
+        .split(".")
+        .reduceRight<unknown>((a, k) => ({ [k]: a }), val) as Record<
+        string,
+        unknown
+      >;
+      return JSON.parse(JSON.stringify({ ...acc, ...nested })) as Record<
+        string,
+        unknown
+      >;
+    },
+    {},
+  );
 
   return Object.keys(result).length > 0 ? result : undefined;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -115,10 +115,35 @@ export interface FileSystemSerdesConfig {
    */
   storageMode?: FileSystemSerdesMode;
   /**
-   * When set, a preview of the value is stored inline in the checkpoint
-   * envelope alongside the file pointer.
+   * Optional function that generates a preview object from the value.
+   * When provided, the preview is stored inline in the checkpoint envelope
+   * alongside the file pointer, making data visible in the console and API
+   * without reading the full file.
+   *
+   * Use {@link buildPreview} with a {@link PreviewConfig} for the built-in
+   * field selection logic, or provide your own implementation.
+   *
+   * @example
+   * ```typescript
+   * // Using the built-in buildPreview helper
+   * createFileSystemSerdes("/mnt/s3", {
+   *   generatePreview: (value) => buildPreview(value, {
+   *     mode: PreviewMode.EXCLUDE_ALL,
+   *     include: [{ name: "id" }, { name: "status" }],
+   *     mask: [{ name: "email" }],
+   *   }),
+   * });
+   *
+   * // Custom implementation
+   * createFileSystemSerdes("/mnt/s3", {
+   *   generatePreview: (value) => ({
+   *     id: (value as any).id,
+   *     summary: `Order ${(value as any).id}`,
+   *   }),
+   * });
+   * ```
    */
-  preview?: PreviewConfig;
+  generatePreview?: (value: unknown) => Record<string, unknown> | undefined;
 }
 
 /** @internal */
@@ -330,9 +355,7 @@ export function createFileSystemSerdes(
 
       if (storageMode === FileSystemSerdesMode.ALWAYS) {
         const filePath = await writeToFile(basePath, value, context);
-        const preview = config.preview
-          ? buildPreview(value, config.preview)
-          : undefined;
+        const preview = config.generatePreview?.(value);
         const envelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }
           : { file: filePath };
@@ -343,9 +366,7 @@ export function createFileSystemSerdes(
       const inlineJson = JSON.stringify(value);
       if (Buffer.byteLength(inlineJson, "utf-8") > OVERFLOW_THRESHOLD_BYTES) {
         const filePath = await writeToFile(basePath, value, context);
-        const preview = config.preview
-          ? buildPreview(value, config.preview)
-          : undefined;
+        const preview = config.generatePreview?.(value);
         const envelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }
           : { file: filePath };

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -23,22 +23,84 @@ export enum FileSystemSerdesMode {
   OVERFLOW = "OVERFLOW",
 }
 
-/** @internal */
-type FileSystemEnvelope =
-  | { data: string }
-  | { file: string; preview?: Record<string, unknown> };
+/**
+ * Controls whether a preview field is matched by name anywhere in the object
+ * tree, or by exact dot-notation path from the root.
+ *
+ * @public
+ */
+export enum FieldMatchMode {
+  /** Match the field name at any depth in the object tree (default). */
+  ANYWHERE = "ANYWHERE",
+  /**
+   * Match by exact dot-notation path from root.
+   * A single segment (e.g. `"email"`) matches only the root-level field.
+   * A dotted path (e.g. `"user.email"`) matches that exact nested location.
+   */
+  PATH = "PATH",
+}
 
-async function writeToFile(
-  basePath: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any,
-  context: SerdesContext,
-): Promise<string> {
-  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
-  await mkdir(dir, { recursive: true });
-  const filePath = join(dir, `${context.entityId}.json`);
-  await writeFile(filePath, JSON.stringify(value), "utf-8");
-  return filePath;
+/**
+ * Controls which fields are included in the preview by default.
+ *
+ * @public
+ */
+export enum PreviewMode {
+  /** Include all fields, then apply `exclude` and `mask` rules. */
+  INCLUDE_ALL = "INCLUDE_ALL",
+  /** Exclude all fields, then apply `include` and `mask` rules. */
+  EXCLUDE_ALL = "EXCLUDE_ALL",
+}
+
+/**
+ * A field selector used in preview include/exclude/mask lists.
+ *
+ * @public
+ */
+export interface PreviewField {
+  /** Field name or dot-notation path. */
+  name: string;
+  /** How to match the field. Defaults to `FieldMatchMode.ANYWHERE`. */
+  match?: FieldMatchMode;
+}
+
+/**
+ * Configuration for the preview feature of {@link createFileSystemSerdes}.
+ *
+ * When configured, a subset of the original value is stored inline in the
+ * checkpoint envelope alongside the file pointer, making it visible in the
+ * console and API without reading the full file.
+ *
+ * @public
+ */
+export interface PreviewConfig {
+  /**
+   * Whether to start with all fields included or all excluded.
+   */
+  mode: PreviewMode;
+  /**
+   * Fields to include (used with `EXCLUDE_ALL` mode, or to override `INCLUDE_ALL`).
+   */
+  include?: PreviewField[];
+  /**
+   * Fields to exclude (used with `INCLUDE_ALL` mode, or to override `EXCLUDE_ALL`).
+   */
+  exclude?: PreviewField[];
+  /**
+   * Fields to mask — if visible, their value is replaced with `maskString`.
+   */
+  mask?: PreviewField[];
+  /**
+   * String used to replace masked field values.
+   * @defaultValue `"***"`
+   */
+  maskString?: string;
+  /**
+   * Maximum size in bytes for the preview object (JSON-serialized).
+   * Fields are added until this limit is reached.
+   * @defaultValue `4096`
+   */
+  maxPreviewBytes?: number;
 }
 
 /**
@@ -53,22 +115,10 @@ export interface FileSystemSerdesConfig {
    */
   storageMode?: FileSystemSerdesMode;
   /**
-   * Optional function that generates a preview object from the value.
-   * When provided, the preview is stored inline in the checkpoint envelope
-   * alongside the file pointer, making data visible in the console and API
-   * without reading the full file.
-   *
-   * @example
-   * ```typescript
-   * createFileSystemSerdes("/mnt/s3", {
-   *   generatePreview: (value) => ({
-   *     id: (value as any).id,
-   *     status: (value as any).status,
-   *   }),
-   * });
-   * ```
+   * When set, a preview of the value is stored inline in the checkpoint
+   * envelope alongside the file pointer.
    */
-  generatePreview?: (value: unknown) => Record<string, unknown> | undefined;
+  preview?: PreviewConfig;
 }
 
 /**
@@ -78,9 +128,116 @@ export interface FileSystemSerdesConfig {
  * filesystem via S3 Files, enabling durable, shared state across invocations
  * and parallel function instances without checkpoint size constraints.
  *
+/** @internal */
+type FileSystemEnvelope =
+  | { data: string }
+  | { file: string; preview?: Record<string, unknown> };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function writeToFile(
+  basePath: string,
+  value: any,
+  context: SerdesContext,
+): Promise<string> {
+  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, `${context.entityId}.json`);
+  await writeFile(filePath, JSON.stringify(value), "utf-8");
+  return filePath;
+}
+
+/** Returns true if the field at `path` (dot-notation) matches the given PreviewField rule. */
+function fieldMatches(path: string, field: PreviewField): boolean {
+  const mode = field.match ?? FieldMatchMode.ANYWHERE;
+  if (mode === FieldMatchMode.PATH) {
+    return path === field.name;
+  }
+  // ANYWHERE: match if any segment of the path equals the field name
+  return path.split(".").includes(field.name);
+}
+
+function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
+  return fields?.some((f) => fieldMatches(path, f)) ?? false;
+}
+
+/**
+ * Builds a preview object from `value` according to `config`.
+ * Only top-level and nested scalar/object fields are included (no special array handling).
+ * Fields are added until `maxPreviewBytes` is reached.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildPreview(
+  value: any,
+  config: PreviewConfig,
+): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+
+  const maskString = config.maskString ?? "***";
+  const maxBytes = config.maxPreviewBytes ?? 4096;
+  const preview: Record<string, unknown> = {};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function collect(obj: any, pathPrefix: string): void {
+    if (obj === null || typeof obj !== "object") return;
+    for (const key of Object.keys(obj)) {
+      const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+      const masked = isMatched(path, config.mask);
+      const visible =
+        masked || // mask implies visible, unless explicitly excluded
+        (config.mode === PreviewMode.INCLUDE_ALL
+          ? !isMatched(path, config.exclude)
+          : isMatched(path, config.include));
+      // exclude always wins — even over mask
+      const excluded = isMatched(path, config.exclude);
+
+      if (!visible || excluded) {
+        // Recurse into objects to find nested matches
+        if (
+          obj[key] !== null &&
+          typeof obj[key] === "object" &&
+          !Array.isArray(obj[key])
+        ) {
+          collect(obj[key], path);
+        }
+        continue;
+      }
+
+      if (masked) {
+        const candidate = { ...preview, [path]: maskString };
+        if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
+          return;
+        preview[path] = maskString;
+        continue;
+      }
+
+      // For objects, recurse rather than storing the whole object
+      if (
+        obj[key] !== null &&
+        typeof obj[key] === "object" &&
+        !Array.isArray(obj[key])
+      ) {
+        collect(obj[key], path);
+        continue;
+      }
+
+      const candidate = { ...preview, [path]: obj[key] };
+      if (Buffer.byteLength(JSON.stringify(candidate), "utf-8") > maxBytes)
+        return;
+      preview[path] = obj[key];
+    }
+  }
+
+  collect(value, "");
+  return Object.keys(preview).length > 0 ? preview : undefined;
+}
+
+/**
+ * Creates a Serdes that stores serialized values on the filesystem.
+ *
  * The checkpoint stores a JSON envelope that is either:
- * - `{"data":"<inline JSON>"}` — value stored inline (OVERFLOW mode, under threshold)
  * - `{"file":"<path>"}` — value stored in a file (ALWAYS mode, or OVERFLOW above threshold)
+ * - `{"file":"<path>","preview":{...}}` — file pointer with inline preview (when preview is configured)
  *
  * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
  * @param config - Optional configuration options
@@ -96,6 +253,17 @@ export interface FileSystemSerdesConfig {
  * // Only overflow to filesystem when payload exceeds ~256KB
  * context.configureSerdes({
  *   defaultSerdes: createFileSystemSerdes("/mnt/s3", { storageMode: FileSystemSerdesMode.OVERFLOW }),
+ * });
+ *
+ * // With preview: show id and masked email in checkpoint
+ * context.configureSerdes({
+ *   defaultSerdes: createFileSystemSerdes("/mnt/s3", {
+ *     preview: {
+ *       mode: PreviewMode.EXCLUDE_ALL,
+ *       include: [{ name: "id" }, { name: "status" }],
+ *       mask: [{ name: "email" }],
+ *     },
+ *   }),
  * });
  * ```
  *
@@ -116,7 +284,9 @@ export function createFileSystemSerdes(
 
       if (storageMode === FileSystemSerdesMode.ALWAYS) {
         const filePath = await writeToFile(basePath, value, context);
-        const preview = config.generatePreview?.(value);
+        const preview = config.preview
+          ? buildPreview(value, config.preview)
+          : undefined;
         const envelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }
           : { file: filePath };
@@ -127,7 +297,9 @@ export function createFileSystemSerdes(
       const inlineJson = JSON.stringify(value);
       if (Buffer.byteLength(inlineJson, "utf-8") > OVERFLOW_THRESHOLD_BYTES) {
         const filePath = await writeToFile(basePath, value, context);
-        const preview = config.generatePreview?.(value);
+        const preview = config.preview
+          ? buildPreview(value, config.preview)
+          : undefined;
         const envelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }
           : { file: filePath };

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -257,13 +257,27 @@ export function buildPreview(
 }
 
 /**
- * Creates a Serdes that stores serialized values on the filesystem.
+ * Creates a Serdes that stores serialized values on a durable filesystem.
+ *
+ * **⚠️ WARNING: Do NOT use with Lambda's ephemeral `/tmp` storage.**
+ * Lambda's `/tmp` filesystem is local to a single execution environment and is
+ * not shared across invocations or function instances. On replay, a different
+ * execution environment may be used and the file will not be found, causing
+ * deserialization to fail.
+ *
+ * **Use only with a durable, shared filesystem such as:**
+ * - **Amazon S3 Files** — mount an S3 bucket as a filesystem via the Lambda console or IaC
+ * - **Amazon EFS** — mount an EFS file system to your Lambda function
+ *
+ * Both options provide persistence across invocations and are accessible from
+ * multiple concurrent function instances, which is required for correct replay behavior.
  *
  * The checkpoint stores a JSON envelope that is either:
- * - `{"file":"<path>"}` — value stored in a file (ALWAYS mode, or OVERFLOW above threshold)
+ * - `{"data":"<inline JSON>"}` — value stored inline (OVERFLOW mode, under threshold)
+ * - `{"file":"<path>"}` — value stored in a file
  * - `{"file":"<path>","preview":{...}}` — file pointer with inline preview (when preview is configured)
  *
- * @param basePath - Directory path where data files will be stored (e.g. the S3 Files mount point)
+ * @param basePath - Directory path where data files will be stored (e.g. `/mnt/s3` for S3 Files, `/mnt/efs` for EFS)
  * @param config - Optional configuration options
  * @returns A Serdes that reads/writes JSON files under basePath
  *

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -194,6 +194,9 @@ export function buildPreview(
 
     for (const key of Object.keys(obj)) {
       if (DANGEROUS_KEYS.has(key)) continue;
+      // Skip keys containing dots — they're indistinguishable from nested paths
+      // in the dot-notation path system used by preview field matching and rebuild.
+      if (key.includes(".")) continue;
       const path = pathPrefix ? `${pathPrefix}.${key}` : key;
       const masked = isMatched(path, config.mask);
       const excluded = isMatched(path, config.exclude);
@@ -311,12 +314,15 @@ export function buildPreview(
  * });
  * ```
  *
+ * Limitations:
+ * - Field names containing dots are not supported in preview field selectors.
+ *   A dot in a field name is indistinguishable from a path separator.
+ * - Array structure is not preserved in preview output — fields from array
+ *   elements are merged into a plain object at the array's path.
+ *
  * @public
  */
-export function createFileSystemSerdes(
-  basePath: string,
-  config: FileSystemSerdesConfig = {},
-): AnySerdes {
+export function createFileSystemSerdes(): AnySerdes {
   const storageMode = config.storageMode ?? FileSystemSerdesMode.ALWAYS;
   return {
     serialize: async (

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -322,7 +322,10 @@ export function buildPreview(
  *
  * @public
  */
-export function createFileSystemSerdes(): AnySerdes {
+export function createFileSystemSerdes(
+  basePath: string,
+  config: FileSystemSerdesConfig = {},
+): AnySerdes {
   const storageMode = config.storageMode ?? FileSystemSerdesMode.ALWAYS;
   return {
     serialize: async (

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
@@ -1,0 +1,195 @@
+/**
+ * Controls whether a preview field is matched by name anywhere in the object
+ * tree, or by exact dot-notation path from the root.
+ *
+ * @public
+ */
+export enum FieldMatchMode {
+  /** Match the field name at any depth in the object tree (default). */
+  ANYWHERE = "ANYWHERE",
+  /**
+   * Match by exact dot-notation path from root.
+   * A single segment (e.g. `"email"`) matches only the root-level field.
+   * A dotted path (e.g. `"user.email"`) matches that exact nested location.
+   */
+  PATH = "PATH",
+}
+
+/**
+ * Controls which fields are included in the preview by default.
+ *
+ * @public
+ */
+export enum PreviewMode {
+  /** Include all fields, then apply `exclude` and `mask` rules. */
+  INCLUDE_ALL = "INCLUDE_ALL",
+  /** Exclude all fields, then apply `include` and `mask` rules. */
+  EXCLUDE_ALL = "EXCLUDE_ALL",
+}
+
+/**
+ * A field selector used in preview include/exclude/mask lists.
+ *
+ * @public
+ */
+export interface PreviewField {
+  /** Field name or dot-notation path. */
+  name: string;
+  /** How to match the field. Defaults to `FieldMatchMode.ANYWHERE`. */
+  match?: FieldMatchMode;
+}
+
+/**
+ * Configuration for {@link buildPreview}.
+ *
+ * @public
+ */
+export interface PreviewConfig {
+  /** Whether to start with all fields included or all excluded. */
+  mode: PreviewMode;
+  /** Fields to include (used with `EXCLUDE_ALL` mode, or to override `INCLUDE_ALL`). */
+  include?: PreviewField[];
+  /** Fields to exclude (used with `INCLUDE_ALL` mode, or to override `EXCLUDE_ALL`). */
+  exclude?: PreviewField[];
+  /** Fields to mask — if visible, their value is replaced with `maskString`. */
+  mask?: PreviewField[];
+  /**
+   * String used to replace masked field values.
+   * @defaultValue `"***"`
+   */
+  maskString?: string;
+  /**
+   * Maximum size in bytes for the preview object (JSON-serialized).
+   * Fields are added until this limit is reached.
+   * @defaultValue `4096`
+   */
+  maxPreviewBytes?: number;
+}
+
+/** Returns true if the field at `path` (dot-notation) matches the given PreviewField rule. */
+function fieldMatches(path: string, field: PreviewField): boolean {
+  const mode = field.match ?? FieldMatchMode.ANYWHERE;
+  if (mode === FieldMatchMode.PATH) {
+    return path === field.name;
+  }
+  return path.split(".").includes(field.name);
+}
+
+function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
+  return fields?.some((f) => fieldMatches(path, f)) ?? false;
+}
+
+/**
+ * Builds a preview object from `value` according to `config`.
+ *
+ * Traverses the object tree and collects fields based on the include/exclude/mask
+ * rules in `config`. The result is a nested object mirroring the original structure,
+ * capped at `config.maxPreviewBytes` (default 4096 bytes).
+ *
+ * Priority rules:
+ * - `exclude` always wins — excluded fields are never shown, even if in `mask`
+ * - `mask` implies visibility — masked fields are shown (with `maskString`) unless excluded
+ *
+ * Limitations:
+ * - Field names containing dots are not supported (indistinguishable from path separators)
+ * - Array structure is not preserved — fields from array elements are merged into a plain object
+ *
+ * @example
+ * ```typescript
+ * const preview = buildPreview(order, {
+ *   mode: PreviewMode.EXCLUDE_ALL,
+ *   include: [{ name: "id" }, { name: "status" }],
+ *   mask: [{ name: "email" }],
+ * });
+ * // { id: "order-123", status: "pending", user: { email: "***" } }
+ * ```
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildPreview(
+  value: any,
+  config: PreviewConfig,
+): Record<string, unknown> | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+
+  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+  const maskString = config.maskString ?? "***";
+  const maxBytes = config.maxPreviewBytes ?? 4096;
+
+  const pairs: Array<[string, unknown]> = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function collect(obj: any, pathPrefix: string): void {
+    if (obj === null || typeof obj !== "object") return;
+
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        collect(item, pathPrefix);
+      }
+      return;
+    }
+
+    for (const key of Object.keys(obj)) {
+      if (DANGEROUS_KEYS.has(key)) continue;
+      if (key.includes(".")) continue;
+      const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+      const masked = isMatched(path, config.mask);
+      const excluded = isMatched(path, config.exclude);
+      const visible =
+        !excluded &&
+        (masked ||
+          (config.mode === PreviewMode.INCLUDE_ALL
+            ? true
+            : isMatched(path, config.include)));
+
+      if (!visible) {
+        collect(obj[key], path);
+        continue;
+      }
+
+      if (masked) {
+        pairs.push([path, maskString]);
+        continue;
+      }
+
+      if (obj[key] !== null && typeof obj[key] === "object") {
+        collect(obj[key], path);
+      } else {
+        pairs.push([path, obj[key]]);
+      }
+    }
+  }
+
+  collect(value, "");
+  if (pairs.length === 0) return undefined;
+
+  const accepted: Array<[string, unknown]> = [];
+  let estimatedSize = 2; // "{}"
+  for (const [path, val] of pairs) {
+    const entrySize = Buffer.byteLength(
+      `"${path}":${JSON.stringify(val)},`,
+      "utf-8",
+    );
+    if (estimatedSize + entrySize > maxBytes) break;
+    accepted.push([path, val]);
+    estimatedSize += entrySize;
+  }
+
+  if (accepted.length === 0) return undefined;
+
+  const result: Record<string, unknown> = {};
+  for (const [path, val] of accepted) {
+    const parts = path.split(".");
+    let node = result;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (typeof node[parts[i]] !== "object" || node[parts[i]] === null) {
+        node[parts[i]] = {};
+      }
+      node = node[parts[i]] as Record<string, unknown>;
+    }
+    node[parts[parts.length - 1]] = val;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
@@ -93,6 +93,9 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  * Limitations:
  * - Field names containing dots are not supported (indistinguishable from path separators)
  * - Array structure is not preserved — fields from array elements are merged into a plain object
+ * - When array elements have heterogeneous shapes at the same field path, later elements
+ *   overwrite earlier primitives in the preview (e.g. `[{ user: "arb" }, { user: { email: "x" } }]`
+ *   produces `{ user: { email: "x" } }` — `"arb"` is lost)
  *
  * @example
  * ```typescript


### PR DESCRIPTION
Adds an optional generatePreview function to FileSystemSerdesConfig that stores a subset of the serialized value inline in the checkpoint envelope alongside the file pointer. This makes step data visible in the
  AWS console and API without reading the full file from the filesystem.

**New generatePreview option in FileSystemSerdesConfig:**

```
  createFileSystemSerdes("/mnt/s3", {
    generatePreview: (value) => {...}
  });
```

  Checkpoint envelope with preview:

```
  { "file": "/mnt/s3/.../1.json", "preview": { "id": "order-123", "user": { "email": "***" } } }
```
