### PR TITLE
chore: release 1.1.3

### DIFF
--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -7,11 +7,19 @@
  *
  * SDK_NAME is a fixed string matching the cross-SDK convention:
  * aws-durable-execution-sdk-\{language\}
+ * Alternate version if SDK path is within the Lambda bundled runtime.
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
+const runtimeDir = process.env.LAMBDA_RUNTIME_DIR || "/var/runtime";
+const isRuntimeBundled =
+  typeof __dirname !== "undefined" && __dirname.startsWith(runtimeDir);
+
 export const SDK_NAME = "aws-durable-execution-sdk-js";
-export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";
+const baseVersion = process.env.NPM_PACKAGE_VERSION || "0.0.0";
+export const SDK_VERSION = isRuntimeBundled
+  ? `${baseVersion}-bundled`
+  : baseVersion;

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -1,14 +1,17 @@
 /**
  * SDK metadata injected by Rollup at build time from package.json.
+ * These values are inserted into UserAgent headers.
  *
- * At build time, Rollup replaces process.env.NPM_PACKAGE_NAME and
- * process.env.NPM_PACKAGE_VERSION with actual values from package.json.
+ * At build time, Rollup replaces process.env.NPM_PACKAGE_VERSION
+ * with actual values from package.json.
+ *
+ * SDK_NAME is a fixed string matching the cross-SDK convention:
+ * aws-durable-execution-sdk-\{language\}
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
-export const SDK_NAME =
-  process.env.NPM_PACKAGE_NAME || "@aws/durable-execution-sdk-js";
+export const SDK_NAME = "aws-durable-execution-sdk-js";
 export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";


### PR DESCRIPTION
Releases SDK version 1.1.3 on the v1.x branch.

## Cherry-picks from main

- `b8ad139` fix(sdk): update UserAgent header format (#522)
- `2655eb0` feat(sdk): Lambda bundled runtime useragent header (5f951b1)

Both commits modify only `packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts`. Cherry-picks applied without conflicts.

## Version bump

- `packages/aws-durable-execution-sdk-js`: 1.1.2 → 1.1.3

Following prior release convention, only `package.json` is updated in the bump commit (no lockfile changes).

## Testing

`npm run test -w packages/aws-durable-execution-sdk-js`:
- 72 test suites passed
- 793 tests passed
- `version.ts` covered at 100% lines/statements/functions (87.5% branch — same as main)