### PR TITLE
feat(sdk): add in safe DurableContext detection

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -69,9 +69,15 @@ export interface DurableExecution {
   setTerminating(): void;
 }
 
+export const DURABLE_CONTEXT_BRAND = Symbol.for(
+  "@aws/durable-execution-sdk-js/durable-context",
+);
+
 export class DurableContextImpl<
   Logger extends DurableLogger,
 > implements DurableContext<Logger> {
+  readonly [DURABLE_CONTEXT_BRAND] = true;
+
   private _stepPrefix?: string;
   private _stepCounter: number = 0;
   private durableLogger: Logger;
@@ -92,6 +98,10 @@ export class DurableContextImpl<
   public readonly executionContext: {
     readonly durableExecutionArn: string;
   };
+
+  get [Symbol.toStringTag](): string {
+    return "DurableContext";
+  }
 
   constructor(
     private _executionContext: ExecutionContext,

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -143,6 +143,38 @@ describe("DurableContext", () => {
 
       expect(context.lambdaContext).toBe(mockContext);
     });
+
+    it("should expose Symbol.toStringTag for nominal type detection", () => {
+      const executionContext = createMockExecutionContext();
+      const context = createDurableContext(
+        executionContext,
+        mockContext,
+        DurableExecutionMode.ExecutionMode,
+        mockLogger,
+        undefined,
+        mockDurableExecution,
+      );
+
+      expect((context as any)[Symbol.toStringTag]).toBe("DurableContext");
+      expect(Object.prototype.toString.call(context)).toBe(
+        "[object DurableContext]",
+      );
+    });
+
+    it("should expose a Symbol.for() brand for cross-library identity", () => {
+      const executionContext = createMockExecutionContext();
+      const context = createDurableContext(
+        executionContext,
+        mockContext,
+        DurableExecutionMode.ExecutionMode,
+        mockLogger,
+        undefined,
+        mockDurableExecution,
+      );
+
+      const brand = Symbol.for("@aws/durable-execution-sdk-js/durable-context");
+      expect((context as any)[brand]).toBe(true);
+    });
   });
 
   describe("withModeManagement", () => {


### PR DESCRIPTION
## Summary

Adds two class-side markers on `DurableContextImpl` so external libraries can detect a durable context without importing the SDK or relying on brittle name checks.

- **`Symbol.for("@aws/durable-execution-sdk-js/durable-context")` brand:** primary identity marker. Package-namespaced global registry key so callers can write `ctx?.[Symbol.for("@aws/durable-execution-sdk-js/durable-context")] === true` with no SDK dependency. Follows the React `$$typeof` / Vue / Apollo / Zod convention for cross-library nominal identity.
- **`Symbol.toStringTag` getter returning `"DurableContext"`:** debug/display ergonomics. `Object.prototype.toString.call(ctx)` now returns `"[object DurableContext]"`. Matches the existing pattern on `DurablePromise` and `DurableExecutionInvocationInput`.

### Motivation

Lambda middleware libraries (Powertools, Middy, etc.) need to branch behaviour on durable-vs-regular contexts. Today the options are:

  | Approach | Issue |
  |---|---|
  | `ctx.constructor.name === "DurableContextImpl"` | Mangled to `"n"` by default esbuild `--minify` |
  | `ctx instanceof DurableContextImpl` | Requires importing the SDK as a hard dep; breaks across realms or duplicate copies |
  | Duck-type `typeof ctx.step === "function"` of `'step' in ctx` | Works (what Middy / Powertools does today), but coupled to public method names |

A `Symbol.for()` brand sidesteps all three: minification-proof (string literals are not mangled), no SDK import needed, cross-realm safe via the global symbol registry, and purpose-built for nominal identity rather than display or shape.

cc @dreamorosi

ref:
- https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/packages/idempotency/src/makeIdempotent.ts#L25

AI disclosure; used Claude Opus 4.7 to make PR. Edited and reviewed by human.