### PR TITLE
fix(sdk): ensure child context result matches replay on first run

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.history.json
@@ -1,0 +1,269 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "86bac1e1-726f-439d-abee-614524cf9273",
+    "EventTimestamp": "2026-06-15T22:40:19.936Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "map-with-errors",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "process-item-0",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "6151f5ab282d90e4",
+    "Name": "process-item-1",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 7,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "process-item-2",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "6151f5ab282d90e4",
+    "Name": "process-item-1",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Custom callback error for item 2"
+        }
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "2f221a18eb863803",
+    "Name": "process-item-0",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"Processed item 1\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "b425e0c75591aa8f",
+    "Name": "process-item-2",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"Processed item 3\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "MapIteration",
+    "EventId": 12,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "map-item-1",
+    "EventTimestamp": "2026-06-15T22:40:19.946Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "Custom callback error for item 2"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 13,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "map-item-0",
+    "EventTimestamp": "2026-06-15T22:40:19.947Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"Processed item 1\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 14,
+    "Id": "13cee27a2bd93915",
+    "Name": "map-item-2",
+    "EventTimestamp": "2026-06-15T22:40:19.947Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"Processed item 3\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 15,
+    "Id": "c4ca4238a0b92382",
+    "Name": "map-with-errors",
+    "EventTimestamp": "2026-06-15T22:40:19.947Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":\"Processed item 1\",\"index\":0,\"status\":\"SUCCEEDED\"},{\"error\":{\"ErrorType\":\"ChildContextError\",\"ErrorMessage\":\"Custom callback error for item 2\",\"Cause\":{\"ErrorType\":\"CallbackError\",\"ErrorMessage\":\"Custom callback error for item 2\",\"Cause\":{\"ErrorType\":\"CallbackError\",\"ErrorMessage\":\"Custom callback error for item 2\"}}},\"index\":1,\"status\":\"FAILED\"},{\"result\":\"Processed item 3\",\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 16,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "capture-errors",
+    "EventTimestamp": "2026-06-15T22:40:19.947Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 17,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "capture-errors",
+    "EventTimestamp": "2026-06-15T22:40:19.947Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "{\"errorInfo\":[{\"wrapperType\":\"ChildContextError\",\"wrapperMessage\":\"Custom callback error for item 2\",\"causeType\":\"CallbackError\",\"causeMessage\":\"Custom callback error for item 2\"}],\"successCount\":2,\"failureCount\":1}"
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 18,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "force-replay",
+    "EventTimestamp": "2026-06-15T22:40:19.950Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-06-15T22:40:20.950Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 19,
+    "EventTimestamp": "2026-06-15T22:40:19.972Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-15T22:40:19.936Z",
+      "EndTimestamp": "2026-06-15T22:40:19.972Z",
+      "Error": {},
+      "RequestId": "c4be7976-5bdc-4930-ba27-5fbaf238b08d"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 20,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "force-replay",
+    "EventTimestamp": "2026-06-15T22:40:20.951Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 21,
+    "EventTimestamp": "2026-06-15T22:40:20.953Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-15T22:40:20.951Z",
+      "EndTimestamp": "2026-06-15T22:40:20.953Z",
+      "Error": {},
+      "RequestId": "c14145fa-4ca0-4c44-8d08-5487b02e9ce7"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 22,
+    "Id": "86bac1e1-726f-439d-abee-614524cf9273",
+    "EventTimestamp": "2026-06-15T22:40:20.954Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"beforeReplay\":{\"errorInfo\":[{\"wrapperType\":\"ChildContextError\",\"wrapperMessage\":\"Custom callback error for item 2\",\"causeType\":\"CallbackError\",\"causeMessage\":\"Custom callback error for item 2\"}],\"successCount\":2,\"failureCount\":1},\"afterReplay\":{\"errorInfo\":[{\"wrapperType\":\"ChildContextError\",\"wrapperMessage\":\"Custom callback error for item 2\",\"causeType\":\"CallbackError\",\"causeMessage\":\"Custom callback error for item 2\"}],\"successCount\":2,\"failureCount\":1}}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.test.ts
@@ -1,0 +1,49 @@
+import { handler } from "./map-error-type-preservation-replay";
+import { createTests } from "../../../utils/test-helper";
+
+/**
+ * Tests for map error type preservation through ser/des round-trip.
+ *
+ * Map/parallel uses createBatchResultSerdes as the default serdes, which
+ * uses serializeBatchError/reconstructBatchError to preserve the error
+ * cause chain (type + message) through the serialize/deserialize round-trip.
+ *
+ * Without this, after deserialization the cause would be rebuilt as a generic
+ * StepError("Unknown error") instead of preserving the original CallbackError type.
+ */
+createTests({
+  handler,
+  localRunnerConfig: {
+    skipTime: true,
+  },
+  tests: (runner, { assertEventSignatures }) => {
+    it("should preserve error cause type and message through map ser/des round-trip", async () => {
+      const execution = await runner.run();
+      const result = execution.getResult() as any;
+
+      // Verify basic structure
+      expect(result.beforeReplay.successCount).toBe(2);
+      expect(result.beforeReplay.failureCount).toBe(1);
+
+      // Before replay: error info captured on first run
+      const errorBefore = result.beforeReplay.errorInfo[0];
+      expect(errorBefore.wrapperType).toBe("ChildContextError");
+      expect(errorBefore.causeType).toBe("CallbackError");
+      expect(errorBefore.causeMessage).toBe("Custom callback error for item 2");
+
+      assertEventSignatures(execution);
+
+      // After replay: the map result was deserialized from checkpoint.
+      // The cause error type must still be "CallbackError", not "StepError".
+      const errorAfter = result.afterReplay.errorInfo[0];
+      expect(errorAfter.wrapperType).toBe("ChildContextError");
+      expect(errorAfter.causeType).toBe("CallbackError");
+      expect(errorAfter.causeMessage).toBe("Custom callback error for item 2");
+
+      // The before and after should be identical
+      expect(result.afterReplay.errorInfo).toEqual(
+        result.beforeReplay.errorInfo,
+      );
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/error-type-preservation-replay/map-error-type-preservation-replay.ts
@@ -1,0 +1,89 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  CallbackError,
+  retryPresets,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map Error Type Preservation Across Replay",
+  description:
+    "Verifies that map results with errors preserve the original error type " +
+    "and cause chain after going through the child context ser/des round-trip and replay.",
+};
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const items = [
+      { id: 1, shouldFail: false },
+      { id: 2, shouldFail: true },
+      { id: 3, shouldFail: false },
+    ];
+
+    const results = await context.map(
+      "map-with-errors",
+      items,
+      async (childContext, item, index) => {
+        return await childContext.step(
+          `process-item-${index}`,
+          async () => {
+            if (item.shouldFail) {
+              throw new CallbackError(
+                `Custom callback error for item ${item.id}`,
+              );
+            }
+            return `Processed item ${item.id}`;
+          },
+          { retryStrategy: retryPresets.noRetry },
+        );
+      },
+      {
+        completionConfig: {
+          toleratedFailureCount: 3,
+        },
+      },
+    );
+
+    // Capture error info BEFORE the wait — this is what map returned on first run.
+    const errors = results.getErrors();
+    const errorInfo = errors.map((error) => ({
+      wrapperType: (error as any).errorType,
+      wrapperMessage: error.message,
+      causeType: (error.cause as any)?.errorType,
+      causeMessage: error.cause?.message,
+    }));
+
+    const capturedBeforeReplay = await context.step(
+      "capture-errors",
+      async () => ({
+        errorInfo,
+        successCount: results.successCount,
+        failureCount: results.failureCount,
+      }),
+    );
+
+    // Wait forces a replay — on the next invocation, the map result
+    // comes from the child context checkpoint (deserialized).
+    await context.wait("force-replay", { seconds: 1 });
+
+    // After replay, access the map result again.
+    // The error cause chain should be preserved through the round-trip.
+    const errorsAfterReplay = results.getErrors();
+    const errorInfoAfterReplay = errorsAfterReplay.map((error) => ({
+      wrapperType: (error as any).errorType,
+      wrapperMessage: error.message,
+      causeType: (error.cause as any)?.errorType,
+      causeMessage: error.cause?.message,
+    }));
+
+    return {
+      beforeReplay: capturedBeforeReplay,
+      afterReplay: {
+        errorInfo: errorInfoAfterReplay,
+        successCount: results.successCount,
+        failureCount: results.failureCount,
+      },
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.history.json
@@ -1,0 +1,139 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "50a4ac30-d22e-4a47-98c4-6937507651da",
+    "EventTimestamp": "2026-06-15T22:40:19.932Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "\"hello\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "serdes-child",
+    "EventTimestamp": "2026-06-15T22:40:19.937Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "inner-step",
+    "EventTimestamp": "2026-06-15T22:40:19.937Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "inner-step",
+    "EventTimestamp": "2026-06-15T22:40:19.937Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"hello\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "RunInChildContext",
+    "EventId": 5,
+    "Id": "c4ca4238a0b92382",
+    "Name": "serdes-child",
+    "EventTimestamp": "2026-06-15T22:40:19.939Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "HELLO"
+      }
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "capture-result",
+    "EventTimestamp": "2026-06-15T22:40:19.939Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 7,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "capture-result",
+    "EventTimestamp": "2026-06-15T22:40:19.939Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"HELLO\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 8,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "force-replay",
+    "EventTimestamp": "2026-06-15T22:40:19.943Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-06-15T22:40:20.943Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-06-15T22:40:19.965Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-15T22:40:19.931Z",
+      "EndTimestamp": "2026-06-15T22:40:19.965Z",
+      "Error": {},
+      "RequestId": "74899685-8b1c-414f-a055-652d93d61f0a"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 10,
+    "Id": "eccbc87e4b5ce2fe",
+    "Name": "force-replay",
+    "EventTimestamp": "2026-06-15T22:40:20.943Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 11,
+    "EventTimestamp": "2026-06-15T22:40:20.945Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-15T22:40:20.944Z",
+      "EndTimestamp": "2026-06-15T22:40:20.945Z",
+      "Error": {},
+      "RequestId": "1aca0710-6ef3-48cd-a11a-3010b99b380d"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 12,
+    "Id": "50a4ac30-d22e-4a47-98c4-6937507651da",
+    "EventTimestamp": "2026-06-15T22:40:20.946Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"capturedOnFirstRun\":\"HELLO\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.test.ts
@@ -1,0 +1,48 @@
+import { handler } from "./run-in-child-context-serdes";
+import { createTests } from "../../../utils/test-helper";
+import {
+  OperationType,
+  OperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+
+/**
+ * Tests for child context ser/des round-trip behavior.
+ *
+ * Small payload path: runInChildContext should return deserialize(serialize(result))
+ * on first run so it matches what replay returns (deserialized from checkpoint).
+ */
+createTests({
+  handler,
+  localRunnerConfig: {
+    skipTime: true,
+  },
+  tests: (runner, { assertEventSignatures }) => {
+    it("should apply ser/des round-trip for small payloads on first run", async () => {
+      const execution = await runner.run({
+        payload: "hello",
+      });
+
+      const result = execution.getResult() as {
+        capturedOnFirstRun: string;
+      };
+
+      // Verify operations succeeded
+      const childOp = runner.getOperation("serdes-child");
+      expect(childOp.getType()).toBe(OperationType.CONTEXT);
+      expect(childOp.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+      const captureOp = runner.getOperation("capture-result");
+      expect(captureOp.getType()).toBe(OperationType.STEP);
+      expect(captureOp.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+      // Verify at least 2 invocations (first run + replay after wait)
+      expect(execution.getInvocations().length).toBeGreaterThanOrEqual(2);
+
+      assertEventSignatures(execution);
+
+      // On first run, runInChildContext must return deserialize(serialize(result))
+      // so that the caller sees the same value as on replay.
+      expect(result.capturedOnFirstRun).toBe("HELLO");
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/serdes/run-in-child-context-serdes.ts
@@ -1,0 +1,119 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Run in Child Context with Serdes",
+  description:
+    "Verifies runInChildContext with custom serdes returns " +
+    "deserialize(serialize(result)) on first run to match replay behavior.",
+};
+
+/**
+ * Custom serdes that uppercases on serialize and returns as-is on deserialize.
+ * This makes it easy to detect whether the result went through ser/des:
+ * - If the result is uppercase, it went through serialize → deserialize
+ * - If the result is lowercase, it was returned raw without the round-trip
+ */
+export const uppercaseSerdes: Serdes<string> = {
+  serialize: async (value: string | undefined, _context: SerdesContext) => {
+    if (value === undefined) return undefined;
+    return value.toUpperCase();
+  },
+  deserialize: async (data: string | undefined, _context: SerdesContext) => {
+    return data;
+  },
+};
+
+/**
+ * Standard case: small payload with custom serdes.
+ * First run should return deserialize(serialize(result)) = "HELLO".
+ */
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const childResult = await context.runInChildContext(
+      "serdes-child",
+      async (childContext: DurableContext) => {
+        return await childContext.step("inner-step", async () => {
+          return (event as string) || "hello";
+        });
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Capture result in a step to checkpoint what was returned on first invocation.
+    const captured = await context.step("capture-result", async () => {
+      return childResult;
+    });
+
+    // Wait forces a second invocation (replay).
+    await context.wait("force-replay", { seconds: 1 });
+
+    return { capturedOnFirstRun: captured };
+  },
+);
+
+/**
+ * Large payload case: exceeds 256KB checkpoint limit, triggers ReplayChildren.
+ * First run should return the raw result (replay re-executes the child function).
+ */
+export const largePayloadHandler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    // 300KB string exceeds the 256KB CHECKPOINT_SIZE_LIMIT_BYTES
+    const largeValue = "x".repeat(300 * 1024);
+
+    const childResult = await context.runInChildContext(
+      "large-child",
+      async (childContext: DurableContext) => {
+        return await childContext.step("large-step", async () => {
+          return largeValue;
+        });
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Capture to checkpoint what was returned on first run.
+    const captured = await context.step("capture-large-result", async () => {
+      // Only capture the first 10 chars + length to avoid huge checkpoint
+      return {
+        prefix: childResult.substring(0, 10),
+        length: childResult.length,
+      };
+    });
+
+    await context.wait("force-replay-large", { seconds: 1 });
+
+    return captured;
+  },
+);
+
+/**
+ * Virtual context case: virtualContext=true means no checkpointing.
+ * First run should return the raw result (no replay path to match).
+ */
+export const virtualContextHandler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const childResult = await context.runInChildContext(
+      "virtual-child",
+      async (childContext: DurableContext) => {
+        return await childContext.step("virtual-step", async () => {
+          return (event as string) || "hello";
+        });
+      },
+      { serdes: uppercaseSerdes, virtualContext: true },
+    );
+
+    // Capture what was returned from the virtual child context.
+    const captured = await context.step("capture-virtual-result", async () => {
+      return childResult;
+    });
+
+    await context.wait("force-replay-virtual", { seconds: 1 });
+
+    return { capturedOnFirstRun: captured };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -925,6 +925,31 @@ Resources:
           DURABLE_EXAMPLES_VERBOSE: "true"
     Metadata:
       SkipBuild: "True"
+  MapErrorTypePreservationReplay:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: MapErrorTypePreservationAcrossReplay-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: map-error-type-preservation-replay.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
   MapFailureThresholdExceededCount:
     Type: AWS::Serverless::Function
     Properties:
@@ -1879,6 +1904,31 @@ Resources:
       FunctionName: RunInChildContextLargeData-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: run-in-child-context-large-data.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+    Metadata:
+      SkipBuild: "True"
+  RunInChildContextSerdes:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: RuninChildContextwithSerdes-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: run-in-child-context-serdes.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.test.ts
@@ -210,6 +210,42 @@ describe("BatchResult", () => {
       expect(failedItem.error.cause).toBeInstanceOf(Error);
     });
 
+    it("should preserve the original error type and message of the cause through serialization round-trip", async () => {
+      // ChildContextError wrapping a CallbackError, as produced by map/parallel
+      // when an item throws a durable error.
+      const callbackError = new CallbackError("Custom callback error message");
+      const childContextError = new ChildContextError(
+        callbackError.message,
+        callbackError,
+      );
+
+      const items: BatchItem<string>[] = [
+        { index: 0, error: childContextError, status: BatchItemStatus.FAILED },
+      ];
+      const batchResult = new BatchResultImpl(items, "ALL_COMPLETED");
+
+      const serdes = createBatchResultSerdes<string>();
+      const serialized = await serdes.serialize(batchResult, {
+        entityId: "test",
+        durableExecutionArn: "arn:test",
+      });
+      const restored = await serdes.deserialize(serialized, {
+        entityId: "test",
+        durableExecutionArn: "arn:test",
+      });
+
+      const failedItem = restored!.failed()[0];
+      // The wrapper type/message are preserved...
+      expect(failedItem.error.errorType).toBe("ChildContextError");
+      expect(failedItem.error.message).toBe("Custom callback error message");
+      // ...and so is the original cause's type and message (not flattened into
+      // a generic StepError("Unknown error")).
+      const cause = failedItem.error.cause as { errorType?: string } & Error;
+      expect(cause).toBeInstanceOf(Error);
+      expect(cause.errorType).toBe("CallbackError");
+      expect(cause.message).toBe("Custom callback error message");
+    });
+
     it("should return BatchResultImpl instance as-is when passed directly", () => {
       // Create a BatchResultImpl with a ChildContextError
       const customError = new CallbackError("Should be preserved");

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
@@ -6,6 +6,79 @@ import {
 } from "../../errors/durable-error/durable-error";
 import { Serdes, SerdesContext } from "../../utils/serdes/serdes";
 
+/**
+ * Durable error type names that can be reconstructed into their concrete
+ * {@link DurableOperationError} subclass (preserving `errorType`).
+ */
+const KNOWN_DURABLE_ERROR_TYPES = new Set([
+  "StepError",
+  "CallbackError",
+  "CallbackTimeoutError",
+  "CallbackSubmitterError",
+  "InvokeError",
+  "ChildContextError",
+  "PromiseCombinatorError",
+  "WaitForConditionError",
+]);
+
+/**
+ * Wire representation of a batch item error. Extends the standard
+ * {@link ErrorObject} with a nested `Cause` so the original error (type and
+ * message) is preserved across the serialize/deserialize round-trip. The base
+ * {@link ErrorObject} format has no field for the cause, so it would otherwise
+ * be dropped and rebuilt as a generic error.
+ */
+interface SerializedBatchError extends ErrorObject {
+  Cause?: SerializedBatchError;
+}
+
+/** Serialize an Error (and its cause chain) into a SerializedBatchError. */
+function serializeBatchError(
+  error: Error | undefined,
+): SerializedBatchError | undefined {
+  if (!error) {
+    return undefined;
+  }
+
+  const serialized: SerializedBatchError =
+    error instanceof DurableOperationError
+      ? error.toErrorObject()
+      : { ErrorType: error.name, ErrorMessage: error.message };
+
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    serialized.Cause = serializeBatchError(cause);
+  }
+
+  return serialized;
+}
+
+/** Reconstruct an Error (and its cause chain) from a SerializedBatchError. */
+function reconstructBatchError(errorObject: SerializedBatchError): Error {
+  let error: Error;
+  if (
+    errorObject.ErrorType &&
+    KNOWN_DURABLE_ERROR_TYPES.has(errorObject.ErrorType)
+  ) {
+    error = DurableOperationError.fromErrorObject(errorObject);
+  } else {
+    error = new Error(errorObject.ErrorMessage);
+    error.name = errorObject.ErrorType || "Error";
+    error.stack = errorObject.StackTrace?.join("\n");
+  }
+
+  // Override the cause with the reconstructed original error when present so
+  // the cause's type and message survive (fromErrorObject otherwise synthesizes
+  // a generic cause from the top-level fields).
+  if (errorObject.Cause) {
+    (error as { cause?: Error }).cause = reconstructBatchError(
+      errorObject.Cause,
+    );
+  }
+
+  return error;
+}
+
 export class BatchResultImpl<R> implements BatchResult<R> {
   constructor(
     public readonly all: Array<BatchItem<R>>,
@@ -118,8 +191,8 @@ export function restoreBatchResult<R>(data: unknown): BatchResult<R> {
         ...item,
         result: item.result as R,
         error: item.error
-          ? (DurableOperationError.fromErrorObject(
-              item.error,
+          ? (reconstructBatchError(
+              item.error as SerializedBatchError,
             ) as ChildContextError)
           : undefined,
       }),
@@ -149,8 +222,8 @@ export function createBatchResultSerdes<R>(): Serdes<BatchResult<R>> {
         all: value.all.map((item) => ({
           ...item,
           error:
-            item.error instanceof DurableOperationError
-              ? item.error.toErrorObject()
+            item.error instanceof Error
+              ? serializeBatchError(item.error)
               : undefined,
         })),
         completionReason: value.completionReason,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler-serdes.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler-serdes.integration.test.ts
@@ -1,0 +1,141 @@
+import { createTestDurableContext } from "../../testing/create-test-durable-context";
+import { CallbackError } from "../../errors/durable-error/durable-error";
+import { createBatchResultSerdes } from "./batch-result";
+
+/**
+ * Integration tests for map/parallel error type preservation through
+ * the createBatchResultSerdes serialize/deserialize round-trip.
+ *
+ * Verifies that error cause chains (type + message) survive the
+ * serialization round-trip that occurs when the child context result
+ * is checkpointed and later deserialized on replay.
+ */
+describe("map/parallel error type preservation through serdes", () => {
+  it("should preserve error cause type and message through map result serialization round-trip", async () => {
+    const { context } = createTestDurableContext();
+
+    const items = [
+      { id: 1, shouldFail: false },
+      { id: 2, shouldFail: true },
+      { id: 3, shouldFail: false },
+    ];
+
+    const result = await context.map(
+      "map-with-errors",
+      items,
+      async (childContext, item) => {
+        return await childContext.step(
+          `process-${item.id}`,
+          async () => {
+            if (item.shouldFail) {
+              throw new CallbackError(
+                `Custom callback error for item ${item.id}`,
+              );
+            }
+            return `Processed item ${item.id}`;
+          },
+          { retryStrategy: () => ({ shouldRetry: false }) },
+        );
+      },
+      {
+        completionConfig: { toleratedFailureCount: 3 },
+      },
+    );
+
+    // Verify the result structure
+    expect(result.successCount).toBe(2);
+    expect(result.failureCount).toBe(1);
+
+    // Get the error from the failed item
+    const errors = result.getErrors();
+    expect(errors).toHaveLength(1);
+
+    const error = errors[0];
+    expect((error as any).errorType).toBe("ChildContextError");
+    expect((error.cause as any)?.errorType).toBe("CallbackError");
+    expect(error.cause?.message).toBe("Custom callback error for item 2");
+
+    // Now simulate what happens on replay: serialize then deserialize the BatchResult
+    const serdes = createBatchResultSerdes<string>();
+    const serialized = await serdes.serialize(result, {
+      entityId: "test",
+      durableExecutionArn: "arn:test",
+    });
+    const deserialized = await serdes.deserialize(serialized, {
+      entityId: "test",
+      durableExecutionArn: "arn:test",
+    });
+
+    // After deserialization, error types must be preserved
+    const deserializedErrors = deserialized!.getErrors();
+    expect(deserializedErrors).toHaveLength(1);
+
+    const deserializedError = deserializedErrors[0];
+    expect((deserializedError as any).errorType).toBe("ChildContextError");
+    expect((deserializedError.cause as any)?.errorType).toBe("CallbackError");
+    expect(deserializedError.cause?.message).toBe(
+      "Custom callback error for item 2",
+    );
+  });
+
+  it("should preserve error cause type and message through parallel result serialization round-trip", async () => {
+    const { context } = createTestDurableContext();
+
+    const result = await context.parallel(
+      "parallel-with-errors",
+      [
+        async (childContext) => {
+          return await childContext.step("success-branch", async () => {
+            return "branch completed";
+          });
+        },
+        async (childContext) => {
+          return await childContext.step(
+            "failing-branch",
+            async () => {
+              throw new CallbackError("Custom callback error from parallel");
+            },
+            { retryStrategy: () => ({ shouldRetry: false }) },
+          );
+        },
+      ],
+      {
+        completionConfig: { toleratedFailureCount: 1 },
+      },
+    );
+
+    // Verify the result structure
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+
+    const errors = result.getErrors();
+    expect(errors).toHaveLength(1);
+
+    const error = errors[0];
+    expect((error as any).errorType).toBe("ChildContextError");
+    expect((error.cause as any)?.errorType).toBe("CallbackError");
+    expect(error.cause?.message).toBe("Custom callback error from parallel");
+
+    // Simulate replay: serialize then deserialize
+    const serdes = createBatchResultSerdes<string>();
+    const serialized = await serdes.serialize(result, {
+      entityId: "test",
+      durableExecutionArn: "arn:test",
+    });
+    const deserialized = await serdes.deserialize(serialized, {
+      entityId: "test",
+      durableExecutionArn: "arn:test",
+    });
+
+    // After deserialization, error types must be preserved
+    const deserializedErrors = deserialized!.getErrors();
+    expect(deserializedErrors).toHaveLength(1);
+
+    const deserializedError = deserializedErrors[0];
+    expect((deserializedError as any).errorType).toBe("ChildContextError");
+    expect((deserializedError.cause as any)?.errorType).toBe("CallbackError");
+    expect(deserializedError.cause?.message).toBe(
+      "Custom callback error from parallel",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -116,7 +116,7 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         "test-name",
         expect.any(Function),
-        { subType: undefined },
+        { subType: undefined, serdes: expect.any(Object) },
       );
     });
 
@@ -135,7 +135,7 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: undefined },
+        { subType: undefined, serdes: expect.any(Object) },
       );
     });
 
@@ -158,7 +158,7 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: "TOP_TYPE" },
+        { subType: "TOP_TYPE", serdes: expect.any(Object) },
       );
     });
   });
@@ -227,7 +227,7 @@ describe("Concurrent Execution Handler", () => {
         expect(mockRunInChildContext).toHaveBeenCalledWith(
           nameParam,
           expect.any(Function),
-          { subType: expectedSubType },
+          { subType: expectedSubType, serdes: expect.any(Object) },
         );
       },
     );
@@ -361,7 +361,7 @@ describe("Concurrent Execution Handler", () => {
       expect(mockRunInChildContext).toHaveBeenCalledWith(
         undefined,
         expect.any(Function),
-        { subType: undefined },
+        { subType: undefined, serdes: expect.any(Object) },
       );
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -14,7 +14,11 @@ import {
 } from "../../types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { log } from "../../utils/logger/logger";
-import { BatchResultImpl, restoreBatchResult } from "./batch-result";
+import {
+  BatchResultImpl,
+  restoreBatchResult,
+  createBatchResultSerdes,
+} from "./batch-result";
 import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 
@@ -595,7 +599,8 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
       const result = await runInChildContext(name, executeOperation, {
         subType: config?.topLevelSubType,
         summaryGenerator: config?.summaryGenerator,
-        serdes: config?.serdes,
+        // Use BatchResult serdes to preserve Error types through serialization.
+        serdes: config?.serdes || createBatchResultSerdes(),
       });
 
       // Restore BatchResult methods if the result came from deserialized data

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -628,6 +628,110 @@ describe("runInChildContext with custom serdes", () => {
     });
   });
 
+  test("should apply serdes round-trip for small payloads (under checkpoint limit)", async () => {
+    const asymmetricSerdes = {
+      serialize: async (
+        value: string | undefined,
+      ): Promise<string | undefined> =>
+        value === undefined ? undefined : value.toUpperCase(),
+      deserialize: async (
+        data: string | undefined,
+      ): Promise<string | undefined> => data,
+    };
+
+    const childFunction = jest.fn().mockResolvedValue("hello");
+
+    const result = await runInChildContext("serdes-child", childFunction, {
+      serdes: asymmetricSerdes,
+    });
+
+    expect(result).toBe("HELLO");
+  });
+
+  test("should checkpoint the serialized value for small payloads", async () => {
+    const asymmetricSerdes = {
+      serialize: async (
+        value: string | undefined,
+      ): Promise<string | undefined> =>
+        value === undefined ? undefined : value.toUpperCase(),
+      deserialize: async (
+        data: string | undefined,
+      ): Promise<string | undefined> => data,
+    };
+
+    const childFunction = jest.fn().mockResolvedValue("hello");
+
+    await runInChildContext("serdes-child", childFunction, {
+      serdes: asymmetricSerdes,
+    });
+
+    expect(mockCheckpoint).toHaveBeenNthCalledWith(2, "test-step-id", {
+      Id: "test-step-id",
+      ParentId: "parent-step-123",
+      Action: OperationAction.SUCCEED,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Type: OperationType.CONTEXT,
+      Payload: "HELLO",
+      Name: "serdes-child",
+      ContextOptions: undefined,
+    });
+  });
+
+  test("should return raw result for virtual context (no checkpoint, no replay)", async () => {
+    // Virtual contexts never checkpoint so there's no replay path to match.
+    // Return the raw result without serialize/deserialize overhead.
+    const asymmetricSerdes = {
+      serialize: async (
+        value: string | undefined,
+      ): Promise<string | undefined> =>
+        value === undefined ? undefined : value.toUpperCase(),
+      deserialize: async (
+        data: string | undefined,
+      ): Promise<string | undefined> => data,
+    };
+
+    const childFunction = jest.fn().mockResolvedValue("hello");
+
+    const result = await runInChildContext(
+      "virtual-serdes-child",
+      childFunction,
+      {
+        serdes: asymmetricSerdes,
+        virtualContext: true,
+      },
+    );
+
+    // Raw result returned — no round-trip needed for virtual contexts.
+    expect(result).toBe("hello");
+    // Virtual contexts do not checkpoint.
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("should skip serdes round-trip for large payloads (over checkpoint limit)", async () => {
+    // Large payloads trigger ReplayChildren — replay re-executes the function
+    // rather than deserializing the checkpoint. First-run returns raw result.
+    const asymmetricSerdes = {
+      serialize: async (
+        value: string | undefined,
+      ): Promise<string | undefined> =>
+        value === undefined ? undefined : value.toUpperCase(),
+      deserialize: async (
+        data: string | undefined,
+      ): Promise<string | undefined> => data,
+    };
+
+    // 300KB string exceeds the 256KB checkpoint limit.
+    const largeValue = "x".repeat(300 * 1024);
+    const childFunction = jest.fn().mockResolvedValue(largeValue);
+
+    const result = await runInChildContext("large-payload", childFunction, {
+      serdes: asymmetricSerdes,
+    });
+
+    // Result is returned raw — NOT uppercased — because replay re-executes.
+    expect(result).toBe(largeValue);
+  });
+
   test("should deserialize completed child context result with custom serdes", async () => {
     const customSerdes = createClassSerdesWithDates(TestResult, ["timestamp"]);
     const testResult = new TestResult("cached-value", new Date("2023-01-01"));

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -253,15 +253,20 @@ export const handleCompletedChildContext = async <
       undefined,
       entityId, // parentId
     );
-    return await runWithContext(entityId, entityId, () =>
+
+    const replayedResult = await runWithContext(entityId, entityId, () =>
       fn(durableChildContext),
     );
+
+    // Large payloads: replay re-executes the child function, so return raw result.
+    return replayedResult;
   }
 
   log("⏭️", "Child context already finished, returning cached result:", {
     entityId,
   });
 
+  // Small payloads: replay deserializes the checkpoint, so match that here.
   return await safeDeserialize(
     serdes,
     result,
@@ -432,7 +437,21 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       await plugin.onOperationEnd?.({ ...opInfo, isReplay: true });
     }
 
-    return result;
+    // Large payloads: replay re-executes the child function, so return raw result.
+    // Virtual contexts: never checkpoint, so no replay path to match.
+    if (replayChildren || isVirtual) {
+      return result;
+    }
+
+    // Small payloads: replay deserializes the checkpoint, so match that here.
+    return await safeDeserialize(
+      serdes,
+      serializedResult,
+      entityId,
+      name,
+      context.terminationManager,
+      context.durableExecutionArn,
+    );
   } catch (error) {
     log(
       "❌",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.integration.test.ts
@@ -1,0 +1,264 @@
+import {
+  createDurableContext,
+  DurableExecution,
+} from "../../context/durable-context/durable-context";
+import {
+  ExecutionContext,
+  DurableContext,
+  DurableExecutionMode,
+  DurableLogger,
+} from "../../types";
+import { TerminationManager } from "../../termination-manager/termination-manager";
+import {
+  OperationType,
+  OperationStatus,
+  OperationAction,
+  CheckpointDurableExecutionRequest,
+} from "@aws-sdk/client-lambda";
+import { hashId, getStepData } from "../../utils/step-id-utils/step-id-utils";
+import { createDefaultLogger } from "../../utils/logger/default-logger";
+import { Serdes, SerdesContext } from "../../utils/serdes/serdes";
+
+jest.mock("../../termination-manager/termination-manager");
+
+/**
+ * Integration tests for child context ser/des round-trip behavior.
+ *
+ * These tests use a real DurableContext with mocked checkpoint to verify that
+ * runInChildContext applies the serialize/deserialize round-trip on first execution,
+ * ensuring the first-run result matches what replay would return.
+ */
+describe("runInChildContext serdes round-trip", () => {
+  let mockExecutionContext: ExecutionContext;
+  let mockParentContext: any;
+  let durableContext: DurableContext<DurableLogger>;
+  let checkpointCalls: any[];
+  let mockDurableExecution: DurableExecution;
+
+  /**
+   * Asymmetric serdes: serialize uppercases, deserialize is identity.
+   * If first-run returns "HELLO", the round-trip was applied.
+   * If first-run returns "hello", the raw result was returned without the round-trip.
+   */
+  const uppercaseSerdes: Serdes<string> = {
+    serialize: async (
+      value: string | undefined,
+      _context: SerdesContext,
+    ): Promise<string | undefined> =>
+      value === undefined ? undefined : value.toUpperCase(),
+    deserialize: async (
+      data: string | undefined,
+      _context: SerdesContext,
+    ): Promise<string | undefined> => data,
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    checkpointCalls = [];
+
+    mockDurableExecution = {
+      checkpointManager: {
+        checkpoint: jest
+          .fn()
+          .mockImplementation((_stepId: string, data: any) => {
+            const checkpointData = {
+              CheckpointToken: "mock-token",
+              Updates: [data],
+            };
+            checkpointCalls.push({
+              checkpointToken: "mock-token",
+              data: checkpointData,
+            });
+            return Promise.resolve({ CheckpointToken: "mock-token" });
+          }),
+        force: jest.fn(),
+        setTerminating: jest.fn(),
+        hasPendingAncestorCompletion: jest.fn(),
+        markAncestorFinished: jest.fn(),
+        markOperationState: jest.fn(),
+        markOperationAwaited: jest.fn(),
+        waitForStatusChange: jest.fn().mockResolvedValue(undefined),
+        waitForRetryTimer: jest.fn().mockResolvedValue(undefined),
+        getOperationState: jest.fn(),
+        getAllOperations: jest.fn().mockReturnValue([]),
+      },
+    } as any;
+
+    const mockTerminationManager = {
+      terminate: jest.fn(),
+      getTerminationPromise: jest.fn().mockResolvedValue({}),
+      isTerminated: false,
+      terminationPromise: Promise.resolve(),
+      handleTermination: jest.fn(),
+      addListener: jest.fn(),
+    } as unknown as TerminationManager;
+
+    mockExecutionContext = {
+      durableExecutionClient: {
+        getExecutionState: jest.fn().mockResolvedValue({}),
+        checkpoint: jest
+          .fn()
+          .mockImplementation((data: CheckpointDurableExecutionRequest) => {
+            const checkpointToken = data.CheckpointToken;
+            checkpointCalls.push({ checkpointToken, data });
+            return Promise.resolve({ CheckpointToken: "mock-token" });
+          }),
+      },
+      _stepData: {},
+      terminationManager: mockTerminationManager,
+      durableExecutionArn: "mock-execution-arn",
+      pendingCompletions: new Set<string>(),
+      getStepData: jest.fn((stepId: string) => {
+        return getStepData(mockExecutionContext._stepData, stepId);
+      }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
+      requestId: "mock-request-id",
+      tenantId: undefined,
+    } satisfies ExecutionContext;
+
+    mockParentContext = { awsRequestId: "mock-request-id" };
+
+    durableContext = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+      DurableExecutionMode.ExecutionMode,
+      createDefaultLogger(),
+      undefined,
+      mockDurableExecution,
+    );
+  });
+
+  test("should return deserialize(serialize(result)) on first run for small payloads", async () => {
+    const result = await durableContext.runInChildContext(
+      "serdes-child",
+      async (_childContext) => {
+        return "hello";
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // serialize("hello") = "HELLO", deserialize("HELLO") = "HELLO"
+    expect(result).toBe("HELLO");
+  });
+
+  test("should checkpoint the serialized value", async () => {
+    await durableContext.runInChildContext(
+      "serdes-child",
+      async (_childContext) => {
+        return "hello";
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Find the SUCCEED checkpoint call
+    const succeedCheckpoint = checkpointCalls.find(
+      (call) => call.data.Updates[0].Action === OperationAction.SUCCEED,
+    );
+    expect(succeedCheckpoint).toBeDefined();
+    expect(succeedCheckpoint.data.Updates[0].Payload).toBe("HELLO");
+  });
+
+  test("should return raw result for virtual contexts (no checkpoint, no replay)", async () => {
+    const result = await durableContext.runInChildContext(
+      "virtual-child",
+      async (_childContext) => {
+        return "hello";
+      },
+      { serdes: uppercaseSerdes, virtualContext: true },
+    );
+
+    // Virtual contexts never checkpoint, so no replay path exists.
+    // Return raw result without ser/des overhead.
+    expect(result).toBe("hello");
+    // Virtual contexts should not checkpoint
+    expect(checkpointCalls).toHaveLength(0);
+  });
+
+  test("should return raw result for large payloads (ReplayChildren mode)", async () => {
+    const largeValue = "x".repeat(300 * 1024); // >256KB
+
+    const result = await durableContext.runInChildContext(
+      "large-child",
+      async (_childContext) => {
+        return largeValue;
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Large payloads trigger ReplayChildren — replay re-executes the child function.
+    // First-run should return raw result to match that behavior.
+    expect(result).toBe(largeValue);
+  });
+
+  test("should deserialize correctly on replay (completed child context)", async () => {
+    // Simulate a completed child context with serialized result in checkpoint
+    mockExecutionContext._stepData = {
+      [hashId("1")]: {
+        Id: "1",
+        Type: OperationType.CONTEXT,
+        StartTimestamp: new Date(),
+        Status: OperationStatus.SUCCEEDED,
+        ContextDetails: {
+          Result: "HELLO", // This is the serialized (uppercased) value
+        },
+      },
+    };
+
+    const result = await durableContext.runInChildContext(
+      "serdes-child",
+      async (_childContext) => {
+        // This should NOT execute since the context is already completed
+        return "should-not-run";
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // On replay: deserialize("HELLO") = "HELLO"
+    expect(result).toBe("HELLO");
+  });
+
+  test("first run and replay should return the same value", async () => {
+    // First run
+    const firstRunResult = await durableContext.runInChildContext(
+      "serdes-child",
+      async (_childContext) => {
+        return "hello";
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Now simulate replay by creating a new context with completed step data
+    mockExecutionContext._stepData = {
+      [hashId("1")]: {
+        Id: "1",
+        Type: OperationType.CONTEXT,
+        StartTimestamp: new Date(),
+        Status: OperationStatus.SUCCEEDED,
+        ContextDetails: {
+          Result: "HELLO", // checkpointed from first run
+        },
+      },
+    };
+
+    const replayContext = createDurableContext(
+      mockExecutionContext,
+      mockParentContext,
+      DurableExecutionMode.ReplayMode,
+      createDefaultLogger(),
+      undefined,
+      mockDurableExecution,
+    );
+
+    const replayResult = await replayContext.runInChildContext(
+      "serdes-child",
+      async (_childContext) => {
+        return "hello"; // won't execute
+      },
+      { serdes: uppercaseSerdes },
+    );
+
+    // Both should be identical
+    expect(firstRunResult).toBe(replayResult);
+    expect(firstRunResult).toBe("HELLO");
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-js/issues/595

*Description of changes:*
- Child context results now go through the same serialize/deserialize round-trip on first run that replay would apply, ensuring deterministic values regardless of when or how many times the execution resumes.

**run-in-child-context-handler.ts**
- Small payloads: return `deserialize(serialize(result))` to match replay
- Large payloads (ReplayChildren): return raw result since replay
  re-executes the child function
- Virtual contexts: return raw result since they never checkpoint

**concurrent-execution-handler.ts**
- Default map/parallel to `createBatchResultSerdes` so errors survive the round-trip

**batch-result.ts**
- Added `serializeBatchError`/`reconstructBatchError` to preserve error type and cause chain through serialization

*Testing:*
Add tests using an asymmetric serdes that exercise the standard and virtual-context paths; existing tests only used lossless serdes and could not detect the divergence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.