### PR TITLE
fix(ci): use GitHub API to fetch current labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            const hasBypassLabel = labels.includes('safe-to-merge');
+            // Fetch current labels via API (event payload has stale data)
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const labelNames = labels.map(label => label.name);
+            const hasBypassLabel = labelNames.includes('safe-to-merge');
+
+            console.log(`Current labels: ${labelNames.join(', ')}`);
 
             if (hasBypassLabel) {
               console.log('✅ Maintainer approved bypass with safe-to-merge label');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
 
   # Always succeed for external PRs to allow merging
   external-pr-status:
-    if: github.event.pull_request.head.repo.full_name != github.repository && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: External PR Status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ permissions:
 
 # Cancel when pull request is updated
 concurrency:
-  group: ${{ github.head_ref || github.ref_name || github.run_id }}
+  group: ${{ github.event_name }}-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- Event payload contains labels from when event was triggered, not current labels
- Use github.rest.issues.listLabelsOnIssue to get up-to-date label state
- Fixes safe-to-merge label detection for external PRs