### PR TITLE
fix(ci): Update npm publish workflow permissions and env

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@
 
 name: npm publish
 permissions:
-  id-token: write  # Required for OIDC
+  id-token: write # Required for OIDC
   contents: read
 on:
   release:
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,7 @@
 
 name: npm publish
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 on:
   release:
@@ -26,8 +27,6 @@ jobs:
       - name: iterate and publish
         run: ./.github/workflows/iterate-publish-npm.sh ${{ github.event.release.prerelease && 'true' || 'false' }}
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   notify-release:
     needs: [npm-publish]


### PR DESCRIPTION
Add id-token permission for OIDC and remove NODE_AUTH_TOKEN from env.

*Issue #, if available:*

*Description of changes:* Removing the usage of NODE_AUTH_TOKEN from env and use OIDC token isntead of NPM Access token. Access Tokens from can be revoked and are unsafe compared to OIDC: https://github.com/orgs/community/discussions/196340. They also need to be renewed every 90 days which can be confusing to operators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
