### PR TITLE
feat(ci): derive npm dist-tag from version (port to v1.x)

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -1,23 +1,133 @@
 #!/bin/bash
 set -uo pipefail
 
-PRERELEASE=${1:-false}
-FAILED=0
+# Publishes each package to npm, choosing the dist-tag from the VERSION itself
+# (the GitHub Release "prerelease" checkbox is intentionally ignored). The
+# current `latest` on the registry is the reference point:
+#
+#   stable, version >  latest   -> latest            (move latest forward)
+#   stable, version <  latest   -> v<major>          (backport line tag; latest unchanged)
+#   prerelease, version > latest-> beta              (prerelease of a future line)
+#   prerelease, version <= latest -> REJECT          (no betas for old/shipped lines)
+#   version already published   -> skip              (idempotent re-run)
+#   no latest yet (first publish)-> latest / beta by version
+#
+# This keeps `latest` always pointing at the highest released line while v1/v2
+# are maintained in parallel. The decision logic lives in (and is unit-tested
+# via) scripts/test-publish/decide-dist-tag.js.
 
-for package_dir in packages/*; do
-  if [ -d "$package_dir" ] && [[ "$package_dir" == "packages/aws-durable-execution-sdk-js-testing" || "$package_dir" == "packages/aws-durable-execution-sdk-js" || "$package_dir" == "packages/aws-durable-execution-sdk-js-eslint-plugin" ]]; then
-    echo "Publishing package in $package_dir";
-    cd "$package_dir";
-    if [ "$PRERELEASE" = "true" ]; then
-      npm publish --access public --tag beta || FAILED=1
-    else
-      npm publish --access public || FAILED=1
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DECIDE="$SCRIPT_DIR/scripts/test-publish/decide-dist-tag.js"
+
+# Packages to publish. Tests override this with TEST_PACKAGES (space-separated).
+if [ -n "${TEST_PACKAGES:-}" ]; then
+  read -ra PACKAGES <<< "$TEST_PACKAGES"
+else
+  PACKAGES=(
+    "packages/aws-durable-execution-sdk-js"
+    "packages/aws-durable-execution-sdk-js-testing"
+    "packages/aws-durable-execution-sdk-js-eslint-plugin"
+  )
+fi
+
+pkg_field() {
+  node -e 'process.stdout.write(String(require(require("path").resolve(process.argv[1], "package.json"))[process.argv[2]]))' "$1" "$2"
+}
+
+# Fetch the packument (`npm view <name> --json`). Prints the JSON on success,
+# prints empty for a brand-new (never-published, E404) package, and returns
+# non-zero ONLY on a genuine read failure (network/registry) so the caller can
+# abort rather than guess.
+fetch_packument() {
+  local name=$1 errfile out status err
+  errfile=$(mktemp)
+  out=$(npm view "$name" --json 2>"$errfile"); status=$?
+  err=$(cat "$errfile"); rm -f "$errfile"
+  if [ $status -eq 0 ]; then printf '%s' "$out"; return 0; fi
+  if printf '%s' "$err" | grep -qiE "E404|404 Not Found"; then
+    printf ''; return 0   # package not published yet
+  fi
+  echo "ERROR: failed to read registry state for $name: $err" >&2
+  return 1
+}
+
+# Parallel arrays describing what we will do, filled by the pre-flight pass.
+P_DIR=(); P_NAME=(); P_VER=(); P_TAG=()
+
+# ---------- PRE-FLIGHT: decide for every package before publishing anything ----------
+for dir in "${PACKAGES[@]}"; do
+  [ -d "$dir" ] || continue
+  name=$(pkg_field "$dir" name)
+  version=$(pkg_field "$dir" version)
+
+  if ! packument=$(fetch_packument "$name"); then
+    echo "ERROR: aborting release; could not determine current 'latest' for $name (no packages published)."
+    exit 1
+  fi
+
+  if ! decision=$(node "$DECIDE" "$version" "$packument"); then
+    echo "ERROR: could not decide a dist-tag for $name@$version (invalid version in package.json?)."
+    echo "       Aborting before any publish (nothing was published)."
+    exit 1
+  fi
+  case "$decision" in
+    reject)
+      echo "ERROR: $name@$version violates the release policy (a prerelease must be greater than the current 'latest')."
+      echo "       Aborting before any publish (nothing was published)."
+      exit 1
+      ;;
+    skip)   echo "Plan: $name@$version -> already published; will skip" ;;
+    latest) echo "Plan: $name@$version -> 'latest'" ;;
+    beta)   echo "Plan: $name@$version -> 'beta'" ;;
+    *)      echo "Plan: $name@$version -> '$decision' (backport line tag; 'latest' unchanged)" ;;
+  esac
+
+  P_DIR+=("$dir"); P_NAME+=("$name"); P_VER+=("$version"); P_TAG+=("$decision")
+done
+
+# ---------- PUBLISH + POST-PUBLISH verification ----------
+FAILED=0
+for i in "${!P_DIR[@]}"; do
+  dir=${P_DIR[$i]}; name=${P_NAME[$i]}; version=${P_VER[$i]}; tag=${P_TAG[$i]}
+
+  if [ "$tag" = "skip" ]; then
+    echo "Skipping $name@$version (already published)."
+    continue
+  fi
+
+  echo "Publishing $name@$version to '$tag'"
+  if ! (cd "$dir" && npm publish --access public --tag "$tag"); then
+    echo "ERROR: failed to publish $name@$version"
+    FAILED=1
+    continue
+  fi
+
+  # Tests (and any caller) can skip the registry round-trip.
+  [ "${SKIP_DIST_TAG_VERIFY:-}" = "1" ] && continue
+
+  # Confirm the dist-tag we targeted now points at the published version.
+  # Fixed retries cover npm registry propagation lag (tunable for tests).
+  attempts=${DIST_TAG_VERIFY_ATTEMPTS:-5}
+  delay=${DIST_TAG_VERIFY_DELAY:-10}
+  ok=0
+  for ((a = 1; a <= attempts; a++)); do
+    published=$(npm view "$name" "dist-tags.$tag" 2>/dev/null || echo "")
+    if [ "$published" = "$version" ]; then
+      echo "OK: $name '$tag' -> $version confirmed"
+      ok=1
+      break
     fi
-    cd ../..;
+    echo "  not visible yet ($tag='$published'); attempt $a/$attempts"
+    [ "$a" -lt "$attempts" ] && sleep "$delay"
+  done
+  if [ "$ok" -ne 1 ]; then
+    echo "ERROR: $name '$tag' does not point to $version after $attempts attempts"
+    FAILED=1
   fi
 done
 
 if [ "$FAILED" -ne 0 ]; then
-  echo "ERROR: One or more packages failed to publish"
+  echo "ERROR: one or more packages failed to publish or verify"
   exit 1
 fi
+echo "All packages published and verified."

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Make script executable
         run: chmod +x ./.github/workflows/iterate-publish-npm.sh
       - name: iterate and publish
-        run: ./.github/workflows/iterate-publish-npm.sh ${{ github.event.release.prerelease && 'true' || 'false' }}
+        # The dist-tag is derived from each package's version (see
+        # iterate-publish-npm.sh), so the GitHub Release prerelease flag is
+        # intentionally not passed.
+        run: ./.github/workflows/iterate-publish-npm.sh
         shell: bash
 
   notify-release:

--- a/.github/workflows/scripts/test-publish/decide-dist-tag.js
+++ b/.github/workflows/scripts/test-publish/decide-dist-tag.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// Pure decision logic: which npm dist-tag (if any) a version should get, based
+// on the package's CURRENT `latest` on the registry and its already-published
+// versions. No I/O here — the caller passes registry state in as arguments, so
+// the policy is trivially unit-testable.
+//
+// CLI usage:
+//   node decide-dist-tag.js <version> [packumentJson]
+//     packumentJson: the JSON from `npm view <name> --json` ("" if the package
+//     has never been published). Prints exactly one decision token:
+//       skip        version already published (idempotent re-run)
+//       latest      publish to the `latest` tag
+//       beta        publish to the `beta` tag
+//       v<major>    publish to a release-line tag (backport; does NOT move latest)
+//       reject      policy violation; the caller must abort
+//
+// Policy (per package; V = version being released, L = current `latest`):
+//   no L yet (first publish):  V prerelease -> beta,  otherwise -> latest
+//   V already published:       skip
+//   V is a prerelease:         V > L -> beta      else -> reject (no old-line betas)
+//   V is stable:               V > L -> latest    else -> v<major(V)> (backport)
+
+/**
+ * @param {string} v
+ * @returns {{major:number,minor:number,patch:number,prerelease:string[]}}
+ */
+export function parseSemver(v) {
+  // Drop build metadata (everything after the first '+'); it has no precedence.
+  const core = String(v).split("+")[0];
+  const m = core.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+  if (!m) throw new Error(`invalid semver version: ${v}`);
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ? m[4].split(".") : [],
+  };
+}
+
+/** @param {string} id */
+const isNumericId = (id) => /^\d+$/.test(id);
+
+/**
+ * Compare two semver versions per the spec (incl. prerelease precedence).
+ * @returns {-1|0|1}
+ */
+export function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  for (const k of /** @type {const} */ (["major", "minor", "patch"])) {
+    if (pa[k] !== pb[k]) return pa[k] < pb[k] ? -1 : 1;
+  }
+  // Core versions equal: a version WITH a prerelease is lower than one without.
+  if (pa.prerelease.length === 0 && pb.prerelease.length === 0) return 0;
+  if (pa.prerelease.length === 0) return 1;
+  if (pb.prerelease.length === 0) return -1;
+  const n = Math.max(pa.prerelease.length, pb.prerelease.length);
+  for (let i = 0; i < n; i++) {
+    const ai = pa.prerelease[i];
+    const bi = pb.prerelease[i];
+    if (ai === undefined) return -1; // fewer identifiers => lower precedence
+    if (bi === undefined) return 1;
+    const an = isNumericId(ai);
+    const bn = isNumericId(bi);
+    if (an && bn) {
+      if (ai !== bi) return Number(ai) < Number(bi) ? -1 : 1;
+    } else if (an) {
+      return -1; // numeric identifiers are lower than alphanumeric
+    } else if (bn) {
+      return 1;
+    } else if (ai !== bi) {
+      return ai < bi ? -1 : 1; // lexical ASCII order
+    }
+  }
+  return 0;
+}
+
+/** @param {string} v */
+export function isPrerelease(v) {
+  return parseSemver(v).prerelease.length > 0;
+}
+
+/**
+ * Decide the dist-tag (or special action) for a version.
+ * @param {string} version       version being released
+ * @param {string|null} latest   current `latest` on the registry, or null/"" if none
+ * @param {string[]} versions    all already-published versions
+ * @returns {"skip"|"latest"|"beta"|"reject"|`v${number}`}
+ */
+export function decide(version, latest, versions = []) {
+  if (versions.includes(version)) return "skip";
+  if (!latest) return isPrerelease(version) ? "beta" : "latest";
+
+  const cmp = compareSemver(version, latest);
+  if (isPrerelease(version)) {
+    // Only prereleases ABOVE the current latest get the shared `beta` channel.
+    return cmp > 0 ? "beta" : "reject";
+  }
+  // Stable: only a version greater than current latest may move `latest`.
+  // Anything lower is a backport to an older line -> release-line tag.
+  return cmp > 0 ? "latest" : `v${parseSemver(version).major}`;
+}
+
+/**
+ * Extract { latest, versions } from `npm view <name> --json` output.
+ * @param {string} packumentJson
+ */
+export function fromPackument(packumentJson) {
+  if (!packumentJson || !packumentJson.trim()) {
+    return { latest: null, versions: /** @type {string[]} */ ([]) };
+  }
+  const pk = JSON.parse(packumentJson);
+  const distTags = pk["dist-tags"] || {};
+  let versions = [];
+  if (Array.isArray(pk.versions)) versions = pk.versions;
+  else if (pk.versions && typeof pk.versions === "object")
+    versions = Object.keys(pk.versions);
+  else if (typeof pk.versions === "string") versions = [pk.versions];
+  return { latest: distTags.latest || null, versions };
+}
+
+// --- CLI ---
+import { pathToFileURL } from "node:url";
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const version = process.argv[2];
+  const packumentJson = process.argv[3] || "";
+  if (!version) {
+    console.error("usage: decide-dist-tag.js <version> [packumentJson]");
+    process.exit(2);
+  }
+  const { latest, versions } = fromPackument(packumentJson);
+  process.stdout.write(decide(version, latest, versions));
+}

