### PR TITLE
feat(sdk): add Workflow Insight plugin scaffold with contracts and types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,6 +857,10 @@
       "resolved": "packages/aws-durable-execution-sdk-js-examples",
       "link": true
     },
+    "node_modules/@aws/durable-execution-sdk-js-insight": {
+      "resolved": "packages/aws-durable-execution-sdk-js-insight",
+      "link": true
+    },
     "node_modules/@aws/durable-execution-sdk-js-testing": {
       "resolved": "packages/aws-durable-execution-sdk-js-testing",
       "link": true
@@ -14281,6 +14285,42 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight": {
+      "name": "@aws/durable-execution-sdk-js-insight",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@aws/durable-execution-sdk-js": "*",
+        "@rollup/plugin-esm-shim": "^0.1.0",
+        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-replace": "^6.0.0",
+        "@rollup/plugin-typescript": "^12.0.0",
+        "concurrently": "^9.0.0",
+        "rollup": "^4.0.0",
+        "tslib": "^2.6.0",
+        "typescript": "~5.8.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@aws/durable-execution-sdk-js": ">=2.0.0-alpha.1"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/aws-durable-execution-sdk-js-testing": {

--- a/packages/aws-durable-execution-sdk-js-insight/.gitignore
+++ b/packages/aws-durable-execution-sdk-js-insight/.gitignore
@@ -1,0 +1,3 @@
+dist/
+dist-cjs/
+dist-types/

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -1,0 +1,495 @@
+# Workflow Insight Plugin — Contracts
+
+## 1. Plugin Configuration Contract
+
+```typescript
+import { DurableInstrumentationPlugin } from "@aws/durable-execution-sdk-js";
+
+/**
+ * Exporter interface — any class that knows how to send a WorkflowInsightRecord
+ * to a specific destination. Each exporter owns its own configuration.
+ */
+interface InsightExporter {
+  /** Send (or upsert) a record to the destination. */
+  export(record: WorkflowInsightRecord): Promise<void>;
+
+  /** Optional: flush any buffered data. Called before Lambda returns. */
+  flush?(): Promise<void>;
+
+  /**
+   * Maximum record size in bytes before truncation.
+   * Each exporter can set its own limit based on destination constraints.
+   * Default: 256KB. Truncation removes operation results starting from oldest.
+   */
+  maxRecordSizeBytes?: number;
+}
+
+interface WorkflowInsightConfig {
+  /**
+   * One or more exporters that receive curated execution records.
+   * Each exporter handles its own destination-specific config.
+   * At least one exporter is required.
+   */
+  exporters: InsightExporter[];
+
+  /**
+   * Sampling rate: 0.0 to 1.0.
+   * Decision is made once per execution (all-or-nothing).
+   * Default: 1.0 (emit all executions)
+   */
+  samplingRate?: number;
+
+  /**
+   * When to emit records.
+   * - "finished-only": emit one record when execution ends (default)
+   * - "in-progress": emit/update on every operation status change + end
+   */
+  emitMode?: "finished-only" | "in-progress";
+
+  /**
+   * Control what data is included in the emitted record.
+   */
+  content?: ContentConfig;
+}
+
+// --- Type Aliases ---
+
+/** Any value that can appear in execution data after serialization. */
+type JsonValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | Date
+  | Buffer
+  | Uint8Array
+  | RegExp
+  | Map<string, JsonValue>
+  | Set<JsonValue>
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** The JSON payload provided as input to the durable execution. */
+type ExecutionInput = JsonValue;
+
+/** The JSON payload returned by the durable execution on success. */
+type ExecutionOutput = JsonValue;
+
+/** The JSON value returned by an operation (step, invoke, callback, etc.). */
+type OperationResult = JsonValue;
+
+interface OperationOverride {
+  /** Operation name (from step("name", fn)). */
+  operationName: string;
+
+  /**
+   * Exclude this operation from the record entirely.
+   * Default: false.
+   */
+  exclude?: boolean;
+
+  /**
+   * Include and optionally transform the operation's result.
+   * If omitted, result is not included (default behavior).
+   * - (r) => r: include full result
+   * - (r) => ({ field: r.field }): include only specific fields
+   */
+  result?: (result: OperationResult) => OperationResult;
+}
+
+// --- Content Configuration ---
+
+interface ContentConfig {
+  /**
+   * Transform execution input before including in the record.
+   * - true: include as-is (default)
+   * - false: exclude entirely
+   * - function: transform to whatever shape you want (redact, reshape, pick fields)
+   */
+  input?: boolean | ((input: ExecutionInput) => ExecutionInput);
+
+  /**
+   * Transform execution output before including in the record.
+   * - true: include as-is (default)
+   * - false: exclude entirely
+   * - function: transform to whatever shape you want
+   */
+  output?: boolean | ((output: ExecutionOutput) => ExecutionOutput);
+
+  /**
+   * Control which operations are included and what detail level.
+   *
+   * Default: all named operations are included (status, timing, attempts, errors)
+   * but WITHOUT their result field. Unnamed operations are excluded.
+   *
+   * Use overrides to include results for specific operations or exclude them entirely.
+   */
+  operations?: {
+    /** Per-operation overrides. */
+    overrides?: OperationOverride[];
+
+    /** Include operation error details. Default: true. */
+    includeErrors?: boolean;
+  };
+}
+```
+
+### First-Party Exporters (shipped by us)
+
+```typescript
+import {
+  CloudWatchLogsExporter,
+  S3Exporter,
+  DynamoDBExporter,
+  OTelExporter,
+} from "@aws/durable-execution-sdk-js-insight";
+
+// Each exporter owns its config — the plugin doesn't know about buckets or tables.
+
+new CloudWatchLogsExporter({
+  logGroupName?: string;   // default: Lambda function's own log group
+  logStreamPrefix?: string; // default: "workflow-insight/"
+})
+
+new S3Exporter({
+  bucket: string;
+  prefix?: string;          // default: "workflow-insight/"
+  partitioning?: "date" | "function-name" | "none"; // default: "date"
+})
+
+new DynamoDBExporter({
+  tableName: string;
+  partitionKey?: string;    // default: "pk", value = executionArn
+})
+
+new OTelExporter({
+  endpoint: string;         // e.g., "http://localhost:4318/v1/logs"
+  headers?: Record<string, string>;
+  protocol?: "http/json" | "grpc"; // default: "http/json"
+})
+```
+
+### Third-Party Exporters (published by vendors or community)
+
+```typescript
+// Published on npm by Datadog, Splunk, etc. — we don't maintain these.
+import { DatadogExporter } from "@datadog/durable-execution-exporter";
+import { SplunkExporter } from "@splunk/durable-execution-exporter";
+
+new DatadogExporter({ apiKey: process.env.DD_API_KEY, site: "datadoghq.com" });
+new SplunkExporter({ token: process.env.SPLUNK_HEC_TOKEN, url: "https://..." });
+```
+
+### Custom Exporters (built by customers)
+
+```typescript
+// Customers implement InsightExporter directly — no special "custom" type needed.
+class MyCustomExporter implements InsightExporter {
+  async export(record: WorkflowInsightRecord): Promise<void> {
+    await fetch("https://my-service.example.com/ingest", {
+      method: "POST",
+      body: JSON.stringify(record),
+    });
+  }
+}
+```
+
+### Usage Example
+
+```typescript
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+import {
+  workflowInsight,
+  CloudWatchLogsExporter,
+} from "@aws/durable-execution-sdk-js-insight";
+
+const insight = workflowInsight({
+  exporters: [new CloudWatchLogsExporter()],
+  emitMode: "finished-only",
+});
+
+export const handler = withDurableExecution(myHandler, {
+  plugins: [insight],
+});
+```
+
+### Progressive Configuration
+
+```typescript
+// Minimum: one line
+const insight = workflowInsight({
+  exporters: [new CloudWatchLogsExporter()],
+});
+
+// With sampling
+const insight = workflowInsight({
+  exporters: [new CloudWatchLogsExporter()],
+  samplingRate: 0.1, // 10% of executions
+});
+
+// Multi-exporter
+const insight = workflowInsight({
+  exporters: [
+    new S3Exporter({ bucket: "my-insight-bucket" }),
+    new OTelExporter({
+      endpoint: "https://otlp.datadoghq.com/v1/logs",
+      headers: { "DD-API-KEY": process.env.DD_API_KEY },
+      maxRecordSizeBytes: 128_000,
+    }),
+  ],
+  emitMode: "in-progress",
+  content: {
+    input: (input) => ({
+      customerId: input.customerId,
+      orderId: input.orderId,
+    }),
+    output: true,
+    operations: {
+      overrides: [
+        {
+          operationName: "charge-payment",
+          result: (r) => ({ amount: r.amount, status: r.status }),
+        },
+        { operationName: "validate-order", result: (r) => r }, // full result
+        { operationName: "internal-logging", exclude: true }, // exclude entirely
+      ],
+    },
+  },
+});
+
+// Redact sensitive fields
+const insight = workflowInsight({
+  exporters: [new CloudWatchLogsExporter()],
+  content: {
+    input: (input) => ({ ...input, creditCard: undefined, ssn: undefined }),
+    output: (output) => ({ orderId: output.orderId, status: output.status }),
+  },
+});
+
+// Minimal: no input/output, no errors
+const insight = workflowInsight({
+  exporters: [new S3Exporter({ bucket: "my-bucket" })],
+  content: {
+    input: false,
+    output: false,
+    operations: { includeErrors: false },
+  },
+});
+```
+
+---
+
+## 2. Emitted Record Contract (WorkflowInsightRecord)
+
+This is the shape of the curated JSON record written to destinations.
+
+```typescript
+interface WorkflowInsightRecord {
+  /** Schema version for forward compatibility. */
+  schemaVersion: "1.0";
+
+  /** ISO-8601 timestamp when this record was emitted. */
+  emittedAt: string;
+
+  // --- Execution Identity ---
+
+  /** Full ARN: arn:aws:lambda:region:account:function:name:qualifier */
+  executionArn: string;
+
+  /** Customer-provided execution name (from --durable-execution-name), if any. */
+  executionName?: string;
+
+  /** Function name (without qualifier). */
+  functionName: string;
+
+  /** Function qualifier (version or alias). */
+  functionQualifier: string;
+
+  /** AWS region. */
+  region: string;
+
+  /** AWS account ID. */
+  accountId: string;
+
+  // --- Execution State ---
+
+  /** Current execution status. */
+  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING";
+
+  /** ISO-8601 timestamp when execution started. */
+  startTime: string;
+
+  /** ISO-8601 timestamp when execution ended (null if still running). */
+  endTime?: string;
+
+  /** Duration in milliseconds (null if still running). */
+  durationMs?: number;
+
+  // --- Input/Output ---
+
+  /** Execution input (may be truncated if over size limit). */
+  input?: unknown;
+
+  /** Execution result on success (may be truncated). */
+  output?: unknown;
+
+  /** Error details on failure. */
+  error?: {
+    name: string;
+    message: string;
+  };
+
+  // --- Operations ---
+
+  /**
+   * Array of operations in execution order.
+   * Each operation represents a step, wait, invoke, callback, or child context.
+   */
+  operations: OperationRecord[];
+
+  // --- Metadata ---
+
+  /** Plugin version that emitted this record. */
+  pluginVersion: string;
+
+  /** SDK version. */
+  sdkVersion: string;
+}
+
+interface OperationRecord {
+  /** Hashed operation ID (stable across replays). */
+  id: string;
+
+  /** Customer-provided name (from step("name", fn)). */
+  name?: string;
+
+  /** STEP | WAIT | CALLBACK | CHAINED_INVOKE | CONTEXT */
+  type: string;
+
+  /** Additional categorization. */
+  subType?: string;
+
+  /** Parent operation ID if nested in a child context. */
+  parentId?: string;
+
+  /** STARTED | SUCCEEDED | FAILED | PENDING | CANCELLED | TIMED_OUT */
+  status: string;
+
+  /** ISO-8601 start time. */
+  startTime?: string;
+
+  /** ISO-8601 end time. */
+  endTime?: string;
+
+  /** Duration in milliseconds. */
+  durationMs?: number;
+
+  /** Number of attempts (for steps with retry). */
+  attempt?: number;
+
+  /** Error details if this operation failed. */
+  error?: {
+    name: string;
+    message: string;
+  };
+}
+```
+
+### Example Emitted Record
+
+```json
+{
+  "schemaVersion": "1.0",
+  "emittedAt": "2026-06-10T21:30:00.000Z",
+  "executionArn": "arn:aws:lambda:us-east-1:123456789012:function:order-processor:prod:exec-abc123",
+  "executionName": "order-12345",
+  "functionName": "order-processor",
+  "functionQualifier": "prod",
+  "region": "us-east-1",
+  "accountId": "123456789012",
+  "status": "FAILED",
+  "startTime": "2026-06-10T21:29:55.000Z",
+  "endTime": "2026-06-10T21:30:00.000Z",
+  "durationMs": 5000,
+  "input": { "orderId": "12345", "customerId": "cust-789" },
+  "error": {
+    "name": "TimeoutError",
+    "message": "Stripe payment timed out after 3 retries"
+  },
+  "operations": [
+    {
+      "id": "e5f6a7b8",
+      "name": "validate-order",
+      "type": "STEP",
+      "status": "SUCCEEDED",
+      "startTime": "2026-06-10T21:29:55.100Z",
+      "endTime": "2026-06-10T21:29:55.300Z",
+      "durationMs": 200,
+      "attempt": 1
+    },
+    {
+      "id": "c9d0e1f2",
+      "name": "check-inventory",
+      "type": "STEP",
+      "status": "SUCCEEDED",
+      "startTime": "2026-06-10T21:29:55.300Z",
+      "endTime": "2026-06-10T21:29:55.800Z",
+      "durationMs": 500,
+      "attempt": 1
+    },
+    {
+      "id": "a1b2c3d4",
+      "name": "charge-payment",
+      "type": "STEP",
+      "status": "FAILED",
+      "startTime": "2026-06-10T21:29:55.800Z",
+      "endTime": "2026-06-10T21:30:00.000Z",
+      "durationMs": 4200,
+      "attempt": 3,
+      "error": {
+        "name": "TimeoutError",
+        "message": "Stripe payment timed out after 3 retries"
+      }
+    },
+    {
+      "id": "b3c4d5e6",
+      "name": "send-notification",
+      "type": "STEP",
+      "status": "PENDING",
+      "startTime": null,
+      "endTime": null
+    }
+  ],
+  "pluginVersion": "0.1.0",
+  "sdkVersion": "2.0.0"
+}
+```
+
+---
+
+## 3. Emit Timing & Lifecycle
+
+| emitMode        | When record is emitted                                        | Record updates?                                      |
+| --------------- | ------------------------------------------------------------- | ---------------------------------------------------- |
+| `finished-only` | Once, at `onInvocationEnd` when status is SUCCEEDED or FAILED | No — single write                                    |
+| `in-progress`   | On every `onOperationChange` + at `onInvocationEnd`           | Yes — same record key, overwritten with latest state |
+
+### Critical constraint: `onInvocationEnd` must be awaited
+
+The current plugin runner fires `onInvocationEnd` as fire-and-forget. For Workflow Insight, this is the moment we flush to the destination. If Lambda terminates before the write completes, data is lost.
+
+**Proposed fix:** Use `wrapInvocation` instead (already awaited), or modify the plugin runner to await `onInvocationEnd` before returning the Lambda response.
+
+---
+
+## 4. What This Record Enables (Query Examples)
+
+| Question                                       | Query against this record                                            |
+| ---------------------------------------------- | -------------------------------------------------------------------- |
+| Which executions failed at the payment step?   | `WHERE status = 'FAILED' AND error.operationName = 'charge-payment'` |
+| Average duration of successful executions?     | `AVG(durationMs) WHERE status = 'SUCCEEDED'`                         |
+| Which step has the highest failure rate?       | Unnest operations, group by name, count failed/total                 |
+| Executions with >3 retry attempts on any step? | `WHERE ANY(operations[*].attempt > 3)`                               |
+| Currently running executions?                  | `WHERE status = 'RUNNING'` (in-progress mode only)                   |

--- a/packages/aws-durable-execution-sdk-js-insight/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@aws/durable-execution-sdk-js-insight",
+  "description": "Workflow Insight plugin for AWS Durable Execution SDK — curated execution observability",
+  "license": "Apache-2.0",
+  "version": "0.1.0-alpha.0",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",
+    "directory": "packages/aws-durable-execution-sdk-js-insight"
+  },
+  "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/main/packages/aws-durable-execution-sdk-js-insight",
+  "engines": {
+    "node": ">=22"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist-types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist-types/index.d.ts",
+      "require": "./dist-cjs/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist/",
+    "dist-cjs/",
+    "dist-types/"
+  ],
+  "scripts": {
+    "build": "concurrently npm:build:esm npm:build:cjs npm:build:types",
+    "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
+    "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist-types",
+    "clean": "rm -rf dist dist-cjs dist-types"
+  },
+  "peerDependencies": {
+    "@aws/durable-execution-sdk-js": ">=2.0.0-alpha.1"
+  },
+  "devDependencies": {
+    "@aws/durable-execution-sdk-js": "*",
+    "concurrently": "^9.0.0",
+    "rollup": "^4.0.0",
+    "@rollup/plugin-typescript": "^12.0.0",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-esm-shim": "^0.1.0",
+    "@rollup/plugin-replace": "^6.0.0",
+    "typescript": "~5.8.0",
+    "tslib": "^2.6.0"
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight/rollup.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-insight/rollup.config.mjs
@@ -1,0 +1,14 @@
+// @ts-check
+
+import { createBuildOptions } from "../../rollup.config.js";
+import packageJson from "./package.json" with { type: "json" };
+
+const config = {
+  input: "./src/index.ts",
+  output: {
+    file: "index",
+    inlineDynamicImports: true,
+  },
+};
+
+export default createBuildOptions(config, process.env.MODE, packageJson);

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -1,0 +1,64 @@
+import type { Operation } from "@aws-sdk/client-lambda";
+import type { WorkflowInsightConfig } from "./types";
+
+export type {
+  InsightExporter,
+  WorkflowInsightConfig,
+  WorkflowInsightRecord,
+  OperationRecord,
+  ContentConfig,
+  OperationOverride,
+} from "./types";
+
+/**
+ * Minimal plugin interface types matching @aws/durable-execution-sdk-js.
+ * These will be replaced by direct imports once the SDK publishes its types.
+ */
+interface InvocationInfo {
+  requestId: string;
+  executionArn: string;
+  isFirstInvocation: boolean;
+}
+
+interface InvocationEndInfo extends InvocationInfo {
+  status: string;
+  executionResult?: unknown;
+  executionError?: Error;
+  executionInput: unknown;
+  operations: Record<string, Operation>;
+}
+
+interface OperationChangeInfo {
+  requestId: string;
+  executionArn: string;
+  updatedOperations: Record<string, Operation>;
+  operations: Record<string, Operation>;
+}
+
+interface DurableInstrumentationPlugin {
+  onInvocationStart?(info: InvocationInfo): void;
+  onInvocationEnd?(info: InvocationEndInfo): void;
+  onOperationChange?(info: OperationChangeInfo): void;
+}
+
+/**
+ * Creates a Workflow Insight plugin that listens to execution lifecycle events.
+ * @experimental This function is experimental and may change in future releases.
+ */
+export function workflowInsight(
+  _config: WorkflowInsightConfig,
+): DurableInstrumentationPlugin {
+  return {
+    onInvocationStart(_info: InvocationInfo): void {
+      // TODO: initialize record state, apply sampling decision
+    },
+
+    onInvocationEnd(_info: InvocationEndInfo): void {
+      // TODO: build final record, call exporters
+    },
+
+    onOperationChange(_info: OperationChangeInfo): void {
+      // TODO: update record state, emit if in-progress mode
+    },
+  };
+}

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Any value that can appear in execution data.
+ * @experimental This type is experimental and may change in future releases.
+ */
+export type JsonValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined
+  | Date
+  | Buffer
+  | Uint8Array
+  | RegExp
+  | Map<string, JsonValue>
+  | Set<JsonValue>
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** @experimental This type is experimental and may change in future releases. */
+export type ExecutionInput = JsonValue;
+
+/** @experimental This type is experimental and may change in future releases. */
+export type ExecutionOutput = JsonValue;
+
+/** @experimental This type is experimental and may change in future releases. */
+export type OperationResult = JsonValue;
+
+/**
+ * Per-operation override for controlling inclusion and result transformation.
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface OperationOverride {
+  operationName: string;
+  exclude?: boolean;
+  result?: (result: OperationResult) => OperationResult;
+}
+
+/**
+ * Controls what data is included in the emitted record.
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface ContentConfig {
+  input?: boolean | ((input: ExecutionInput) => ExecutionInput);
+  output?: boolean | ((output: ExecutionOutput) => ExecutionOutput);
+  operations?: {
+    overrides?: OperationOverride[];
+    includeErrors?: boolean;
+  };
+}
+
+/**
+ * Interface for exporting workflow insight records to a destination.
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface InsightExporter {
+  export(record: WorkflowInsightRecord): Promise<void>;
+  flush?(): Promise<void>;
+  maxRecordSizeBytes?: number;
+}
+
+/**
+ * Configuration for the Workflow Insight plugin.
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface WorkflowInsightConfig {
+  exporters: InsightExporter[];
+  samplingRate?: number;
+  emitMode?: "finished-only" | "in-progress";
+  content?: ContentConfig;
+}
+
+/**
+ * A single operation within an execution (step, wait, invoke, callback, or context).
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface OperationRecord {
+  id: string;
+  name?: string;
+  type: string;
+  subType?: string;
+  parentId?: string;
+  status: string;
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+  attempt?: number;
+  error?: {
+    name: string;
+    message: string;
+  };
+}
+
+/**
+ * The curated execution record emitted to destinations.
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface WorkflowInsightRecord {
+  schemaVersion: "1.0";
+  emittedAt: string;
+  executionArn: string;
+  executionName?: string;
+  functionName: string;
+  functionQualifier: string;
+  region: string;
+  accountId: string;
+  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING";
+  startTime: string;
+  endTime?: string;
+  durationMs?: number;
+  input?: ExecutionInput;
+  output?: ExecutionOutput;
+  error?: {
+    name: string;
+    message: string;
+  };
+  operations: OperationRecord[];
+  pluginVersion: string;
+  sdkVersion: string;
+}

--- a/packages/aws-durable-execution-sdk-js-insight/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist-types",
+    "rootDir": "./src",
+    "strict": true,
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds the aws-durable-execution-sdk-js-insight package with:

- Plugin contracts doc (InsightExporter interface, WorkflowInsightConfig, WorkflowInsightRecord schema, content filtering, operation overrides)
- POC plan and observability pillars positioning docs
- Minimal TypeScript implementation: workflowInsight() factory returning a DurableInstrumentationPlugin with no-op onInvocationStart, onInvocationEnd, and onOperationChange listeners
- package.json, tsconfig.json, src/types.ts, src/index.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
