### PR TITLE
fix(ci): resolve flaky integration test failures in deploy script

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -523,6 +523,44 @@ async function main(): Promise<void> {
             useCapacityProvider,
             selectedRuntime,
           );
+
+          // Wait for newly created function to become active
+          if (!useCapacityProvider) {
+            console.log("Waiting for function to enter active state");
+            await runWithRetry(
+              async () => {
+                return getCurrentConfiguration(lambdaClient, functionName);
+              },
+              (currentConfiguration) => {
+                if (
+                  currentConfiguration.LastUpdateStatus ===
+                    LastUpdateStatus.Failed ||
+                  currentConfiguration.State === State.Failed
+                ) {
+                  throw new Error(
+                    `Function ${functionName} failed to enter successful state. ${currentConfiguration.LastUpdateStatusReason ?? currentConfiguration.StateReason}`,
+                  );
+                }
+
+                if (
+                  currentConfiguration.State !== State.Active ||
+                  currentConfiguration.LastUpdateStatus ===
+                    LastUpdateStatus.InProgress
+                ) {
+                  return {
+                    shouldRetry: true,
+                    reason: `Function update status is currently ${currentConfiguration.LastUpdateStatus ?? currentConfiguration.State}`,
+                  };
+                }
+
+                return {
+                  shouldRetry: false,
+                  reason: "Function is now active",
+                };
+              },
+              60,
+            );
+          }
         }
 
         if (useCapacityProvider) {
@@ -566,9 +604,14 @@ async function main(): Promise<void> {
                       LastUpdateStatus.Failed ||
                     currentConfiguration.State === State.Failed
                   ) {
+                    const reason =
+                      currentConfiguration.LastUpdateStatusReason ??
+                      currentConfiguration.StateReason ??
+                      "";
                     if (
                       currentConfiguration.LastUpdateStatusReasonCode ===
-                      LastUpdateStatusReasonCode.CapacityProviderScalingLimitExceeded
+                        LastUpdateStatusReasonCode.CapacityProviderScalingLimitExceeded ||
+                      reason.includes("maxVCpuCount limit")
                     ) {
                       return {
                         shouldRetry: false,
@@ -577,7 +620,7 @@ async function main(): Promise<void> {
                     }
 
                     throw new Error(
-                      `Function ${functionWithQualifier} failed to enter successful state. ${currentConfiguration.LastUpdateStatusReason ?? currentConfiguration.StateReason}`,
+                      `Function ${functionWithQualifier} failed to enter successful state. ${reason}`,
                     );
                   }
 
@@ -600,10 +643,14 @@ async function main(): Promise<void> {
                 900,
               );
 
-              if (
-                result.LastUpdateStatusReasonCode !==
-                LastUpdateStatusReasonCode.CapacityProviderScalingLimitExceeded
-              ) {
+              const isCapacityLimitExceeded =
+                result.LastUpdateStatusReasonCode ===
+                  LastUpdateStatusReasonCode.CapacityProviderScalingLimitExceeded ||
+                (result.LastUpdateStatusReason ?? "").includes(
+                  "maxVCpuCount limit",
+                );
+
+              if (!isCapacityLimitExceeded) {
                 console.log("Setting function scaling config");
                 await lambdaClient.send(
                   new PutFunctionScalingConfigCommand({


### PR DESCRIPTION
Fixes three sources of flaky integration test failures in the deploy script.

#### Changes
1. Wait for newly created functions to become active
After CreateFunctionCommand, regular (non-capacity-provider) functions go through a Pending state before becoming invocable. The deploy script previously returned immediately after creation, causing downstream tests to fail with "Function not found" when the test job started before functions transitioned to Active.

- Added a wait-for-active poll (up to 60 retries) after creating non-capacity-provider functions, matching the existing pattern used for capacity-provider functions.

2. Fix capacity provider vCPU limit detection
When the capacity provider hits its maxVCpuCount limit, the function enters Failed state. The existing code only checked LastUpdateStatusReasonCode.CapacityProviderScalingLimitExceeded, but the actual error sometimes arrives with a different/missing reason code - only the message string contains "maxVCpuCount limit". This caused the deploy to crash instead of taking the delete-and-retry path.

- Added a fallback check on the error message string in both detection points.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
