### PR TITLE
test(ci): add regression test for prerelease publish tag handling

### DIFF
--- a/.github/workflows/scripts/test-publish/assert-publish-tags.js
+++ b/.github/workflows/scripts/test-publish/assert-publish-tags.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// Assert every recorded `npm publish` invocation in $NPM_LOG used a --tag
+// flag whose value is a non-empty string other than `latest`. Used by the
+// test-publish-tags workflow to verify that prerelease GitHub Releases
+// never end up assigning the `latest` dist-tag.
+//
+// Inputs:
+//   NPM_LOG              path to a JSON-lines log produced by mock-npm.js
+//   ASSERT_RESULT_PATH   path to write the structured JSON result document
+//
+// Outputs:
+//   stdout: brief human-readable PASS/FAIL summary
+//   $ASSERT_RESULT_PATH: full JSON result document, suitable for upload as
+//                        a workflow artifact
+//
+// Exit codes:
+//   0  all invocations used --tag <non-latest, non-empty>
+//   1  one or more invocations failed the assertion (or the log was empty)
+//   2  misuse (required env vars missing)
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+const logPath = process.env.NPM_LOG;
+const resultPath = process.env.ASSERT_RESULT_PATH;
+if (!logPath || !resultPath) {
+  console.error(
+    "assert-publish-tags: NPM_LOG and ASSERT_RESULT_PATH must both be set",
+  );
+  process.exit(2);
+}
+
+// Treat a missing log file the same as an empty one: nothing was recorded.
+// Both cases are surfaced to the operator via the empty-log failure reason.
+const lines = existsSync(logPath)
+  ? readFileSync(logPath, "utf8").split("\n").filter(Boolean)
+  : [];
+
+const invocations = lines.map((line, idx) => {
+  const index = idx + 1;
+
+  let args;
+  try {
+    args = JSON.parse(line);
+  } catch (err) {
+    return {
+      index,
+      args: line,
+      tag: null,
+      result: "fail",
+      reason: `malformed log entry (not valid JSON): ${err.message}`,
+    };
+  }
+  if (!Array.isArray(args)) {
+    return {
+      index,
+      args,
+      tag: null,
+      result: "fail",
+      reason: "malformed log entry (not a JSON array)",
+    };
+  }
+
+  const tagIdx = args.indexOf("--tag");
+  if (tagIdx === -1) {
+    return { index, args, tag: null, result: "fail", reason: "missing --tag" };
+  }
+  if (tagIdx === args.length - 1) {
+    return {
+      index,
+      args,
+      tag: null,
+      result: "fail",
+      reason: "--tag has no value",
+    };
+  }
+  const tag = args[tagIdx + 1];
+  if (typeof tag !== "string" || tag === "") {
+    return { index, args, tag, result: "fail", reason: "--tag value is empty" };
+  }
+  if (tag === "latest") {
+    return { index, args, tag, result: "fail", reason: "used --tag latest" };
+  }
+  return { index, args, tag, result: "ok" };
+});
+
+const failures = invocations.filter((i) => i.result === "fail").length;
+const empty = invocations.length === 0;
+const passed = !empty && failures === 0;
+
+const result = {
+  passed,
+  ...(empty && { reason: "log was empty (no invocations recorded)" }),
+  summary: {
+    total: invocations.length,
+    ok: invocations.length - failures,
+    fail: failures,
+  },
+  invocations,
+};
+
+writeFileSync(resultPath, JSON.stringify(result, null, 2) + "\n");
+
+const plural = (n) => (n === 1 ? "" : "s");
+
+if (passed) {
+  console.log(
+    `PASS: ${invocations.length} invocation${plural(invocations.length)}, all used non-latest --tag`,
+  );
+} else if (empty) {
+  console.log("FAIL: log was empty (no invocations recorded)");
+} else {
+  console.log(
+    `FAIL: ${failures}/${invocations.length} invocation${plural(invocations.length)} failed`,
+  );
+  for (const inv of invocations.filter((i) => i.result === "fail")) {
+    console.log(`  invocation ${inv.index}: ${inv.reason}`);
+  }
+}
+
+process.exit(passed ? 0 : 1);

