### PR TITLE
feat(ci): npm publish github workflow now differentiates between github p…

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+PRERELEASE=${1:-false}
+
 for package_dir in packages/*; do
   if [ -d "$package_dir" ] && [[ "$package_dir" == "packages/aws-durable-execution-sdk-js-testing" || "$package_dir" == "packages/aws-durable-execution-sdk-js" || "$package_dir" == "packages/aws-durable-execution-sdk-js-eslint-plugin" ]]; then
     echo "$package_dir";
     cd "$package_dir";
     echo "Publishing package in $package_dir";
-    npm publish --access public;
+    if [ "$PRERELEASE" = "true" ]; then
+      npm publish --access public --tag prerelease;
+    else
+      npm publish --access public;
+    fi
     cd ../..;
   fi
 done

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Make script executable
         run: chmod +x ./.github/workflows/iterate-publish-npm.sh
       - name: iterate and publish
-        run: ./.github/workflows/iterate-publish-npm.sh
+        run: ./.github/workflows/iterate-publish-npm.sh ${{ github.event.release.prerelease && 'true' || 'false' }}
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* npm-publish.yml github workflow now differentiates between github prerelease and release events. We previously published prerelease Github Releases as latest to npm which is a bug.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I tested a similar workflow in a dummy repository with a dummy package published to npm.

See: 
https://www.npmjs.com/package/test-publish-npm-silanhe?activeTab=versions
https://github.com/SilanHe/test-publish-npm-silanhe/releases/tag/2.0.2-alpha
https://github.com/SilanHe/test-publish-npm-silanhe/blob/main/.github/workflows/npm-publish.yml#L32