### PR TITLE
refactor(sdk): merge onOperationFirst into onOperation with isReplay flag

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -268,7 +268,10 @@ export const createStepHandler = <Logger extends DurableLogger>(
             stepData = context.getStepData(stepId);
             const operationInfo = toOperationInfo(stepData);
             backfillOperationInfo(operationInfo, opInfo);
-            plugin.onOperationFirstStart?.(operationInfo);
+            plugin.onOperationStart?.({
+              ...operationInfo,
+              isReplay: false,
+            });
           } else {
             checkpoint
               .checkpoint(stepId, {
@@ -283,13 +286,16 @@ export const createStepHandler = <Logger extends DurableLogger>(
                 stepData = context.getStepData(stepId);
                 const operationInfo = toOperationInfo(stepData);
                 backfillOperationInfo(operationInfo, opInfo);
-                plugin.onOperationFirstStart?.(operationInfo);
+                plugin.onOperationStart?.({
+                  ...operationInfo,
+                  isReplay: false,
+                });
               });
           }
         } else {
           const operationInfo = toOperationInfo(stepData);
           backfillOperationInfo(operationInfo, opInfo);
-          plugin.onOperationStart?.(operationInfo);
+          plugin.onOperationStart?.({ ...operationInfo, isReplay: true });
         }
 
         try {
@@ -355,7 +361,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
           );
           backfillOperationInfo(attemptEndInfo, opInfo);
           plugin.onOperationAttemptEnd?.(attemptEndInfo);
