### PR TITLE
feat(sdk): Lambda bundled runtime useragent header

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -7,11 +7,19 @@
  *
  * SDK_NAME is a fixed string matching the cross-SDK convention:
  * aws-durable-execution-sdk-\{language\}
+ * Alternate version if SDK path is within the Lambda bundled runtime.
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
+const runtimeDir = process.env.LAMBDA_RUNTIME_DIR || "/var/runtime";
+const isRuntimeBundled =
+  typeof __dirname !== "undefined" && __dirname.startsWith(runtimeDir);
+
 export const SDK_NAME = "aws-durable-execution-sdk-js";
-export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";
+const baseVersion = process.env.NPM_PACKAGE_VERSION || "0.0.0";
+export const SDK_VERSION = isRuntimeBundled
+  ? `${baseVersion}-bundled`
+  : baseVersion;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

**Note:** we are waiting to confirm the Lambda bundled runtime SDK path. Do NOT merge this PR until we get confirmation.

Updating the UserAgent header string to indicate whether the SDK is being run within the Lambda bundled runtime.

- A new boolean checks if the SDK's current path matches the path where it would be installed in the Lambda bundled runtime.
- If the above boolean is true, the string inserted into the UserAgent header will include "-bundled". Example:
`aws-durable-execution-sdk-js/{version}bundled`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
