### PR TITLE
feat(sdk): Plugin interface and runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 *.tsbuildinfo
 .rollup.cache
 */.rollup.cache
+*.d.ts.map
+*.d.ts
+*.tgz
 
 # VS Code
 .vscode/

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -87,6 +87,7 @@ export {
   ExecutionEndInfo,
   OperationChangeInfo,
   OperationInfo,
+  OperationEndInfo,
   AttemptInfo,
   AttemptEndInfo,
   AttemptEndInfoOutcome,

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -81,3 +81,14 @@ export { createLinearRetryStrategy } from "./utils/retry/linear-retry-strategy/l
 export { retryPresets } from "./utils/retry/retry-presets/retry-presets";
 export { withRetry, WithRetryConfig, RetryableFunc } from "./utils/with-retry";
 export { DurableExecutionInvocationInputWithClient } from "./utils/durable-execution-invocation-input/durable-execution-invocation-input";
+export {
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  ExecutionEndInfo,
+  OperationChangeInfo,
+  OperationInfo,
+  AttemptInfo,
+  AttemptEndInfo,
+  AttemptEndInfoOutcome,
+  shouldSampleExecution,
+} from "./types/plugin";

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -90,5 +90,4 @@ export {
   AttemptInfo,
   AttemptEndInfo,
   AttemptEndInfoOutcome,
-  shouldSampleExecution,
 } from "./types/plugin";

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
@@ -12,6 +12,7 @@ import {
   DurableExecutionInvocationInput,
   DurableExecutionInvocationOutput,
 } from "./core";
+import { DurableInstrumentationPlugin } from "./plugin";
 
 /**
  * A handler function type for a durable execution that provides automatic state persistence,
@@ -116,6 +117,28 @@ export interface DurableExecutionConfig {
    * ```
    */
   client?: LambdaClient;
+
+  /**
+   * Optional array of instrumentation plugins for observability and tracing.
+   *
+   * Plugins receive lifecycle callbacks at key points during durable execution,
+   * enabling integration with tracing systems (e.g., OpenTelemetry, X-Ray),
+   * custom metrics, and logging enrichment.
+   *
+   * Multiple plugins can be provided and will be called in order. Plugin errors
+   * are swallowed to prevent instrumentation from affecting execution correctness.
+   *
+   * @example
+   * ```typescript
+   * import { withDurableExecution } from '@aws/durable-execution-sdk-js';
+   * import { myTracingPlugin } from './tracing';
+   *
+   * export const handler = withDurableExecution(myHandler, {
+   *   plugins: [myTracingPlugin]
+   * });
+   * ```
+   */
+  plugins?: DurableInstrumentationPlugin[];
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
@@ -137,6 +137,8 @@ export interface DurableExecutionConfig {
    *   plugins: [myTracingPlugin]
    * });
    * ```
+   *
+   * @experimental This parameter is experimental and may be changed or removed in future releases.
    */
   plugins?: DurableInstrumentationPlugin[];
 }

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -1,5 +1,10 @@
 import { Operation } from "@aws-sdk/client-lambda";
 
+/**
+ * Information about a durable operation.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface OperationInfo {
   Id: string;
   Name?: string;
@@ -10,16 +15,31 @@ export interface OperationInfo {
   EndTimestamp?: Date;
 }
 
+/**
+ * Information about an operation attempt.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface AttemptInfo extends OperationInfo {
   Attempt: number;
 }
 
+/**
+ * Possible outcomes for an operation attempt.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export enum AttemptEndInfoOutcome {
   SUCCEEDED = "succeeded",
   FAILED = "failed",
   RETRYING = "retrying",
 }
 
+/**
+ * Information provided when an operation attempt ends.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface AttemptEndInfo extends AttemptInfo {
   outcome:
     | AttemptEndInfoOutcome.SUCCEEDED
@@ -29,11 +49,21 @@ export interface AttemptEndInfo extends AttemptInfo {
   nextAttemptDelaySeconds?: number;
 }
 
+/**
+ * Information about a durable execution invocation.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface InvocationInfo {
   requestId: string;
   executionArn: string;
 }
 
+/**
+ * Information provided when a durable execution ends.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface ExecutionEndInfo extends InvocationInfo {
   status: "SUCCEEDED" | "FAILED";
   executionResult?: unknown;
@@ -42,11 +72,21 @@ export interface ExecutionEndInfo extends InvocationInfo {
   operations: Record<string, Operation>;
 }
 
+/**
+ * Information provided when operations change during execution.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface OperationChangeInfo extends InvocationInfo {
   updatedOperations: Record<string, Operation>;
   operations: Record<string, Operation>;
 }
 
+/**
+ * Plugin interface for instrumenting durable execution lifecycle events.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export interface DurableInstrumentationPlugin {
   onExecutionStart?(info: InvocationInfo): void;
   onExecutionEnd?(info: ExecutionEndInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -1,0 +1,79 @@
+import { Operation } from "@aws-sdk/client-lambda";
+
+export interface OperationInfo {
+  Id: string;
+  Name?: string;
+  Type: string;
+  SubType?: string;
+  ParentId?: string;
+  StartTimestamp?: Date;
+  EndTimestamp?: Date;
+}
+
+export interface AttemptInfo extends OperationInfo {
+  Attempt: number;
+}
+
+export enum AttemptEndInfoOutcome {
+  SUCCEEDED = "succeeded",
+  FAILED = "failed",
+  RETRYING = "retrying",
+}
+
+export interface AttemptEndInfo extends AttemptInfo {
+  outcome:
+    | AttemptEndInfoOutcome.SUCCEEDED
+    | AttemptEndInfoOutcome.FAILED
+    | AttemptEndInfoOutcome.RETRYING;
+  error?: Error;
+  nextAttemptDelaySeconds?: number;
+}
+
+export interface InvocationInfo {
+  requestId: string;
+  executionArn: string;
+}
+
+export interface ExecutionEndInfo extends InvocationInfo {
+  status: "SUCCEEDED" | "FAILED";
+  executionResult?: unknown;
+  executionError?: Error;
+  executionInput: unknown;
+  operations: Record<string, Operation>;
+}
+
+export interface OperationChangeInfo extends InvocationInfo {
+  updatedOperations: Record<string, Operation>;
+  operations: Record<string, Operation>;
+}
+
+export interface DurableInstrumentationPlugin {
+  onExecutionStart?(info: InvocationInfo): void;
+  onExecutionEnd?(info: ExecutionEndInfo): void;
+  onInvocationStart?(info: InvocationInfo): void;
+  wrapInvocation?<T>(info: InvocationInfo, fn: () => T): T;
+  onInvocationEnd?(info: InvocationInfo): void;
+  onOperationFirstStart?(info: OperationInfo): void;
+  onOperationStart?(info: OperationInfo): void;
+  wrapChildContextFn?<T>(info: OperationInfo, fn: () => T): T;
+  onOperationFirstEnd?(info: OperationInfo & { error?: Error }): void;
+  onOperationAttemptStart?(info: AttemptInfo): void;
+  wrapOperationAttemptFn?<T>(info: AttemptInfo, fn: () => T): T;
+  onOperationAttemptEnd?(info: AttemptEndInfo): void;
+  onOperationChange?(info: OperationChangeInfo): void;
+  enrichLogContext?(): Record<string, string | number | boolean> | undefined;
+}
+
+export function shouldSampleExecution(
+  executionArn: string,
+  samplingRate: number,
+): boolean {
+  if (samplingRate >= 1.0) return true;
+  if (samplingRate <= 0.0) return false;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < executionArn.length; i++) {
+    hash ^= executionArn.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash / 0xffffffff < samplingRate;
+}

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -57,6 +57,7 @@ export interface AttemptEndInfo extends AttemptInfo {
 export interface InvocationInfo {
   requestId: string;
   executionArn: string;
+  isFirstInvocation: boolean;
 }
 
 /**
@@ -88,7 +89,6 @@ export interface OperationChangeInfo extends InvocationInfo {
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface DurableInstrumentationPlugin {
-  onExecutionStart?(info: InvocationInfo): void;
   onExecutionEnd?(info: ExecutionEndInfo): void;
   onInvocationStart?(info: InvocationInfo): void;
   wrapInvocation?<T>(info: InvocationInfo, fn: () => T): T;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -16,6 +16,15 @@ export interface OperationInfo {
 }
 
 /**
+ * Information provided when a durable operation ends.
+ *
+ * @experimental This interface is experimental and may be changed or removed in future releases.
+ */
+export interface OperationEndInfo extends OperationInfo {
+  error?: Error;
+}
+
+/**
  * Information about an operation attempt.
  *
  * @experimental This interface is experimental and may be changed or removed in future releases.
@@ -96,7 +105,7 @@ export interface DurableInstrumentationPlugin {
   onOperationFirstStart?(info: OperationInfo): void;
   onOperationStart?(info: OperationInfo): void;
   wrapChildContextFn?<T>(info: OperationInfo, fn: () => T): T;
-  onOperationFirstEnd?(info: OperationInfo & { error?: Error }): void;
+  onOperationFirstEnd?(info: OperationEndInfo): void;
   onOperationAttemptStart?(info: AttemptInfo): void;
   wrapOperationAttemptFn?<T>(info: AttemptInfo, fn: () => T): T;
   onOperationAttemptEnd?(info: AttemptEndInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -63,17 +63,3 @@ export interface DurableInstrumentationPlugin {
   onOperationChange?(info: OperationChangeInfo): void;
   enrichLogContext?(): Record<string, string | number | boolean> | undefined;
 }
-
-export function shouldSampleExecution(
-  executionArn: string,
-  samplingRate: number,
-): boolean {
-  if (samplingRate >= 1.0) return true;
-  if (samplingRate <= 0.0) return false;
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < executionArn.length; i++) {
-    hash ^= executionArn.charCodeAt(i);
-    hash = (hash * 0x01000193) >>> 0;
-  }
-  return hash / 0xffffffff < samplingRate;
-}

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -102,15 +102,23 @@ export interface OperationChangeInfo extends InvocationInfo {
 export interface DurableInstrumentationPlugin {
   onExecutionEnd?(info: ExecutionEndInfo): void;
   onInvocationStart?(info: InvocationInfo): void;
-  wrapInvocation?<T>(info: InvocationInfo, fn: () => T): T;
+  wrapInvocation?(info: InvocationInfo, fn: CustomerFn): CustomerFnResult;
   onInvocationEnd?(info: InvocationInfo): void;
   onOperationFirstStart?(info: OperationInfo): void;
   onOperationStart?(info: OperationInfo): void;
-  wrapChildContextFn?<T>(info: OperationInfo, fn: () => T): T;
+  wrapChildContextFn?(info: OperationInfo, fn: CustomerFn): CustomerFnResult;
   onOperationFirstEnd?(info: OperationEndInfo): void;
   onOperationAttemptStart?(info: AttemptInfo): void;
-  wrapOperationAttemptFn?<T>(info: AttemptInfo, fn: () => T): T;
+  wrapOperationAttemptFn?(info: AttemptInfo, fn: CustomerFn): CustomerFnResult;
   onOperationAttemptEnd?(info: AttemptEndInfo): void;
   onOperationChange?(info: OperationChangeInfo): void;
   enrichLogContext?(): Record<string, string | number | boolean> | undefined;
 }
+
+/**
+ * Internal type aliases used by the plugin.
+ *
+ * @experimental These types are experimental and may be changed or removed in future releases.
+ */
+export type CustomerFnResult = unknown;
+export type CustomerFn = () => CustomerFnResult;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -3,7 +3,7 @@ import { Operation } from "@aws-sdk/client-lambda";
 /**
  * Information about a durable operation.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface OperationInfo {
   Id: string;
@@ -18,7 +18,7 @@ export interface OperationInfo {
 /**
  * Information about an operation attempt.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface AttemptInfo extends OperationInfo {
   Attempt: number;
@@ -27,7 +27,7 @@ export interface AttemptInfo extends OperationInfo {
 /**
  * Possible outcomes for an operation attempt.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This enum is experimental and may be changed or removed in future releases.
  */
 export enum AttemptEndInfoOutcome {
   SUCCEEDED = "succeeded",
@@ -38,7 +38,7 @@ export enum AttemptEndInfoOutcome {
 /**
  * Information provided when an operation attempt ends.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface AttemptEndInfo extends AttemptInfo {
   outcome:
@@ -52,7 +52,7 @@ export interface AttemptEndInfo extends AttemptInfo {
 /**
  * Information about a durable execution invocation.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface InvocationInfo {
   requestId: string;
@@ -62,7 +62,7 @@ export interface InvocationInfo {
 /**
  * Information provided when a durable execution ends.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface ExecutionEndInfo extends InvocationInfo {
   status: "SUCCEEDED" | "FAILED";
@@ -75,7 +75,7 @@ export interface ExecutionEndInfo extends InvocationInfo {
 /**
  * Information provided when operations change during execution.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface OperationChangeInfo extends InvocationInfo {
   updatedOperations: Record<string, Operation>;
@@ -85,7 +85,7 @@ export interface OperationChangeInfo extends InvocationInfo {
 /**
  * Plugin interface for instrumenting durable execution lifecycle events.
  *
- * @experimental This function is experimental and may be changed or removed in future releases.
+ * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface DurableInstrumentationPlugin {
   onExecutionStart?(info: InvocationInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -7,10 +7,12 @@ import { Operation } from "@aws-sdk/client-lambda";
  */
 export interface OperationInfo {
   Id: string;
+  HashId: string;
   Name?: string;
   Type: string;
   SubType?: string;
   ParentId?: string;
+  HashParentId?: string;
   StartTimestamp?: Date;
   EndTimestamp?: Date;
 }

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -7,12 +7,12 @@ import { Operation } from "@aws-sdk/client-lambda";
  */
 export interface OperationInfo {
   Id: string;
-  HashId: string;
+  HashedId: string;
   Name?: string;
   Type: string;
   SubType?: string;
   ParentId?: string;
-  HashParentId?: string;
+  HashedParentId?: string;
   StartTimestamp?: Date;
   EndTimestamp?: Date;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -1,0 +1,64 @@
+import { Operation } from "@aws-sdk/client-lambda";
+import {
+  OperationInfo,
+  AttemptInfo,
+  AttemptEndInfo,
+  AttemptEndInfoOutcome,
+} from "../../types/plugin";
+
+export function toOperationInfo(operation?: Operation): OperationInfo {
+  return {
+    Id: operation?.Id ?? "",
+    Name: operation?.Name,
+    Type: operation?.Type ?? "",
+    SubType: operation?.SubType,
+    ParentId: operation?.ParentId,
+    StartTimestamp: operation?.StartTimestamp,
+    EndTimestamp: operation?.EndTimestamp,
+  };
+}
+
+export function toAttemptInfo(
+  operation?: Operation,
+  attempt?: number,
+): AttemptInfo {
+  return {
+    ...toOperationInfo(operation),
+    Attempt: attempt ?? (operation?.StepDetails?.Attempt || 0),
+  };
+}
+
+export function toAttemptEndInfo(
+  operation: Operation | undefined,
+  outcome: AttemptEndInfoOutcome,
+  options?: {
+    attempt?: number;
+    error?: Error;
+    nextAttemptDelaySeconds?: number;
+  },
+): AttemptEndInfo {
+  return {
+    ...toAttemptInfo(operation, options?.attempt),
+    outcome,
+    error: options?.error,
+    nextAttemptDelaySeconds: options?.nextAttemptDelaySeconds,
+  };
+}
+
+/**
+ * Backfills missing fields on an OperationInfo (or subtype) with the provided defaults.
+ * Only sets a field if it's not already present (undefined or empty string).
+ */
+export function backfillOperationInfo<T extends OperationInfo>(
+  info: T,
+  defaults: Partial<OperationInfo>,
+): T {
+  info.Id = defaults.Id ?? "";
+  if (!info.Type) info.Type = defaults.Type ?? "";
+  if (!info.SubType) info.SubType = defaults.SubType;
+  if (!info.Name) info.Name = defaults.Name;
+  if (!info.ParentId) info.ParentId = defaults.ParentId;
+  if (!info.StartTimestamp) info.StartTimestamp = defaults.StartTimestamp;
+  if (!info.EndTimestamp) info.EndTimestamp = defaults.EndTimestamp;
+  return info;
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -5,6 +5,7 @@ import {
   AttemptEndInfo,
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
+import { hashId } from "../step-id-utils/step-id-utils";
 
 /**
  * Converts an Operation to an OperationInfo.
@@ -14,10 +15,14 @@ import {
 export function toOperationInfo(operation?: Operation): OperationInfo {
   return {
     Id: operation?.Id ?? "",
+    HashedId: hashId(operation?.Id ?? ""),
     Name: operation?.Name,
     Type: operation?.Type ?? "",
     SubType: operation?.SubType,
     ParentId: operation?.ParentId,
+    HashedParentId: operation?.ParentId
+      ? hashId(operation.ParentId)
+      : undefined,
     StartTimestamp: operation?.StartTimestamp,
     EndTimestamp: operation?.EndTimestamp,
   };
@@ -71,10 +76,15 @@ export function backfillOperationInfo<T extends OperationInfo>(
   defaults: Partial<OperationInfo>,
 ): T {
   info.Id = defaults.Id ?? "";
+  info.HashedId = defaults.HashedId ?? hashId(info.Id);
   if (!info.Type) info.Type = defaults.Type ?? "";
   if (!info.SubType) info.SubType = defaults.SubType;
   if (!info.Name) info.Name = defaults.Name;
   if (!info.ParentId) info.ParentId = defaults.ParentId;
+  if (!info.HashedParentId)
+    info.HashedParentId =
+      defaults.HashedParentId ??
+      (info.ParentId ? hashId(info.ParentId) : undefined);
   if (!info.StartTimestamp) info.StartTimestamp = defaults.StartTimestamp;
   if (!info.EndTimestamp) info.EndTimestamp = defaults.EndTimestamp;
   return info;

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -6,6 +6,11 @@ import {
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
 
+/**
+ * Converts an Operation to an OperationInfo.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export function toOperationInfo(operation?: Operation): OperationInfo {
   return {
     Id: operation?.Id ?? "",
@@ -18,6 +23,11 @@ export function toOperationInfo(operation?: Operation): OperationInfo {
   };
 }
 
+/**
+ * Converts an Operation to an AttemptInfo.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export function toAttemptInfo(
   operation?: Operation,
   attempt?: number,
@@ -28,6 +38,11 @@ export function toAttemptInfo(
   };
 }
 
+/**
+ * Converts an Operation to an AttemptEndInfo with the given outcome.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export function toAttemptEndInfo(
   operation: Operation | undefined,
   outcome: AttemptEndInfoOutcome,
@@ -48,6 +63,8 @@ export function toAttemptEndInfo(
 /**
  * Backfills missing fields on an OperationInfo (or subtype) with the provided defaults.
  * Only sets a field if it's not already present (undefined or empty string).
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
  */
 export function backfillOperationInfo<T extends OperationInfo>(
   info: T,

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -1,0 +1,547 @@
+import { createPluginRunner } from "./plugin-runner";
+import {
+  DurableInstrumentationPlugin,
+  AttemptEndInfoOutcome,
+  AttemptInfo,
+  InvocationInfo,
+  OperationInfo,
+  ExecutionEndInfo,
+  OperationChangeInfo,
+  AttemptEndInfo,
+} from "../../types/plugin";
+
+describe("createPluginRunner", () => {
+  const invocationInfo: InvocationInfo = {
+    requestId: "req-1",
+    executionArn: "arn:aws:lambda:us-east-1:123:function:fn:1/exec/abc",
+  };
+
+  const operationInfo: OperationInfo = {
+    Id: "op-1",
+    Name: "my-step",
+    Type: "STEP",
+  };
+
+  const attemptInfo: AttemptInfo = {
+    ...operationInfo,
+    Attempt: 1,
+  };
+
+  const attemptEndInfo: AttemptEndInfo = {
+    ...attemptInfo,
+    outcome: AttemptEndInfoOutcome.SUCCEEDED,
+  };
+
+  const executionEndInfo: ExecutionEndInfo = {
+    ...invocationInfo,
+    status: "SUCCEEDED",
+    executionResult: { ok: true },
+    executionInput: { data: "input" },
+    operations: {},
+  };
+
+  const operationChangeInfo: OperationChangeInfo = {
+    ...invocationInfo,
+    updatedOperations: {},
+    operations: {},
+  };
+
+  describe("empty plugins array", () => {
+    it("returns an empty object when no plugins are provided", () => {
+      const runner = createPluginRunner([]);
+      expect(runner).toEqual({});
+    });
+  });
+
+  describe("fire-and-forget hooks (run)", () => {
+    it("calls onExecutionStart on all plugins", () => {
+      const plugin1: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionStart: jest.fn(),
+      };
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      runner.onExecutionStart!(invocationInfo);
+
+      expect(plugin1.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+    });
+
+    it("calls onInvocationStart on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onInvocationStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onInvocationStart!(invocationInfo);
+
+      expect(plugin.onInvocationStart).toHaveBeenCalledWith(invocationInfo);
+    });
+
+    it("calls onOperationFirstStart on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationFirstStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationFirstStart!(operationInfo);
+
+      expect(plugin.onOperationFirstStart).toHaveBeenCalledWith(operationInfo);
+    });
+
+    it("calls onOperationStart on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationStart!(operationInfo);
+
+      expect(plugin.onOperationStart).toHaveBeenCalledWith(operationInfo);
+    });
+
+    it("calls onOperationFirstEnd on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationFirstEnd: jest.fn(),
+      };
+      const infoWithError = { ...operationInfo, error: new Error("oops") };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationFirstEnd!(infoWithError);
+
+      expect(plugin.onOperationFirstEnd).toHaveBeenCalledWith(infoWithError);
+    });
+
+    it("calls onOperationAttemptStart on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationAttemptStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationAttemptStart!(attemptInfo);
+
+      expect(plugin.onOperationAttemptStart).toHaveBeenCalledWith(attemptInfo);
+    });
+
+    it("calls onOperationAttemptEnd on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationAttemptEnd: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationAttemptEnd!(attemptEndInfo);
+
+      expect(plugin.onOperationAttemptEnd).toHaveBeenCalledWith(attemptEndInfo);
+    });
+
+    it("calls onOperationChange on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationChange: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationChange!(operationChangeInfo);
+
+      expect(plugin.onOperationChange).toHaveBeenCalledWith(
+        operationChangeInfo,
+      );
+    });
+
+    it("swallows synchronous errors from plugins", () => {
+      const throwingPlugin: DurableInstrumentationPlugin = {
+        onExecutionStart: () => {
+          throw new Error("sync plugin error");
+        },
+      };
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([throwingPlugin, plugin2]);
+
+      expect(() => runner.onExecutionStart!(invocationInfo)).not.toThrow();
+      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+    });
+
+    it("swallows async errors from plugins (fire-and-forget)", () => {
+      const asyncThrowingPlugin: DurableInstrumentationPlugin = {
+        onOperationStart: () => {
+          return Promise.reject(new Error("async plugin error")) as any;
+        },
+      };
+
+      const runner = createPluginRunner([asyncThrowingPlugin]);
+
+      expect(() => runner.onOperationStart!(operationInfo)).not.toThrow();
+    });
+
+    it("skips plugins that do not implement the hook", () => {
+      const plugin1: DurableInstrumentationPlugin = {};
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      runner.onExecutionStart!(invocationInfo);
+
+      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+    });
+  });
+
+  describe("awaited hooks (runAwait)", () => {
+    it("calls onExecutionEnd on all plugins sequentially", async () => {
+      const callOrder: string[] = [];
+      const plugin1: DurableInstrumentationPlugin = {
+        onExecutionEnd: async () => {
+          callOrder.push("plugin1");
+        },
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        onExecutionEnd: async () => {
+          callOrder.push("plugin2");
+        },
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      await runner.onExecutionEnd!(executionEndInfo);
+
+      expect(callOrder).toEqual(["plugin1", "plugin2"]);
+    });
+
+    it("calls onInvocationEnd on all plugins", async () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onInvocationEnd: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      await runner.onInvocationEnd!(invocationInfo);
+
+      expect(plugin.onInvocationEnd).toHaveBeenCalledWith(invocationInfo);
+    });
+
+    it("swallows errors from async plugins and continues to next", async () => {
+      const plugin1: DurableInstrumentationPlugin = {
+        onExecutionEnd: async () => {
+          throw new Error("plugin1 failed");
+        },
+      };
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+
+      await expect(
+        runner.onExecutionEnd!(executionEndInfo),
+      ).resolves.toBeUndefined();
+      expect(plugin2.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
+    });
+
+    it("skips plugins that do not implement the awaited hook", async () => {
+      const plugin1: DurableInstrumentationPlugin = {};
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      await runner.onExecutionEnd!(executionEndInfo);
+
+      expect(plugin2.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
+    });
+  });
+
+  describe("callback-wrapping hooks (runAsCallback)", () => {
+    it("wrapInvocation calls fn through the plugin chain", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapInvocation!(invocationInfo, () => "hello");
+
+      expect(result).toBe("hello");
+    });
+
+    it("wrapInvocation chains multiple plugins in right-to-left order", () => {
+      const callOrder: string[] = [];
+
+      const plugin1: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => {
+          callOrder.push("plugin1-before");
+          const result = fn();
+          callOrder.push("plugin1-after");
+          return result;
+        },
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => {
+          callOrder.push("plugin2-before");
+          const result = fn();
+          callOrder.push("plugin2-after");
+          return result;
+        },
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const result = runner.wrapInvocation!(invocationInfo, () => {
+        callOrder.push("fn");
+        return "result";
+      });
+
+      expect(result).toBe("result");
+      // plugin1 wraps plugin2 which wraps fn (reduceRight)
+      expect(callOrder).toEqual([
+        "plugin1-before",
+        "plugin2-before",
+        "fn",
+        "plugin2-after",
+        "plugin1-after",
+      ]);
+    });
+
+    it("wrapChildContextFn calls fn through the plugin chain", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapChildContextFn: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapChildContextFn!(operationInfo, () => 42);
+
+      expect(result).toBe(42);
+    });
+
+    it("wrapOperationAttemptFn calls fn through the plugin chain", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapOperationAttemptFn: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapOperationAttemptFn!(attemptInfo, () => "done");
+
+      expect(result).toBe("done");
+    });
+
+    it("wrapInvocation skips plugins that do not implement it", () => {
+      const plugin1: DurableInstrumentationPlugin = {};
+      const plugin2: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const result = runner.wrapInvocation!(invocationInfo, () => "value");
+
+      expect(result).toBe("value");
+    });
+
+    it("wrapInvocation propagates errors from the wrapped fn", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+
+      expect(() =>
+        runner.wrapInvocation!(invocationInfo, () => {
+          throw new Error("fn error");
+        }),
+      ).toThrow("fn error");
+    });
+
+    it("wrapInvocation propagates errors from a plugin", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapInvocation: () => {
+          throw new Error("plugin error");
+        },
+      };
+
+      const runner = createPluginRunner([plugin]);
+
+      expect(() =>
+        runner.wrapInvocation!(invocationInfo, () => "value"),
+      ).toThrow("plugin error");
+    });
+
+    it("wrapInvocation allows plugin to modify the return value", () => {
+      const plugin = {
+        wrapInvocation: (_info: any, fn: () => any) => {
+          const result = fn();
+          return `modified-${result}`;
+        },
+      } as DurableInstrumentationPlugin;
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapInvocation!(invocationInfo, () => "original");
+
+      expect(result).toBe("modified-original");
+    });
+
+    it("wrapInvocation allows plugin to short-circuit without calling fn", () => {
+      const fn = jest.fn().mockReturnValue("should not be called");
+      const plugin = {
+        wrapInvocation: () => "short-circuited",
+      } as unknown as DurableInstrumentationPlugin;
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapInvocation!(invocationInfo, fn);
+
+      expect(result).toBe("short-circuited");
+      expect(fn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enrichLogContext", () => {
+    it("merges log context from all plugins", () => {
+      const plugin1: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ traceId: "trace-1", service: "svc" }),
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ spanId: "span-1" }),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const context = runner.enrichLogContext!();
+
+      expect(context).toEqual({
+        traceId: "trace-1",
+        service: "svc",
+        spanId: "span-1",
+      });
+    });
+
+    it("later plugins override earlier plugins for same keys", () => {
+      const plugin1: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ key: "first" }),
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ key: "second" }),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const context = runner.enrichLogContext!();
+
+      expect(context).toEqual({ key: "second" });
+    });
+
+    it("returns empty object when no plugins implement enrichLogContext", () => {
+      const plugin1: DurableInstrumentationPlugin = {};
+      const plugin2: DurableInstrumentationPlugin = {};
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const context = runner.enrichLogContext!();
+
+      expect(context).toEqual({});
+    });
+
+    it("skips plugins that return undefined from enrichLogContext", () => {
+      const plugin1: DurableInstrumentationPlugin = {
+        enrichLogContext: () => undefined,
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ key: "value" }),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const context = runner.enrichLogContext!();
+
+      expect(context).toEqual({ key: "value" });
+    });
+
+    it("swallows errors from enrichLogContext and continues", () => {
+      const plugin1: DurableInstrumentationPlugin = {
+        enrichLogContext: () => {
+          throw new Error("enrichLogContext error");
+        },
+      };
+      const plugin2: DurableInstrumentationPlugin = {
+        enrichLogContext: () => ({ key: "value" }),
+      };
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+      const context = runner.enrichLogContext!();
+
+      expect(context).toEqual({ key: "value" });
+    });
+  });
+
+  describe("multiple plugins integration", () => {
+    it("all hooks are called on all plugins for a full lifecycle", async () => {
+      const plugin1 = {
+        onExecutionStart: jest.fn(),
+        onInvocationStart: jest.fn(),
+        wrapInvocation: jest.fn((_info: any, fn: () => any) => fn()),
+        onOperationFirstStart: jest.fn(),
+        onOperationStart: jest.fn(),
+        onOperationAttemptStart: jest.fn(),
+        wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
+        onOperationAttemptEnd: jest.fn(),
+        onOperationFirstEnd: jest.fn(),
+        onOperationChange: jest.fn(),
+        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+        onInvocationEnd: jest.fn().mockResolvedValue(undefined),
+        enrichLogContext: jest.fn().mockReturnValue({ p1: "v1" }),
+      } as unknown as jest.Mocked<DurableInstrumentationPlugin>;
+
+      const plugin2 = {
+        onExecutionStart: jest.fn(),
+        onInvocationStart: jest.fn(),
+        wrapInvocation: jest.fn((_info: any, fn: () => any) => fn()),
+        onOperationFirstStart: jest.fn(),
+        onOperationStart: jest.fn(),
+        onOperationAttemptStart: jest.fn(),
+        wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
+        onOperationAttemptEnd: jest.fn(),
+        onOperationFirstEnd: jest.fn(),
+        onOperationChange: jest.fn(),
+        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+        onInvocationEnd: jest.fn().mockResolvedValue(undefined),
+        enrichLogContext: jest.fn().mockReturnValue({ p2: "v2" }),
+      } as unknown as jest.Mocked<DurableInstrumentationPlugin>;
+
+      const runner = createPluginRunner([plugin1, plugin2]);
+
+      // Simulate a full lifecycle
+      runner.onExecutionStart!(invocationInfo);
+      runner.onInvocationStart!(invocationInfo);
+      runner.wrapInvocation!(invocationInfo, () => "invocation-result");
+      runner.onOperationFirstStart!(operationInfo);
+      runner.onOperationStart!(operationInfo);
+      runner.onOperationAttemptStart!(attemptInfo);
+      runner.wrapOperationAttemptFn!(attemptInfo, () => "attempt-result");
+      runner.onOperationAttemptEnd!(attemptEndInfo);
+      runner.onOperationFirstEnd!(operationInfo);
+      runner.onOperationChange!(operationChangeInfo);
+      await runner.onExecutionEnd!(executionEndInfo);
+      await runner.onInvocationEnd!(invocationInfo);
+      const logCtx = runner.enrichLogContext!();
+
+      // Verify all hooks called on both plugins
+      expect(plugin1.onExecutionStart).toHaveBeenCalledTimes(1);
+      expect(plugin2.onExecutionStart).toHaveBeenCalledTimes(1);
+      expect(plugin1.onInvocationStart).toHaveBeenCalledTimes(1);
+      expect(plugin2.onInvocationStart).toHaveBeenCalledTimes(1);
+      expect(plugin1.wrapInvocation).toHaveBeenCalledTimes(1);
+      expect(plugin2.wrapInvocation).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationFirstStart).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationFirstStart).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationStart).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationStart).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationAttemptStart).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationAttemptStart).toHaveBeenCalledTimes(1);
+      expect(plugin1.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
+      expect(plugin2.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationFirstEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationFirstEnd).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationChange).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationChange).toHaveBeenCalledTimes(1);
+      expect(plugin1.onExecutionEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onExecutionEnd).toHaveBeenCalledTimes(1);
+      expect(plugin1.onInvocationEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onInvocationEnd).toHaveBeenCalledTimes(1);
+      expect(logCtx).toEqual({ p1: "v1", p2: "v2" });
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -19,6 +19,7 @@ describe("createPluginRunner", () => {
 
   const operationInfo: OperationInfo = {
     Id: "op-1",
+    HashedId: "op-1-hash",
     Name: "my-step",
     Type: "STEP",
   };

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -236,7 +236,7 @@ describe("createPluginRunner", () => {
   describe("callback-wrapping hooks (runAsCallback)", () => {
     it("wrapInvocation calls fn through the plugin chain", () => {
       const plugin: DurableInstrumentationPlugin = {
-        wrapInvocation: (_info, fn) => fn(),
+        wrapInvocation: <T>(_info: InvocationInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin]);
@@ -249,7 +249,7 @@ describe("createPluginRunner", () => {
       const callOrder: string[] = [];
 
       const plugin1: DurableInstrumentationPlugin = {
-        wrapInvocation: (_info, fn) => {
+        wrapInvocation: <T>(_info: InvocationInfo, fn: () => T): T => {
           callOrder.push("plugin1-before");
           const result = fn();
           callOrder.push("plugin1-after");
@@ -257,7 +257,7 @@ describe("createPluginRunner", () => {
         },
       };
       const plugin2: DurableInstrumentationPlugin = {
-        wrapInvocation: (_info, fn) => {
+        wrapInvocation: <T>(_info: InvocationInfo, fn: () => T): T => {
           callOrder.push("plugin2-before");
           const result = fn();
           callOrder.push("plugin2-after");
@@ -284,7 +284,7 @@ describe("createPluginRunner", () => {
 
     it("wrapChildContextFn calls fn through the plugin chain", () => {
       const plugin: DurableInstrumentationPlugin = {
-        wrapChildContextFn: (_info, fn) => fn(),
+        wrapChildContextFn: <T>(_info: OperationInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin]);
@@ -295,7 +295,7 @@ describe("createPluginRunner", () => {
 
     it("wrapOperationAttemptFn calls fn through the plugin chain", () => {
       const plugin: DurableInstrumentationPlugin = {
-        wrapOperationAttemptFn: (_info, fn) => fn(),
+        wrapOperationAttemptFn: <T>(_info: AttemptInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin]);
@@ -307,7 +307,7 @@ describe("createPluginRunner", () => {
     it("wrapInvocation skips plugins that do not implement it", () => {
       const plugin1: DurableInstrumentationPlugin = {};
       const plugin2: DurableInstrumentationPlugin = {
-        wrapInvocation: (_info, fn) => fn(),
+        wrapInvocation: <T>(_info: InvocationInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin1, plugin2]);
@@ -318,7 +318,7 @@ describe("createPluginRunner", () => {
 
     it("wrapInvocation propagates errors from the wrapped fn", () => {
       const plugin: DurableInstrumentationPlugin = {
-        wrapInvocation: (_info, fn) => fn(),
+        wrapInvocation: <T>(_info: InvocationInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin]);
@@ -462,7 +462,7 @@ describe("createPluginRunner", () => {
 
     it("does not interfere when fn succeeds and plugin behaves correctly", () => {
       const plugin: DurableInstrumentationPlugin = {
-        wrapOperationAttemptFn: (_info, fn) => fn(),
+        wrapOperationAttemptFn: <T>(_info: AttemptInfo, fn: () => T): T => fn(),
       };
 
       const runner = createPluginRunner([plugin]);

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -190,63 +190,57 @@ describe("createPluginRunner", () => {
     });
   });
 
-  describe("awaited hooks (runAwait)", () => {
-    it("calls onExecutionEnd on all plugins sequentially", async () => {
-      const callOrder: string[] = [];
-      const plugin1: DurableInstrumentationPlugin = {
-        onExecutionEnd: async () => {
-          callOrder.push("plugin1");
-        },
+  describe("onExecutionEnd and onInvocationEnd hooks (run)", () => {
+    it("calls onExecutionEnd on all plugins", () => {
+      const plugin1: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionEnd: jest.fn(),
       };
-      const plugin2: DurableInstrumentationPlugin = {
-        onExecutionEnd: async () => {
-          callOrder.push("plugin2");
-        },
+      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
+        onExecutionEnd: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin1, plugin2]);
-      await runner.onExecutionEnd!(executionEndInfo);
+      runner.onExecutionEnd!(executionEndInfo);
 
-      expect(callOrder).toEqual(["plugin1", "plugin2"]);
+      expect(plugin1.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
+      expect(plugin2.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
     });
 
-    it("calls onInvocationEnd on all plugins", async () => {
+    it("calls onInvocationEnd on all plugins", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
-        onInvocationEnd: jest.fn().mockResolvedValue(undefined),
+        onInvocationEnd: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin]);
-      await runner.onInvocationEnd!(invocationInfo);
+      runner.onInvocationEnd!(invocationInfo);
 
       expect(plugin.onInvocationEnd).toHaveBeenCalledWith(invocationInfo);
     });
 
-    it("swallows errors from async plugins and continues to next", async () => {
+    it("swallows errors from plugins and continues to next", () => {
       const plugin1: DurableInstrumentationPlugin = {
-        onExecutionEnd: async () => {
+        onExecutionEnd: () => {
           throw new Error("plugin1 failed");
         },
       };
       const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+        onExecutionEnd: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin1, plugin2]);
 
-      await expect(
-        runner.onExecutionEnd!(executionEndInfo),
-      ).resolves.toBeUndefined();
+      expect(() => runner.onExecutionEnd!(executionEndInfo)).not.toThrow();
       expect(plugin2.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
     });
 
-    it("skips plugins that do not implement the awaited hook", async () => {
+    it("skips plugins that do not implement the hook", () => {
       const plugin1: DurableInstrumentationPlugin = {};
       const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionEnd: jest.fn().mockResolvedValue(undefined),
+        onExecutionEnd: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin1, plugin2]);
-      await runner.onExecutionEnd!(executionEndInfo);
+      runner.onExecutionEnd!(executionEndInfo);
 
       expect(plugin2.onExecutionEnd).toHaveBeenCalledWith(executionEndInfo);
     });
@@ -466,7 +460,7 @@ describe("createPluginRunner", () => {
   });
 
   describe("multiple plugins integration", () => {
-    it("all hooks are called on all plugins for a full lifecycle", async () => {
+    it("all hooks are called on all plugins for a full lifecycle", () => {
       const plugin1 = {
         onExecutionStart: jest.fn(),
         onInvocationStart: jest.fn(),
@@ -512,8 +506,8 @@ describe("createPluginRunner", () => {
       runner.onOperationAttemptEnd!(attemptEndInfo);
       runner.onOperationFirstEnd!(operationInfo);
       runner.onOperationChange!(operationChangeInfo);
-      await runner.onExecutionEnd!(executionEndInfo);
-      await runner.onInvocationEnd!(invocationInfo);
+      runner.onExecutionEnd!(executionEndInfo);
+      runner.onInvocationEnd!(invocationInfo);
       const logCtx = runner.enrichLogContext!();
 
       // Verify all hooks called on both plugins

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -14,6 +14,7 @@ describe("createPluginRunner", () => {
   const invocationInfo: InvocationInfo = {
     requestId: "req-1",
     executionArn: "arn:aws:lambda:us-east-1:123:function:fn:1/exec/abc",
+    isFirstInvocation: true,
   };
 
   const operationInfo: OperationInfo = {
@@ -54,21 +55,6 @@ describe("createPluginRunner", () => {
   });
 
   describe("fire-and-forget hooks (run)", () => {
-    it("calls onExecutionStart on all plugins", () => {
-      const plugin1: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionStart: jest.fn(),
-      };
-      const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionStart: jest.fn(),
-      };
-
-      const runner = createPluginRunner([plugin1, plugin2]);
-      runner.onExecutionStart!(invocationInfo);
-
-      expect(plugin1.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
-      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
-    });
-
     it("calls onInvocationStart on all plugins", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
         onInvocationStart: jest.fn(),
@@ -151,18 +137,18 @@ describe("createPluginRunner", () => {
 
     it("swallows synchronous errors from plugins", () => {
       const throwingPlugin: DurableInstrumentationPlugin = {
-        onExecutionStart: () => {
+        onInvocationStart: () => {
           throw new Error("sync plugin error");
         },
       };
       const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionStart: jest.fn(),
+        onInvocationStart: jest.fn(),
       };
 
       const runner = createPluginRunner([throwingPlugin, plugin2]);
 
-      expect(() => runner.onExecutionStart!(invocationInfo)).not.toThrow();
-      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+      expect(() => runner.onInvocationStart!(invocationInfo)).not.toThrow();
+      expect(plugin2.onInvocationStart).toHaveBeenCalledWith(invocationInfo);
     });
 
     it("swallows async errors from plugins (fire-and-forget)", () => {
@@ -180,13 +166,13 @@ describe("createPluginRunner", () => {
     it("skips plugins that do not implement the hook", () => {
       const plugin1: DurableInstrumentationPlugin = {};
       const plugin2: jest.Mocked<DurableInstrumentationPlugin> = {
-        onExecutionStart: jest.fn(),
+        onInvocationStart: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin1, plugin2]);
-      runner.onExecutionStart!(invocationInfo);
+      runner.onInvocationStart!(invocationInfo);
 
-      expect(plugin2.onExecutionStart).toHaveBeenCalledWith(invocationInfo);
+      expect(plugin2.onInvocationStart).toHaveBeenCalledWith(invocationInfo);
     });
   });
 
@@ -565,7 +551,6 @@ describe("createPluginRunner", () => {
   describe("multiple plugins integration", () => {
     it("all hooks are called on all plugins for a full lifecycle", () => {
       const plugin1 = {
-        onExecutionStart: jest.fn(),
         onInvocationStart: jest.fn(),
         wrapInvocation: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationFirstStart: jest.fn(),
@@ -581,7 +566,6 @@ describe("createPluginRunner", () => {
       } as unknown as jest.Mocked<DurableInstrumentationPlugin>;
 
       const plugin2 = {
-        onExecutionStart: jest.fn(),
         onInvocationStart: jest.fn(),
         wrapInvocation: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationFirstStart: jest.fn(),
@@ -599,7 +583,6 @@ describe("createPluginRunner", () => {
       const runner = createPluginRunner([plugin1, plugin2]);
 
       // Simulate a full lifecycle
-      runner.onExecutionStart!(invocationInfo);
       runner.onInvocationStart!(invocationInfo);
       runner.wrapInvocation!(invocationInfo, () => "invocation-result");
       runner.onOperationFirstStart!(operationInfo);
@@ -614,8 +597,6 @@ describe("createPluginRunner", () => {
       const logCtx = runner.enrichLogContext!();
 
       // Verify all hooks called on both plugins
-      expect(plugin1.onExecutionStart).toHaveBeenCalledTimes(1);
-      expect(plugin2.onExecutionStart).toHaveBeenCalledTimes(1);
       expect(plugin1.onInvocationStart).toHaveBeenCalledTimes(1);
       expect(plugin2.onInvocationStart).toHaveBeenCalledTimes(1);
       expect(plugin1.wrapInvocation).toHaveBeenCalledTimes(1);

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -383,6 +383,109 @@ describe("createPluginRunner", () => {
       expect(result).toBe("short-circuited");
       expect(fn).not.toHaveBeenCalled();
     });
+
+    it("re-throws sync error from fn even if a plugin swallows it", () => {
+      const originalError = new Error("customer fn error");
+      const plugin: DurableInstrumentationPlugin = {
+        wrapOperationAttemptFn: (_info, fn) => {
+          try {
+            return fn();
+          } catch {
+            // Plugin swallows the error
+            return "swallowed" as any;
+          }
+        },
+      };
+
+      const runner = createPluginRunner([plugin]);
+
+      expect(() =>
+        runner.wrapOperationAttemptFn!(attemptInfo, () => {
+          throw originalError;
+        }),
+      ).toThrow(originalError);
+    });
+
+    it("re-throws async error from fn even if a plugin swallows it", async () => {
+      const originalError = new Error("async customer fn error");
+      const plugin: DurableInstrumentationPlugin = {
+        wrapOperationAttemptFn: (_info, fn) => {
+          try {
+            const result = fn();
+            if (result && typeof (result as any).catch === "function") {
+              return (result as any).catch(() => "swallowed");
+            }
+            return result;
+          } catch {
+            return "swallowed" as any;
+          }
+        },
+      };
+
+      const runner = createPluginRunner([plugin]);
+
+      await expect(
+        runner.wrapOperationAttemptFn!(attemptInfo, () =>
+          Promise.reject(originalError),
+        ),
+      ).rejects.toThrow(originalError);
+    });
+
+    it("re-throws fn error even when multiple plugins try to swallow it", () => {
+      const originalError = new Error("must not be lost");
+      const swallowingPlugin: DurableInstrumentationPlugin = {
+        wrapInvocation: (_info, fn) => {
+          try {
+            return fn();
+          } catch {
+            return "swallowed" as any;
+          }
+        },
+      };
+
+      const runner = createPluginRunner([swallowingPlugin, swallowingPlugin]);
+
+      expect(() =>
+        runner.wrapInvocation!(invocationInfo, () => {
+          throw originalError;
+        }),
+      ).toThrow(originalError);
+    });
+
+    it("re-throws fn error through wrapChildContextFn when plugin swallows it", () => {
+      const originalError = new Error("child context fn error");
+      const plugin: DurableInstrumentationPlugin = {
+        wrapChildContextFn: (_info, fn) => {
+          try {
+            return fn();
+          } catch {
+            return "swallowed" as any;
+          }
+        },
+      };
+
+      const runner = createPluginRunner([plugin]);
+
+      expect(() =>
+        runner.wrapChildContextFn!(operationInfo, () => {
+          throw originalError;
+        }),
+      ).toThrow(originalError);
+    });
+
+    it("does not interfere when fn succeeds and plugin behaves correctly", () => {
+      const plugin: DurableInstrumentationPlugin = {
+        wrapOperationAttemptFn: (_info, fn) => fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      const result = runner.wrapOperationAttemptFn!(
+        attemptInfo,
+        () => "success",
+      );
+
+      expect(result).toBe("success");
+    });
   });
 
   describe("enrichLogContext", () => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -17,14 +17,26 @@ export function createPluginRunner(
   plugins: DurableInstrumentationPlugin[],
 ): DurableInstrumentationPlugin {
   if (plugins.length === 0) return {};
-  type WrapperHookFn = (info: any, fn: () => any) => any;
-  type SimpleCallback = () => any;
-  type DataCallback = (info: any) => any;
+
+  type CustomerFnResult = any;
+  type CallbackResult = any;
+  type SimpleCallback = () => CustomerFnResult;
+  type WrapperHookFn = (info: PluginInfo, fn: SimpleCallback) => CallbackResult;
+  type PluginInfo =
+    | OperationInfo
+    | InvocationInfo
+    | ExecutionEndInfo
+    | AttemptEndInfo
+    | AttemptInfo
+    | OperationChangeInfo
+    | undefined;
+  type DataCallback = (info: PluginInfo) => CallbackResult;
   type PluginHookFn = SimpleCallback | DataCallback;
+
   const runAsCallback = <K extends keyof DurableInstrumentationPlugin>(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
-    fn: () => any,
+    fn: () => CustomerFnResult,
   ) => {
     let fnError: { error: unknown } | undefined;
 
@@ -60,7 +72,7 @@ export function createPluginRunner(
 
     // If the result is async, ensure fn errors are re-thrown even if swallowed by a plugin
     if (result && typeof result.then === "function") {
-      return result.then((val: any) => {
+      return result.then((val: CustomerFnResult) => {
         if (fnError) throw fnError.error;
         return val;
       });
@@ -77,7 +89,7 @@ export function createPluginRunner(
   ) =>
     plugins.forEach((p) => {
       try {
-        const result = (p[method] as PluginHookFn)?.(info);
+        const result = (p[method] as PluginHookFn)?.(info as PluginInfo);
         // Fire-and-forget — never block the SDK on plugin async work
         if (result && typeof result.catch === "function") {
           result.catch(() => {});

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -23,6 +23,25 @@ export function createPluginRunner(
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
     fn: () => any,
   ) => {
+    let fnError: { error: unknown } | undefined;
+
+    // Wrap the original fn to capture any error it throws
+    const guardedFn = () => {
+      try {
+        const result = fn();
+        if (result && typeof result.then === "function") {
+          return result.catch((err: unknown) => {
+            fnError = { error: err };
+            throw err; // re-throw so plugins still see it
+          });
+        }
+        return result;
+      } catch (err) {
+        fnError = { error: err };
+        throw err; // re-throw so plugins still see it
+      }
+    };
+
     const chain = plugins.reduceRight(
       (next, plugin) => () => {
         const hookFn = plugin[method] as any;
@@ -30,12 +49,23 @@ export function createPluginRunner(
           return hookFn.call(plugin, info, next);
         }
         return next();
-        // we don't catch errors for customer fn execution so that they can propagate to the handler as before
       },
-      fn,
+      guardedFn,
     );
 
-    return chain();
+    const result = chain();
+
+    // If the result is async, ensure fn errors are re-thrown even if swallowed by a plugin
+    if (result && typeof result.then === "function") {
+      return result.then((val: any) => {
+        if (fnError) throw fnError.error;
+        return val;
+      });
+    }
+
+    // Sync path: if fn threw but the chain swallowed it, re-throw
+    if (fnError) throw fnError.error;
+    return result;
   };
 
   const run = <K extends keyof DurableInstrumentationPlugin>(

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -5,6 +5,7 @@ import {
   ExecutionEndInfo,
   InvocationInfo,
   OperationChangeInfo,
+  OperationEndInfo,
   OperationInfo,
 } from "../../types/plugin";
 
@@ -20,8 +21,7 @@ export function createPluginRunner(
 
   type CustomerFnResult = any;
   type CallbackResult = any;
-  type SimpleCallback = () => CallbackResult;
-  type WrapperHookFn = (info: PluginInfo, fn: SimpleCallback) => CallbackResult;
+  type CustomerFn = () => CustomerFnResult;
   type PluginInfo =
     | OperationInfo
     | InvocationInfo
@@ -30,13 +30,16 @@ export function createPluginRunner(
     | AttemptInfo
     | OperationChangeInfo
     | undefined;
-  type DataCallback = (info: PluginInfo) => CallbackResult;
-  type PluginHookFn = SimpleCallback | DataCallback;
+  type PluginWrapperHookFn = (
+    info: PluginInfo,
+    fn: CustomerFnResult,
+  ) => CallbackResult;
+  type PluginHookFn = (info: PluginInfo) => CallbackResult;
 
   const runAsCallback = <K extends keyof DurableInstrumentationPlugin>(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
-    fn: () => CustomerFnResult,
+    fn: CustomerFn,
   ) => {
     let fnError: { error: unknown } | undefined;
 
@@ -59,7 +62,7 @@ export function createPluginRunner(
 
     const chain = plugins.reduceRight(
       (next, plugin) => () => {
-        const hookFn = plugin[method] as WrapperHookFn;
+        const hookFn = plugin[method] as PluginWrapperHookFn;
         if (hookFn) {
           return hookFn.call(plugin, info, next);
         }
@@ -102,20 +105,24 @@ export function createPluginRunner(
   return {
     onExecutionEnd: (info: ExecutionEndInfo) => run("onExecutionEnd", info),
     onInvocationStart: (info: InvocationInfo) => run("onInvocationStart", info),
-    wrapInvocation: <T>(info: InvocationInfo, fn: () => T): T =>
+    wrapInvocation: (info: InvocationInfo, fn: CustomerFn): CustomerFnResult =>
       runAsCallback("wrapInvocation", info, fn),
     onInvocationEnd: (info: InvocationInfo) => run("onInvocationEnd", info),
     onOperationFirstStart: (info: OperationInfo) =>
       run("onOperationFirstStart", info),
     onOperationStart: (info: OperationInfo) => run("onOperationStart", info),
-    wrapChildContextFn: <T>(info: OperationInfo, fn: () => T): T =>
-      runAsCallback("wrapChildContextFn", info, fn),
-    onOperationFirstEnd: (info: OperationInfo & { error?: Error }) =>
+    wrapChildContextFn: (
+      info: OperationInfo,
+      fn: CustomerFn,
+    ): CustomerFnResult => runAsCallback("wrapChildContextFn", info, fn),
+    onOperationFirstEnd: (info: OperationEndInfo) =>
       run("onOperationFirstEnd", info),
     onOperationAttemptStart: (info: AttemptInfo) =>
       run("onOperationAttemptStart", info),
-    wrapOperationAttemptFn: <T>(info: AttemptInfo, fn: () => T): T =>
-      runAsCallback("wrapOperationAttemptFn", info, fn),
+    wrapOperationAttemptFn: (
+      info: AttemptInfo,
+      fn: CustomerFn,
+    ): CustomerFnResult => runAsCallback("wrapOperationAttemptFn", info, fn),
     onOperationAttemptEnd: (info: AttemptEndInfo) =>
       run("onOperationAttemptEnd", info),
     onOperationChange: (info: OperationChangeInfo) =>

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -7,7 +7,26 @@ import {
   OperationChangeInfo,
   OperationEndInfo,
   OperationInfo,
+  CustomerFnResult,
+  CustomerFn,
 } from "../../types/plugin";
+
+type CallbackResult = unknown;
+type CallbackFn = () => CallbackResult;
+type PluginInfo =
+  | OperationInfo
+  | OperationEndInfo
+  | InvocationInfo
+  | ExecutionEndInfo
+  | AttemptEndInfo
+  | AttemptInfo
+  | OperationChangeInfo
+  | undefined;
+type PluginWrapperHookFn = (
+  info: PluginInfo,
+  fn: CustomerFnResult,
+) => CallbackResult;
+type PluginHookFn = (info: PluginInfo) => CallbackResult;
 
 /**
  * Creates a composite plugin runner that dispatches lifecycle events to all registered plugins.
@@ -19,24 +38,6 @@ export function createPluginRunner(
 ): DurableInstrumentationPlugin {
   if (plugins.length === 0) return {};
 
-  type CustomerFnResult = any;
-  type CallbackResult = any;
-  type CustomerFn = () => CustomerFnResult;
-  type PluginInfo =
-    | OperationInfo
-    | OperationEndInfo
-    | InvocationInfo
-    | ExecutionEndInfo
-    | AttemptEndInfo
-    | AttemptInfo
-    | OperationChangeInfo
-    | undefined;
-  type PluginWrapperHookFn = (
-    info: PluginInfo,
-    fn: CustomerFnResult,
-  ) => CallbackResult;
-  type PluginHookFn = (info: PluginInfo) => CallbackResult;
-
   const runAsCallback = <K extends keyof DurableInstrumentationPlugin>(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
@@ -47,9 +48,12 @@ export function createPluginRunner(
     // Wrap the original fn to capture any error it throws
     const guardedFn = () => {
       try {
-        const result = fn();
-        if (result && typeof result.then === "function") {
-          return result.catch((err: unknown) => {
+        const result: CustomerFnResult = fn();
+        if (
+          result != null &&
+          typeof (result as Promise<unknown>).then === "function"
+        ) {
+          return (result as Promise<unknown>).catch((err: unknown) => {
             fnError = { error: err };
             throw err; // re-throw so plugins still see it
           });
@@ -61,7 +65,7 @@ export function createPluginRunner(
       }
     };
 
-    const chain = plugins.reduceRight(
+    const chain: CallbackFn = plugins.reduceRight(
       (next, plugin) => () => {
         const hookFn = plugin[method] as PluginWrapperHookFn;
         if (hookFn) {
@@ -72,11 +76,14 @@ export function createPluginRunner(
       guardedFn,
     );
 
-    const result = chain();
+    const result: CallbackResult = chain();
 
     // If the result is async, ensure fn errors are re-thrown even if swallowed by a plugin
-    if (result && typeof result.then === "function") {
-      return result.then((val: CustomerFnResult) => {
+    if (
+      result != null &&
+      typeof (result as PromiseLike<unknown>).then === "function"
+    ) {
+      return (result as PromiseLike<unknown>).then((val: CustomerFnResult) => {
         if (fnError) throw fnError.error;
         return val;
       });
@@ -95,8 +102,11 @@ export function createPluginRunner(
       try {
         const result = (p[method] as PluginHookFn)?.(info as PluginInfo);
         // Fire-and-forget — never block the SDK on plugin async work
-        if (result && typeof result.catch === "function") {
-          result.catch(() => {});
+        if (
+          result != null &&
+          typeof (result as Promise<unknown>).then === "function"
+        ) {
+          (result as Promise<unknown>).catch(() => {});
         }
       } catch {
         // Sync errors also swallowed

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -1,0 +1,101 @@
+import {
+  DurableInstrumentationPlugin,
+  AttemptEndInfo,
+  AttemptInfo,
+  ExecutionEndInfo,
+  InvocationInfo,
+  OperationChangeInfo,
+  OperationInfo,
+} from "../../types/plugin";
+
+export function createPluginRunner(
+  plugins: DurableInstrumentationPlugin[],
+): DurableInstrumentationPlugin {
+  if (plugins.length === 0) return {};
+
+  const runAsCallback = <K extends keyof DurableInstrumentationPlugin>(
+    method: K,
+    info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
+    fn: () => any,
+  ) => {
+    const chain = plugins.reduceRight(
+      (next, plugin) => () => {
+        const hookFn = plugin[method] as any;
+        if (hookFn) {
+          return hookFn.call(plugin, info, next);
+        }
+        return next();
+        // we don't catch errors for customer fn execution so that they can propagate to the handler as before
+      },
+      fn,
+    );
+
+    return chain();
+  };
+
+  const run = <K extends keyof DurableInstrumentationPlugin>(
+    method: K,
+    info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
+  ) =>
+    plugins.forEach((p) => {
+      try {
+        const result = (p[method] as any)?.(info);
+        // Fire-and-forget — never block the SDK on plugin async work
+        if (result && typeof result.catch === "function") {
+          result.catch(() => {});
+        }
+      } catch {
+        // Sync errors also swallowed
+      }
+    });
+
+  const runAwait = async <K extends keyof DurableInstrumentationPlugin>(
+    method: K,
+    info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
+  ) => {
+    for (const p of plugins) {
+      try {
+        await (p[method] as any)?.(info);
+      } catch {
+        // Plugin errors must never affect SDK execution
+      }
+    }
+  };
+
+  return {
+    onExecutionStart: (info: InvocationInfo) => run("onExecutionStart", info),
+    onExecutionEnd: async (info: ExecutionEndInfo) =>
+      runAwait("onExecutionEnd", info),
+    onInvocationStart: (info: InvocationInfo) => run("onInvocationStart", info),
+    wrapInvocation: <T>(info: InvocationInfo, fn: () => T): T =>
+      runAsCallback("wrapInvocation", info, fn),
+    onInvocationEnd: async (info: InvocationInfo) =>
+      runAwait("onInvocationEnd", info),
+    onOperationFirstStart: (info: OperationInfo) =>
+      run("onOperationFirstStart", info),
+    onOperationStart: (info: OperationInfo) => run("onOperationStart", info),
+    wrapChildContextFn: <T>(info: OperationInfo, fn: () => T): T =>
+      runAsCallback("wrapChildContextFn", info, fn),
+    onOperationFirstEnd: (info: OperationInfo & { error?: Error }) =>
+      run("onOperationFirstEnd", info),
+    onOperationAttemptStart: (info: AttemptInfo) =>
+      run("onOperationAttemptStart", info),
+    wrapOperationAttemptFn: <T>(info: AttemptInfo, fn: () => T): T =>
+      runAsCallback("wrapOperationAttemptFn", info, fn),
+    onOperationAttemptEnd: (info: AttemptEndInfo) =>
+      run("onOperationAttemptEnd", info),
+    onOperationChange: (info: OperationChangeInfo) =>
+      run("onOperationChange", info),
+    enrichLogContext: () =>
+      plugins.reduce(
+        (acc, p) => {
+          try {
+            return { ...acc, ...p.enrichLogContext?.() };
+          } catch {
+            return acc;
+          }
+        },
+        {} as Record<string, string | number | boolean>,
+      ),
+  };
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -42,11 +42,11 @@ export function createPluginRunner(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
     fn: CustomerFn,
-  ) => {
+  ): CustomerFnResult => {
     let fnError: { error: unknown } | undefined;
 
     // Wrap the original fn to capture any error it throws
-    const guardedFn = () => {
+    const guardedFn: CallbackResult | CustomerFnResult = () => {
       try {
         const result: CustomerFnResult = fn();
         if (
@@ -65,7 +65,7 @@ export function createPluginRunner(
       }
     };
 
-    const chain: CallbackFn = plugins.reduceRight(
+    const chain: CallbackFn = plugins.reduceRight<CallbackFn>(
       (next, plugin) => () => {
         const hookFn = plugin[method] as PluginWrapperHookFn;
         if (hookFn) {
@@ -73,7 +73,7 @@ export function createPluginRunner(
         }
         return next();
       },
-      guardedFn,
+      guardedFn as CallbackFn,
     );
 
     const result: CallbackResult = chain();
@@ -97,7 +97,7 @@ export function createPluginRunner(
   const run = <K extends keyof DurableInstrumentationPlugin>(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
-  ) =>
+  ): void =>
     plugins.forEach((p) => {
       try {
         const result = (p[method] as PluginHookFn)?.(info as PluginInfo);

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -17,7 +17,10 @@ export function createPluginRunner(
   plugins: DurableInstrumentationPlugin[],
 ): DurableInstrumentationPlugin {
   if (plugins.length === 0) return {};
-
+  type WrapperHookFn = (info: any, fn: () => any) => any;
+  type SimpleCallback = () => any;
+  type DataCallback = (info: any) => any;
+  type PluginHookFn = SimpleCallback | DataCallback;
   const runAsCallback = <K extends keyof DurableInstrumentationPlugin>(
     method: K,
     info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
@@ -44,7 +47,7 @@ export function createPluginRunner(
 
     const chain = plugins.reduceRight(
       (next, plugin) => () => {
-        const hookFn = plugin[method] as any;
+        const hookFn = plugin[method] as WrapperHookFn;
         if (hookFn) {
           return hookFn.call(plugin, info, next);
         }
@@ -74,7 +77,7 @@ export function createPluginRunner(
   ) =>
     plugins.forEach((p) => {
       try {
-        const result = (p[method] as any)?.(info);
+        const result = (p[method] as PluginHookFn)?.(info);
         // Fire-and-forget — never block the SDK on plugin async work
         if (result && typeof result.catch === "function") {
           result.catch(() => {});
@@ -85,7 +88,6 @@ export function createPluginRunner(
     });
 
   return {
-    onExecutionStart: (info: InvocationInfo) => run("onExecutionStart", info),
     onExecutionEnd: (info: ExecutionEndInfo) => run("onExecutionEnd", info),
     onInvocationStart: (info: InvocationInfo) => run("onInvocationStart", info),
     wrapInvocation: <T>(info: InvocationInfo, fn: () => T): T =>

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -24,6 +24,7 @@ export function createPluginRunner(
   type CustomerFn = () => CustomerFnResult;
   type PluginInfo =
     | OperationInfo
+    | OperationEndInfo
     | InvocationInfo
     | ExecutionEndInfo
     | AttemptEndInfo

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -49,28 +49,13 @@ export function createPluginRunner(
       }
     });
 
-  const runAwait = async <K extends keyof DurableInstrumentationPlugin>(
-    method: K,
-    info: Parameters<NonNullable<DurableInstrumentationPlugin[K]>>[0],
-  ) => {
-    for (const p of plugins) {
-      try {
-        await (p[method] as any)?.(info);
-      } catch {
-        // Plugin errors must never affect SDK execution
-      }
-    }
-  };
-
   return {
     onExecutionStart: (info: InvocationInfo) => run("onExecutionStart", info),
-    onExecutionEnd: async (info: ExecutionEndInfo) =>
-      runAwait("onExecutionEnd", info),
+    onExecutionEnd: (info: ExecutionEndInfo) => run("onExecutionEnd", info),
     onInvocationStart: (info: InvocationInfo) => run("onInvocationStart", info),
     wrapInvocation: <T>(info: InvocationInfo, fn: () => T): T =>
       runAsCallback("wrapInvocation", info, fn),
-    onInvocationEnd: async (info: InvocationInfo) =>
-      runAwait("onInvocationEnd", info),
+    onInvocationEnd: (info: InvocationInfo) => run("onInvocationEnd", info),
     onOperationFirstStart: (info: OperationInfo) =>
       run("onOperationFirstStart", info),
     onOperationStart: (info: OperationInfo) => run("onOperationStart", info),

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -8,6 +8,11 @@ import {
   OperationInfo,
 } from "../../types/plugin";
 
+/**
+ * Creates a composite plugin runner that dispatches lifecycle events to all registered plugins.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
 export function createPluginRunner(
   plugins: DurableInstrumentationPlugin[],
 ): DurableInstrumentationPlugin {

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -20,7 +20,7 @@ export function createPluginRunner(
 
   type CustomerFnResult = any;
   type CallbackResult = any;
-  type SimpleCallback = () => CustomerFnResult;
+  type SimpleCallback = () => CallbackResult;
   type WrapperHookFn = (info: PluginInfo, fn: SimpleCallback) => CallbackResult;
   type PluginInfo =
     | OperationInfo


### PR DESCRIPTION
*Issue #, if available:* #545

*Description of changes:* 

Introduce the plugin system foundation for the durable execution SDK:

- DurableInstrumentationPlugin interface with lifecycle hooks for
  execution, invocation, operation, and attempt-level events
- Plugin runner that composes multiple plugins with fire-and-forget and callback-wrapping execution semantics
- Operation utility helpers (toOperationInfo, toAttemptInfo, etc.)
- Export plugin types from the public API
- Add plugins config field to DurableExecutionConfig

This is a pure additive change with no wiring into the SDK handlers.
Subsequent PRs will wire the hooks into the execution lifecycle and
individual operation handlers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
