### PR TITLE
ci: Add error handling to npm publish script

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
+set -uo pipefail
 
 PRERELEASE=${1:-false}
+FAILED=0
 
 for package_dir in packages/*; do
   if [ -d "$package_dir" ] && [[ "$package_dir" == "packages/aws-durable-execution-sdk-js-testing" || "$package_dir" == "packages/aws-durable-execution-sdk-js" || "$package_dir" == "packages/aws-durable-execution-sdk-js-eslint-plugin" ]]; then
-    echo "$package_dir";
-    cd "$package_dir";
     echo "Publishing package in $package_dir";
+    cd "$package_dir";
     if [ "$PRERELEASE" = "true" ]; then
-      npm publish --access public --tag beta;
+      npm publish --access public --tag beta || FAILED=1
     else
-      npm publish --access public;
+      npm publish --access public || FAILED=1
     fi
     cd ../..;
   fi
 done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "ERROR: One or more packages failed to publish"
+  exit 1
+fi


### PR DESCRIPTION
https://github.com/aws/aws-durable-execution-sdk-js/pull/560

We have to do 2 version release now on - sdk and release, this change will fail npm publish on second release and won't notify slack interest channel.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
