### PR TITLE
fix(ci): prevent external PRs from trying to access secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
   integration-tests:
     needs: build
     # Skip integration tests for PRs from forked repos (no access to secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write
@@ -84,7 +84,7 @@ jobs:
   capacity-provider-tests:
     needs: build
     # Skip for PRs from forked repos (no access to secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The previous condition allowed external PRs to run integration tests when the safe-to-merge label was added, because pull_request_target events would bypass the fork protection.
This removes the || github.event_name != 'pull_request' condition that was causing the security vulnerability.

What Still Works
  - External PRs can be merged when maintainers add safe-to-merge label
  - The external-pr-status job still checks for the label and allows merging
  - Maintainers retain control over which external PRs get merged

What's Now Secure

  - External PRs cannot run integration tests (no AWS secrets access)
  - External PRs cannot run capacity provider tests (no AWS secrets access)
  - Adding safe-to-merge label only enables merging, not secret access
