### PR TITLE
ci: enable merging external PRs with label-based approval

### DIFF
--- a/.github/EXTERNAL_PR_POLICY.md
+++ b/.github/EXTERNAL_PR_POLICY.md
@@ -1,0 +1,20 @@
+# External PR Policy
+
+## For Maintainers
+
+External PRs skip integration tests for security. To merge:
+
+1. **Review code carefully**
+2. **Add `safe-to-merge` label** for safe changes (docs, small fixes)
+3. **Use "Squash and merge"**
+
+## Safe Changes
+
+- Documentation updates
+- Comment/JSDoc fixes
+- Small typo corrections
+- Non-functional changes
+
+## Changes Needing Full Tests
+
+Create internal branch and recreate the PR for full integration testing.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,3 +92,26 @@ jobs:
     with:
       node-version: "24.x"
     secrets: inherit
+
+  # Always succeed for external PRs to allow merging
+  external-pr-status:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: External PR Status
+        run: |
+          echo "✅ External PR - Integration tests skipped for security"
+          echo "Maintainer: Add 'safe-to-merge' label and use squash & merge"
+      - name: Check for bypass label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const hasBypassLabel = labels.includes('safe-to-merge');
+
+            if (hasBypassLabel) {
+              console.log('✅ Maintainer approved bypass with safe-to-merge label');
+            } else {
+              console.log('⚠️  No bypass label - PR cannot be merged until maintainer adds safe-to-merge label');
+              core.setFailed('External PR requires maintainer approval via safe-to-merge label');
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: ["main", "v1.x"]
   pull_request:
     branches: ["main", "v1.x"]
+  pull_request_target:
+    types: [labeled, unlabeled]
+    branches: ["main", "v1.x"]
 
 permissions:
   contents: read # This is required for actions/checkout
@@ -95,7 +98,7 @@ jobs:
 
   # Always succeed for external PRs to allow merging
   external-pr-status:
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.head.repo.full_name != github.repository && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     runs-on: ubuntu-latest
     steps:
       - name: External PR Status


### PR DESCRIPTION
- Add external-pr-status job for external PRs
- Require 'safe-to-merge' label for external PR bypass
- Add policy documentation for maintainers
- Maintain security while enabling legitimate contributions