### PR TITLE
fix(examples): Make CLI error test resilient to npm warnings

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/__tests__/__snapshots__/run-durable.integration.test.ts.snap
+++ b/packages/aws-durable-execution-sdk-js-examples/src/__tests__/__snapshots__/run-durable.integration.test.ts.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`run-durable CLI Integration Tests with format=cjs Core Error Cases should error when file does not exist 1`] = `
-"Error: File not found: nonexistent-file.js
-"
-`;
-
 exports[`run-durable CLI Integration Tests with format=cjs End-to-End Execution should successfully execute test handler end-to-end 1`] = `
 [
   "Skip time: false, Verbose: false, Show history: false",
@@ -31,11 +26,6 @@ exports[`run-durable CLI Integration Tests with format=cjs End-to-End Execution 
   ""Custom Handler Success!"",
   "",
 ]
-`;
-
-exports[`run-durable CLI Integration Tests with format=mjs Core Error Cases should error when file does not exist 1`] = `
-"Error: File not found: nonexistent-file.js
-"
 `;
 
 exports[`run-durable CLI Integration Tests with format=mjs End-to-End Execution should successfully execute test handler end-to-end 1`] = `

--- a/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
@@ -67,7 +67,7 @@ describe.each(["cjs", "mjs"])(
 
         expect(exitCode).toBe(1);
         expect(stdout).toBe("");
-        expect(stderr).toMatchSnapshot();
+        expect(stderr).toContain("Error: File not found: nonexistent-file.js");
       });
 
       it("should error when handler export not found", () => {


### PR DESCRIPTION
*Issue #, if available:* N/A

To fix https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/26315494254

*Description of changes:*
Replace toMatchSnapshot() with toContain() for stderr assertions in run-durable CLI integration tests. The snapshot was brittle because npx writes environment-specific warnings (e.g., deprecated "always-auth" config) to stderr, causing failures in CI.

Root cause: actions/setup-node@v4 adds always-auth=true to ~/.npmrc (actions/setup-node#1305). npm 11 (Node 24.x) emits a deprecation warning to stderr for this, breaking snapshot equality.

Testing: Reproduced locally with Node 24 (npm 11.11.0) + always-auth=true in ~/.npmrc. Confirmed the old snapshot assertion fails and the new toContain() assertion passes across both Node 22.x and 24.x.

Alternatives considered:

- Filtering npm warnings from stderr before snapshot comparison - adds maintenance burden as new warning prefixes appear
- Removing "always-auth" from CI runner's .npmrc - fragile since runner images change and other warnings could appear
- Suppressing npm warnings via --loglevel=error on npx - could hide legitimate errors during debugging
- Updating snapshots to include the warning - would fail on any machine without that specific npm config


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
