### PR TITLE
fix(ci): Upgrade actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches: ["main", "v1.x"]
@@ -22,9 +19,9 @@ jobs:
     # Note: To re-run `lint-commits` after fixing the PR title, close-and-reopen the PR.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "npm"
@@ -36,9 +33,9 @@ jobs:
     needs: lint-commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/capacity-provider-tests.yml
+++ b/.github/workflows/capacity-provider-tests.yml
@@ -1,8 +1,5 @@
 name: Capacity Provider Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   workflow_call:
     inputs:
@@ -17,10 +14,10 @@ jobs:
       id-token: write # Required for AWS credentials
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"
@@ -62,10 +59,10 @@ jobs:
       id-token: write # Required for AWS credentials
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"
@@ -106,10 +103,10 @@ jobs:
       id-token: write # Required for AWS credentials
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"

--- a/.github/workflows/cleanup-integration-tests.yml
+++ b/.github/workflows/cleanup-integration-tests.yml
@@ -1,8 +1,5 @@
 name: Cleanup Integration Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   pull_request:
     types: [closed]
@@ -24,10 +21,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: "npm"
@@ -66,10 +63,10 @@ jobs:
         node-version: ["22.x", "24.x"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           cache: "npm"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,5 @@
 name: Integration Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   workflow_call:
     inputs:
@@ -22,10 +19,10 @@ jobs:
       id-token: write # Required for AWS credentials
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"
@@ -66,10 +63,10 @@ jobs:
       id-token: write # Required for AWS credentials
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,9 +3,6 @@
 
 name: npm publish
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   id-token: write # Required for OIDC
   contents: read
@@ -16,10 +13,10 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.target_commitish }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,6 @@
 
 name: Scorecard supply-chain security
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -38,7 +35,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/sync-package.yml
+++ b/.github/workflows/sync-package.yml
@@ -2,7 +2,6 @@ name: Sync package
 
 env:
   AWS_REGION: "us-west-2"
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # permission can be added at job level or workflow level
 permissions:
@@ -31,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: "npm"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,5 @@
 name: Unit Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   workflow_call:
     inputs:
@@ -22,9 +19,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: "npm"

--- a/packages/aws-durable-execution-sdk-js-examples/src/__tests__/__snapshots__/run-durable.integration.test.ts.snap
+++ b/packages/aws-durable-execution-sdk-js-examples/src/__tests__/__snapshots__/run-durable.integration.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`run-durable CLI Integration Tests with format=cjs Core Error Cases should error when file does not exist 1`] = `
+"Error: File not found: nonexistent-file.js
+"
+`;
+
 exports[`run-durable CLI Integration Tests with format=cjs End-to-End Execution should successfully execute test handler end-to-end 1`] = `
 [
   "Skip time: false, Verbose: false, Show history: false",
@@ -26,6 +31,11 @@ exports[`run-durable CLI Integration Tests with format=cjs End-to-End Execution 
   ""Custom Handler Success!"",
   "",
 ]
+`;
+
+exports[`run-durable CLI Integration Tests with format=mjs Core Error Cases should error when file does not exist 1`] = `
+"Error: File not found: nonexistent-file.js
+"
 `;
 
 exports[`run-durable CLI Integration Tests with format=mjs End-to-End Execution should successfully execute test handler end-to-end 1`] = `

--- a/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
@@ -67,7 +67,7 @@ describe.each(["cjs", "mjs"])(
 
         expect(exitCode).toBe(1);
         expect(stdout).toBe("");
-        expect(stderr).toContain("Error: File not found: nonexistent-file.js");
+        expect(stderr).toMatchSnapshot();
       });
 
       it("should error when handler export not found", () => {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Upgrade actions/checkout from v4 to v6 and actions/setup-node from v4 to v6 across all workflows. This resolves:

1. "Node.js 20 is deprecated" warning - checkout v6 natively targets Node 24
2. "npm warn Unknown user config always-auth" causing snapshot test failures - setup-node v6 no longer writes always-auth to .npmrc (fixed in v6.1.0, actions/setup-node#1436)

Since both v6 actions natively target Node 24, the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var is removed from all
workflows.

Also reverts the toContain() workaround from #565 since the root cause is now addressed by the action upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