--- a/.github/workflows/scripts/test-publish/assert-publish-tags.test.js
+++ b/.github/workflows/scripts/test-publish/assert-publish-tags.test.js
@@ -1,0 +1,221 @@
+// @ts-check
+//
+// Unit tests for assert-publish-tags.js. Each test writes a fixture log,
+// spawns the script as a subprocess with controlled env vars, and asserts on
+// the exit code and the JSON result document the script writes to disk.
+//
+// Run locally with:
+//   node --test .github/workflows/scripts/test-publish/*.test.js
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "assert-publish-tags.js",
+);
+
+let workDir = "";
+
+before(() => {
+  workDir = mkdtempSync(join(tmpdir(), "assert-publish-tags-test-"));
+});
+
+after(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Run the script under test against a fixture log.
+ * Returns the exit code, captured stdout/stderr, and the parsed result document
+ * (or null if the script exited before writing the result file).
+ */
+function runWith(logContent, { withResultPath = true } = {}) {
+  const npmLog = join(workDir, `log-${Math.random().toString(36).slice(2)}`);
+  const resultPath = join(
+    workDir,
+    `result-${Math.random().toString(36).slice(2)}.json`,
+  );
+  writeFileSync(npmLog, logContent);
+
+  const env = { ...process.env, NPM_LOG: npmLog };
+  if (withResultPath) env.ASSERT_RESULT_PATH = resultPath;
+  else delete env.ASSERT_RESULT_PATH;
+
+  const r = spawnSync("node", [SCRIPT], { env, encoding: "utf8" });
+
+  const result =
+    withResultPath && existsSync(resultPath)
+      ? JSON.parse(readFileSync(resultPath, "utf8"))
+      : null;
+
+  return { exit: r.status, stdout: r.stdout, stderr: r.stderr, result };
+}
+
+/** Helper to build a JSON Lines log from arrays of args. */
+function logFor(...invocations) {
+  return invocations.map((args) => JSON.stringify(args)).join("\n") + "\n";
+}
+
+test("passes when every invocation has --tag <non-latest>", () => {
+  const { exit, result, stdout } = runWith(
+    logFor(
+      ["publish", "--access", "public", "--tag", "beta"],
+      ["publish", "--access", "public", "--tag", "next"],
+    ),
+  );
+  assert.equal(exit, 0);
+  assert.equal(result.passed, true);
+  assert.equal(result.summary.total, 2);
+  assert.equal(result.summary.ok, 2);
+  assert.equal(result.summary.fail, 0);
+  assert.match(stdout, /^PASS:/);
+});
+
+test("fails when an invocation has no --tag", () => {
+  const { exit, result, stdout } = runWith(
+    logFor(["publish", "--access", "public"]),
+  );
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].result, "fail");
+  assert.equal(result.invocations[0].reason, "missing --tag");
+  assert.equal(result.invocations[0].tag, null);
+  assert.match(stdout, /missing --tag/);
+});
+
+test("fails when an invocation uses --tag latest", () => {
+  const { exit, result, stdout } = runWith(
+    logFor(["publish", "--access", "public", "--tag", "latest"]),
+  );
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].reason, "used --tag latest");
+  assert.equal(result.invocations[0].tag, "latest");
+  assert.match(stdout, /used --tag latest/);
+});
+
+test("fails when log is empty (no invocations recorded)", () => {
+  const { exit, result, stdout } = runWith("");
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.match(result.reason, /log was empty/);
+  assert.equal(result.summary.total, 0);
+  assert.deepEqual(result.invocations, []);
+  assert.match(stdout, /log was empty/);
+});
+
+test("aggregates ok and fail counts across multiple invocations", () => {
+  const { exit, result } = runWith(
+    logFor(
+      ["publish", "--access", "public", "--tag", "beta"],
+      ["publish", "--access", "public", "--tag", "latest"],
+      ["publish", "--access", "public"],
+    ),
+  );
+  assert.equal(exit, 1);
+  assert.equal(result.summary.total, 3);
+  assert.equal(result.summary.ok, 1);
+  assert.equal(result.summary.fail, 2);
+  assert.equal(result.invocations[0].result, "ok");
+  assert.equal(result.invocations[0].tag, "beta");
+  assert.equal(result.invocations[1].result, "fail");
+  assert.equal(result.invocations[1].reason, "used --tag latest");
+  assert.equal(result.invocations[2].result, "fail");
+  assert.equal(result.invocations[2].reason, "missing --tag");
+});
+
+test("preserves args verbatim in the result document", () => {
+  const args = ["publish", "--access", "public", "--tag", "beta"];
+  const { result } = runWith(logFor(args));
+  assert.deepEqual(result.invocations[0].args, args);
+});
+
+test("exits 2 when ASSERT_RESULT_PATH is missing", () => {
+  const { exit, result, stderr } = runWith(
+    logFor(["publish", "--access", "public", "--tag", "beta"]),
+    { withResultPath: false },
+  );
+  assert.equal(exit, 2);
+  assert.equal(result, null);
+  assert.match(stderr, /NPM_LOG and ASSERT_RESULT_PATH must both be set/);
+});
+
+test("fails when --tag is the last arg (no value follows it)", () => {
+  const { exit, result } = runWith(
+    logFor(["publish", "--access", "public", "--tag"]),
+  );
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].result, "fail");
+  assert.equal(result.invocations[0].reason, "--tag has no value");
+  assert.equal(result.invocations[0].tag, null);
+});
+
+test("fails when --tag value is the empty string", () => {
+  const { exit, result } = runWith(
+    logFor(["publish", "--access", "public", "--tag", ""]),
+  );
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].result, "fail");
+  assert.equal(result.invocations[0].reason, "--tag value is empty");
+});
+
+test("fails on a malformed JSON line", () => {
+  const { exit, result } = runWith("this is not json\n");
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].result, "fail");
+  assert.match(
+    result.invocations[0].reason,
+    /malformed log entry \(not valid JSON\)/,
+  );
+});
+
+test("fails on a JSON line that is not an array", () => {
+  const { exit, result } = runWith('{"not":"an array"}\n');
+  assert.equal(exit, 1);
+  assert.equal(result.passed, false);
+  assert.equal(result.invocations[0].result, "fail");
+  assert.match(
+    result.invocations[0].reason,
+    /malformed log entry \(not a JSON array\)/,
+  );
+});
+
+test("treats a missing log file as empty (no invocations recorded)", () => {
+  const npmLog = join(
+    workDir,
+    `nonexistent-${Math.random().toString(36).slice(2)}`,
+  );
+  const resultPath = join(
+    workDir,
+    `result-${Math.random().toString(36).slice(2)}.json`,
+  );
+  // Don't create npmLog. Asserter should treat the missing file as empty.
+
+  const env = {
+    ...process.env,
+    NPM_LOG: npmLog,
+    ASSERT_RESULT_PATH: resultPath,
+  };
+  const r = spawnSync("node", [SCRIPT], { env, encoding: "utf8" });
+
+  assert.equal(r.status, 1);
+  const result = JSON.parse(readFileSync(resultPath, "utf8"));
+  assert.equal(result.passed, false);
+  assert.match(result.reason, /log was empty/);
+  assert.equal(result.summary.total, 0);
+});

