### PR TITLE
ci: Update checkout action to use release tag name

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+PRERELEASE=${1:-false}
+
 for package_dir in packages/*; do
   if [ -d "$package_dir" ] && [[ "$package_dir" == "packages/aws-durable-execution-sdk-js-testing" || "$package_dir" == "packages/aws-durable-execution-sdk-js" || "$package_dir" == "packages/aws-durable-execution-sdk-js-eslint-plugin" ]]; then
     echo "$package_dir";
     cd "$package_dir";
     echo "Publishing package in $package_dir";
-    npm publish --access public;
+    if [ "$PRERELEASE" = "true" ]; then
+      npm publish --access public --tag beta;
+    else
+      npm publish --access public --tag v1x;
+    fi
     cd ../..;
   fi
 done

--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -10,7 +10,7 @@ for package_dir in packages/*; do
     if [ "$PRERELEASE" = "true" ]; then
       npm publish --access public --tag beta;
     else
-      npm publish --access public --tag v1x;
+      npm publish --access public;
     fi
     cd ../..;
   fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Make script executable
         run: chmod +x ./.github/workflows/iterate-publish-npm.sh
       - name: iterate and publish
-        run: ./.github/workflows/iterate-publish-npm.sh
+        run: ./.github/workflows/iterate-publish-npm.sh ${{ github.event.release.prerelease && 'true' || 'false' }}
         shell: bash
 
   notify-release:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Also porting prelease workflow changes from [main](https://github.com/aws/aws-durable-execution-sdk-js/pull/540/changes#diff-e3f1a5c3fe06fa02b7880ba43027c2b0b941f3ed16aae5477ee8af555480e611R10).

If `target_commitish` is not specified in the [`create_release API`](https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release) call, then it defaults to the branch used to create the release. The Github release UI does not seem to provide the commit SHA for the tag as the `target_commitish`. See [here](https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/26245850284/job/77267621921#step:2:70) where we only checkout the branch.

Checking out the commit referenced by the `tag_name` of the release instead. This preserves our ability to release in different branches but ensures that the release is the code commit referenced by the tag and not the newest commit in the branch.

Just tested in my personal dummy package repo: 
* https://github.com/SilanHe/test-publish-npm-silanhe/actions/runs/26654766314/job/78562008979#step:2:67
* https://www.npmjs.com/package/test-publish-npm-silanhe/v/1.4.2?activeTab=versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