--- a/.github/workflows/scripts/test-publish/decide-dist-tag.test.js
+++ b/.github/workflows/scripts/test-publish/decide-dist-tag.test.js
@@ -1,0 +1,105 @@
+// @ts-check
+//
+// Unit tests for decide-dist-tag.js. Run locally with:
+//   node --test .github/workflows/scripts/test-publish/*.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseSemver,
+  compareSemver,
+  isPrerelease,
+  decide,
+  fromPackument,
+} from "./decide-dist-tag.js";
+
+test("parseSemver: parses core, prerelease, ignores build metadata", () => {
+  assert.deepEqual(parseSemver("1.2.3"), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+    prerelease: [],
+  });
+  assert.deepEqual(parseSemver("2.0.0-alpha.1"), {
+    major: 2,
+    minor: 0,
+    patch: 0,
+    prerelease: ["alpha", "1"],
+  });
+  assert.deepEqual(parseSemver("1.0.0-rc.2+build.7").prerelease, ["rc", "2"]);
+  assert.throws(() => parseSemver("not.a.version"));
+});
+
+test("compareSemver: numeric core ordering (not string ordering)", () => {
+  assert.equal(compareSemver("1.10.0", "1.9.0"), 1); // 10 > 9, the classic trap
+  assert.equal(compareSemver("2.0.0", "1.9.9"), 1);
+  assert.equal(compareSemver("1.0.0", "1.0.0"), 0);
+});
+
+test("compareSemver: a prerelease is lower than its release", () => {
+  assert.equal(compareSemver("2.0.0-beta.1", "2.0.0"), -1);
+  assert.equal(compareSemver("2.0.0", "2.0.0-beta.1"), 1);
+});
+
+test("compareSemver: higher core beats prerelease status", () => {
+  assert.equal(compareSemver("3.0.0-alpha.1", "2.0.0"), 1);
+  assert.equal(compareSemver("2.1.0-beta.1", "2.0.0"), 1);
+});
+
+test("compareSemver: prerelease identifier precedence (spec §11)", () => {
+  assert.equal(compareSemver("1.0.0-alpha", "1.0.0-alpha.1"), -1); // fewer ids = lower
+  assert.equal(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta"), -1); // numeric < alnum
+  assert.equal(compareSemver("1.0.0-alpha.beta", "1.0.0-beta"), -1); // lexical
+  assert.equal(compareSemver("1.0.0-beta.2", "1.0.0-beta.11"), -1); // numeric compare
+});
+
+test("isPrerelease", () => {
+  assert.equal(isPrerelease("1.0.0"), false);
+  assert.equal(isPrerelease("1.0.0-rc.1"), true);
+});
+
+test("decide: first publish (no latest yet)", () => {
+  assert.equal(decide("1.0.0", null, []), "latest");
+  assert.equal(decide("1.0.0-rc.1", null, []), "beta");
+});
+
+test("decide: already-published version is skipped (idempotent)", () => {
+  assert.equal(decide("1.1.1", "2.0.0", ["1.0.0", "1.1.1", "2.0.0"]), "skip");
+});
+
+test("decide: stable forward release moves latest", () => {
+  assert.equal(decide("2.0.0", "1.9.0", ["1.9.0"]), "latest");
+  assert.equal(decide("3.0.0", "2.5.0", ["2.5.0"]), "latest"); // new higher major
+});
+
+test("decide: stable backport to older line -> v<major>, never latest", () => {
+  // v2 is latest; shipping v1.1.9 must NOT move latest.
+  assert.equal(decide("1.1.9", "2.0.0", ["2.0.0"]), "v1");
+});
+
+test("decide: prerelease above latest -> beta", () => {
+  assert.equal(decide("3.0.0-beta.1", "2.0.0", ["2.0.0"]), "beta");
+  assert.equal(decide("2.1.0-alpha.1", "2.0.0", ["2.0.0"]), "beta");
+});
+
+test("decide: prerelease at/below latest -> reject (no old-line betas)", () => {
+  // v2 is latest; a v1 beta is not allowed.
+  assert.equal(decide("1.5.0-beta.1", "2.0.0", ["2.0.0"]), "reject");
+  // a beta of an already-released version is also rejected.
+  assert.equal(decide("2.0.0-beta.1", "2.0.0", ["2.0.0"]), "reject");
+});
+
+test("fromPackument: empty input means brand-new package", () => {
+  assert.deepEqual(fromPackument(""), { latest: null, versions: [] });
+});
+
+test("fromPackument: extracts latest and version keys", () => {
+  const pk = JSON.stringify({
+    "dist-tags": { latest: "2.0.0", beta: "3.0.0-beta.1" },
+    versions: { "1.0.0": {}, "2.0.0": {}, "3.0.0-beta.1": {} },
+  });
+  assert.deepEqual(fromPackument(pk), {
+    latest: "2.0.0",
+    versions: ["1.0.0", "2.0.0", "3.0.0-beta.1"],
+  });
+});

--- a/.github/workflows/scripts/test-publish/e2e.sh
+++ b/.github/workflows/scripts/test-publish/e2e.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# End-to-end scenarios for iterate-publish-npm.sh, run against fixture packages
+# with the registry-aware mock npm on PATH. Exits non-zero if any scenario fails.
+#
+#   PATH must include the dir containing the mock `npm` (the workflow sets this).
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+PUBLISH="$REPO_ROOT/.github/workflows/iterate-publish-npm.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+export DIST_TAG_VERIFY_ATTEMPTS=${DIST_TAG_VERIFY_ATTEMPTS:-2}
+export DIST_TAG_VERIFY_DELAY=${DIST_TAG_VERIFY_DELAY:-1}
+
+FAILS=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILS=$((FAILS + 1)); }
+
+# mkpkg <dir> <name> <version>
+mkpkg() {
+  mkdir -p "$1"
+  printf '{"name":"%s","version":"%s"}\n' "$2" "$3" > "$1/package.json"
+}
+
+# fresh <name> -> sets PKG_DIR, NPM_LOG, MOCK_REGISTRY for a scenario
+fresh() {
+  PKG_DIR="$WORK/$1"; mkdir -p "$PKG_DIR"
+  export NPM_LOG="$WORK/$1.log"; : > "$NPM_LOG"
+  export MOCK_REGISTRY="$WORK/$1.reg.json"; echo '{}' > "$MOCK_REGISTRY"
+}
+
+# logged_tag_is <expected-tag> : true if a publish with that --tag was recorded
+logged_tag_is() { grep -q "\"publish\".*\"--tag\",\"$1\"" "$NPM_LOG"; }
+no_publish()    { ! grep -q '"publish"' "$NPM_LOG"; }
+reg_latest()    { node -e 'const r=JSON.parse(require("fs").readFileSync(process.env.MOCK_REGISTRY,"utf8"));process.stdout.write((r[process.argv[1]]&&r[process.argv[1]].distTags&&r[process.argv[1]].distTags.latest)||"")' "$1"; }
+
+echo "1) forward stable release -> latest"
+fresh s1
+mkpkg "$PKG_DIR" core 2.0.0
+echo '{"core":{"distTags":{"latest":"1.9.0"},"versions":["1.9.0"]}}' > "$MOCK_REGISTRY"
+if TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && logged_tag_is latest && [ "$(reg_latest core)" = "2.0.0" ]; then
+  pass "2.0.0 published to latest; latest moved to 2.0.0"
+else fail "forward release did not go to latest"; fi
+
+echo "2) backport below latest -> v<major>, latest unchanged"
+fresh s2
+mkpkg "$PKG_DIR" core 1.1.9
+echo '{"core":{"distTags":{"latest":"2.0.0"},"versions":["2.0.0"]}}' > "$MOCK_REGISTRY"
+if TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && logged_tag_is v1 && [ "$(reg_latest core)" = "2.0.0" ]; then
+  pass "1.1.9 published to v1; latest still 2.0.0"
+else fail "backport did not go to v1 / moved latest"; fi
+
+echo "3) prerelease above latest -> beta"
+fresh s3
+mkpkg "$PKG_DIR" core 3.0.0-beta.1
+echo '{"core":{"distTags":{"latest":"2.0.0"},"versions":["2.0.0"]}}' > "$MOCK_REGISTRY"
+if TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && logged_tag_is beta; then
+  pass "3.0.0-beta.1 published to beta"
+else fail "prerelease above latest did not go to beta"; fi
+
+echo "4) old-line prerelease -> reject, nothing published"
+fresh s4
+mkpkg "$PKG_DIR" core 1.5.0-beta.1
+echo '{"core":{"distTags":{"latest":"2.0.0"},"versions":["2.0.0"]}}' > "$MOCK_REGISTRY"
+if ! TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && no_publish; then
+  pass "old-line prerelease rejected before any publish"
+else fail "old-line prerelease was not rejected"; fi
+
+echo "5) already-published version -> skip"
+fresh s5
+mkpkg "$PKG_DIR" core 2.0.0
+echo '{"core":{"distTags":{"latest":"2.0.0"},"versions":["1.0.0","2.0.0"]}}' > "$MOCK_REGISTRY"
+if TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && no_publish; then
+  pass "already-published version skipped (idempotent)"
+else fail "already-published version was not skipped"; fi
+
+echo "6) registry read failure -> abort, nothing published"
+fresh s6
+mkpkg "$PKG_DIR" core 2.0.0
+if ! MOCK_VIEW_FAIL=1 TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1 && no_publish; then
+  pass "aborted on registry read failure"
+else fail "did not abort on registry read failure"; fi
+
+echo "7) post-publish tag/version mismatch -> fail"
+fresh s7
+mkpkg "$PKG_DIR" core 2.0.0
+echo '{"core":{"distTags":{"latest":"1.9.0"},"versions":["1.9.0"]}}' > "$MOCK_REGISTRY"
+if ! MOCK_BREAK_VERIFY=1 TEST_PACKAGES="$PKG_DIR" bash "$PUBLISH" >/dev/null 2>&1; then
+  pass "post-publish verification caught the mismatch"
+else fail "post-publish mismatch was not detected"; fi
+
+echo
+if [ "$FAILS" -ne 0 ]; then echo "E2E FAILED: $FAILS scenario(s)"; exit 1; fi
+echo "E2E PASSED: all scenarios"