--- a/.github/workflows/scripts/test-publish/mock-npm.js
+++ b/.github/workflows/scripts/test-publish/mock-npm.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// Mock `npm` for the test-publish-tags workflow.
+//
+// Records each invocation as a JSON array of args, one per line, in $NPM_LOG.
+// `iterate-publish-npm.sh` only ever calls `npm publish`, so a no-op mock that
+// records invocations is sufficient to verify --tag handling without ever
+// hitting the real npm registry.
+//
+// Wire up by symlinking this file as `npm` in a directory at the front of
+// PATH and exporting NPM_LOG=<path> before invoking the script under test.
+
+import { appendFileSync } from "fs";
+
+const logPath = process.env.NPM_LOG;
+if (!logPath) {
+  console.error("mock-npm: NPM_LOG must be set");
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+appendFileSync(logPath, JSON.stringify(args) + "\n");

--- a/.github/workflows/scripts/test-publish/mock-npm.test.js
+++ b/.github/workflows/scripts/test-publish/mock-npm.test.js
@@ -1,0 +1,109 @@
+// @ts-check
+//
+// Unit tests for mock-npm.js. The asserter (assert-publish-tags.js) depends on
+// mock-npm producing exactly one JSON-array line per invocation and appending
+// (not overwriting) on subsequent calls. These tests pin that contract.
+//
+// Run locally with:
+//   node --test .github/workflows/scripts/test-publish/*.test.js
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "mock-npm.js");
+
+let workDir = "";
+
+before(() => {
+  workDir = mkdtempSync(join(tmpdir(), "mock-npm-test-"));
+});
+
+after(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Run mock-npm with the given args. Returns the exit code, captured streams,
+ * and the contents of NPM_LOG (or null if the file wasn't created).
+ */
+function run(args, { setLog = true } = {}) {
+  const npmLog = join(workDir, `log-${Math.random().toString(36).slice(2)}`);
+  const env = { ...process.env };
+  if (setLog) env.NPM_LOG = npmLog;
+  else delete env.NPM_LOG;
+
+  const r = spawnSync("node", [SCRIPT, ...args], { env, encoding: "utf8" });
+  const log =
+    setLog && existsSync(npmLog) ? readFileSync(npmLog, "utf8") : null;
+  return { exit: r.status, stdout: r.stdout, stderr: r.stderr, npmLog, log };
+}
+
+test("records a single invocation as a JSON Lines array of args", () => {
+  const args = ["publish", "--access", "public", "--tag", "beta"];
+  const { exit, log } = run(args);
+  assert.equal(exit, 0);
+  assert.equal(log, JSON.stringify(args) + "\n");
+});
+
+test("appends on subsequent invocations (does not overwrite)", () => {
+  const npmLog = join(workDir, "appending.log");
+  const env = { ...process.env, NPM_LOG: npmLog };
+  spawnSync("node", [SCRIPT, "publish", "--tag", "beta"], { env });
+  spawnSync("node", [SCRIPT, "publish", "--tag", "next"], { env });
+  spawnSync("node", [SCRIPT, "publish", "--tag", "rc"], { env });
+
+  const lines = readFileSync(npmLog, "utf8").split("\n").filter(Boolean);
+  assert.equal(lines.length, 3);
+  assert.deepEqual(JSON.parse(lines[0]), ["publish", "--tag", "beta"]);
+  assert.deepEqual(JSON.parse(lines[1]), ["publish", "--tag", "next"]);
+  assert.deepEqual(JSON.parse(lines[2]), ["publish", "--tag", "rc"]);
+});
+
+test("preserves args containing spaces and special characters verbatim", () => {
+  const args = [
+    "publish",
+    "--registry=https://example.com/path?x=1&y=2",
+    "--note",
+    "value with spaces",
+    "--quote",
+    'has "quotes" and \\backslashes',
+  ];
+  const { exit, log } = run(args);
+  assert.equal(exit, 0);
+  assert.deepEqual(JSON.parse(log.trim()), args);
+});
+
+test("handles invocation with no positional args", () => {
+  const { exit, log } = run([]);
+  assert.equal(exit, 0);
+  assert.equal(log, "[]\n");
+});
+
+test("exits 2 with a clear error when NPM_LOG is unset", () => {
+  const { exit, stderr, log } = run(["publish"], { setLog: false });
+  assert.equal(exit, 2);
+  assert.equal(log, null);
+  assert.match(stderr, /NPM_LOG must be set/);
+});
+
+test("creates the log file if it does not exist yet", () => {
+  // Same as the "single invocation" test, but assert the file was created
+  // from scratch rather than appended to a pre-existing file.
+  const npmLog = join(workDir, "fresh.log");
+  assert.equal(existsSync(npmLog), false);
+
+  const env = { ...process.env, NPM_LOG: npmLog };
+  const r = spawnSync("node", [SCRIPT, "publish"], { env });
+
+  assert.equal(r.status, 0);
+  assert.equal(existsSync(npmLog), true);
+  assert.equal(
+    readFileSync(npmLog, "utf8"),
+    JSON.stringify(["publish"]) + "\n",
+  );
+});

--- a/.github/workflows/test-publish-tags.yml
+++ b/.github/workflows/test-publish-tags.yml
@@ -1,0 +1,87 @@
+# Regression test verifying the publish script does not assign the `latest`
+# dist-tag when invoked for a prerelease.
+#
+# Approach: install a mock `npm` on PATH that records every invocation's args
+# (instead of actually publishing), run iterate-publish-npm.sh with
+# prerelease=true, then assert via assert-publish-tags.js that every
+# recorded `npm publish` invocation included a --tag flag whose value is
+# not `latest`.
+#
+# This catches regressions in iterate-publish-npm.sh's prerelease branch at
+# PR review time without ever talking to the real npm registry.
+
+name: test publish tags
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/npm-publish.yml
+      - .github/workflows/iterate-publish-npm.sh
+      - .github/workflows/scripts/test-publish/**
+      - .github/workflows/test-publish-tags.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-test-asserter:
+    name: unit-test asserter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Run node --test on test-publish/ scripts
+        shell: bash
+        run: node --test .github/workflows/scripts/test-publish/*.test.js
+
+  prerelease-uses-non-latest-tag:
+    name: prerelease publish uses non-latest --tag
+    needs: unit-test-asserter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install mock npm on PATH and export log paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/mock-bin"
+          ln -s "$GITHUB_WORKSPACE/.github/workflows/scripts/test-publish/mock-npm.js" \
+                "$RUNNER_TEMP/mock-bin/npm"
+          : > "$RUNNER_TEMP/npm-args.log"
+          {
+            echo "NPM_LOG=$RUNNER_TEMP/npm-args.log"
+            echo "ASSERT_RESULT_PATH=$RUNNER_TEMP/assert-result.json"
+          } >> "$GITHUB_ENV"
+
+      - name: Run publish script with prerelease=true (mocked npm)
+        shell: bash
+        # iterate-publish-npm.sh is committed mode 100644; the production
+        # npm-publish.yml chmods it before running. Invoke via `bash` here
+        # so this test does not depend on the file mode.
+        run: |
+          PATH="$RUNNER_TEMP/mock-bin:$PATH" \
+            bash .github/workflows/iterate-publish-npm.sh true
+
+      - name: Assert every invocation used a non-latest --tag
+        shell: bash
+        run: node .github/workflows/scripts/test-publish/assert-publish-tags.js
+
+      - name: Upload assertion result
+        # Always upload so the result is downloadable for audit, including on
+        # failure. `if-no-files-found: warn` (rather than `error`) because if
+        # the assert step exits 2 (env vars unset) it does not write a result
+        # file; the assert step's own non-zero exit already fails the job and
+        # we don't want the upload step to report a redundant failure.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: assert-publish-tags-result
+          path: ${{ runner.temp }}/assert-result.json
+          if-no-files-found: warn


### PR DESCRIPTION
*Description of changes:*
Adds a workflow that mocks `npm` on PATH and verifies that iterate-publish-npm.sh, when invoked with prerelease=true, calls `npm publish --tag <non-latest>` for every package in the loop.

Catches the regression class where prerelease GitHub Releases silently publish to the `latest` dist-tag, at PR review time, before the change can reach a real release.

Approach:

- mock-npm.js records each `npm publish` invocation as JSON Lines in $NPM_LOG instead of contacting the registry.
- assert-publish-tags.js parses the log, asserts every recorded invocation included `--tag <non-latest>`, writes a structured JSON result to $ASSERT_RESULT_PATH that the workflow uploads as an artifact for audit.
- assert-publish-tags.test.js exercises the asserter against fixture logs (pass case, missing --tag, --tag latest, empty log, mixed pass/fail aggregation, args preservation, env var misuse).
- test-publish-tags.yml triggers on PRs that touch publish workflow files, plus workflow_dispatch. Runs the asserter unit tests as a separate job that the integration test depends on, so a broken asserter fails fast.

Uses Node's built-in test runner (node --test); no new dependencies.

*Issue #, if available:*




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
