### PR TITLE
ci: Opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: ["main", "v1.x"]

--- a/.github/workflows/capacity-provider-tests.yml
+++ b/.github/workflows/capacity-provider-tests.yml
@@ -1,5 +1,8 @@
 name: Capacity Provider Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cleanup-integration-tests.yml
+++ b/.github/workflows/cleanup-integration-tests.yml
@@ -1,5 +1,8 @@
 name: Cleanup Integration Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,8 @@
 name: Integration Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,10 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: npm publish
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,6 +3,10 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -10,9 +14,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '40 10 * * 4'
+    - cron: "40 10 * * 4"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/sync-package.yml
+++ b/.github/workflows/sync-package.yml
@@ -2,6 +2,7 @@ name: Sync package
 
 env:
   AWS_REGION: "us-west-2"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # permission can be added at job level or workflow level
 permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable to all workflows that use `actions/checkout@v4` and `actions/setup-node@v4`.

GitHub is deprecating Node.js 20 for Actions runners. Node.js 24 will become the default on June 2nd, 2026, and Node.js 20 will be removed entirely on September 16th, 2026. This change opts in early to avoid disruption.

## Changes

Added the env variable to:
- build.yml
- capacity-provider-tests.yml
- cleanup-integration-tests.yml
- integration-tests.yml
- npm-publish.yml
- scorecard.yml
- sync-package.yml
- unit-tests.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
