### PR TITLE
fix: preserve BatchResult errors after replay

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/tolerated-failure-count/parallel-tolerated-failure-count.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/tolerated-failure-count/parallel-tolerated-failure-count.test.ts
@@ -15,6 +15,7 @@ createTests({
       expect(result.completionReason).toBe("ALL_COMPLETED");
       expect(result.hasFailure).toBe(true);
       expect(result.totalCount).toBe(5);
+      expect(result.errors).toEqual(["Branch 2 failed", "Branch 4 failed"]);
 
       // Verify individual branch statuses
       [

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/tolerated-failure-count/parallel-tolerated-failure-count.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/tolerated-failure-count/parallel-tolerated-failure-count.ts
@@ -71,6 +71,7 @@ export const handler = withDurableExecution(
       totalCount: results.totalCount,
       completionReason: results.completionReason,
       hasFailure: results.hasFailure,
+      errors: results.getErrors().map((error) => error.message),
     };
   },
 );

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -116,7 +116,10 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         "test-name",
         expect.any(Function),
-        { subType: undefined, serdes: expect.any(Object) },
+        expect.objectContaining({
+          serdes: expect.any(Object),
+          subType: undefined,
+        }),
       );
     });
 
@@ -135,7 +138,10 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: undefined, serdes: expect.any(Object) },
+        expect.objectContaining({
+          serdes: expect.any(Object),
+          subType: undefined,
+        }),
       );
     });
 
@@ -158,7 +164,10 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: "TOP_TYPE", serdes: expect.any(Object) },
+        expect.objectContaining({
+          serdes: expect.any(Object),
+          subType: "TOP_TYPE",
+        }),
       );
     });
   });
@@ -227,7 +236,10 @@ describe("Concurrent Execution Handler", () => {
         expect(mockRunInChildContext).toHaveBeenCalledWith(
           nameParam,
           expect.any(Function),
-          { subType: expectedSubType, serdes: expect.any(Object) },
+          expect.objectContaining({
+            serdes: expect.any(Object),
+            subType: expectedSubType,
+          }),
         );
       },
     );
@@ -361,7 +373,10 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: undefined, serdes: expect.any(Object) },
+        expect.objectContaining({
+          serdes: expect.any(Object),
+          subType: undefined,
+        }),
       );
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -16,8 +16,8 @@ import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
 import {
   BatchResultImpl,
-  restoreBatchResult,
   createBatchResultSerdes,
+  restoreBatchResult,
 } from "./batch-result";
 import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
@@ -599,8 +599,7 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
       const result = await runInChildContext(name, executeOperation, {
         subType: config?.topLevelSubType,
         summaryGenerator: config?.summaryGenerator,
-        // Use BatchResult serdes to preserve Error types through serialization.
-        serdes: config?.serdes || createBatchResultSerdes(),
+        serdes: config?.serdes ?? createBatchResultSerdes<TResult>(),
       });
 
       // Restore BatchResult methods if the result came from deserialized data


### PR DESCRIPTION
Closes #554.

## Summary
- use the existing `BatchResult` serdes as the default for concurrent batch results, so map/parallel failures keep their serialized error objects across replay
- add a tolerated-failure parallel regression that asserts `getErrors()` returns the original branch messages instead of `Unknown error`

## Verification
- `npm test --workspace packages/aws-durable-execution-sdk-js -- --runInBand packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.test.ts packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts`
- `npx jest --runInBand src/examples/parallel/tolerated-failure-count/parallel-tolerated-failure-count.test.ts --config jest.config.js`