### PR TITLE
fix(sdk): fix AtMostOncePerRetry shouldRetry:false crashing with missing metadata and throwing wrong error type

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -177,10 +177,17 @@ export const createStepHandler = <Logger extends DurableLogger>(
           checkpoint.markOperationState(
             stepId,
             OperationLifecycleState.COMPLETED,
+            {
+              metadata: {
+                stepId,
+                name,
+                type: OperationType.STEP,
+                subType: OperationSubType.STEP,
+                parentId,
+              },
+            },
           );
-          throw DurableOperationError.fromErrorObject(
-            createErrorObjectFromError(error),
-          );
+          throw error;
         }
 
         await checkpoint.checkpoint(stepId, {


### PR DESCRIPTION

Solves https://github.com/aws/aws-durable-execution-sdk-js/issues/529
Also aligns with the behaviour according to the documentation: https://docs.aws.amazon.com/durable-execution/sdk-reference/error-handling/errors/#step-interrupted

# Issue
When a step configured with `AtMostOncePerRetry` semantics is interrupted (e.g. Lambda timeout) and the retry strategy returns `shouldRetry: false`, two bugs occur on the next replay:

**Bug 1: crash before throw (metadata missing)**
`markOperationState` is called without `metadata` on the `shouldRetry: false` path. On replay, the checkpoint manager's `operations` map is empty (fresh Lambda instance), so the first call for that stepId has no metadata → throws: `"metadata required on first call for <stepId>"`

The `shouldRetry: true` path correctly passes metadata. There things work properly.

**Bug 2: wrong error type thrown to handler**
After fixing Bug 1, the handler receives `StepError` instead of `StepInterruptedError` because the throw goes through `DurableOperationError.fromErrorObject()` which has no case for `"StepInterruptedError"` in its switch statement → falls to default → `StepError`.

The docs state `StepInterruptedError` is thrown: https://github.com/aws/aws-durable-execution-docs/blob/90cc9acb004c75085346722c36f2528fe1d3b11c/examples/typescript/sdk-reference/error-handling/step-interrupted.ts#L7

# Description of changes:

- `step-handler.ts`: add missing `metadata` to `markOperationState` call on `shouldRetry: false` path (matching the `shouldRetry: true` path at line 201)
- `step-handler.ts`: replace `throw DurableOperationError.fromErrorObject(...)` with `throw error` to surface `StepInterruptedError` directly to the handler

Before fix:-
<img width="1398" height="533" alt="image" src="https://github.com/user-attachments/assets/341ac192-dbed-4ae4-95d8-66f1d952d08a" />

After fix:-
<img width="2044" height="538" alt="image" src="https://github.com/user-attachments/assets/aca8d594-38cd-4d18-89d9-a57459518347" />

Code:-
```import { withDurableExecution, StepSemantics } from '@aws/durable-execution-sdk-js';

export const handler = withDurableExecution(async (event, context) => {

    const message = await context.step('Step1', async () => {
    await new Promise(resolve => setTimeout(resolve, 10000)); // 10 seconds
    return 'Hello from Durable Lambda!';
  }, {
    semantics: StepSemantics.AtMostOncePerRetry,
    retryStrategy: () => ({ shouldRetry: false })
  });

  const response = {
    statusCode: 200,
    body: JSON.stringify(message),
  };
  return response;
});
```