### PR TITLE
fix(sdk): remove esm-shim banner from ESM dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5963,6 +5963,10 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cdk-bundling-integration-test": {
+      "resolved": "packages/cdk-bundling-integration-test",
+      "link": true
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -7888,6 +7892,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esm-integration-test": {
+      "resolved": "packages/esm-integration-test",
+      "link": true
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -9561,6 +9569,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lambda-runtime-detection-integration-test": {
+      "resolved": "packages/lambda-runtime-detection-integration-test",
+      "link": true
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -15447,7 +15459,483 @@
         "eslint": ">=6.0.0"
       }
     },
+    "packages/cdk-bundling-integration-test": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*",
+        "esbuild": "^0.25.10"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cdk-bundling-integration-test/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "packages/cjs-integration-test": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*"
+      }
+    },
+    "packages/esm-integration-test": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*"
+      }
+    },
+    "packages/lambda-runtime-detection-integration-test": {
       "version": "1.0.0",
       "dependencies": {
         "@aws/durable-execution-sdk-js": "*"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test && npm run test -w packages/esm-integration-test && npm run test -w packages/cdk-bundling-integration-test",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test && npm run test -w packages/esm-integration-test && npm run test -w packages/cdk-bundling-integration-test && npm run test -w packages/lambda-runtime-detection-integration-test",
     "test:integration": "node .github/workflows/scripts/integration-test/integration-test.js",
     "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin",
     "postpublish": "git restore .",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@eslint/compat": "^1.4.1",
     "@eslint/js": "^9.29.0",
     "@microsoft/api-documenter": "^7.28.1",
+    "@rollup/plugin-esm-shim": "^0.1.8",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^12.1.4",
     "@tsconfig/node20": "^20.1.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/cjs-integration-test && npm run test -w packages/esm-integration-test && npm run test -w packages/cdk-bundling-integration-test",
     "test:integration": "node .github/workflows/scripts/integration-test/integration-test.js",
     "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin",
     "postpublish": "git restore .",
@@ -34,7 +34,6 @@
     "@eslint/compat": "^1.4.1",
     "@eslint/js": "^9.29.0",
     "@microsoft/api-documenter": "^7.28.1",
-    "@rollup/plugin-esm-shim": "^0.1.8",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^12.1.4",
     "@tsconfig/node20": "^20.1.5",

--- a/packages/aws-durable-execution-sdk-js-testing/rollup.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-testing/rollup.config.mjs
@@ -16,4 +16,14 @@ if (process.env.MODE === "esm") {
   config.input["cli/run-durable"] = "./src/cli/run-durable/index.ts";
 }
 
-export default createBuildOptions(config, process.env.MODE, packageJson);
+// `esmShim: true` synthesises top-level `__filename` / `__dirname`
+// in the ESM dist via `@rollup/plugin-esm-shim`. This package's
+// `checkpoint-worker-manager.ts` references bare `__dirname`, and
+// the ESM dist is consumed directly by Node (the `run-durable` CLI
+// binary — never re-bundled by esbuild), so the banner is safe here.
+// The SDK package opts out because consumers DO re-bundle its .mjs
+// into CJS, which would crash on the banner's `import.meta.url`
+// reference.
+export default createBuildOptions(config, process.env.MODE, packageJson, {
+  esmShim: true,
+});

--- a/packages/aws-durable-execution-sdk-js/eslint.config.js
+++ b/packages/aws-durable-execution-sdk-js/eslint.config.js
@@ -56,6 +56,17 @@ module.exports = [
     },
   },
   {
+    // Jest's manual-mocks directory has a fixed `__mocks__` name —
+    // exempt it from the kebab-case rule.
+    files: ["src/**/__mocks__/**/*.ts"],
+    plugins: {
+      "filename-convention": filenameConvention,
+    },
+    rules: {
+      "filename-convention/kebab-case": "off",
+    },
+  },
+  {
     ignores: ["dist/**/*", "node_modules/**/*"],
   },
 ];

--- a/packages/aws-durable-execution-sdk-js/jest.config.js
+++ b/packages/aws-durable-execution-sdk-js/jest.config.js
@@ -41,6 +41,14 @@ module.exports = {
     "!src/testing/**", // Exclude all testing utilities from library coverage
     "!src/index.ts", // Exclude barrel export file from coverage
     "!src/run-durable.ts", // Exclude temporary file from coverage
+    // version.ts uses `import.meta.url` at module scope, which
+    // ts-jest cannot compile (Jest forces module: commonjs). Jest
+    // tests substitute a manual mock via moduleNameMapper, so the
+    // real module is never loaded during tests — but coverage
+    // instrumentation walks the real source file and trips the
+    // ts-jest TS1343 error. The detection logic is exercised
+    // end-to-end by packages/lambda-runtime-detection-integration-test.
+    "!src/utils/constants/version.ts",
   ],
   // Set environment variables for tests
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],

