### PR TITLE
fix(sdk): swap exports order to fix esbuild CJS bundling

### DIFF
--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -18,8 +18,8 @@
   "exports": {
     ".": {
       "types": "./dist-types/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist-cjs/index.js"
+      "require": "./dist-cjs/index.js",
+      "import": "./dist/index.mjs"
     }
   },
   "files": [


### PR DESCRIPTION
esbuild prioritizes import condition over require when bundling for CJS, causing fileURLToPath errors. Swapping the order ensures esbuild uses the correct CJS bundle for CommonJS builds.

*Issue #, if available:*
#553

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
