### PR TITLE
docs(sdk): remove self-referential comment from createClassSerdesWithDates

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts
@@ -219,8 +219,6 @@ export function createClassSerdes<T extends object>(
  * - Getters/setters are not preserved
  * - Nested class instances lose their prototype
  *
- * For classes with Date properties, use createClassSerdesWithDates instead.
- *
  * @beta
  */
 export function createClassSerdesWithDates<T extends object>(


### PR DESCRIPTION
"For classes with Date properties, use createClassSerdesWithDates instead" is not required in the JSdoc of createClassSerdesWithDates.

*Description of changes:*
Removed line "For classes with Date properties, use createClassSerdesWithDates instead"