--- a/packages/aws-durable-execution-sdk-js/jest.config.js
+++ b/packages/aws-durable-execution-sdk-js/jest.config.js
@@ -10,6 +10,16 @@ module.exports = {
   transform: {
     "^.+\\.ts$": "ts-jest",
   },
+  // Map the real version module to a hand-rolled stub so ts-jest never
+  // has to compile the real file's `import.meta.url` reference (which
+  // it would reject with TS1343 because Jest forces module: commonjs).
+  // The stub provides the same exports — SDK_NAME and SDK_VERSION —
+  // suitable for tests that only need to read them.
+  moduleNameMapper: {
+    "^./version$": "<rootDir>/src/utils/constants/__mocks__/version.ts",
+    "^../utils/constants/version$":
+      "<rootDir>/src/utils/constants/__mocks__/version.ts",
+  },
   moduleFileExtensions: ["ts", "js", "json", "node"],
   collectCoverage: true,
   coverageDirectory: "coverage/library",

--- a/packages/aws-durable-execution-sdk-js/src/run-durable.ts
+++ b/packages/aws-durable-execution-sdk-js/src/run-durable.ts
@@ -2,7 +2,8 @@
 
 import { Context } from "aws-lambda";
 import { withDurableExecution } from "./with-durable-execution";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 import { DurableExecutionInvocationInput } from "./types";
 
 // Set verbose mode for local testing
@@ -58,8 +59,13 @@ if (!handlerPath) {
   process.exit(1);
 }
 
-// Convert relative path to absolute
-const projectRoot = resolve(__dirname, ".."); // Go up one level from src
+// Convert relative path to absolute. Source the current module's
+// directory from `import.meta.url` (the rollup CJS output rewrites
+// this to use `__filename`/`__dirname`, so the same expression works
+// in both module systems without relying on `@rollup/plugin-esm-shim`
+// to inject a synthetic `__dirname` into the ESM dist).
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(moduleDir, ".."); // Go up one level from src
 const absolutePath = resolve(projectRoot, handlerPath);
 
 // Run the handler with optional invocationId

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/__mocks__/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/__mocks__/version.ts
@@ -1,0 +1,8 @@
+// Test stub for `version.ts`. The real module reads `import.meta.url`
+// at top level, which ts-jest cannot compile because Jest forces
+// `module: commonjs`. Tests don't care whether the SDK was loaded
+// from inside the Lambda runtime; they just need the two exported
+// constants the rest of the SDK reads.
+
+export const SDK_NAME = "aws-durable-execution-sdk-js";
+export const SDK_VERSION = process.env.NPM_PACKAGE_VERSION || "0.0.0";

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/version.ts
@@ -20,45 +20,33 @@ import { dirname } from "node:path";
 
 const runtimeDir = process.env.LAMBDA_RUNTIME_DIR || "/var/runtime";
 
+// Capture this module's path at module scope. `import.meta.url` is
+// per-module and is only resolvable in true ESM contexts, so it must
+// be referenced at top level — not from inside a function, and not
+// via `new Function("return import.meta")` or `eval(...)` (both run
+// their body in non-module scope, where `import.meta` is undefined).
+// In CJS the rollup output makes `__filename` a normal binding, so
+// the typeof guard takes that branch.
+//
+// The Jest unit tests never run this file directly: a manual mock
+// at `__mocks__/version.ts` substitutes a hardcoded SDK_VERSION,
+// which sidesteps ts-jest's TS1343 ("import.meta is only allowed
+// when module is es2020+") error during CJS test compilation.
+let moduleFilePath: string | undefined;
+if (typeof __filename !== "undefined") {
+  moduleFilePath = __filename;
+} else if (typeof import.meta?.url === "string") {
+  moduleFilePath = fileURLToPath(import.meta.url);
+}
+
 // Check if this code is running from a bundle in Lambda runtime
 // Use file path detection to determine if running in Lambda runtime directory
 function isInLambdaRuntime(): boolean {
   try {
-    // Check if we're in a Jest test environment first
-    if (
-      typeof process !== "undefined" &&
-      process.env &&
-      process.env.NODE_ENV === "test"
-    ) {
+    if (!moduleFilePath) {
       return false;
     }
-
-    // File path detection for reliable detection
-    let currentFilePath: string | undefined;
-
-    // CJS: use __filename if available
-    if (typeof __filename !== "undefined") {
-      currentFilePath = __filename;
-    } else {
-      // ESM: use import.meta.url
-      try {
-        // Use Function constructor to avoid TypeScript compilation errors in Jest
-        const getImportMeta = new Function("return import.meta");
-        const importMeta = getImportMeta();
-        if (importMeta && importMeta.url) {
-          currentFilePath = fileURLToPath(importMeta.url);
-        }
-      } catch {
-        // Fallback if import.meta is not available
-      }
-    }
-
-    if (currentFilePath) {
-      const libraryDirectory = dirname(currentFilePath);
-      return libraryDirectory.startsWith(runtimeDir);
-    }
-
-    return false;
+    return dirname(moduleFilePath).startsWith(runtimeDir);
   } catch {
     return false;
   }

--- a/packages/cdk-bundling-integration-test/README.md
+++ b/packages/cdk-bundling-integration-test/README.md
@@ -1,0 +1,62 @@
+# CDK Bundling Integration Test
+
+This package reproduces the AWS CDK `NodejsFunction` bundling path
+that downstream consumers hit at Lambda cold start. It guards against
+regressions where the SDK's `dist/index.mjs` contains top-level
+`import.meta.url` references that crash module init when the .mjs is
+re-bundled into CJS by esbuild.
+
+## Background
+
+The 1.1.3-1.1.5 SDK regressions ([#539], [#546], [#562]) all manifest
+as `TypeError: fileURLToPath(undefined)` at Lambda cold start. The
+trigger is `@rollup/plugin-esm-shim` injecting top-level constructs
+that reference `import.meta.url` into `dist/index.mjs` whenever any
+source file uses bare `__filename` or `__dirname`. When esbuild
+re-bundles that .mjs into CJS for Lambda, `import.meta` is undefined
+in the CJS context, so any literal `import.meta.url` survives into the
+output and crashes when evaluated.
+
+Note: `mainFields: ['main', 'module']` does NOT save consumers from
+this. The SDK's `package.json` `exports` map takes precedence, so
+esbuild still resolves the SDK to `dist/index.mjs` via the `import`
+condition.
+
+## Usage
+
+```bash
+npm run test -w packages/cdk-bundling-integration-test
+```
+
+## What it does
+
+1. Builds a CDK Lambda bundling layout in a temp dir:
+   - A `bundleRoot` containing a TypeScript handler that imports the
+     SDK, with the SDK symlinked into its `node_modules`.
+   - A `loadDir` declaring `"type": "commonjs"` so Node loads CJS
+     bundles the same way Lambda's CJS runtime does.
+2. Runs esbuild with the same flags `aws-cdk-lib`'s `NodejsFunction`
+   uses by default: `--platform=node --target=node22 --minify
+--external:@aws-sdk/* --external:@smithy/*`. The format and
+   `--main-fields` flip depending on the scenario.
+3. Loads the bundled artifact, which runs its top-level module init —
+   the same path that crashes the Lambda — then invokes the handler
+   to confirm exports are reachable.
+
+## Scenarios
+
+- **CJS** — `OutputFormat.CJS` with `mainFields=main,module`. The
+  bundle is loaded via `require()`.
+- **ESM** — `OutputFormat.ESM` with `mainFields=module,main`. The
+  bundle is loaded via dynamic `import()`.
+- **ESM + require polyfill** — `OutputFormat.ESM` with a `require`
+  polyfill banner (`createRequire(import.meta.url)`). Mirrors a
+  common `NodejsFunction.bundling.banner` pattern.
+- **CJS + bundleAwsSDK** / **ESM + bundleAwsSDK** —
+  `bundleAwsSDK: true` opts into inlining `@aws-sdk/*` and
+  `@smithy/*` instead of marking them external, exercising a
+  different resolution path through esbuild.
+
+[#539]: https://github.com/aws/aws-durable-execution-sdk-js/pull/539
+[#546]: https://github.com/aws/aws-durable-execution-sdk-js/pull/546
+[#562]: https://github.com/aws/aws-durable-execution-sdk-js/pull/562

--- a/packages/cdk-bundling-integration-test/package.json
+++ b/packages/cdk-bundling-integration-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cdk-bundling-integration-test",
+  "version": "1.0.0",
+  "description": "Integration test that bundles a Lambda handler with the same esbuild flags AWS CDK NodejsFunction uses (OutputFormat.CJS) and verifies the bundle loads without crashing module init",
+  "type": "module",
+  "main": "test.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "@aws/durable-execution-sdk-js": "*",
+    "esbuild": "^0.25.10"
+  }
+}

--- a/packages/cdk-bundling-integration-test/test.js
+++ b/packages/cdk-bundling-integration-test/test.js
@@ -1,0 +1,210 @@
+// Reproduces the AWS CDK NodejsFunction bundling path that downstream
+// consumers hit at Lambda cold start. Runs both the CJS scenario
+// (CDK's default OutputFormat.CJS, which crashed in 1.1.3-1.1.5 due
+// to PR #539 / #546 / #562) and the ESM scenario (OutputFormat.ESM)
+// to make sure the fix doesn't break the ESM path.
+//
+// In the CJS scenario the crash happened because `dist/index.mjs`
+// contained constructs referencing top-level `import.meta.url`. When a
+// Lambda handler that imports the SDK got bundled to CJS by esbuild,
+// those `import.meta.url` references survived as literals in CJS
+// context where `import.meta` is undefined → `TypeError:
+// fileURLToPath(undefined)` at module init.
+//
+// Note: `mainFields: ['main', 'module']` does NOT save us. The SDK's
+// `exports` map takes precedence, so esbuild still resolves
+// `@aws/durable-execution-sdk-js` to `dist/index.mjs` via the `import`
+// condition.
+
+import { build } from "esbuild";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const sdkRequire = createRequire(import.meta.url);
+const sdkSource = dirname(
+  sdkRequire.resolve("@aws/durable-execution-sdk-js"),
+).replace(/\/dist-cjs$/, "");
+const lambdaClientSource = dirname(
+  sdkRequire.resolve("@aws-sdk/client-lambda"),
+).replace(/\/dist[^/]*$/, "");
+
+// Mirror a real CDK Lambda bundling layout. The bundling root must
+// live OUTSIDE the workspace (this package has `"type": "module"`,
+// which makes esbuild resolve the SDK to its CJS dist instead of the
+// ESM dist — masking the bug). We use os.tmpdir() instead of the
+// package directory.
+//
+//  - bundleRoot: the project root the user-authored handler lives in,
+//    plus a node_modules tree containing the SDK. CDK's NodejsFunction
+//    runs esbuild with the entry's project root as cwd, so esbuild's
+//    package resolution sees the SDK as a top-level installed dep.
+//    The entry file is written here too so its parent package.json is
+//    bundleRoot's (no "type": "module" inheritance).
+//  - loadDir: where we write the bundled artifact. We declare
+//    `"type": "commonjs"` so Node loads .js bundles as CJS the way
+//    Lambda's CJS runtime does. The .mjs ESM bundle is loaded by
+//    file extension regardless.
+const tmp = mkdtempSync(join(tmpdir(), "cdk-bundling-integration-test-"));
+const bundleRoot = join(tmp, "bundle-root");
+const loadDir = join(tmp, "load-dir");
+mkdirSync(bundleRoot, { recursive: true });
+mkdirSync(loadDir, { recursive: true });
+writeFileSync(
+  join(bundleRoot, "package.json"),
+  JSON.stringify({ name: "lambda-handler", version: "0.0.0" }),
+);
+writeFileSync(
+  join(loadDir, "package.json"),
+  JSON.stringify({ type: "commonjs" }),
+);
+
+// Write the handler entry inside bundleRoot. `import` syntax in a
+// .ts file is the canonical CDK Lambda shape.
+const entryPath = join(bundleRoot, "entry.ts");
+writeFileSync(
+  entryPath,
+  `import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+export const handler = async () => ({ ok: typeof withDurableExecution });
+`,
+);
+
+// Symlink the SDK into bundleRoot/node_modules so esbuild's package
+// resolution treats it as a normal installed dependency.
+mkdirSync(join(bundleRoot, "node_modules", "@aws"), { recursive: true });
+symlinkSync(
+  sdkSource,
+  join(bundleRoot, "node_modules", "@aws", "durable-execution-sdk-js"),
+  "dir",
+);
+
+// CDK's NodejsFunction marks @aws-sdk/* as external (the Lambda
+// runtime ships it pre-installed); the produced bundle emits
+// require/import calls against `@aws-sdk/client-lambda`. Symlink the
+// real package — it's already installed transitively as a dep of the
+// SDK — into loadDir/node_modules so the resolution succeeds at load.
+mkdirSync(join(loadDir, "node_modules", "@aws-sdk"), { recursive: true });
+symlinkSync(
+  lambdaClientSource,
+  join(loadDir, "node_modules", "@aws-sdk", "client-lambda"),
+  "dir",
+);
+
+// Bundle flags mirror aws-cdk-lib NodejsFunction's defaults.
+// mainFields flips depending on output format (CDK does the same).
+// The packages we mark external are the ones CDK marks external by
+// default (LAMBDA_NODEJS_SDK_V3_EXCLUDE_SMITHY_PACKAGES feature flag).
+async function runScenario({
+  label,
+  format,
+  outFile,
+  loadBundle,
+  banner,
+  // CDK NodejsFunction marks @aws-sdk/* and @smithy/* as external by
+  // default. `bundleAwsSDK: true` opts into bundling them, which makes
+  // esbuild trace and inline the AWS SDK code instead of leaving
+  // require/import calls in the bundle.
+  bundleAwsSDK = false,
+}) {
+  const outPath = join(loadDir, outFile);
+  await build({
+    entryPoints: [entryPath],
+    absWorkingDir: bundleRoot,
+    bundle: true,
+    platform: "node",
+    format,
+    target: "node22",
+    minify: true,
+    mainFields: format === "esm" ? ["module", "main"] : ["main", "module"],
+    external: bundleAwsSDK ? [] : ["@aws-sdk/*", "@smithy/*"],
+    outfile: outPath,
+    banner: banner ? { js: banner } : undefined,
+    logLevel: "error",
+  });
+  console.log(`✓ [${label}] esbuild produced a ${format.toUpperCase()} bundle`);
+
+  const bundled = await loadBundle(outPath);
+  if (typeof bundled.handler !== "function") {
+    throw new Error(
+      `[${label}] handler is not a function (got ${typeof bundled.handler})`,
+    );
+  }
+  const result = await bundled.handler();
+  if (result?.ok !== "function") {
+    throw new Error(
+      `[${label}] handler did not return expected shape: ${JSON.stringify(result)}`,
+    );
+  }
+  console.log(`✓ [${label}] bundled handler loaded and ran without errors`);
+}
+
+try {
+  await runScenario({
+    label: "CJS",
+    format: "cjs",
+    outFile: "index.js",
+    loadBundle: (out) => {
+      // require()ing the bundle runs its top-level module init, which
+      // is where the production crash happens.
+      const requireFromLoadDir = createRequire(join(loadDir, "package.json"));
+      return requireFromLoadDir(out);
+    },
+  });
+  await runScenario({
+    label: "ESM",
+    format: "esm",
+    outFile: "index.mjs",
+    // .mjs is unambiguously ESM regardless of the nearest package.json.
+    loadBundle: (out) => import(pathToFileURL(out).href),
+  });
+  // CDK's NodejsFunction supports a `banner` bundling option, commonly
+  // used with ESM output to make `require` available inside the bundle
+  // (some npm packages still call `require` even when imported via
+  // ESM). Verifies the SDK behaves correctly when a polyfilled
+  // `require` is present in the ESM scope.
+  await runScenario({
+    label: "ESM + require polyfill",
+    format: "esm",
+    outFile: "index-polyfilled.mjs",
+    loadBundle: (out) => import(pathToFileURL(out).href),
+    banner:
+      "import { createRequire } from 'module';" +
+      "const require = createRequire(import.meta.url);",
+  });
+  // bundleAwsSDK opts into inlining @aws-sdk/* and @smithy/*. Pulls in
+  // a much larger graph of transitive deps and exercises a different
+  // resolution path through the bundler.
+  await runScenario({
+    label: "CJS + bundleAwsSDK",
+    format: "cjs",
+    outFile: "index-bundled-sdk.js",
+    bundleAwsSDK: true,
+    loadBundle: (out) => {
+      const requireFromLoadDir = createRequire(join(loadDir, "package.json"));
+      return requireFromLoadDir(out);
+    },
+  });
+  await runScenario({
+    label: "ESM + bundleAwsSDK",
+    format: "esm",
+    outFile: "index-bundled-sdk.mjs",
+    bundleAwsSDK: true,
+    loadBundle: (out) => import(pathToFileURL(out).href),
+  });
+  console.log("✓ CDK bundling integration test passed");
+} catch (error) {
+  console.error("✗ CDK bundling integration test failed:");
+  console.error(error);
+  process.exit(1);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/packages/esm-integration-test/README.md
+++ b/packages/esm-integration-test/README.md
@@ -1,0 +1,21 @@
+# ESM Integration Test
+
+This package tests ECMAScript Module (ESM) compatibility of the AWS Durable Execution SDK.
+
+## Purpose
+
+- Verifies that external ESM projects can successfully import and use the SDK
+- Catches ESM regressions during development
+- Runs as part of the main test suite to ensure compatibility
+
+## Usage
+
+```bash
+npm run test -w packages/esm-integration-test
+```
+
+## What it tests
+
+- Basic ESM `import` of the SDK
+- Availability of core exports like `withDurableExecution`
+- No runtime errors during import in ESM environments

--- a/packages/esm-integration-test/package.json
+++ b/packages/esm-integration-test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "esm-integration-test",
+  "version": "1.0.0",
+  "description": "ESM integration test to verify external ECMAScript Module compatibility",
+  "type": "module",
+  "main": "test.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "@aws/durable-execution-sdk-js": "*"
+  }
+}

--- a/packages/esm-integration-test/test.js
+++ b/packages/esm-integration-test/test.js
@@ -1,0 +1,17 @@
+console.log("Testing ESM integration...");
+
+try {
+  const sdk = await import("@aws/durable-execution-sdk-js");
+  console.log("✓ SDK imported successfully");
+
+  const { withDurableExecution } = sdk;
+  if (typeof withDurableExecution !== "function") {
+    throw new Error("withDurableExecution is not a function");
+  }
+
+  console.log("✓ withDurableExecution export verified");
+  console.log("✓ ESM integration test passed");
+} catch (error) {
+  console.error("✗ ESM integration test failed:", error.message);
+  process.exit(1);
+}

--- a/packages/lambda-runtime-detection-integration-test/README.md
+++ b/packages/lambda-runtime-detection-integration-test/README.md
@@ -1,0 +1,56 @@
+# Lambda Runtime Detection Integration Test
+
+This package verifies that the SDK's `isInLambdaRuntime()` correctly
+detects whether it's running from inside the Lambda runtime directory,
+and exposes the result via the `-bundled` suffix on the SDK_VERSION
+string baked into outgoing UserAgent headers.
+
+## Background
+
+`@aws/durable-execution-sdk-js` reports two version flavours:
+
+- `<version>` for SDK copies installed as a normal user dependency
+  (the typical case).
+- `<version>-bundled` when the SDK is shipped pre-installed inside a
+  Lambda Runtime layer.
+
+The detection compares the directory of the currently-executing
+module file against `LAMBDA_RUNTIME_DIR` (defaults to `/var/runtime`).
+The module-file path is sourced differently depending on module
+system: `__filename` in CJS, `import.meta.url` in ESM. Both branches
+need to actually return the SDK's path; an earlier ESM implementation
+used `new Function("return import.meta")()`, which runs its body in
+non-module scope where `import.meta` is unavailable, so ESM
+consumers silently dropped the `-bundled` suffix.
+
+## Usage
+
+```bash
+npm run test -w packages/lambda-runtime-detection-integration-test
+```
+
+## What it does
+
+Spawns child Node processes with controlled `LAMBDA_RUNTIME_DIR`
+settings, instantiates `DurableExecutionApiClient` in each child
+(which constructs a `LambdaClient` with the SDK's name and version
+baked into `customUserAgent`), and asserts that the resulting
+SDK_VERSION string carries (or doesn't carry) the `-bundled` suffix.
+
+Scenarios:
+
+- **CJS / runtime dir matches** — child loads the SDK via `require()`
+  and sets `LAMBDA_RUNTIME_DIR` to the SDK's install path; expects
+  `-bundled`.
+- **CJS / runtime dir does not match** — same but with a different
+  `LAMBDA_RUNTIME_DIR`; expects no `-bundled`.
+- **ESM / runtime dir matches** — child loads the SDK via dynamic
+  `import` and sets `LAMBDA_RUNTIME_DIR` to the SDK's install path;
+  expects `-bundled`.
+- **ESM / runtime dir does not match** — same but with a different
+  `LAMBDA_RUNTIME_DIR`; expects no `-bundled`.
+
+Child processes are needed because the detection runs at
+module-load time. The detection logic itself is hidden from Jest by
+a manual mock, so this integration test is the only place it's
+exercised.

--- a/packages/lambda-runtime-detection-integration-test/package.json
+++ b/packages/lambda-runtime-detection-integration-test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lambda-runtime-detection-integration-test",
+  "version": "1.0.0",
+  "description": "Integration test that verifies isInLambdaRuntime() correctly detects whether the SDK is running from inside the Lambda runtime directory, in both CJS and ESM module contexts",
+  "type": "module",
+  "main": "test.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "@aws/durable-execution-sdk-js": "*"
+  }
+}

--- a/packages/lambda-runtime-detection-integration-test/test.js
+++ b/packages/lambda-runtime-detection-integration-test/test.js
@@ -1,0 +1,123 @@
+// Verifies that isInLambdaRuntime() correctly detects whether the SDK
+// is running from inside the Lambda runtime directory, in BOTH CJS
+// and ESM module contexts. The function is invoked at module-load
+// time and the result is baked into the SDK_VERSION exposed via the
+// LambdaClient's customUserAgent — so we spawn a child Node process
+// for each scenario, instantiate DurableExecutionApiClient, and
+// inspect the resulting UserAgent for the `-bundled` suffix.
+//
+// We can't unit-test this in Jest: the real version module reads
+// `import.meta.url` at top level, which ts-jest cannot compile
+// (Jest forces module: commonjs). The Jest config substitutes a
+// hardcoded mock for `version.ts`, so the real detection logic
+// never runs under Jest at all.
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
+const sdkRequire = createRequire(import.meta.url);
+const sdkRoot = dirname(
+  sdkRequire.resolve("@aws/durable-execution-sdk-js"),
+).replace(/\/dist-cjs$/, "");
+
+// Probe script: instantiates DurableExecutionApiClient (which builds
+// a LambdaClient with the SDK's name + version baked into
+// customUserAgent) and prints the customUserAgent as JSON.
+const cjsProbe = `
+const sdk = require("@aws/durable-execution-sdk-js");
+const c = new sdk.DurableExecutionApiClient();
+process.stdout.write(JSON.stringify(c.client.config.customUserAgent));
+`;
+
+const esmProbe = `
+import * as sdk from "@aws/durable-execution-sdk-js";
+const c = new sdk.DurableExecutionApiClient();
+process.stdout.write(JSON.stringify(c.client.config.customUserAgent));
+`;
+
+function probe({ moduleSystem, env }) {
+  const inputType = moduleSystem === "esm" ? "module" : "commonjs";
+  const script = moduleSystem === "esm" ? esmProbe : cjsProbe;
+  const result = spawnSync(
+    process.execPath,
+    [`--input-type=${inputType}`, "-e", script],
+    {
+      encoding: "utf8",
+      env: {
+        // Start from a clean slate so the parent's NODE_ENV (set by
+        // some CI configurations) doesn't leak into the child.
+        PATH: process.env.PATH,
+        ...env,
+      },
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`child process exited ${result.status}: ${result.stderr}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function getSdkVersionEntry(customUserAgent) {
+  const entry = customUserAgent.find(
+    ([name]) => name === "aws-durable-execution-sdk-js",
+  );
+  if (!entry) {
+    throw new Error(
+      `customUserAgent missing SDK entry: ${JSON.stringify(customUserAgent)}`,
+    );
+  }
+  return entry[1];
+}
+
+const scenarios = [
+  {
+    label: "CJS, runtime dir matches SDK install",
+    moduleSystem: "cjs",
+    env: { LAMBDA_RUNTIME_DIR: sdkRoot },
+    expectBundled: true,
+  },
+  {
+    label: "CJS, runtime dir does not match",
+    moduleSystem: "cjs",
+    env: { LAMBDA_RUNTIME_DIR: "/var/runtime" },
+    expectBundled: false,
+  },
+  {
+    label: "ESM, runtime dir matches SDK install",
+    moduleSystem: "esm",
+    env: { LAMBDA_RUNTIME_DIR: sdkRoot },
+    expectBundled: true,
+  },
+  {
+    label: "ESM, runtime dir does not match",
+    moduleSystem: "esm",
+    env: { LAMBDA_RUNTIME_DIR: "/var/runtime" },
+    expectBundled: false,
+  },
+];
+
+let failed = 0;
+for (const scenario of scenarios) {
+  try {
+    const ua = probe(scenario);
+    const version = getSdkVersionEntry(ua);
+    const isBundled = version.endsWith("-bundled");
+    if (isBundled !== scenario.expectBundled) {
+      throw new Error(
+        `expected SDK_VERSION to ${scenario.expectBundled ? "" : "NOT "}` +
+          `end with "-bundled", got "${version}"`,
+      );
+    }
+    console.log(`✓ [${scenario.label}] SDK_VERSION = "${version}"`);
+  } catch (error) {
+    console.error(`✗ [${scenario.label}] ${error.message}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) {
+  console.error(`✗ ${failed} scenario(s) failed`);
+  process.exit(1);
+}
+console.log("✓ Lambda runtime detection integration test passed");

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@
 
 import typescript from "@rollup/plugin-typescript";
 import json from "@rollup/plugin-json";
+import esmShim from "@rollup/plugin-esm-shim";
 import replace from "@rollup/plugin-replace";
 
 const plugins = [json()];
@@ -17,9 +18,17 @@ const commonOutputOptions = {
  * @param {import('rollup').RollupOptions} options
  * @param {string | undefined} mode
  * @param {Record<string, unknown>} packageJson
+ * @param {{ esmShim?: boolean }} [extraOptions] Per-package overrides.
+ *   - `esmShim`: opt into `@rollup/plugin-esm-shim`, which injects a
+ *     top-level banner into the ESM dist that synthesises
+ *     `__filename` / `__dirname` / `require` from `import.meta.url`.
+ *     Only safe for packages whose ESM dist is consumed directly by
+ *     Node (not re-bundled into CJS by downstream toolchains like
+ *     esbuild — see PR fix(sdk): remove esm-shim banner from ESM
+ *     dist for context).
  * @returns {import('rollup').RollupOptions}
  */
-export function createBuildOptions(options, mode, packageJson) {
+export function createBuildOptions(options, mode, packageJson, extraOptions) {
   if (mode !== "esm" && mode !== "cjs") {
     throw new Error(`Invalid mode ${mode}`);
   }
@@ -71,6 +80,7 @@ export function createBuildOptions(options, mode, packageJson) {
           exclude: ["**/__tests__/**/*"],
         }),
         ...inputPlugins,
+        ...(extraOptions?.esmShim ? [esmShim()] : []),
       ],
       output: {
         ...commonOutputOptions,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@
 
 import typescript from "@rollup/plugin-typescript";
 import json from "@rollup/plugin-json";
-import esmShim from "@rollup/plugin-esm-shim";
 import replace from "@rollup/plugin-replace";
 
 const plugins = [json()];
@@ -72,7 +71,6 @@ export function createBuildOptions(options, mode, packageJson) {
           exclude: ["**/__tests__/**/*"],
         }),
         ...inputPlugins,
-        esmShim(),
       ],
       output: {
         ...commonOutputOptions,


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

n/a — discovered while bumping `@aws/durable-execution-sdk-js` from 1.1.2 → 1.1.5 in a downstream consumer.

### Description

This PR has grown in scope since the first push to address review feedback. Four commits, each focused:

#### 1. Remove the `@rollup/plugin-esm-shim` banner from the ESM dist

`@aws/durable-execution-sdk-js@1.1.3 / 1.1.4 / 1.1.5` ship a `dist/index.mjs` with a top-level `cjsUrl.fileURLToPath(import.meta.url)` shim banner injected by `@rollup/plugin-esm-shim`. When a downstream consumer re-bundles the .mjs into CJS via esbuild (the default for AWS CDK `NodejsFunction` with `OutputFormat.CJS`), the literal `import.meta.url` survives into the CJS output, where `import.meta` is `undefined`, and Lambda module init crashes before the handler runs:

```
TypeError: The "path" argument must be of type string or an instance of URL. Received undefined
    at Object.fileURLToPath (node:internal/url:1606:11)
    at Object.<anonymous> (/var/task/index.js:1:931)
```

The shim was emitted because `version.ts` references `__filename` as a bare identifier inside `isInLambdaRuntime()`. Once any source file does so, `@rollup/plugin-esm-shim` injects an unconditional banner at the top of every emitted `.mjs`. Removing the plugin from the rollup config is sufficient to fix the bundling crash — the source can keep using bare `__filename` (it's a real CJS global at runtime in the dist-cjs build).

#### 2. Make ESM Lambda runtime detection actually work

Review on the first push pointed out that dropping the `__filename` fast-path would break CJS detection. While restoring the fast-path I noticed the ESM branch reads `import.meta` via `new Function("return import.meta")()`, which runs its body in non-module scope where `import.meta` is unavailable. The inner call throws, the outer try/catch swallows it, and ESM consumers silently get the un-suffixed SDK_VERSION.

Instrumented the SDK source with `console.log` statements inside `isInLambdaRuntime()` and deployed a test stack with two durable Lambdas (one CJS, one ESM bundled by CDK `NodejsFunction`). CloudWatch confirmed:

- **Before** (Function-constructor approach): ESM Lambda logged `Function-constructor threw: Cannot use 'import.meta' outside a module`, `currentFilePath` stayed `undefined`.
- **After** (this PR's fix, using top-level `import.meta.url`): ESM Lambda logged `branch=esm:import.meta.url, moduleFilePath=/var/task/index.mjs`. CJS Lambda continues logging `branch=cjs:__filename, moduleFilePath=/var/task/index.js`.

Both branches now read the SDK module's actual file path, so the `dirname(...).startsWith(LAMBDA_RUNTIME_DIR)` comparison runs against real input.

##### Instrumentation diffs and CloudWatch output

Two `console.log`-based probes were run in sequence: one against the unfixed source to diagnose, one against the fixed source to verify. Neither is committed.

**Probe 1** — instrumentation applied to the original `version.ts` (Function-constructor branch):

```diff
 function isInLambdaRuntime(): boolean {
   try {
     // ...NODE_ENV=test early-return omitted...
     let currentFilePath: string | undefined;
+    let branch: string;

     if (typeof __filename !== "undefined") {
       currentFilePath = __filename;
+      branch = "cjs:__filename";
     } else {
+      branch = "esm:Function-constructor";
       try {
         const getImportMeta = new Function("return import.meta");
         const importMeta = getImportMeta();
         if (importMeta && importMeta.url) {
           currentFilePath = fileURLToPath(importMeta.url);
         }
-      } catch {}
+      } catch (e) {
+        console.log(
+          "[isInLambdaRuntime] Function-constructor threw:",
+          (e as Error).message,
+        );
+      }
     }

+    console.log(
+      "[isInLambdaRuntime] branch=" + branch,
+      JSON.stringify({ currentFilePath, runtimeDir }),
+    );
     // ...startsWith comparison unchanged...
```

CloudWatch (Probe 1, against unfixed SDK):

```
[CJS Lambda]
[isInLambdaRuntime] branch=cjs:__filename
{"currentFilePath":"/var/task/index.js","runtimeDir":"/var/runtime"}

[ESM Lambda]
[isInLambdaRuntime] Function-constructor threw: Cannot use 'import.meta' outside a module
[isInLambdaRuntime] branch=esm:Function-constructor
{"runtimeDir":"/var/runtime"}
```

The ESM line confirms the Function-constructor diagnosis: `currentFilePath` never gets set, so detection silently returns `false`.

**Probe 2** — instrumentation applied to the fixed `version.ts` (top-level `import.meta.url`):

```diff
 let moduleFilePath: string | undefined;
+let _branch: string;
 if (typeof __filename !== "undefined") {
   moduleFilePath = __filename;
+  _branch = "cjs:__filename";
 } else if (typeof import.meta?.url === "string") {
   moduleFilePath = fileURLToPath(import.meta.url);
+  _branch = "esm:import.meta.url";
+} else {
+  _branch = "none";
 }
+console.log(
+  "[version] branch=" + _branch,
+  JSON.stringify({ moduleFilePath, runtimeDir }),
+);
```

CloudWatch (Probe 2, against the fix from this PR):

```
[CJS Lambda]
[version] branch=cjs:__filename
{"moduleFilePath":"/var/task/index.js","runtimeDir":"/var/runtime"}

[ESM Lambda]
[version] branch=esm:import.meta.url
{"moduleFilePath":"/var/task/index.mjs","runtimeDir":"/var/runtime"}
```

`moduleFilePath` now populates in both module systems. The `startsWith(/var/runtime)` comparison still returns `false` for both Lambdas because the test stack puts the bundled SDK at `/var/task/`, not in a Lambda Runtime layer at `/var/runtime/` — that's the expected outcome for a non-bundled SDK install. The probe's job is to confirm the upstream input (`moduleFilePath`) is correctly populated, not the downstream classification.

The previous `version.ts` had a `process.env.NODE_ENV === "test"` short-circuit so it could be loaded by Jest without exercising `__filename`. With the new top-level `import.meta.url` reference, ts-jest (which forces `module: commonjs`) refuses to compile the file with `TS1343: 'import.meta' is only allowed when 'module' is es2020+`. Rather than work around the compiler, this PR adds a Jest manual mock at `src/utils/constants/__mocks__/version.ts` that returns hardcoded `SDK_NAME` / `SDK_VERSION` values during tests, and wires it through `moduleNameMapper`. That means:

- Jest never compiles the real `version.ts`, so the ts-jest TS1343 error doesn't fire.
- The `NODE_ENV=test` short-circuit is no longer needed (and is removed); Jest can never reach the real detection code at all.
- `__mocks__/` is exempted from the package's kebab-case filename rule (Jest requires the literal directory name).

#### 3. Add integration tests covering all three regressions

- **`packages/esm-integration-test`** — mirrors the existing `cjs-integration-test`. Direct ESM `import()` of the published `dist/index.mjs`, no bundler involved.
- **`packages/cdk-bundling-integration-test`** — reproduces the AWS CDK `NodejsFunction` bundling path end-to-end. Five scenarios (CJS, ESM, ESM + require polyfill, CJS + bundleAwsSDK, ESM + bundleAwsSDK), each bundling a Lambda-shaped handler with `aws-cdk-lib/NodejsFunction`'s default esbuild flags and require/import-loading the result. Confirmed to fail against the unpatched `v1.x` SDK with the production crash and pass after.
- **`packages/lambda-runtime-detection-integration-test`** — spawns child Node processes (one CJS, one ESM) with controlled `LAMBDA_RUNTIME_DIR` and asserts the SDK_VERSION baked into `LambdaClient.config.customUserAgent` carries (or doesn't carry) the `-bundled` suffix. Four scenarios; needed because the manual Jest mock means the real detection logic isn't exercised by unit tests.

#### 4. Repair `__dirname` references downstream of the esm-shim removal

Pushing the previous three commits surfaced two pre-existing bare-`__dirname` references that the deleted shim plugin had been silently propping up:

- `packages/aws-durable-execution-sdk-js/src/run-durable.ts` — used by the `npm run run-locally` developer script via `tsx`. Replaced with `dirname(fileURLToPath(import.meta.url))`.
- `packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/worker/checkpoint-worker-manager.ts` — used by the `run-durable` CLI binary that the examples package's e2e integration tests shell out to. Loaded as ESM by Node, never re-bundled by esbuild, so the original esm-shim banner crash doesn't apply here. Restored the shim plugin **only for this package** by adding an opt-in `extraOptions.esmShim` flag to the shared `createBuildOptions` factory.

Also added one Jest config tweak triggered by §2: Istanbul (Jest's coverage instrumenter) walks the real `version.ts` source even when `moduleNameMapper` substitutes the mock at runtime, and ts-jest rejects the file's `import.meta.url` reference with TS1343 during coverage collection. Excluded `version.ts` from `collectCoverageFrom`. The detection logic is exercised end-to-end by `lambda-runtime-detection-integration-test`, not by Jest unit tests, so unit-test coverage of the file would have been meaningless anyway.

### Demo/Screenshots

`head -20 packages/aws-durable-execution-sdk-js/dist/index.mjs` before and after:

Before (1.1.5):
```js
import { fileURLToPath } from 'node:url';
import { dirname } from 'node:path';


// -- Shims --
import cjsUrl from 'node:url';
import cjsPath from 'node:path';
import cjsModule from 'node:module';
const __filename = cjsUrl.fileURLToPath(import.meta.url);
const __dirname = cjsPath.dirname(__filename);
const require = cjsModule.createRequire(import.meta.url);
```

After:
```js
import { OperationType, OperationStatus, OperationAction, ... } from '@aws-sdk/client-lambda';
import { EventEmitter } from 'events';
import { AsyncLocalStorage } from 'async_hooks';
import { createHash } from 'crypto';
import { Console } from 'node:console';
import util from 'node:util';
import { fileURLToPath } from 'node:url';
import { dirname } from 'node:path';
```

The `// -- Shims --` block and its top-level `import.meta.url` references are gone.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Existing SDK unit tests (793/793) pass.

#### Integration Tests

Three new packages added under `packages/`, all wired into the root `npm test` script:

- `esm-integration-test` (plain ESM `import` of the dist).
- `cdk-bundling-integration-test` (5 esbuild scenarios mirroring AWS CDK `NodejsFunction`'s defaults).
- `lambda-runtime-detection-integration-test` (4 spawn-based scenarios covering CJS+ESM × runtime-dir-matches/doesn't-match).

#### Real Lambda

Deployed a CDK stack with two durable Lambdas (`OutputFormat.CJS` and `OutputFormat.ESM`) that import the SDK and run `withDurableExecution`. Both invoked successfully via their `:live` aliases on `nodejs:22.DurableFunction.v16` runtime, returning the durable step result with `status: "success"` in CloudWatch — confirming the bundling fix and the runtime-detection branches both work in a real Lambda environment. Stack has been torn down.

#### AWS Powertools e2e

The original reproducer for this regression was the AWS Powertools idempotency e2e suite, which started failing on the bump from `^1.1.3` → `^1.1.5`. Built a tarball from this branch, vendored it into Powertools, and re-ran the e2e workflow — green: https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/26477242071

#### Examples

Not applicable — this is a build-pipeline / runtime-detection fix.

[#546]: https://github.com/aws/aws-durable-execution-sdk-js/pull/546
[#562]: https://github.com/aws/aws-durable-execution-sdk-js/pull/562



