### PR TITLE
fix(testing-sdk): defer TimerScheduler entry removal until after updateCheckpoint

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/__tests__/timer-scheduler.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/__tests__/timer-scheduler.test.ts
@@ -322,6 +322,69 @@ describe("TimerScheduler", () => {
     });
   });
 
+  describe("in-flight tracking during updateCheckpoint", () => {
+    it("should keep hasScheduledFunction true while updateCheckpoint is in flight", async () => {
+      let resolveCheckpoint: (() => void) | undefined;
+      const checkpointPromise = new Promise<void>((resolve) => {
+        resolveCheckpoint = resolve;
+      });
+      const mockStartInvocation = jest.fn().mockResolvedValue(undefined);
+      const mockOnError = jest.fn();
+
+      scheduler.scheduleFunction(
+        mockStartInvocation,
+        mockOnError,
+        undefined,
+        () => checkpointPromise,
+      );
+
+      // Fire the timer
+      await jest.advanceTimersByTimeAsync(0);
+
+      // updateCheckpoint is in flight, startInvocation hasn't started yet
+      expect(mockStartInvocation).not.toHaveBeenCalled();
+      expect(scheduler.hasScheduledFunction()).toBe(true);
+
+      // Resolve updateCheckpoint → startInvocation begins → timer deleted
+      resolveCheckpoint!();
+      await jest.advanceTimersByTimeAsync(0);
+
+      expect(mockStartInvocation).toHaveBeenCalledTimes(1);
+      expect(scheduler.hasScheduledFunction()).toBe(false);
+    });
+
+    it("should keep hasScheduledFunction true during updateCheckpoint even on checkpoint rejection", async () => {
+      let rejectCheckpoint: ((err: unknown) => void) | undefined;
+      const checkpointPromise = new Promise<void>((_resolve, reject) => {
+        rejectCheckpoint = reject;
+      });
+      const mockStartInvocation = jest.fn().mockResolvedValue(undefined);
+      const mockOnError = jest.fn();
+
+      scheduler.scheduleFunction(
+        mockStartInvocation,
+        mockOnError,
+        undefined,
+        () => checkpointPromise,
+      );
+
+      await jest.advanceTimersByTimeAsync(0);
+
+      // updateCheckpoint is in flight
+      expect(scheduler.hasScheduledFunction()).toBe(true);
+
+      // Reject updateCheckpoint
+      rejectCheckpoint!(new Error("checkpoint failed"));
+      await jest.advanceTimersByTimeAsync(0);
+
+      // onError should be called, startInvocation should NOT be called
+      expect(mockOnError).toHaveBeenCalledTimes(1);
+      expect(mockStartInvocation).not.toHaveBeenCalled();
+      // Timer should be cleaned up even on rejection (no leak)
+      expect(scheduler.hasScheduledFunction()).toBe(false);
+    });
+  });
+
   describe("updateCheckpoint functionality", () => {
     it("should work correctly when updateCheckpoint is not provided", async () => {
       const mockFn = jest.fn().mockResolvedValue(undefined);

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/timer-scheduler.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/orchestration/timer-scheduler.ts
@@ -37,13 +37,18 @@ export class TimerScheduler implements Scheduler {
       `Scheduling function to run in ${delayMs}ms - Scheduler ID: ${id}`,
     );
     const timer = setTimeout(() => {
-      this.runningTimers.delete(timer);
       defaultLogger.debug(
         `Running scheduled function after ${delayMs}ms - Scheduler ID: ${id}`,
       );
       (updateCheckpoint ? updateCheckpoint() : Promise.resolve())
-        .then(() => startInvocation())
-        .catch(onError);
+        .then(() => {
+          this.runningTimers.delete(timer);
+          return startInvocation();
+        })
+        .catch((err: unknown) => {
+          this.runningTimers.delete(timer);
+          onError(err);
+        });
     }, delayMs);
     this.runningTimers.add(timer);
   }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-js/pull/544

*Description of changes:*
Move runningTimers.delete(timer) from the synchronous setTimeout callback into the .then() chain - after updateCheckpoint resolves but before startInvocation begins. This closes a race window where hasScheduledFunction() returns false while updateCheckpoint is still clearing pendingOperations, causing the orchestrator's PENDING validation to incorrectly reject with "Cannot return PENDING status with no pending operations."


Added new tests, failing without fix - 
https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/27040006108/job/79813694644
https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/27040006108/job/79813694778

After fix - 
https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/27041361767/job/79818075054?pr=611
https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/27041361767/job/79818075018?pr=611




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
