### PR TITLE
fix(sdk): exit non-zero on partial publish failure

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
+set -uo pipefail
 
 PRERELEASE=${1:-false}
+FAILED=0
 
 for package_dir in packages/*; do
   if [ -d "$package_dir" ] && [[ "$package_dir" == "packages/aws-durable-execution-sdk-js-testing" || "$package_dir" == "packages/aws-durable-execution-sdk-js" || "$package_dir" == "packages/aws-durable-execution-sdk-js-eslint-plugin" ]]; then
-    echo "$package_dir";
-    cd "$package_dir";
     echo "Publishing package in $package_dir";
+    cd "$package_dir";
     if [ "$PRERELEASE" = "true" ]; then
-      npm publish --access public --tag beta;
+      npm publish --access public --tag beta || FAILED=1
     else
-      npm publish --access public;
+      npm publish --access public || FAILED=1
     fi
     cd ../..;
   fi
 done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "ERROR: One or more packages failed to publish"
+  exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Backports the post-#540 robustness improvements to `.github/workflows/iterate-publish-npm.sh` from `main` to `v1.x`. Without this, a failing `npm publish` for one of the three workspace packages is silently swallowed by the trailing `cd ../..` in the loop body — the `for` loop's exit status is the status of its last command (the `cd`), so the GitHub Actions step reports success even when one or more packages were not published.

Specifically, mirroring the version on `main` exactly:

- Add `set -uo pipefail`. `set -e` is intentionally omitted so that a  single package failure does not skip the remaining packages; failures  are tracked via `FAILED` instead.
- Track failures with `FAILED=0` and `npm publish ... || FAILED=1` on  both the prerelease and stable branches.
- After the loop, `exit 1` with a clear error message when any publish  failed.
- Drop the now-duplicated `echo "$package_dir"` line; the existing  `echo "Publishing package in $package_dir"` already covers it.

The resulting file is byte-identical to `.github/workflows/iterate-publish-npm.sh` on `main`, keeping the two release branches in lockstep.

*Verification:*

- `bash -n .github/workflows/iterate-publish-npm.sh` — syntax OK.
- `diff` against `origin/main`'s version of the same file returns no differences.

*Context:*

- PR #540 introduced prerelease support and basic error handling on `main`.
- `main` then received the additional hardening above on the same script.
- PR #589 brought the prerelease support over to `v1.x` but the follow-up hardening was not part of that backport this PR closes  that gap.

*Refs:* #540, #589

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