--- a/.github/workflows/scripts/test-publish/registry-mock-npm.js
+++ b/.github/workflows/scripts/test-publish/registry-mock-npm.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// Registry-aware mock `npm` for the test-npm-validation workflow (ES module).
+// Simulates just enough of the registry to exercise iterate-publish-npm.sh
+// without ever touching real npm.
+//
+// State lives in the JSON file at $MOCK_REGISTRY and looks like:
+//   { "<pkg>": { "distTags": { "latest": "2.0.0", ... }, "versions": ["1.0.0", ...] } }
+// Seed it before a test to model the "current" registry; the mock mutates it
+// on publish so post-publish verification can read it back.
+//
+// Supported commands:
+//   npm view <name> --json            -> packument { "dist-tags", "versions" }
+//   npm view <name> dist-tags.<tag>   -> the version for that tag (or "")
+//   npm publish ... --tag <tag>       -> records version + moves <tag> (cwd = pkg dir)
+//
+// Env toggles for negative tests:
+//   MOCK_FAIL_PUBLISH=1  -> publish exits non-zero
+//   MOCK_BREAK_VERIFY=1  -> publish records a wrong version for the tag
+//   MOCK_VIEW_FAIL=1     -> `npm view` fails like a transient registry error
+//                           (no E404), so the script aborts instead of guessing
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+if (process.env.NPM_LOG) {
+  appendFileSync(process.env.NPM_LOG, JSON.stringify(args) + "\n");
+}
+
+const regPath = process.env.MOCK_REGISTRY;
+const readReg = () => {
+  if (!regPath || !existsSync(regPath)) return {};
+  try {
+    return JSON.parse(readFileSync(regPath, "utf8"));
+  } catch {
+    return {};
+  }
+};
+const writeReg = (reg) => {
+  if (regPath) writeFileSync(regPath, JSON.stringify(reg));
+};
+
+if (args[0] === "view") {
+  if (process.env.MOCK_VIEW_FAIL === "1") {
+    console.error("npm error code E500\nnpm error 500 Internal Server Error");
+    process.exit(1);
+  }
+  const name = args[1];
+  const reg = readReg();
+  const entry = reg[name];
+
+  if (!entry) {
+    // Unknown package == never published.
+    console.error(`npm error code E404\nnpm error 404 '${name}' is not in this registry.`);
+    process.exit(1);
+  }
+
+  if (args.includes("--json")) {
+    const versions = {};
+    for (const v of entry.versions || []) versions[v] = {};
+    console.log(JSON.stringify({ "dist-tags": entry.distTags || {}, versions }));
+    process.exit(0);
+  }
+
+  const distTagArg = args.find((a) => a.startsWith("dist-tags."));
+  if (distTagArg) {
+    const tag = distTagArg.slice("dist-tags.".length);
+    console.log((entry.distTags && entry.distTags[tag]) || "");
+    process.exit(0);
+  }
+  process.exit(0);
+}
+
+if (args[0] === "publish") {
+  if (process.env.MOCK_FAIL_PUBLISH === "1") {
+    console.error("registry-mock-npm: simulated publish failure");
+    process.exit(1);
+  }
+  const tagIdx = args.indexOf("--tag");
+  const tag = tagIdx === -1 ? "latest" : args[tagIdx + 1];
+  // `npm publish` runs with cwd set to the package directory.
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  const reg = readReg();
+  const entry = reg[pkg.name] || { distTags: {}, versions: [] };
+  entry.distTags = entry.distTags || {};
+  entry.versions = entry.versions || [];
+  if (!entry.versions.includes(pkg.version)) entry.versions.push(pkg.version);
+  entry.distTags[tag] =
+    process.env.MOCK_BREAK_VERIFY === "1" ? "0.0.0-wrong" : pkg.version;
+  reg[pkg.name] = entry;
+  writeReg(reg);
+  console.log(`+ ${pkg.name}@${pkg.version} (mock, tag=${tag})`);
+  process.exit(0);
+}
+
+// Anything else is a no-op success.
+process.exit(0);

