### PR TITLE
  fix(testing): keep TimerScheduler entries in flight until startInvocation settles

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/__tests__/timer-scheduler.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/__tests__/timer-scheduler.test.ts
@@ -171,6 +171,44 @@ describe("TimerScheduler", () => {
       expect(scheduler.hasScheduledFunction()).toBe(false);
     });
 
+    it("should keep hasScheduledFunction true while the fired function is still running", async () => {
+      let resolveInvocation: (() => void) | undefined;
+      const invocationPromise = new Promise<void>((resolve) => {
+        resolveInvocation = resolve;
+      });
+      const mockFn = jest.fn().mockReturnValue(invocationPromise);
+      const mockOnError = jest.fn();
+
+      scheduler.scheduleFunction(mockFn, mockOnError);
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(scheduler.hasScheduledFunction()).toBe(true);
+
+      resolveInvocation!();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(scheduler.hasScheduledFunction()).toBe(false);
+    });
+
+    it("should keep hasScheduledFunction true while the fired function is still running even on rejection", async () => {
+      let rejectInvocation: ((err: unknown) => void) | undefined;
+      const invocationPromise = new Promise<void>((_resolve, reject) => {
+        rejectInvocation = reject;
+      });
+      const mockFn = jest.fn().mockReturnValue(invocationPromise);
+      const mockOnError = jest.fn();
+
+      scheduler.scheduleFunction(mockFn, mockOnError);
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(scheduler.hasScheduledFunction()).toBe(true);
+
+      rejectInvocation!(new Error("Test error"));
+      await jest.advanceTimersByTimeAsync(0);
+      expect(mockOnError).toHaveBeenCalledTimes(1);
+      expect(scheduler.hasScheduledFunction()).toBe(false);
+    });
+
     it("should call onError when the scheduled function throws an error", async () => {
       const error = new Error("Test error");
       const mockFn = jest.fn().mockRejectedValue(error);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/timer-scheduler.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/timer-scheduler.ts
@@ -37,13 +37,15 @@ export class TimerScheduler implements Scheduler {
       `Scheduling function to run in ${delayMs}ms - Scheduler ID: ${id}`,
     );
     const timer = setTimeout(() => {
-      this.runningTimers.delete(timer);
       defaultLogger.debug(
         `Running scheduled function after ${delayMs}ms - Scheduler ID: ${id}`,
       );
       (updateCheckpoint ? updateCheckpoint() : Promise.resolve())
         .then(() => startInvocation())
-        .catch(onError);
+        .catch(onError)
+        .finally(() => {
+          this.runningTimers.delete(timer);
+        });
     }, delayMs);
     this.runningTimers.add(timer);
   }
@@ -65,13 +67,13 @@ export class TimerScheduler implements Scheduler {
   }
 
   /**
-   * Checks whether there are any functions scheduled for future execution.
+   * Checks whether there are any scheduled functions that have not yet
+   * finished executing. This covers both pending timers and fired-but-
+   * in-flight `startInvocation` work, so the orchestrator's PENDING-status
+   * validation can rely on it as a single "is anything still queued or
+   * running?" signal.
    *
-   * @returns true if there are pending timers, false otherwise
-   *
-   * @remarks
-   * TODO: use this to check if there is a pending function invocation when the invocation status is PENDING
-   * if there is no scheduled function and the invocation status is PENDING, the language SDK has a bug
+   * @returns true if any scheduled function is pending or in flight, false otherwise
    */
   hasScheduledFunction(): boolean {
     return !!this.runningTimers.size;


### PR DESCRIPTION
TimerScheduler.scheduleFunction used to remove the timer from runningTimers synchronously the moment the setTimeout fired — before the chained updateCheckpoint().then(startInvocation) had a chance to begin, let alone finish. That left a window where the underlying scheduled work was running but hasScheduledFunction() returned false.

The window is load-bearing for TestExecutionOrchestrator's invocation- completion validation (test-execution-orchestrator.ts:651-663):

  if (!this.scheduler.hasScheduledFunction() && !this.pendingOperations.size) {
    // reject with "Cannot return PENDING status with no pending operations."
  }

For fast-resolving chained-invoke flows — and for waitForCallback flows where the test harness resolves the callback immediately — the resume timer can fire and tear down its runningTimers entry between the SDK's PENDING-returning invokeHandler completing and the validation running. The outer's pendingOperations slot is already cleared by then, so both conditions report empty and the validation throws.

In production (real AWS backend) this race doesn't manifest because the backend tracks the actual operation graph the SDK reports through checkpoint updates. The validation is mock-only.

Fix: move runningTimers.delete(timer) out of the synchronous setTimeout callback into a .finally(...) chained on the updateCheckpoint -> startInvocation promise, so a scheduled function stays counted from the moment it's scheduled until its work settles (success or failure). Updates the JSDoc on hasScheduledFunction() to describe the new "pending OR in-flight" semantics — the previous TODO comment ("if there is no scheduled function and the invocation status is PENDING, the language SDK has a bug") was contradicted by the fix and would mislead future maintainers. Adds two regression tests covering the in-flight success and rejection paths.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
