### PR TITLE
test: add CJS integration test package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6029,6 +6029,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-integration-test": {
+      "resolved": "packages/cjs-integration-test",
+      "link": true
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -15441,6 +15445,12 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "packages/cjs-integration-test": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test",
     "test:integration": "node .github/workflows/scripts/integration-test/integration-test.js",
     "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin",
     "postpublish": "git restore .",

--- a/packages/cjs-integration-test/README.md
+++ b/packages/cjs-integration-test/README.md
@@ -1,0 +1,17 @@
+# CJS Integration Test
+
+This package tests that the AWS Durable Execution SDK can be consumed by external CommonJS projects without errors.
+
+## Purpose
+
+- Catches CJS compatibility issues like the `fileURLToPath` error we fixed
+- Simulates real-world usage by external projects
+- Runs as a separate package to ensure proper module resolution
+
+## Usage
+
+```bash
+npm run test
+```
+
+This test will fail if there are any CJS import or initialization errors.

--- a/packages/cjs-integration-test/package.json
+++ b/packages/cjs-integration-test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cjs-integration-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "CJS integration test for AWS Durable Execution SDK",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "@aws/durable-execution-sdk-js": "*"
+  }
+}

--- a/packages/cjs-integration-test/test.js
+++ b/packages/cjs-integration-test/test.js
@@ -1,0 +1,28 @@
+/**
+ * CJS Integration Test
+ *
+ * This test verifies the SDK can be consumed by external CJS projects
+ * without errors like the fileURLToPath issue we fixed.
+ */
+
+console.log("Testing CJS import of AWS Durable Execution SDK...");
+
+try {
+  // This import will trigger version detection and any CJS compatibility issues
+  const { withDurableExecution } = require("@aws/durable-execution-sdk-js");
+
+  console.log("✓ SDK imported successfully");
+
+  // Test creating a durable function
+  const handler = withDurableExecution(async (event, context) => {
+    return { message: "Hello from CJS consumer" };
+  });
+
+  console.log("✓ Durable function created successfully");
+  console.log("✓ All CJS integration tests passed");
+} catch (error) {
+  console.error("✗ CJS integration test failed:");
+  console.error(error.message);
+  console.error(error.stack);
+  process.exit(1);
+}


### PR DESCRIPTION
- Add separate test package to verify CJS compatibility
- Ensures external projects can consume SDK without errors
- Catches issues like fileURLToPath bug in CI
- Integrated into root test suite and GitHub Actions