--- a/.github/workflows/test-npm-validation.yml
+++ b/.github/workflows/test-npm-validation.yml
@@ -1,0 +1,59 @@
+name: Test NPM Publish Validation
+
+# Verifies the version-derived dist-tag policy in iterate-publish-npm.sh:
+#  - unit tests for the pure decision logic (decide-dist-tag.js)
+#  - end-to-end runs against fixture packages using a registry-aware mock npm,
+#    covering: forward release -> latest, backport -> v<major>, prerelease ->
+#    beta, old-line prerelease -> reject, already-published -> skip, and a
+#    registry read failure -> abort.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/iterate-publish-npm.sh'
+      - '.github/workflows/npm-publish.yml'
+      - '.github/workflows/test-npm-validation.yml'
+      - '.github/workflows/scripts/test-publish/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: decision logic unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: node --test .github/workflows/scripts/test-publish/*.test.js
+
+  e2e:
+    name: end-to-end pre/post publish checks
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    env:
+      DIST_TAG_VERIFY_ATTEMPTS: "2"
+      DIST_TAG_VERIFY_DELAY: "1"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Set up mock npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bin"
+          ln -sf "$GITHUB_WORKSPACE/.github/workflows/scripts/test-publish/registry-mock-npm.js" "$RUNNER_TEMP/bin/npm"
+          chmod +x "$RUNNER_TEMP/bin/npm"
+          echo "MOCK_BIN=$RUNNER_TEMP/bin" >> "$GITHUB_ENV"
+
+      - name: Run end-to-end scenarios
+        shell: bash
+        run: |
+          export PATH="$MOCK_BIN:$PATH"
+          bash .github/workflows/scripts/test-publish/e2e.sh


### PR DESCRIPTION
Ports the version-derived dist-tag publish logic from main to the v1.x maintenance line. Critical for v1.x: a v1.x release is compared against the current npm 'latest' (v2+), so it publishes to the 'v<major>' line tag and never moves 'latest' backward off the v2 line.

Includes the pure, unit-tested decision module (decide-dist-tag.js), the registry-aware mock + e2e harness, the test workflow, and drops the now- unused prerelease arg from npm-publish.yml. Mirrors the merged main change (incl. the pre-flight exit-code guard for invalid versions).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
