### PR TITLE
test: add CJS integration test package for v1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -654,7 +654,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.943.0.tgz",
       "integrity": "sha512-1VvbsDSBrrvQ2UwdDab+YNpygyoDRSlOQ452KlEPh3jo155bMkiiY1siXaaXj0EMVwhPsLyKvbM4eBSl0Bi0yA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1332,7 +1331,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3972,7 +3970,6 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -5030,7 +5027,6 @@
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -5747,7 +5743,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6101,7 +6096,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -6252,6 +6246,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-integration-test": {
+      "resolved": "packages/cjs-integration-test",
+      "link": true
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.1.0",
@@ -7700,7 +7698,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8859,7 +8856,6 @@
       "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
@@ -10744,7 +10740,6 @@
       "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11483,7 +11478,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11534,7 +11528,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -11764,7 +11757,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -12121,7 +12113,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12238,7 +12229,7 @@
     },
     "packages/aws-durable-execution-sdk-js": {
       "name": "@aws/durable-execution-sdk-js",
-      "version": "1.0.2",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.943.0"
@@ -13639,7 +13630,7 @@
     },
     "packages/aws-durable-execution-sdk-js-examples": {
       "name": "@aws/durable-execution-sdk-js-examples",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.29.0",
@@ -18356,6 +18347,12 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "packages/cjs-integration-test": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*"
       }
     },
     "packages/eslint-plugin-durable-functions": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test",
     "test:integration": "act -W .github/workflows/integration-tests.yml --secret-file .secrets --artifact-server-path /tmp/artifacts --container-architecture linux/amd64",
     "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin",
     "postpublish": "git restore .",

--- a/packages/cjs-integration-test/README.md
+++ b/packages/cjs-integration-test/README.md
@@ -1,0 +1,21 @@
+# CJS Integration Test
+
+This package tests CommonJS (CJS) compatibility of the AWS Durable Execution SDK.
+
+## Purpose
+
+- Verifies that external CommonJS projects can successfully import and use the SDK
+- Catches CJS bundling regressions during development
+- Runs as part of the main test suite to ensure compatibility
+
+## Usage
+
+```bash
+npm run test -w packages/cjs-integration-test
+```
+
+## What it tests
+
+- Basic CJS `require()` import of the SDK
+- Availability of core exports like `withDurableExecution`
+- No runtime errors during import in CJS environments

--- a/packages/cjs-integration-test/package.json
+++ b/packages/cjs-integration-test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cjs-integration-test",
+  "version": "1.0.0",
+  "description": "CJS integration test to verify external CommonJS compatibility",
+  "type": "commonjs",
+  "main": "test.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "@aws/durable-execution-sdk-js": "workspace:*"
+  }
+}

--- a/packages/cjs-integration-test/package.json
+++ b/packages/cjs-integration-test/package.json
@@ -8,6 +8,6 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "@aws/durable-execution-sdk-js": "workspace:*"
+    "@aws/durable-execution-sdk-js": "file:../aws-durable-execution-sdk-js"
   }
 }

--- a/packages/cjs-integration-test/package.json
+++ b/packages/cjs-integration-test/package.json
@@ -8,6 +8,6 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "@aws/durable-execution-sdk-js": "file:../aws-durable-execution-sdk-js"
+    "@aws/durable-execution-sdk-js": "*"
   }
 }

--- a/packages/cjs-integration-test/test.js
+++ b/packages/cjs-integration-test/test.js
@@ -1,0 +1,18 @@
+console.log("Testing CJS integration...");
+
+try {
+  const sdk = require("@aws/durable-execution-sdk-js");
+  console.log("✓ SDK imported successfully");
+
+  // Test basic exports
+  const { withDurableExecution } = sdk;
+  if (typeof withDurableExecution !== "function") {
+    throw new Error("withDurableExecution is not a function");
+  }
+
+  console.log("✓ withDurableExecution export verified");
+  console.log("✓ CJS integration test passed");
+} catch (error) {
+  console.error("✗ CJS integration test failed:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
- Add separate test package to verify CJS compatibility in v1.x branch
- Ensures external projects can consume SDK via CommonJS require()
- Integrated into root test suite to catch future regressions
- Validates basic imports and core exports work in CJS environments