### PR TITLE
refactor(sdk): remove @aws-sdk/client-lambda dependency from plugin interface

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -1,4 +1,3 @@
-import { Operation } from "@aws-sdk/client-lambda";
 import { DurableExecutionInvocationOutput } from "./core";
 
 /**
@@ -24,14 +23,14 @@ export enum PluginInvocationStatus {
  */
 export interface OperationInfo {
   Id: string;
-  HashedId: string;
   Name?: string;
   Type: string;
   SubType?: string;
   ParentId?: string;
-  HashedParentId?: string;
+  Status?: string;
   StartTimestamp?: Date;
   EndTimestamp?: Date;
+  Result?: string;
 }
 
 /**
@@ -95,6 +94,7 @@ export interface InvocationBaseInfo {
  */
 export interface InvocationInfo extends InvocationBaseInfo {
   isFirstInvocation: boolean;
+  operations: Record<string, OperationInfo>;
 }
 
 /**
@@ -108,7 +108,7 @@ export interface InvocationEndInfo extends InvocationInfo {
   executionResult?: unknown;
   executionError?: Error;
   executionInput: unknown;
-  operations: Record<string, Operation>;
+  operations: Record<string, OperationInfo>;
 }
 
 /**
@@ -117,8 +117,8 @@ export interface InvocationEndInfo extends InvocationInfo {
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface OperationChangeInfo extends InvocationBaseInfo {
-  updatedOperations: Record<string, Operation>;
-  operations: Record<string, Operation>;
+  updatedOperations: Record<string, OperationInfo>;
+  operations: Record<string, OperationInfo>;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -9,6 +9,7 @@ import { log } from "../logger/logger";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
 import { hashId } from "../step-id-utils/step-id-utils";
+import { toOperationInfoMap } from "../operation/operation";
 import { EventEmitter } from "events";
 import {
   CheckpointUnrecoverableInvocationError,
@@ -445,12 +446,15 @@ export class CheckpointManager implements Checkpoint {
       }
     });
 
-    if (Object.keys(updatedOperations).length > 0) {
-      this.plugin.onOperationChange?.({
+    if (
+      Object.keys(updatedOperations).length > 0 &&
+      this.plugin.onOperationChange
+    ) {
+      this.plugin.onOperationChange({
         requestId: this.requestId,
         executionArn: this.durableExecutionArn,
-        updatedOperations,
-        operations: this.stepData,
+        updatedOperations: toOperationInfoMap(updatedOperations),
+        operations: toOperationInfoMap(this.stepData),
       });
     }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -5,7 +5,6 @@ import {
   AttemptEndInfo,
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
-import { hashId } from "../step-id-utils/step-id-utils";
 
 /**
  * Converts an Operation to an OperationInfo.
@@ -15,17 +14,34 @@ import { hashId } from "../step-id-utils/step-id-utils";
 export function toOperationInfo(operation?: Operation): OperationInfo {
   return {
     Id: operation?.Id ?? "",
-    HashedId: hashId(operation?.Id ?? ""),
     Name: operation?.Name,
     Type: operation?.Type ?? "",
     SubType: operation?.SubType,
     ParentId: operation?.ParentId,
-    HashedParentId: operation?.ParentId
-      ? hashId(operation.ParentId)
-      : undefined,
+    Status: operation?.Status,
     StartTimestamp: operation?.StartTimestamp,
     EndTimestamp: operation?.EndTimestamp,
+    Result:
+      operation?.StepDetails?.Result ??
+      operation?.CallbackDetails?.Result ??
+      operation?.ContextDetails?.Result ??
+      operation?.ChainedInvokeDetails?.Result,
   };
+}
+
+/**
+ * Converts a Record of Operations to a Record of OperationInfo.
+ *
+ * @experimental This function is experimental and may be changed or removed in future releases.
+ */
+export function toOperationInfoMap(
+  operations: Record<string, Operation>,
+): Record<string, OperationInfo> {
+  const result: Record<string, OperationInfo> = {};
+  for (const [key, op] of Object.entries(operations)) {
+    result[key] = toOperationInfo(op);
+  }
+  return result;
 }
 
 /**
@@ -76,15 +92,10 @@ export function backfillOperationInfo<T extends OperationInfo>(
   defaults: Partial<OperationInfo>,
 ): T {
   info.Id = defaults.Id ?? "";
-  info.HashedId = defaults.HashedId ?? hashId(info.Id);
   if (!info.Type) info.Type = defaults.Type ?? "";
   if (!info.SubType) info.SubType = defaults.SubType;
   if (!info.Name) info.Name = defaults.Name;
   if (!info.ParentId) info.ParentId = defaults.ParentId;
-  if (!info.HashedParentId)
-    info.HashedParentId =
-      defaults.HashedParentId ??
-      (info.ParentId ? hashId(info.ParentId) : undefined);
   if (!info.StartTimestamp) info.StartTimestamp = defaults.StartTimestamp;
   if (!info.EndTimestamp) info.EndTimestamp = defaults.EndTimestamp;
   return info;

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -25,11 +25,11 @@ describe("createPluginRunner", () => {
     requestId: "req-1",
     executionArn: "arn:aws:lambda:us-east-1:123:function:fn:1/exec/abc",
     isFirstInvocation: true,
+    operations: {},
   };
 
   const operationInfo: OperationInfo = {
     Id: "op-1",
-    HashedId: "op-1-hash",
     Name: "my-step",
     Type: "STEP",
   };

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -78,6 +78,7 @@ describe("plugin hooks", () => {
       requestId: "req-123",
       executionArn: "arn:test",
       isFirstInvocation: true,
+      operations: expect.any(Object),
     });
   });
 
@@ -97,6 +98,7 @@ describe("plugin hooks", () => {
       requestId: "req-123",
       executionArn: "arn:test",
       isFirstInvocation: false,
+      operations: expect.any(Object),
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -28,6 +28,7 @@ import {
   DurableLambdaHandler,
 } from "./types/durable-execution";
 import { createPluginRunner } from "./utils/plugin/plugin-runner";
+import { toOperationInfoMap } from "./utils/operation/operation";
 import {
   DurableInstrumentationPlugin,
   InvocationInfo,
@@ -72,6 +73,7 @@ async function runHandler<
     executionArn: executionContext.durableExecutionArn,
     isFirstInvocation:
       durableExecutionMode === DurableExecutionMode.ExecutionMode,
+    operations: toOperationInfoMap(executionContext._stepData),
   };
   plugin.onInvocationStart?.(invocationInfo);
 
@@ -198,7 +200,7 @@ async function runHandler<
             executionInput: customerHandlerEvent,
             executionError: result.error || new Error(result.message),
             executionResult: undefined,
-            operations: executionContext._stepData,
+            operations: toOperationInfoMap(executionContext._stepData),
           });
           return response;
         }
@@ -212,7 +214,7 @@ async function runHandler<
             executionInput: customerHandlerEvent,
             executionResult: undefined,
             executionError: undefined,
-            operations: executionContext._stepData,
+            operations: toOperationInfoMap(executionContext._stepData),
           });
 
           return {
@@ -267,7 +269,7 @@ async function runHandler<
               executionInput: customerHandlerEvent,
               executionResult: result,
               executionError: undefined,
-              operations: executionContext._stepData,
+              operations: toOperationInfoMap(executionContext._stepData),
             });
 
             // Return a response indicating the result was checkpointed
@@ -301,7 +303,7 @@ async function runHandler<
           executionInput: customerHandlerEvent,
           executionResult: result,
           executionError: undefined,
-          operations: executionContext._stepData,
+          operations: toOperationInfoMap(executionContext._stepData),
         });
 
         return {
@@ -323,7 +325,7 @@ async function runHandler<
             executionInput: customerHandlerEvent,
             executionError: error,
             executionResult: undefined,
-            operations: executionContext._stepData,
+            operations: toOperationInfoMap(executionContext._stepData),
           });
           throw error; // Re-throw the error to terminate Lambda execution
         }
@@ -347,7 +349,7 @@ async function runHandler<
           executionError:
             error instanceof Error ? error : new Error(String(error)),
           executionResult: undefined,
-          operations: executionContext._stepData,
+          operations: toOperationInfoMap(executionContext._stepData),
         });
 
         return {


### PR DESCRIPTION
Replace Operation from @aws-sdk/client-lambda with internally-defined OperationInfo in plugin hooks (onInvocationEnd, onOperationChange).

Changes to OperationInfo:
- Removed HashedId and HashedParentId (hashed values now go directly into Id and ParentId)
- Added Status field
- Added Result field

Added operations to InvocationInfo so onInvocationStart receives the current execution state (needed for receiving the latest change in start of each invocation).

Added toOperationInfoMap() utility to convert at the boundary. Guarded conversion behind plugin existence check to avoid unnecessary work when no plugin is registered.

This ensures plugin authors don't need @aws-sdk/client-lambda as a dependency — the plugin interface is fully self-contained.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
