### PR TITLE
feat(ci): add automatic runtime release workflow

### DIFF
--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -1,0 +1,36 @@
+name: Create companion runtime release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  create-runtime-release:
+    runs-on: ubuntu-latest
+    # Only run for SDK releases (tag starts with "sdk-") on the v1.x branch, excluding pre-releases
+    if: startsWith(github.event.release.tag_name, 'sdk-') && github.event.release.target_commitish == 'v1.x' && !github.event.release.prerelease
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create companion runtime release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the version from the SDK's package.json
+          VERSION=$(jq -r .version packages/aws-durable-execution-sdk-js/package.json)
+
+          RUNTIME_RELEASE_TAG="runtime-${VERSION}"
+
+          # Create the runtime tag on the same commit
+          git tag "$RUNTIME_RELEASE_TAG"
+          git push origin "$RUNTIME_RELEASE_TAG"
+
+          # Create a release for that tag, not marked as latest
+          gh release create "$RUNTIME_RELEASE_TAG" \
+            --title "Release ${RUNTIME_RELEASE_TAG}" \
+            --notes "Companion release for Lambda runtime integration. Corresponds to SDK release ${{ github.event.release.tag_name }}." \
+            --latest=false


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Added a new GitHub action which automatically runs whenever there is a new release for the sdk from the `v1.x` branch. The action will create a second companion release, pointing to the same commit as the original release.

The companion releases will be tagged with a consistent format, and will be used by an automated testing harness to run integration tests on new sdk versions being released to the Lambda runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
