### PR TITLE
chore: use camelCase for OperationInfo properties

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -93,19 +93,19 @@ describe("Step Handler - plugin hooks", () => {
 
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledWith(
-      expect.objectContaining({ Attempt: 1 }),
+      expect.objectContaining({ attempt: 1 }),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ Attempt: 1 }),
+      expect.objectContaining({ attempt: 1 }),
       expect.any(Function),
     );
 
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
-        Attempt: 1,
+        attempt: 1,
         outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );
@@ -135,13 +135,13 @@ describe("Step Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ Attempt: 1 }),
+      expect.objectContaining({ attempt: 1 }),
       expect.any(Function),
     );
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
-        Attempt: 1,
+        attempt: 1,
         outcome: AttemptEndInfoOutcome.FAILED,
         error: stepError,
       }),
@@ -186,13 +186,13 @@ describe("Step Handler - plugin hooks", () => {
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ Attempt: 1 }),
+      expect.objectContaining({ attempt: 1 }),
       expect.any(Function),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ Attempt: 1 }),
+      expect.objectContaining({ attempt: 1 }),
       expect.any(Function),
     );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -54,7 +54,6 @@ export const createStepHandler = <Logger extends DurableLogger>(
   createStepId: () => string,
   logger: Logger,
   parentId?: string,
-
   getDefaultSerdes?: () => AnySerdes,
   plugin: DurableInstrumentationPlugin = {},
 ) => {
@@ -94,11 +93,11 @@ export const createStepHandler = <Logger extends DurableLogger>(
       );
 
       const opInfo = {
-        Id: stepId,
-        Name: name,
-        Type: OperationType.STEP,
-        SubType: OperationSubType.STEP,
-        ParentId: parentId,
+        id: stepId,
+        name: name,
+        type: OperationType.STEP,
+        subType: OperationSubType.STEP,
+        parentId: parentId,
       };
 
       // Check if already completed

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -22,15 +22,15 @@ export enum PluginInvocationStatus {
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface OperationInfo {
-  Id: string;
-  Name?: string;
-  Type: string;
-  SubType?: string;
-  ParentId?: string;
-  Status?: string;
-  StartTimestamp?: Date;
-  EndTimestamp?: Date;
-  Result?: string;
+  id: string;
+  name?: string;
+  type: string;
+  subType?: string;
+  parentId?: string;
+  status?: string;
+  startTimestamp?: Date;
+  endTimestamp?: Date;
+  result?: string;
 }
 
 /**
@@ -48,7 +48,7 @@ export interface OperationEndInfo extends OperationInfo {
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface AttemptInfo extends OperationInfo {
-  Attempt: number;
+  attempt: number;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -13,15 +13,15 @@ import {
  */
 export function toOperationInfo(operation?: Operation): OperationInfo {
   return {
-    Id: operation?.Id ?? "",
-    Name: operation?.Name,
-    Type: operation?.Type ?? "",
-    SubType: operation?.SubType,
-    ParentId: operation?.ParentId,
-    Status: operation?.Status,
-    StartTimestamp: operation?.StartTimestamp,
-    EndTimestamp: operation?.EndTimestamp,
-    Result:
+    id: operation?.Id ?? "",
+    name: operation?.Name,
+    type: operation?.Type ?? "",
+    subType: operation?.SubType,
+    parentId: operation?.ParentId,
+    status: operation?.Status,
+    startTimestamp: operation?.StartTimestamp,
+    endTimestamp: operation?.EndTimestamp,
+    result:
       operation?.StepDetails?.Result ??
       operation?.CallbackDetails?.Result ??
       operation?.ContextDetails?.Result ??
@@ -55,7 +55,7 @@ export function toAttemptInfo(
 ): AttemptInfo {
   return {
     ...toOperationInfo(operation),
-    Attempt: attempt ?? (operation?.StepDetails?.Attempt || 0),
+    attempt: attempt ?? (operation?.StepDetails?.Attempt || 0),
   };
 }
 
@@ -91,12 +91,12 @@ export function backfillOperationInfo<T extends OperationInfo>(
   info: T,
   defaults: Partial<OperationInfo>,
 ): T {
-  info.Id = defaults.Id ?? "";
-  if (!info.Type) info.Type = defaults.Type ?? "";
-  if (!info.SubType) info.SubType = defaults.SubType;
-  if (!info.Name) info.Name = defaults.Name;
-  if (!info.ParentId) info.ParentId = defaults.ParentId;
-  if (!info.StartTimestamp) info.StartTimestamp = defaults.StartTimestamp;
-  if (!info.EndTimestamp) info.EndTimestamp = defaults.EndTimestamp;
+  info.id = defaults.id ?? "";
+  if (!info.type) info.type = defaults.type ?? "";
+  if (!info.subType) info.subType = defaults.subType;
+  if (!info.name) info.name = defaults.name;
+  if (!info.parentId) info.parentId = defaults.parentId;
+  if (!info.startTimestamp) info.startTimestamp = defaults.startTimestamp;
+  if (!info.endTimestamp) info.endTimestamp = defaults.endTimestamp;
   return info;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -29,14 +29,14 @@ describe("createPluginRunner", () => {
   };
 
   const operationInfo: OperationInfo = {
-    Id: "op-1",
-    Name: "my-step",
-    Type: "STEP",
+    id: "op-1",
+    name: "my-step",
+    type: "STEP",
   };
 
   const attemptInfo: AttemptInfo = {
     ...operationInfo,
-    Attempt: 1,
+    attempt: 1,
   };
 
   const attemptEndInfo: AttemptEndInfo = {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/pull/637#issue-4669600519

*Description of changes:* use camelCase for OperationInfo properties


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
