### PR TITLE
fix(sdk): remove runtime bundled detection from UserAgent header

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -7,67 +7,11 @@
  *
  * SDK_NAME is a fixed string matching the cross-SDK convention:
  * aws-durable-execution-sdk-\{language\}
- * Alternate version if SDK is bundled into the Lambda runtime.
  *
  * Defaults are provided for test environments where Rollup doesn't run
  * and process.env values are undefined.
  *
  * @internal
  */
-
-import { fileURLToPath } from "node:url";
-import { dirname } from "node:path";
-
-const runtimeDir = process.env.LAMBDA_RUNTIME_DIR || "/var/runtime";
-
-// Check if this code is running from a bundle in Lambda runtime
-// Use file path detection to determine if running in Lambda runtime directory
-function isInLambdaRuntime(): boolean {
-  try {
-    // Check if we're in a Jest test environment first
-    if (
-      typeof process !== "undefined" &&
-      process.env &&
-      process.env.NODE_ENV === "test"
-    ) {
-      return false;
-    }
-
-    // File path detection for reliable detection
-    let currentFilePath: string | undefined;
-
-    // CJS: use __filename if available
-    if (typeof __filename !== "undefined") {
-      currentFilePath = __filename;
-    } else {
-      // ESM: use import.meta.url
-      try {
-        // Use Function constructor to avoid TypeScript compilation errors in Jest
-        const getImportMeta = new Function("return import.meta");
-        const importMeta = getImportMeta();
-        if (importMeta && importMeta.url) {
-          currentFilePath = fileURLToPath(importMeta.url);
-        }
-      } catch {
-        // Fallback if import.meta is not available
-      }
-    }
-
-    if (currentFilePath) {
-      const libraryDirectory = dirname(currentFilePath);
-      return libraryDirectory.startsWith(runtimeDir);
-    }
-
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-const isRuntimeBundled = isInLambdaRuntime();
-
 export const SDK_NAME = "aws-durable-execution-sdk-js";
-const baseVersion = process.env.NPM_PACKAGE_VERSION || "0.0.0";
-export const SDK_VERSION = isRuntimeBundled
-  ? `${baseVersion}-bundled`
-  : baseVersion;
+export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Customers (including Powertools) are experiencing bundling failures after v1.1.3 due to the runtime detection logic in `version.ts`. The code uses `node:url`, `node:path`, `__filename`, and `new Function("return import.meta")` to detect whether the SDK is running from the Lambda bundled runtime directory.

This breaks across CJS, ESM, and ESBuild bundling configurations.

### Changes

Remove the `isInLambdaRuntime()` function and all associated imports from `version.ts`, reverting to the clean state after #522. The file now exports two simple constants with no runtime detection:

- `SDK_NAME = "aws-durable-execution-sdk-js"`
- `SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0"`

### What this does NOT revert

PR #522 (UserAgent format fix removing `@` character) is preserved - that was a valid fix for AWS SDK formatting rules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
