### PR TITLE
chore(sdk): replace onOperationFirstStart with flag

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -268,7 +268,8 @@ export const createStepHandler = <Logger extends DurableLogger>(
             stepData = context.getStepData(stepId);
             const operationInfo = toOperationInfo(stepData);
             backfillOperationInfo(operationInfo, opInfo);
-            plugin.onOperationFirstStart?.(operationInfo);
+            operationInfo.isFirstStart = true;
+            plugin.onOperationStart?.(operationInfo);
           } else {
             checkpoint
               .checkpoint(stepId, {
@@ -283,12 +284,14 @@ export const createStepHandler = <Logger extends DurableLogger>(
                 stepData = context.getStepData(stepId);
                 const operationInfo = toOperationInfo(stepData);
                 backfillOperationInfo(operationInfo, opInfo);
-                plugin.onOperationFirstStart?.(operationInfo);
+                operationInfo.isFirstStart = true;
+                plugin.onOperationStart?.(operationInfo);
               });
           }
         } else {
           const operationInfo = toOperationInfo(stepData);
           backfillOperationInfo(operationInfo, opInfo);
+          operationInfo.isFirstStart = false;
           plugin.onOperationStart?.(operationInfo);
         }
 
@@ -355,7 +358,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
           );
           backfillOperationInfo(attemptEndInfo, opInfo);
           plugin.onOperationAttemptEnd?.(attemptEndInfo);
-          plugin.onOperationFirstEnd?.(attemptEndInfo);
+          plugin.onOperationEnd?.(attemptEndInfo);
           checkpoint.markOperationState(
             stepId,
             OperationLifecycleState.COMPLETED,
@@ -416,7 +419,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
             );
             backfillOperationInfo(attemptEndInfo, opInfo);
             plugin.onOperationAttemptEnd?.(attemptEndInfo);
