### PR TITLE
ci: port lintcommit scope changes from main

### DIFF
--- a/.github/workflows/lintcommit.js
+++ b/.github/workflows/lintcommit.js
@@ -24,7 +24,15 @@ const types = new Set([
   "types",
 ]);
 
-const scopes = new Set(["testing-sdk", "sdk", "examples", "eslint-plugin"]);
+const scopes = new Set([
+  "testing-sdk",
+  "sdk",
+  "examples",
+  "eslint-plugin",
+  "ci",
+  "deps",
+  "deps-dev",
+]);
 
 /**
  * Checks that a pull request title, or commit message subject, follows the expected format:
@@ -144,8 +152,11 @@ function _test() {
     "test: add new tests": undefined,
     "types: add type definitions": undefined,
     "Merge staging into feature/lambda-get-started": undefined,
+    "chore(deps): bump the aws-sdk group across 1 directory with 5 updates":
+      undefined,
+    "chore(deps-dev): bump flatted from 3.4.1 to 3.4.2": undefined,
     "feat(foo): fix the types":
-      'invalid scope "foo" (valid scopes are testing-sdk, sdk, examples, eslint-plugin)',
+      'invalid scope "foo" (valid scopes are testing-sdk, sdk, examples, eslint-plugin, deps, deps-dev)',
   };
 
   let passed = 0;


### PR DESCRIPTION
## Summary

Port CI changes from `main` to `v1.x` to prevent conflicts during future cherry-picks.

### Changes

- **lintcommit.js**: Add `ci`, `deps`, and `deps-dev` to valid PR title scopes (originally from [#489](https://github.com/aws/aws-durable-execution-sdk-js/pull/489))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
