### PR TITLE
fix(sdk): resolve CJS bundling regression with Lambda runtime detection

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -7,16 +7,64 @@
  *
  * SDK_NAME is a fixed string matching the cross-SDK convention:
  * aws-durable-execution-sdk-\{language\}
- * Alternate version if SDK path is within the Lambda bundled runtime.
+ * Alternate version if SDK is bundled into the Lambda runtime.
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
+
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
 const runtimeDir = process.env.LAMBDA_RUNTIME_DIR || "/var/runtime";
-const isRuntimeBundled =
-  typeof __dirname !== "undefined" && __dirname.startsWith(runtimeDir);
+
+// Check if this code is running from a bundle in Lambda runtime
+// Use file path detection to determine if running in Lambda runtime directory
+function isInLambdaRuntime(): boolean {
+  try {
+    // Check if we're in a Jest test environment first
+    if (
+      typeof process !== "undefined" &&
+      process.env &&
+      process.env.NODE_ENV === "test"
+    ) {
+      return false;
+    }
+
+    // File path detection for reliable detection
+    let currentFilePath: string | undefined;
+
+    // CJS: use __filename if available
+    if (typeof __filename !== "undefined") {
+      currentFilePath = __filename;
+    } else {
+      // ESM: use import.meta.url
+      try {
+        // Use Function constructor to avoid TypeScript compilation errors in Jest
+        const getImportMeta = new Function("return import.meta");
+        const importMeta = getImportMeta();
+        if (importMeta && importMeta.url) {
+          currentFilePath = fileURLToPath(importMeta.url);
+        }
+      } catch {
+        // Fallback if import.meta is not available
+      }
+    }
+
+    if (currentFilePath) {
+      const libraryDirectory = dirname(currentFilePath);
+      return libraryDirectory.startsWith(runtimeDir);
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+const isRuntimeBundled = isInLambdaRuntime();
 
 export const SDK_NAME = "aws-durable-execution-sdk-js";
 const baseVersion = process.env.NPM_PACKAGE_VERSION || "0.0.0";


### PR DESCRIPTION
- Replace direct import.meta access with Function constructor approach
- Add robust file path detection for Lambda runtime environment
- Maintain Jest compatibility with early test environment return
- Fix TypeError when bundled to CJS format using esbuild