-            plugin.onOperationFirstEnd?.({
+            plugin.onOperationEnd?.({
               ...attemptEndInfo,
               error: error instanceof Error ? error : new Error(String(error)),
             });

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -88,7 +88,6 @@ export {
   PluginInvocationStatus,
   OperationChangeInfo,
   OperationInfo,
-  OperationEndInfo,
   AttemptInfo,
   AttemptEndInfo,
   AttemptEndInfoOutcome,

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -37,13 +37,6 @@ export interface OperationInfo {
 }
 
 /**
- * Information provided when a durable operation ends.
- *
- * @experimental This interface is experimental and may be changed or removed in future releases.
- */
-export interface OperationEndInfo extends OperationInfo {}
-
-/**
  * Information about an operation attempt.
  *
  * @experimental This interface is experimental and may be changed or removed in future releases.
@@ -136,7 +129,7 @@ export interface DurableInstrumentationPlugin {
   onInvocationEnd?(info: InvocationEndInfo): void;
   onOperationStart?(info: OperationInfo): void;
   wrapChildContextFn?(info: OperationInfo, fn: CustomerFn): CustomerFnResult;
-  onOperationEnd?(info: OperationEndInfo): void;
+  onOperationEnd?(info: OperationInfo): void;
   onOperationAttemptStart?(info: AttemptInfo): void;
   wrapOperationAttemptFn?(info: AttemptInfo, fn: CustomerFn): CustomerFnResult;
   onOperationAttemptEnd?(info: AttemptEndInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -31,6 +31,8 @@ export interface OperationInfo {
   startTimestamp?: Date;
   endTimestamp?: Date;
   result?: string;
+  /** True when this is the very first time the operation starts (not a replay). */
+  isFirstStart?: boolean;
 }
 
 /**
@@ -133,10 +135,9 @@ export interface DurableInstrumentationPlugin {
     fn: () => Promise<DurableExecutionInvocationOutput>,
   ): Promise<DurableExecutionInvocationOutput>;
   onInvocationEnd?(info: InvocationEndInfo): void;
-  onOperationFirstStart?(info: OperationInfo): void;
   onOperationStart?(info: OperationInfo): void;
   wrapChildContextFn?(info: OperationInfo, fn: CustomerFn): CustomerFnResult;
-  onOperationFirstEnd?(info: OperationEndInfo): void;
+  onOperationEnd?(info: OperationEndInfo): void;
   onOperationAttemptStart?(info: AttemptInfo): void;
   wrapOperationAttemptFn?(info: AttemptInfo, fn: CustomerFn): CustomerFnResult;
   onOperationAttemptEnd?(info: AttemptEndInfo): void;

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -31,6 +31,7 @@ export interface OperationInfo {
   startTimestamp?: Date;
   endTimestamp?: Date;
   result?: string;
+  error?: Error;
   /** True when this is the very first time the operation starts (not a replay). */
   isFirstStart?: boolean;
 }
@@ -40,9 +41,7 @@ export interface OperationInfo {
  *
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
-export interface OperationEndInfo extends OperationInfo {
-  error?: Error;
-}
+export interface OperationEndInfo extends OperationInfo {}
 
 /**
  * Information about an operation attempt.

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -77,17 +77,6 @@ describe("createPluginRunner", () => {
       expect(plugin.onInvocationStart).toHaveBeenCalledWith(invocationInfo);
     });
 
-    it("calls onOperationFirstStart on all plugins", () => {
-      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
-        onOperationFirstStart: jest.fn(),
-      };
-
-      const runner = createPluginRunner([plugin]);
-      runner.onOperationFirstStart!(operationInfo);
-
-      expect(plugin.onOperationFirstStart).toHaveBeenCalledWith(operationInfo);
-    });
-
     it("calls onOperationStart on all plugins", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
         onOperationStart: jest.fn(),
@@ -99,16 +88,30 @@ describe("createPluginRunner", () => {
       expect(plugin.onOperationStart).toHaveBeenCalledWith(operationInfo);
     });
 
-    it("calls onOperationFirstEnd on all plugins", () => {
+    it("calls onOperationStart with isFirstStart flag", () => {
       const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
-        onOperationFirstEnd: jest.fn(),
+        onOperationStart: jest.fn(),
+      };
+
+      const runner = createPluginRunner([plugin]);
+      runner.onOperationStart!({ ...operationInfo, isFirstStart: true });
+
+      expect(plugin.onOperationStart).toHaveBeenCalledWith({
+        ...operationInfo,
+        isFirstStart: true,
+      });
+    });
+
+    it("calls onOperationEnd on all plugins", () => {
+      const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+        onOperationEnd: jest.fn(),
       };
       const infoWithError = { ...operationInfo, error: new Error("oops") };
 
       const runner = createPluginRunner([plugin]);
-      runner.onOperationFirstEnd!(infoWithError);
+      runner.onOperationEnd!(infoWithError);
 
-      expect(plugin.onOperationFirstEnd).toHaveBeenCalledWith(infoWithError);
+      expect(plugin.onOperationEnd).toHaveBeenCalledWith(infoWithError);
     });
 
     it("calls onOperationAttemptStart on all plugins", () => {
@@ -764,12 +767,11 @@ describe("createPluginRunner", () => {
             fn: () => Promise<DurableExecutionInvocationOutput>,
           ) => fn(),
         ),
-        onOperationFirstStart: jest.fn(),
         onOperationStart: jest.fn(),
         onOperationAttemptStart: jest.fn(),
         wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationAttemptEnd: jest.fn(),
-        onOperationFirstEnd: jest.fn(),
+        onOperationEnd: jest.fn(),
         onOperationChange: jest.fn(),
         onInvocationEnd: jest.fn().mockResolvedValue(undefined),
         enrichLogContext: jest.fn().mockReturnValue({ p1: "v1" }),
@@ -783,12 +785,11 @@ describe("createPluginRunner", () => {
             fn: () => Promise<DurableExecutionInvocationOutput>,
           ) => fn(),
         ),
-        onOperationFirstStart: jest.fn(),
         onOperationStart: jest.fn(),
         onOperationAttemptStart: jest.fn(),
         wrapOperationAttemptFn: jest.fn((_info: any, fn: () => any) => fn()),
         onOperationAttemptEnd: jest.fn(),
-        onOperationFirstEnd: jest.fn(),
+        onOperationEnd: jest.fn(),
         onOperationChange: jest.fn(),
         onInvocationEnd: jest.fn().mockResolvedValue(undefined),
         enrichLogContext: jest.fn().mockReturnValue({ p2: "v2" }),
@@ -801,12 +802,11 @@ describe("createPluginRunner", () => {
       await runner.wrapInvocation!(invocationInfo, () =>
         Promise.resolve(succeededOutput),
       );
-      runner.onOperationFirstStart!(operationInfo);
       runner.onOperationStart!(operationInfo);
       runner.onOperationAttemptStart!(attemptInfo);
       runner.wrapOperationAttemptFn!(attemptInfo, () => "attempt-result");
       runner.onOperationAttemptEnd!(attemptEndInfo);
-      runner.onOperationFirstEnd!(operationInfo);
+      runner.onOperationEnd!(operationInfo);
       runner.onOperationChange!(operationChangeInfo);
       runner.onInvocationEnd!(invocationEndInfo);
       const logCtx = runner.enrichLogContext!();
@@ -816,8 +816,6 @@ describe("createPluginRunner", () => {
       expect(plugin2.onInvocationStart).toHaveBeenCalledTimes(1);
       expect(plugin1.wrapInvocation).toHaveBeenCalledTimes(1);
       expect(plugin2.wrapInvocation).toHaveBeenCalledTimes(1);
-      expect(plugin1.onOperationFirstStart).toHaveBeenCalledTimes(1);
-      expect(plugin2.onOperationFirstStart).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationStart).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationStart).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationAttemptStart).toHaveBeenCalledTimes(1);
@@ -826,8 +824,8 @@ describe("createPluginRunner", () => {
       expect(plugin2.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
-      expect(plugin1.onOperationFirstEnd).toHaveBeenCalledTimes(1);
-      expect(plugin2.onOperationFirstEnd).toHaveBeenCalledTimes(1);
+      expect(plugin1.onOperationEnd).toHaveBeenCalledTimes(1);
+      expect(plugin2.onOperationEnd).toHaveBeenCalledTimes(1);
       expect(plugin1.onOperationChange).toHaveBeenCalledTimes(1);
       expect(plugin2.onOperationChange).toHaveBeenCalledTimes(1);
       expect(plugin1.onInvocationEnd).toHaveBeenCalledTimes(1);

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -145,15 +145,12 @@ export function createPluginRunner(
         fn,
       ) as Promise<DurableExecutionInvocationOutput>,
     onInvocationEnd: (info: InvocationEndInfo) => run("onInvocationEnd", info),
-    onOperationFirstStart: (info: OperationInfo) =>
-      run("onOperationFirstStart", info),
     onOperationStart: (info: OperationInfo) => run("onOperationStart", info),
     wrapChildContextFn: (
       info: OperationInfo,
       fn: CustomerFn,
     ): CustomerFnResult => runAsCallback("wrapChildContextFn", info, fn),
-    onOperationFirstEnd: (info: OperationEndInfo) =>
-      run("onOperationFirstEnd", info),
+    onOperationEnd: (info: OperationEndInfo) => run("onOperationEnd", info),
     onOperationAttemptStart: (info: AttemptInfo) =>
       run("onOperationAttemptStart", info),
     wrapOperationAttemptFn: (

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.ts
@@ -5,7 +5,6 @@ import {
   InvocationEndInfo,
   InvocationInfo,
   OperationChangeInfo,
-  OperationEndInfo,
   OperationInfo,
   CustomerFnResult,
   CustomerFn,
@@ -16,7 +15,6 @@ type CallbackResult = unknown;
 type CallbackFn = () => CallbackResult;
 type PluginInfo =
   | OperationInfo
-  | OperationEndInfo
   | InvocationInfo
   | InvocationEndInfo
   | AttemptEndInfo
@@ -150,7 +148,7 @@ export function createPluginRunner(
       info: OperationInfo,
       fn: CustomerFn,
     ): CustomerFnResult => runAsCallback("wrapChildContextFn", info, fn),
-    onOperationEnd: (info: OperationEndInfo) => run("onOperationEnd", info),
+    onOperationEnd: (info: OperationInfo) => run("onOperationEnd", info),
     onOperationAttemptStart: (info: AttemptInfo) =>
       run("onOperationAttemptStart", info),
     wrapOperationAttemptFn: (

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -78,7 +78,6 @@ type FileSystemEnvelope =
   | { data: string }
   | { file: string; preview?: Record<string, unknown> };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function writeToFile(
   basePath: string,
   value: any,

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
@@ -109,7 +109,7 @@ function isMatched(path: string, fields: PreviewField[] | undefined): boolean {
  *
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export function buildPreview(
   value: any,
   config: PreviewConfig,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/pull/637#issue-4669600519

*Description of changes:* 
1. replace onOperationFirstStart with flag in OperationInfo 
2. Move error field from OperationEndInfo to OperationInfo since OperationInfo already includes result.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