-          plugin.onOperationFirstEnd?.(attemptEndInfo);
+          plugin.onOperationEnd?.({ ...attemptEndInfo, isReplay: false });
           checkpoint.markOperationState(
             stepId,
             OperationLifecycleState.COMPLETED,
@@ -416,8 +422,9 @@ export const createStepHandler = <Logger extends DurableLogger>(
             );
             backfillOperationInfo(attemptEndInfo, opInfo);
             plugin.onOperationAttemptEnd?.(attemptEndInfo);
-            plugin.onOperationFirstEnd?.({
+            plugin.onOperationEnd?.({
               ...attemptEndInfo,
+              isReplay: false,
               error: error instanceof Error ? error : new Error(String(error)),
             });
             throw DurableOperationError.fromErrorObject(

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -31,6 +31,7 @@ export interface OperationInfo {
   startTimestamp?: Date;
   endTimestamp?: Date;
   result?: string;
+  isReplay: boolean;
 }
 
 /**
@@ -133,10 +134,9 @@ export interface DurableInstrumentationPlugin {
     fn: () => Promise<DurableExecutionInvocationOutput>,
   ): Promise<DurableExecutionInvocationOutput>;
   onInvocationEnd?(info: InvocationEndInfo): void;
-  onOperationFirstStart?(info: OperationInfo): void;
   onOperationStart?(info: OperationInfo): void;
   wrapChildContextFn?(info: OperationInfo, fn: CustomerFn): CustomerFnResult;
-  onOperationFirstEnd?(info: OperationEndInfo): void;
+  onOperationEnd?(info: OperationEndInfo): void;
   onOperationAttemptStart?(info: AttemptInfo): void;
   wrapOperationAttemptFn?(info: AttemptInfo, fn: CustomerFn): CustomerFnResult;
   onOperationAttemptEnd?(info: AttemptEndInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -26,6 +26,7 @@ export function toOperationInfo(operation?: Operation): OperationInfo {
       operation?.CallbackDetails?.Result ??
       operation?.ContextDetails?.Result ??
       operation?.ChainedInvokeDetails?.Result,
+    isReplay: false,
   };
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -32,6 +32,7 @@ describe("createPluginRunner", () => {
     id: "op-1",
     name: "my-step",
     type: "STEP",
+    isReplay: false,
   };
 
   const attemptInfo: AttemptInfo = {
@@ -77,15 +78,15 @@ describe("createPluginRunner", () => {
       expect(plugin.onInvocationStart).toHaveBeenCalledWith(invocationInfo);
     });
 
-    it("calls onOperationFirstStart on all plugins", () => {
+    it("calls onOperationStart on all plugins", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
-        onOperationFirstStart: jest.fn(),
+        onOperationStart: jest.fn(),
       };
 
       const runner = createPluginRunner([plugin]);
-      runner.onOperationFirstStart!(operationInfo);
+      runner.onOperationStart!(operationInfo);
 
-      expect(plugin.onOperationFirstStart).toHaveBeenCalledWith(operationInfo);
+      expect(plugin.onOperationStart).toHaveBeenCalledWith(operationInfo);
     });
 
     it("calls onOperationStart on all plugins", () => {
@@ -99,16 +100,16 @@ describe("createPluginRunner", () => {
       expect(plugin.onOperationStart).toHaveBeenCalledWith(operationInfo);
     });
 
-    it("calls onOperationFirstEnd on all plugins", () => {
+    it("calls onOperationEnd on all plugins", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
-        onOperationFirstEnd: jest.fn(),
+        onOperationEnd: jest.fn(),
       };
       const infoWithError = { ...operationInfo, error: new Error("oops") };
 
       const runner = createPluginRunner([plugin]);
-      runner.onOperationFirstEnd!(infoWithError);
+      runner.onOperationEnd!(infoWithError);
 
-      expect(plugin.onOperationFirstEnd).toHaveBeenCalledWith(infoWithError);
+      expect(plugin.onOperationEnd).toHaveBeenCalledWith(infoWithError);
     });
 
     it("calls onOperationAttemptStart on all plugins", () => {
@@ -764,12 +765,11 @@ describe("createPluginRunner", () => {
             fn: () => Promise<DurableExecutionInvocationOutput>,
           ) => fn(),
         ),
-        onOperationFirstStart: jest.fn(),
         onOperationStart: jest.fn(),
         onOperationAttemptStart: jest.fn(),
         wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationAttemptEnd: jest.fn(),
-        onOperationFirstEnd: jest.fn(),
+        onOperationEnd: jest.fn(),
         onOperationChange: jest.fn(),
         onInvocationEnd: jest.fn().mockResolvedValue(undefined),
         enrichLogContext: jest.fn().mockReturnValue({ p1: "v1" }),
@@ -783,12 +783,11 @@ describe("createPluginRunner", () => {
             fn: () => Promise<DurableExecutionInvocationOutput>,
           ) => fn(),
         ),
-        onOperationFirstStart: jest.fn(),
         onOperationStart: jest.fn(),
         onOperationAttemptStart: jest.fn(),
         wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationAttemptEnd: jest.fn(),
-        onOperationFirstEnd: jest.fn(),
+        onOperationEnd: jest.fn(),
         onOperationChange: jest.fn(),
         onInvocationEnd: jest.fn().mockResolvedValue(undefined),
         enrichLogContext: jest.fn().mockReturnValue({ p2: "v2" }),
@@ -801,12 +800,11 @@ describe("createPluginRunner", () => {
       await runner.wrapInvocation!(invocationInfo, () =>
         Promise.resolve(succeededOutput),
       );
-      runner.onOperationFirstStart!(operationInfo);
       runner.onOperationStart!(operationInfo);
       runner.onOperationAttemptStart!(attemptInfo);
       runner.wrapOperationAttemptFn!(attemptInfo, () => "attempt-result");
       runner.onOperationAttemptEnd!(attemptEndInfo);
-      runner.onOperationFirstEnd!(operationInfo);
+      runner.onOperationEnd!(operationInfo);
       runner.onOperationChange!(operationChangeInfo);
       runner.onInvocationEnd!(invocationEndInfo);
       const logCtx = runner.enrichLogContext!();
@@ -816,8 +814,6 @@ describe("createPluginRunner", () => {
       expect(plugin2.onInvocationStart).toHaveBeenCalledTimes(1);
       expect(plugin1.wrapInvocation).toHaveBeenCalledTimes(1);
       expect(plugin2.wrapInvocation).toHaveBeenCalledTimes(1);
-      expect(plugin1.onOperationFirstStart).toHaveBeenCalledTimes(1);
-      expect(plugin2.onOperationFirstStart).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationStart).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationStart).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationAttemptStart).toHaveBeenCalledTimes(1);
@@ -826,8 +822,8 @@ describe("createPluginRunner", () => {
       expect(plugin2.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
-      expect(plugin1.onOperationFirstEnd).toHaveBeenCalledTimes(1);
-      expect(plugin2.onOperationFirstEnd).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationEnd).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationChange).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationChange).toHaveBeenCalledTimes(1);
       expect(plugin1.onInvocationEnd).toHaveBeenCalledTimes(1);

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -145,15 +145,12 @@ export function createPluginRunner(
         fn,
       ) as Promise<DurableExecutionInvocationOutput>,
     onInvocationEnd: (info: InvocationEndInfo) => run("onInvocationEnd", info),
-    onOperationFirstStart: (info: OperationInfo) =>
-      run("onOperationFirstStart", info),
     onOperationStart: (info: OperationInfo) => run("onOperationStart", info),
     wrapChildContextFn: (
       info: OperationInfo,
       fn: CustomerFn,
     ): CustomerFnResult => runAsCallback("wrapChildContextFn", info, fn),
-    onOperationFirstEnd: (info: OperationEndInfo) =>
-      run("onOperationFirstEnd", info),
+    onOperationEnd: (info: OperationEndInfo) => run("onOperationEnd", info),
     onOperationAttemptStart: (info: AttemptInfo) =>
       run("onOperationAttemptStart", info),
     wrapOperationAttemptFn: (


### PR DESCRIPTION
Remove onOperationFirstStart and onOperationFirstEnd from the plugin interface. Instead, add isReplay: boolean to OperationInfo.

- onOperationStart is now called for both first execution (isReplay: false) and replay (isReplay: true)
- onOperationEnd replaces onOperationFirstEnd (always isReplay: false since it only fires on actual completion)

This simplifies the plugin interface from 12 hooks to 10 and follows the same pattern as InvocationInfo.isFirstInvocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
