### PR TITLE
fix(ci):Change npm publish tag from 'prerelease' to 'beta'

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -8,7 +8,7 @@ for package_dir in packages/*; do
     cd "$package_dir";
     echo "Publishing package in $package_dir";
     if [ "$PRERELEASE" = "true" ]; then
-      npm publish --access public --tag prerelease;
+      npm publish --access public --tag beta;
     else
       npm publish --access public;
     fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Changing npm tag from prerelease to beta on Releases marked as Pre-release on Github. `beta` is a more common tag than `prerelease`. They mean the same thing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
