### PR TITLE
fix(sdk): always re-evaluate termination after checkpoint queue drains

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback-callback-failure.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback-callback-failure.history.json
@@ -1,0 +1,354 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "82934803-886d-4488-a8e6-120038632717",
+    "EventTimestamp": "2026-05-01T19:30:08.193Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "6151f5ab282d90e4",
+    "Name": "prepare-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 7,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "prepare-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "6151f5ab282d90e4",
+    "Name": "prepare-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "b425e0c75591aa8f",
+    "Name": "prepare-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.199Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 12,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 13,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImVkZWI1N2I4LTUxOWEtNDg1NC1iOGNhLWJjNjBhMWZlMzNlNyIsIm9wZXJhdGlvbklkIjoiYjY5N2QyNzdhNTcxZDE3NiIsInRva2VuIjoiZTQzODk4NmMtYTIzMS00ZjJlLTg5NmYtMGEzNWFjNDJjYWEwIn0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 14,
+    "Id": "e61730e6717b1787",
+    "Name": "approval-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 15,
+    "Id": "ef2b084287e9b4f3",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "e61730e6717b1787",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImVkZWI1N2I4LTUxOWEtNDg1NC1iOGNhLWJjNjBhMWZlMzNlNyIsIm9wZXJhdGlvbklkIjoiZWYyYjA4NDI4N2U5YjRmMyIsInRva2VuIjoiMzJjZjFmNDktOTM4Ny00Mzk1LTgxYzUtZGZhZmMzOWQ4N2UyIn0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 16,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "approval-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "13cee27a2bd93915",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 17,
+    "Id": "01969074dcd609ca",
+    "EventTimestamp": "2026-05-01T19:30:08.201Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImVkZWI1N2I4LTUxOWEtNDg1NC1iOGNhLWJjNjBhMWZlMzNlNyIsIm9wZXJhdGlvbklkIjoiMDE5NjkwNzRkY2Q2MDljYSIsInRva2VuIjoiMTRiMDQ0NDgtNWIwMy00YjcxLTg1ZTMtNjNlYzhjOGJhNmU4In0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 18,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 19,
+    "Id": "797da8d133f38126",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "e61730e6717b1787",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 20,
+    "Id": "df5c34dd8665ff93",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 21,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 22,
+    "Id": "797da8d133f38126",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "e61730e6717b1787",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 23,
+    "Id": "df5c34dd8665ff93",
+    "EventTimestamp": "2026-05-01T19:30:08.203Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackFailed",
+    "SubType": "Callback",
+    "EventId": 24,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:08.204Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Rejected by reviewer"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 25,
+    "EventTimestamp": "2026-05-01T19:30:08.224Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:08.193Z",
+      "EndTimestamp": "2026-05-01T19:30:08.224Z",
+      "Error": {},
+      "RequestId": "ab53c81c-5f85-4e2a-9225-7927c817ae07"
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "WaitForCallback",
+    "EventId": 26,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.229Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Rejected by reviewer"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "MapIteration",
+    "EventId": 27,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:08.229Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Rejected by reviewer"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 28,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:08.229Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"error\":{\"cause\":{\"cause\":{\"name\":\"CallbackError\"},\"name\":\"CallbackError\",\"errorType\":\"CallbackError\"},\"name\":\"ChildContextError\",\"errorType\":\"ChildContextError\"},\"index\":0,\"status\":\"FAILED\"},{\"index\":1,\"status\":\"STARTED\"},{\"index\":2,\"status\":\"STARTED\"}],\"completionReason\":\"FAILURE_TOLERANCE_EXCEEDED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 29,
+    "EventTimestamp": "2026-05-01T19:30:08.230Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:08.226Z",
+      "EndTimestamp": "2026-05-01T19:30:08.230Z",
+      "Error": {},
+      "RequestId": "7a27c2e5-0b46-4d25-ae44-4944d7a13bcd"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 30,
+    "Id": "82934803-886d-4488-a8e6-120038632717",
+    "EventTimestamp": "2026-05-01T19:30:08.230Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":0,\"totalFailed\":1,\"completionReason\":\"FAILURE_TOLERANCE_EXCEEDED\",\"items\":[]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback-callback-timeout.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback-callback-timeout.history.json
@@ -1,0 +1,196 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "9cc0a79f-4f8e-472e-a8cd-30b19517b0fd",
+    "EventTimestamp": "2026-05-01T19:30:08.334Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"items\":[{\"id\":1,\"name\":\"timeout-item\"}]}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:08.337Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:08.337Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-timeout-item",
+    "EventTimestamp": "2026-05-01T19:30:08.337Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-timeout-item",
+    "EventTimestamp": "2026-05-01T19:30:08.337Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":1,\"itemName\":\"timeout-item\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 6,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-timeout-item",
+    "EventTimestamp": "2026-05-01T19:30:08.339Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 7,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:08.339Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6IjA1MmIyNzY3LTZjNmItNGRmMy1iYWM3LWEwMjY5NjEyNzM2ZiIsIm9wZXJhdGlvbklkIjoiYjY5N2QyNzdhNTcxZDE3NiIsInRva2VuIjoiZTMwNTBlNzgtOWM1OS00YTc0LThlYWUtY2UwNGFkYjE1ODdjIn0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.340Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.340Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-05-01T19:30:08.362Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:08.334Z",
+      "EndTimestamp": "2026-05-01T19:30:08.362Z",
+      "Error": {},
+      "RequestId": "6959dc7f-fc53-40ed-ad78-c5e390c41db4"
+    }
+  },
+  {
+    "EventType": "CallbackTimedOut",
+    "SubType": "Callback",
+    "EventId": 11,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:18.339Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackTimedOutDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Callback timed out"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "WaitForCallback",
+    "EventId": 12,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-timeout-item",
+    "EventTimestamp": "2026-05-01T19:30:18.343Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackTimeoutError",
+          "ErrorMessage": "Callback timed out"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "MapIteration",
+    "EventId": 13,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:18.343Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackTimeoutError",
+          "ErrorMessage": "Callback timed out"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 14,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:18.343Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"error\":{\"cause\":{\"cause\":{\"name\":\"CallbackTimeoutError\"},\"name\":\"CallbackTimeoutError\",\"errorType\":\"CallbackTimeoutError\"},\"name\":\"ChildContextError\",\"errorType\":\"ChildContextError\"},\"index\":0,\"status\":\"FAILED\"}],\"completionReason\":\"FAILURE_TOLERANCE_EXCEEDED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 15,
+    "EventTimestamp": "2026-05-01T19:30:18.344Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:18.341Z",
+      "EndTimestamp": "2026-05-01T19:30:18.344Z",
+      "Error": {},
+      "RequestId": "ad5d99b0-19c5-4f74-b8f5-f45b8605f9cf"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 16,
+    "Id": "9cc0a79f-4f8e-472e-a8cd-30b19517b0fd",
+    "EventTimestamp": "2026-05-01T19:30:18.344Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":0,\"totalFailed\":1,\"completionReason\":\"FAILURE_TOLERANCE_EXCEEDED\",\"items\":[]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.history.json
@@ -1,0 +1,503 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "30665a9c-8a86-4fa4-9eb9-80752683ed73",
+    "EventTimestamp": "2026-05-01T19:30:08.030Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "6151f5ab282d90e4",
+    "Name": "prepare-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 7,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "prepare-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "2f221a18eb863803",
+    "Name": "prepare-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "6151f5ab282d90e4",
+    "Name": "prepare-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "b425e0c75591aa8f",
+    "Name": "prepare-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.036Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 12,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 13,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImUwY2NmOGQ2LTA3M2UtNDk3YS1iYjgxLTg5NjIzMmZjMDQwMSIsIm9wZXJhdGlvbklkIjoiYjY5N2QyNzdhNTcxZDE3NiIsInRva2VuIjoiOGUxMTdhMjctYWMzMC00NjJmLTk5NDktMjA3ODZlYTk1NmYyIn0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 14,
+    "Id": "e61730e6717b1787",
+    "Name": "approval-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 15,
+    "Id": "ef2b084287e9b4f3",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "e61730e6717b1787",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImUwY2NmOGQ2LTA3M2UtNDk3YS1iYjgxLTg5NjIzMmZjMDQwMSIsIm9wZXJhdGlvbklkIjoiZWYyYjA4NDI4N2U5YjRmMyIsInRva2VuIjoiN2JhOWFhMDAtMjRlYS00NzczLWI4NzYtYmExNTNlNTg5MmVlIn0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 16,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "approval-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "13cee27a2bd93915",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 17,
+    "Id": "01969074dcd609ca",
+    "EventTimestamp": "2026-05-01T19:30:08.038Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6ImUwY2NmOGQ2LTA3M2UtNDk3YS1iYjgxLTg5NjIzMmZjMDQwMSIsIm9wZXJhdGlvbklkIjoiMDE5NjkwNzRkY2Q2MDljYSIsInRva2VuIjoiNzNjZTZlYTMtZTQ0Ny00MDMzLThmYmYtOGZiY2Q1YzNkMGE5In0=",
+      "Timeout": 10,
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 18,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 19,
+    "Id": "797da8d133f38126",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "e61730e6717b1787",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 20,
+    "Id": "df5c34dd8665ff93",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 21,
+    "Id": "80baea63d9af7475",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 22,
+    "Id": "797da8d133f38126",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "e61730e6717b1787",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 23,
+    "Id": "df5c34dd8665ff93",
+    "EventTimestamp": "2026-05-01T19:30:08.040Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 24,
+    "Id": "b697d277a571d176",
+    "EventTimestamp": "2026-05-01T19:30:08.041Z",
+    "ParentId": "4f57d0ecf9622a0b",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "\"approved\""
+      }
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 25,
+    "Id": "ef2b084287e9b4f3",
+    "EventTimestamp": "2026-05-01T19:30:08.041Z",
+    "ParentId": "e61730e6717b1787",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "\"approved\""
+      }
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 26,
+    "Id": "01969074dcd609ca",
+    "EventTimestamp": "2026-05-01T19:30:08.042Z",
+    "ParentId": "bc5861c5c13a0b06",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "\"approved\""
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 27,
+    "EventTimestamp": "2026-05-01T19:30:08.062Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:08.030Z",
+      "EndTimestamp": "2026-05-01T19:30:08.062Z",
+      "Error": {},
+      "RequestId": "f776da84-8dac-46d2-8692-fb24cd7c38fa"
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 28,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "approval-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"\\\"approved\\\"\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 29,
+    "Id": "e61730e6717b1787",
+    "Name": "approval-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"\\\"approved\\\"\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 30,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "approval-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "13cee27a2bd93915",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"\\\"approved\\\"\""
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 31,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "process-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 32,
+    "Id": "453e406dcee4d181",
+    "Name": "process-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 33,
+    "Id": "e0260672e1e9df5a",
+    "Name": "process-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 34,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "process-order-alpha",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 35,
+    "Id": "453e406dcee4d181",
+    "Name": "process-order-beta",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 36,
+    "Id": "e0260672e1e9df5a",
+    "Name": "process-order-gamma",
+    "EventTimestamp": "2026-05-01T19:30:08.066Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 37,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 38,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 39,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 40,
+    "Id": "c4ca4238a0b92382",
+    "Name": "approval-pipeline",
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"},\"index\":0,\"status\":\"SUCCEEDED\"},{\"result\":{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"},\"index\":1,\"status\":\"SUCCEEDED\"},{\"result\":{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"},\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 41,
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:30:08.063Z",
+      "EndTimestamp": "2026-05-01T19:30:08.068Z",
+      "Error": {},
+      "RequestId": "3168b868-3a6a-46e1-9d85-325510babfb7"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 42,
+    "Id": "30665a9c-8a86-4fa4-9eb9-80752683ed73",
+    "EventTimestamp": "2026-05-01T19:30:08.068Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":3,\"totalFailed\":0,\"completionReason\":\"ALL_COMPLETED\",\"items\":[{\"itemId\":1,\"itemName\":\"order-alpha\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"},{\"itemId\":2,\"itemName\":\"order-beta\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"},{\"itemId\":3,\"itemName\":\"order-gamma\",\"preparedAt\":\"2025-01-01T00:00:00Z\",\"approval\":\"\\\"approved\\\"\",\"status\":\"completed\"}]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.test.ts
@@ -1,0 +1,103 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import { handler } from "./map-with-callback";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  invocationType: InvocationType.Event,
+  localRunnerConfig: {
+    skipTime: false,
+  },
+  tests: (runner, { assertEventSignatures }) => {
+    it("should process all items when all callbacks succeed", async () => {
+      const approvalAlpha = runner.getOperation("approval-order-alpha");
+      const approvalBeta = runner.getOperation("approval-order-beta");
+      const approvalGamma = runner.getOperation("approval-order-gamma");
+
+      const executionPromise = runner.run();
+
+      // All 3 items run concurrently (maxConcurrency: 3), so all callbacks
+      // get submitted roughly at the same time. Wait for each and approve.
+      await Promise.all([
+        approvalAlpha.waitForData(WaitingOperationStatus.SUBMITTED),
+        approvalBeta.waitForData(WaitingOperationStatus.SUBMITTED),
+        approvalGamma.waitForData(WaitingOperationStatus.SUBMITTED),
+      ]);
+
+      await approvalAlpha.sendCallbackSuccess(JSON.stringify("approved"));
+      await approvalBeta.sendCallbackSuccess(JSON.stringify("approved"));
+      await approvalGamma.sendCallbackSuccess(JSON.stringify("approved"));
+
+      const execution = await executionPromise;
+      const result = execution.getResult() as any;
+
+      expect(result.totalProcessed).toBe(3);
+      expect(result.totalFailed).toBe(0);
+      expect(result.completionReason).toBe("ALL_COMPLETED");
+      expect(result.items).toHaveLength(3);
+
+      // Verify each item was prepared, approved, and processed
+      for (const item of result.items) {
+        expect(item.status).toBe("completed");
+        expect(item.approval).toBe(JSON.stringify("approved"));
+        expect(item.preparedAt).toBe("2025-01-01T00:00:00Z");
+      }
+
+      // Verify the map has 3 child operations (one per item)
+      const mapOp = runner.getOperation("approval-pipeline");
+      expect(mapOp.getChildOperations()).toHaveLength(3);
+
+      // Verify individual step operations exist
+      expect(runner.getOperation("prepare-order-alpha")).toBeDefined();
+      expect(runner.getOperation("process-order-alpha")).toBeDefined();
+      expect(runner.getOperation("prepare-order-beta")).toBeDefined();
+      expect(runner.getOperation("process-order-beta")).toBeDefined();
+      expect(runner.getOperation("prepare-order-gamma")).toBeDefined();
+      expect(runner.getOperation("process-order-gamma")).toBeDefined();
+
+      assertEventSignatures(execution);
+    }, 30000);
+
+    it("should fail fast when a callback fails and no tolerance is set", async () => {
+      const approvalAlpha = runner.getOperation("approval-order-alpha");
+
+      const executionPromise = runner.run();
+
+      // Fail the first callback
+      await approvalAlpha.waitForData(WaitingOperationStatus.SUBMITTED);
+      await approvalAlpha.sendCallbackFailure({
+        ErrorMessage: "Rejected by reviewer",
+      });
+
+      const execution = await executionPromise;
+      const result = execution.getResult() as any;
+
+      // Default behavior: fail-fast, so at least 1 item fails
+      expect(result.totalFailed).toBeGreaterThanOrEqual(1);
+      expect(result.completionReason).toBe("FAILURE_TOLERANCE_EXCEEDED");
+
+      assertEventSignatures(execution, "callback-failure");
+    });
+
+    it("should handle callback timeout within map iteration", async () => {
+      // Run with a single item that has a short callback timeout (10s from handler)
+      const execution = await runner.run({
+        payload: {
+          items: [{ id: 1, name: "timeout-item" }],
+        },
+      });
+
+      const result = execution.getResult() as any;
+
+      // The callback should time out, causing the map item to fail
+      expect(result.totalFailed).toBe(1);
+      expect(result.totalProcessed).toBe(0);
+      expect(result.completionReason).toBe("FAILURE_TOLERANCE_EXCEEDED");
+
+      assertEventSignatures(execution, "callback-timeout");
+    }, 30000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-callback/map-with-callback.ts
@@ -1,0 +1,72 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map with Callback",
+  description:
+    "Demonstrates map operation where each iteration waits for an external callback",
+};
+
+interface ApprovalItem {
+  id: number;
+  name: string;
+}
+
+/**
+ * Each map iteration:
+ * 1. Runs a step to prepare the item
+ * 2. Waits for an external callback (e.g., human approval)
+ * 3. Runs a final step to process the approved result
+ */
+export const handler = withDurableExecution(
+  async (event: { items?: ApprovalItem[] }, context: DurableContext) => {
+    const items = event.items ?? [
+      { id: 1, name: "order-alpha" },
+      { id: 2, name: "order-beta" },
+      { id: 3, name: "order-gamma" },
+    ];
+
+    const results = await context.map(
+      "approval-pipeline",
+      items,
+      async (ctx: DurableContext, item: ApprovalItem, index: number) => {
+        // Step 1: Prepare the item for approval
+        const prepared = await ctx.step(`prepare-${item.name}`, async () => ({
+          itemId: item.id,
+          itemName: item.name,
+          preparedAt: "2025-01-01T00:00:00Z",
+        }));
+
+        // Step 2: Wait for external approval callback
+        const approval = await ctx.waitForCallback<string>(
+          `approval-${item.name}`,
+          async (callbackId: string) => {
+            // In production, you'd send callbackId to an external system
+            // e.g., sendApprovalEmail(item.name, callbackId)
+          },
+          { timeout: { seconds: 10 } },
+        );
+
+        // Step 3: Process the approved item
+        const processed = await ctx.step(`process-${item.name}`, async () => ({
+          ...prepared,
+          approval,
+          status: "completed",
+        }));
+
+        return processed;
+      },
+      { maxConcurrency: 3 },
+    );
+
+    return {
+      totalProcessed: results.successCount,
+      totalFailed: results.failureCount,
+      completionReason: results.completionReason,
+      items: results.getResults(),
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition-long-poll.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition-long-poll.history.json
@@ -1,0 +1,313 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "e3fd9383-91fe-4317-a95b-0a49ce38f6fd",
+    "EventTimestamp": "2026-05-01T19:26:17.305Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"jobs\":[{\"id\":1,\"name\":\"long-poll-job\",\"completesAfterChecks\":5}]}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:17.309Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:17.309Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:17.309Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:17.309Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"long-poll-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 6,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:17.312Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 7,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:17.312Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":1,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 8,
+    "EventTimestamp": "2026-05-01T19:26:17.333Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:17.305Z",
+      "EndTimestamp": "2026-05-01T19:26:17.333Z",
+      "Error": {},
+      "RequestId": "6b5862b4-2f66-4b06-9265-832281b3df6c"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 9,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:18.316Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 10,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:18.316Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":2,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1,
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 11,
+    "EventTimestamp": "2026-05-01T19:26:18.338Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:18.313Z",
+      "EndTimestamp": "2026-05-01T19:26:18.338Z",
+      "Error": {},
+      "RequestId": "6cb80cad-343f-4cfc-9a25-99504cbe65b8"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 12,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:19.319Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 13,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:19.319Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":3,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1,
+        "CurrentAttempt": 2
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 14,
+    "EventTimestamp": "2026-05-01T19:26:19.345Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:19.317Z",
+      "EndTimestamp": "2026-05-01T19:26:19.345Z",
+      "Error": {},
+      "RequestId": "0ac806c4-4ad5-40cb-9091-0b275cc8a1c9"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 15,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:20.322Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 16,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:20.322Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":4,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1,
+        "CurrentAttempt": 3
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 17,
+    "EventTimestamp": "2026-05-01T19:26:20.344Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:20.320Z",
+      "EndTimestamp": "2026-05-01T19:26:20.344Z",
+      "Error": {},
+      "RequestId": "d67e2823-02b9-4199-bd08-ec33ba0e6e51"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 18,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:21.329Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 19,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:21.329Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":5,\"status\":\"completed\"}"
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 4
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 20,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:21.331Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 21,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-long-poll-job",
+    "EventTimestamp": "2026-05-01T19:26:21.331Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"long-poll-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":5}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 22,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:21.333Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"long-poll-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":5}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 23,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:21.333Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":{\"jobId\":1,\"jobName\":\"long-poll-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":5},\"index\":0,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 24,
+    "EventTimestamp": "2026-05-01T19:26:21.334Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:21.325Z",
+      "EndTimestamp": "2026-05-01T19:26:21.334Z",
+      "Error": {},
+      "RequestId": "f5c12817-ec84-4646-8ece-67a214741d11"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 25,
+    "Id": "e3fd9383-91fe-4317-a95b-0a49ce38f6fd",
+    "EventTimestamp": "2026-05-01T19:26:21.334Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":1,\"totalFailed\":0,\"completionReason\":\"ALL_COMPLETED\",\"jobs\":[{\"jobId\":1,\"jobName\":\"long-poll-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":5}]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition-single-job.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition-single-job.history.json
@@ -1,0 +1,156 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "67b757a6-3953-4ad5-b096-b3a9347ecc4c",
+    "EventTimestamp": "2026-05-01T19:26:17.193Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"jobs\":[{\"id\":99,\"name\":\"instant-job\",\"completesAfterChecks\":1}]}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:17.196Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:17.196Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.196Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.196Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":99,\"jobName\":\"instant-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 6,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.198Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 7,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.198Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":99,\"checkCount\":1,\"status\":\"completed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.199Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-instant-job",
+    "EventTimestamp": "2026-05-01T19:26:17.199Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":99,\"jobName\":\"instant-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 10,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:17.201Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":99,\"jobName\":\"instant-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 11,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:17.201Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":{\"jobId\":99,\"jobName\":\"instant-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1},\"index\":0,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 12,
+    "EventTimestamp": "2026-05-01T19:26:17.201Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:17.193Z",
+      "EndTimestamp": "2026-05-01T19:26:17.201Z",
+      "Error": {},
+      "RequestId": "36edfdec-0e81-4c96-9384-c38ef7e0f32d"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 13,
+    "Id": "67b757a6-3953-4ad5-b096-b3a9347ecc4c",
+    "EventTimestamp": "2026-05-01T19:26:17.201Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":1,\"totalFailed\":0,\"completionReason\":\"ALL_COMPLETED\",\"jobs\":[{\"jobId\":99,\"jobName\":\"instant-job\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1}]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.history.json
@@ -1,0 +1,462 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "ed871e1c-27d6-4755-9a66-0074bb8f16f3",
+    "EventTimestamp": "2026-05-01T19:26:15.064Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "6151f5ab282d90e4",
+    "Name": "submit-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 7,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "submit-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "2f221a18eb863803",
+    "Name": "submit-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"job-fast\",\"submittedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "6151f5ab282d90e4",
+    "Name": "submit-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":2,\"jobName\":\"job-medium\",\"submittedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "b425e0c75591aa8f",
+    "Name": "submit-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:15.070Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"jobName\":\"job-slow\",\"submittedAt\":\"2025-01-01T00:00:00Z\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 12,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.073Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 13,
+    "Id": "e61730e6717b1787",
+    "Name": "poll-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:15.073Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 14,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:15.073Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 15,
+    "Id": "4f57d0ecf9622a0b",
+    "Name": "poll-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.073Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"checkCount\":1,\"status\":\"completed\"}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 16,
+    "Id": "e61730e6717b1787",
+    "Name": "poll-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:15.073Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":2,\"checkCount\":1,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1
+      }
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 17,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:15.075Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"checkCount\":1,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 18,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.077Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 19,
+    "Id": "98c1d2a9d58ce748",
+    "Name": "collect-job-fast",
+    "EventTimestamp": "2026-05-01T19:26:15.077Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"job-fast\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 20,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-05-01T19:26:15.079Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":1,\"jobName\":\"job-fast\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 21,
+    "EventTimestamp": "2026-05-01T19:26:15.097Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:15.064Z",
+      "EndTimestamp": "2026-05-01T19:26:15.097Z",
+      "Error": {},
+      "RequestId": "47dbd907-0f4b-4165-9477-58249bead27a"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 22,
+    "Id": "e61730e6717b1787",
+    "Name": "poll-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:16.078Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 23,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:16.078Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 24,
+    "Id": "e61730e6717b1787",
+    "Name": "poll-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:16.078Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":2,\"checkCount\":2,\"status\":\"completed\"}"
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 25,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:16.078Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"checkCount\":2,\"status\":\"running\"}"
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1,
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 26,
+    "Id": "453e406dcee4d181",
+    "Name": "collect-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:16.080Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 27,
+    "Id": "453e406dcee4d181",
+    "Name": "collect-job-medium",
+    "EventTimestamp": "2026-05-01T19:26:16.080Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":2,\"jobName\":\"job-medium\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":2}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 28,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-05-01T19:26:16.080Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":2,\"jobName\":\"job-medium\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":2}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 29,
+    "EventTimestamp": "2026-05-01T19:26:16.101Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:16.075Z",
+      "EndTimestamp": "2026-05-01T19:26:16.101Z",
+      "Error": {},
+      "RequestId": "7cf0003f-9be7-4792-8146-8c41498a980d"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "WaitForCondition",
+    "EventId": 30,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:17.083Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "WaitForCondition",
+    "EventId": 31,
+    "Id": "bc5861c5c13a0b06",
+    "Name": "poll-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:17.083Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"checkCount\":3,\"status\":\"completed\"}"
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 2
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 32,
+    "Id": "e0260672e1e9df5a",
+    "Name": "collect-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:17.085Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 33,
+    "Id": "e0260672e1e9df5a",
+    "Name": "collect-job-slow",
+    "EventTimestamp": "2026-05-01T19:26:17.085Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"jobName\":\"job-slow\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":3}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 34,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-05-01T19:26:17.087Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"jobId\":3,\"jobName\":\"job-slow\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":3}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 35,
+    "Id": "c4ca4238a0b92382",
+    "Name": "job-pipeline",
+    "EventTimestamp": "2026-05-01T19:26:17.087Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":{\"jobId\":1,\"jobName\":\"job-fast\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1},\"index\":0,\"status\":\"SUCCEEDED\"},{\"result\":{\"jobId\":2,\"jobName\":\"job-medium\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":2},\"index\":1,\"status\":\"SUCCEEDED\"},{\"result\":{\"jobId\":3,\"jobName\":\"job-slow\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":3},\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 36,
+    "EventTimestamp": "2026-05-01T19:26:17.088Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-05-01T19:26:17.079Z",
+      "EndTimestamp": "2026-05-01T19:26:17.088Z",
+      "Error": {},
+      "RequestId": "00f91bb0-be02-467b-898b-f3de2ece74c6"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 37,
+    "Id": "ed871e1c-27d6-4755-9a66-0074bb8f16f3",
+    "EventTimestamp": "2026-05-01T19:26:17.088Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalProcessed\":3,\"totalFailed\":0,\"completionReason\":\"ALL_COMPLETED\",\"jobs\":[{\"jobId\":1,\"jobName\":\"job-fast\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":1},{\"jobId\":2,\"jobName\":\"job-medium\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":2},{\"jobId\":3,\"jobName\":\"job-slow\",\"submittedAt\":\"2025-01-01T00:00:00Z\",\"finalStatus\":\"completed\",\"totalChecks\":3}]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.test.ts
@@ -1,0 +1,78 @@
+import { handler } from "./map-with-condition";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should poll each job until completion and return results", async () => {
+      const execution = await runner.run();
+      const result = execution.getResult() as any;
+
+      expect(result.totalProcessed).toBe(3);
+      expect(result.totalFailed).toBe(0);
+      expect(result.completionReason).toBe("ALL_COMPLETED");
+      expect(result.jobs).toHaveLength(3);
+
+      // Verify each job completed with the correct number of checks
+      const fastJob = result.jobs.find((j: any) => j.jobName === "job-fast");
+      expect(fastJob.finalStatus).toBe("completed");
+      expect(fastJob.totalChecks).toBe(1);
+
+      const mediumJob = result.jobs.find(
+        (j: any) => j.jobName === "job-medium",
+      );
+      expect(mediumJob.finalStatus).toBe("completed");
+      expect(mediumJob.totalChecks).toBe(2);
+
+      const slowJob = result.jobs.find((j: any) => j.jobName === "job-slow");
+      expect(slowJob.finalStatus).toBe("completed");
+      expect(slowJob.totalChecks).toBe(3);
+
+      // Verify the map has 3 child operations
+      const mapOp = runner.getOperation("job-pipeline");
+      expect(mapOp.getChildOperations()).toHaveLength(3);
+
+      // Verify submit and collect steps exist for each job
+      expect(runner.getOperation("submit-job-fast")).toBeDefined();
+      expect(runner.getOperation("collect-job-fast")).toBeDefined();
+      expect(runner.getOperation("submit-job-medium")).toBeDefined();
+      expect(runner.getOperation("collect-job-medium")).toBeDefined();
+      expect(runner.getOperation("submit-job-slow")).toBeDefined();
+      expect(runner.getOperation("collect-job-slow")).toBeDefined();
+
+      assertEventSignatures(execution);
+    });
+
+    it("should handle single job that completes immediately", async () => {
+      const execution = await runner.run({
+        payload: {
+          jobs: [{ id: 99, name: "instant-job", completesAfterChecks: 1 }],
+        },
+      });
+      const result = execution.getResult() as any;
+
+      expect(result.totalProcessed).toBe(1);
+      expect(result.totalFailed).toBe(0);
+      expect(result.jobs).toHaveLength(1);
+      expect(result.jobs[0].finalStatus).toBe("completed");
+      expect(result.jobs[0].totalChecks).toBe(1);
+
+      assertEventSignatures(execution, "single-job");
+    });
+
+    it("should handle jobs requiring many polling iterations", async () => {
+      const execution = await runner.run({
+        payload: {
+          jobs: [{ id: 1, name: "long-poll-job", completesAfterChecks: 5 }],
+        },
+      });
+      const result = execution.getResult() as any;
+
+      expect(result.totalProcessed).toBe(1);
+      expect(result.jobs[0].finalStatus).toBe("completed");
+      expect(result.jobs[0].totalChecks).toBe(5);
+
+      assertEventSignatures(execution, "long-poll");
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/with-condition/map-with-condition.ts
@@ -1,0 +1,95 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map with Wait for Condition",
+  description:
+    "Demonstrates map operation where each iteration polls until a condition is met",
+};
+
+interface JobItem {
+  id: number;
+  name: string;
+  completesAfterChecks: number;
+}
+
+/**
+ * Each map iteration:
+ * 1. Runs a step to submit a job
+ * 2. Polls with waitForCondition until the job is "complete"
+ * 3. Runs a final step to collect the result
+ *
+ * The polling simulates checking an external system (e.g., a batch job, ML training run).
+ */
+export const handler = withDurableExecution(
+  async (event: { jobs?: JobItem[] }, context: DurableContext) => {
+    const jobs = event.jobs ?? [
+      { id: 1, name: "job-fast", completesAfterChecks: 1 },
+      { id: 2, name: "job-medium", completesAfterChecks: 2 },
+      { id: 3, name: "job-slow", completesAfterChecks: 3 },
+    ];
+
+    const results = await context.map(
+      "job-pipeline",
+      jobs,
+      async (ctx: DurableContext, job: JobItem, index: number) => {
+        // Step 1: Submit the job
+        const submitted = await ctx.step(`submit-${job.name}`, async () => ({
+          jobId: job.id,
+          jobName: job.name,
+          submittedAt: "2025-01-01T00:00:00Z",
+        }));
+
+        // Step 2: Poll until the job completes
+        const finalState = await ctx.waitForCondition<{
+          jobId: number;
+          checkCount: number;
+          status: string;
+        }>(
+          `poll-${job.name}`,
+          async (currentState) => {
+            // Simulate checking job status — completes after N checks
+            const newCheckCount = currentState.checkCount + 1;
+            const isComplete = newCheckCount >= job.completesAfterChecks;
+            return {
+              ...currentState,
+              checkCount: newCheckCount,
+              status: isComplete ? "completed" : "running",
+            };
+          },
+          {
+            initialState: {
+              jobId: job.id,
+              checkCount: 0,
+              status: "pending",
+            },
+            waitStrategy: (state, attempt) => ({
+              shouldContinue: state.status !== "completed",
+              delay: { seconds: 1 },
+            }),
+          },
+        );
+
+        // Step 3: Collect the result
+        const collected = await ctx.step(`collect-${job.name}`, async () => ({
+          ...submitted,
+          finalStatus: finalState.status,
+          totalChecks: finalState.checkCount,
+        }));
+
+        return collected;
+      },
+      { maxConcurrency: 3 },
+    );
+
+    return {
+      totalProcessed: results.successCount,
+      totalFailed: results.failureCount,
+      completionReason: results.completionReason,
+      jobs: results.getResults(),
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -1263,7 +1263,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       expect(checkAndTerminateSpy).toHaveBeenCalledTimes(2);
     });
 
-    it("should skip checkAndTerminate when queue drains but termination is already scheduled", async () => {
+    it("should call checkAndTerminate when queue drains even if termination is already scheduled", async () => {
       // Setup: mock the checkpoint API to succeed
       mockClient.checkpointDurableExecution.mockResolvedValue({
         checkpointToken: "new-token",
@@ -1298,13 +1298,12 @@ describe("CheckpointManager - Centralized Termination", () => {
       });
       checkpointPromise.catch(() => {});
 
-      // 3. Let the queue drain — terminationTimer is already set,
-      //    so processQueue should NOT call checkAndTerminate again
+      // 3. Let the queue drain — processQueue should always call
+      //    checkAndTerminate after draining
       await jest.advanceTimersByTimeAsync(0);
 
-      // checkAndTerminate should still have been called only once
-      // (from markOperationState), not again from processQueue
-      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(1);
+      // checkAndTerminate is called again from processQueue after drain
+      expect(checkAndTerminateSpy).toHaveBeenCalledTimes(2);
 
       // 4. Let the cooldown fire — termination should still happen
       jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS + 1);
@@ -1431,6 +1430,116 @@ describe("CheckpointManager - Centralized Termination", () => {
           reason: expect.any(String),
         }),
       );
+    });
+  });
+
+  describe("processQueue re-evaluates termination with pending callbacks", () => {
+    /**
+     * Verifies that processQueue always re-evaluates termination after
+     * the checkpoint queue drains, even when a terminationTimer is set.
+     */
+    it("should call checkAndTerminate after queue drains even when terminationTimer is already set", async () => {
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      const checkAndTerminateSpy = jest.spyOn(
+        checkpointManager as any,
+        "checkAndTerminate",
+      );
+
+      // 1. Enqueue a checkpoint so the queue is non-empty
+      const cp = checkpointManager.checkpoint("branch-succeed", {
+        Action: "SUCCEED" as any,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Type: OperationType.CONTEXT,
+      });
+      cp.catch(() => {});
+
+      // 2. Register a callback branch as IDLE_NOT_AWAITED (no checkAndTerminate)
+      checkpointManager.markOperationState(
+        "pending-cb",
+        OperationLifecycleState.IDLE_NOT_AWAITED,
+        {
+          metadata: {
+            stepId: "pending-cb",
+            type: OperationType.STEP,
+            subType: OperationSubType.WAIT_FOR_CALLBACK,
+          },
+        },
+      );
+
+      // 3. Transition to IDLE_AWAITED — calls checkAndTerminate, but queue
+      //    is non-empty → shouldTerminate returns undefined → abortTermination
+      checkpointManager.markOperationAwaited("pending-cb");
+
+      const callsBeforeDrain = checkAndTerminateSpy.mock.calls.length;
+
+      // 4. Manually set terminationTimer to simulate the scenario where
+      //    a timer was set during batch processing (e.g., by a checkpoint
+      //    response triggering resolveWaitingOperation → state changes →
+      //    checkAndTerminate → scheduleTermination)
+      (checkpointManager as any).terminationTimer = setTimeout(() => {
+        // Stale timer — would fire but may have wrong reason or stale state
+      }, 999999);
+      (checkpointManager as any).terminationReason =
+        TerminationReason.CALLBACK_PENDING;
+
+      // 5. Let the queue drain
+      await jest.advanceTimersByTimeAsync(0);
+
+      const callsAfterDrain = checkAndTerminateSpy.mock.calls.length;
+
+      // KEY ASSERTION: processQueue MUST call checkAndTerminate after drain,
+      // even though terminationTimer is non-null.
+      //
+      // With the bug: `if (!this.terminationTimer)` skips the call → 0 new calls
+      // With the fix: always calls checkAndTerminate → at least 1 new call
+      expect(callsAfterDrain).toBeGreaterThan(callsBeforeDrain);
+    });
+
+    it("should terminate with CALLBACK_PENDING after queue drains when callback branches are pending", async () => {
+      mockClient.checkpointDurableExecution.mockResolvedValue({
+        checkpointToken: "new-token",
+      });
+
+      // 1. Enqueue a checkpoint FIRST so queue is non-empty
+      const cp = checkpointManager.checkpoint("completed-branch", {
+        Action: "SUCCEED" as any,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Type: OperationType.CONTEXT,
+      });
+      cp.catch(() => {});
+
+      // 2. Register pending callback branch (Phase 1: IDLE_NOT_AWAITED)
+      checkpointManager.markOperationState(
+        "pending-cb",
+        OperationLifecycleState.IDLE_NOT_AWAITED,
+        {
+          metadata: {
+            stepId: "pending-cb",
+            type: OperationType.STEP,
+            subType: OperationSubType.WAIT_FOR_CALLBACK,
+          },
+        },
+      );
+
+      // 3. Phase 2: IDLE_AWAITED — checkAndTerminate called but queue non-empty
+      checkpointManager.markOperationAwaited("pending-cb");
+
+      // No termination yet — queue is non-empty
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
+
+      // 4. Queue drains → processQueue should call checkAndTerminate
+      await jest.advanceTimersByTimeAsync(0);
+
+      // 5. Advance past cooldown
+      jest.advanceTimersByTime(CHECKPOINT_TERMINATION_COOLDOWN_MS + 1);
+
+      // Must terminate — pending-cb is still IDLE_AWAITED
+      expect(mockTerminationManager.terminate).toHaveBeenCalledWith({
+        reason: TerminationReason.CALLBACK_PENDING,
+      });
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -354,11 +354,8 @@ export class CheckpointManager implements Checkpoint {
       } else {
         // Queue is empty and processing is done - notify all waiting promises
         this.notifyQueueCompletion();
-        // Re-evaluate termination now that the queue is empty, unless
-        // a termination cooldown is already in progress.
-        if (!this.terminationTimer) {
-          this.checkAndTerminate();
-        }
+        // Re-evaluate termination — earlier calls may have seen a non-empty queue.
+        this.checkAndTerminate();
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/510

*Description of changes:*
Removes the `if (!this.terminationTimer)` guard in processQueue's finally block so that termination is always re-evaluated after the checkpoint queue drains.

### Problem

In map + waitForCallback scenarios, callbacks register as IDLE_AWAITED and set terminationTimer before a completed branch's fire-and-forget checkpoint enters the queue. When the queue drains, the guard sees terminationTimer is
non-null and skips checkAndTerminate. The function never suspends - it wedges until an unrelated timer (e.g., a sibling ctx.wait) fires.

### Fix

Replace the conditional with an unconditional `this.checkAndTerminate()`.
This is safe because `scheduleTermination` already returns early when the same reason is already scheduled — no timer restart, no extra cooldown in the common case.

### Testing

- Added unit tests that fail without the fix and pass with it
- Added map + waitForCallback and map + waitForCondition example tests
- All existing tests pass 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
