### PR TITLE
chore: onOperationStart is always awaited

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -305,7 +305,7 @@ describe("Step Handler", () => {
   //      StepInterruptedError. StepInterruptedError is an internal sentinel used as the
   //      input to retryStrategy; the cause chain preserves it for inspection.
   describe("interrupted step with AT_MOST_ONCE_PER_RETRY", () => {
-    const setupInterruptedStep = (stepId: string) => {
+    const setupInterruptedStep = (stepId: string): void => {
       const hashedStepId = hashId(stepId);
       (mockContext as any)._stepData[hashedStepId] = {
         Id: hashedStepId,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -46,6 +46,7 @@ import {
   backfillOperationInfo,
   toOperationInfo,
 } from "../../utils/operation/operation";
+import { hashId } from "../../utils/step-id-utils/step-id-utils";
 
 export const createStepHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
@@ -93,11 +94,11 @@ export const createStepHandler = <Logger extends DurableLogger>(
       );
 
       const opInfo = {
-        id: stepId,
+        id: hashId(stepId),
         name: name,
         type: OperationType.STEP,
         subType: OperationSubType.STEP,
-        parentId: parentId,
+        parentId: parentId ? hashId(parentId) : undefined,
       };
 
       // Check if already completed
@@ -273,24 +274,21 @@ export const createStepHandler = <Logger extends DurableLogger>(
               isReplay: false,
             });
           } else {
-            checkpoint
-              .checkpoint(stepId, {
-                Id: stepId,
-                ParentId: parentId,
-                Action: OperationAction.START,
-                SubType: OperationSubType.STEP,
-                Type: OperationType.STEP,
-                Name: name,
-              })
-              .then(async () => {
-                stepData = context.getStepData(stepId);
-                const operationInfo = toOperationInfo(stepData);
-                backfillOperationInfo(operationInfo, opInfo);
-                await plugin.onOperationStart?.({
-                  ...operationInfo,
-                  isReplay: false,
-                });
-              });
+            checkpoint.checkpoint(stepId, {
+              Id: stepId,
+              ParentId: parentId,
+              Action: OperationAction.START,
+              SubType: OperationSubType.STEP,
+              Type: OperationType.STEP,
+              Name: name,
+            });
+            const operationInfo = toOperationInfo(stepData);
+            backfillOperationInfo(operationInfo, opInfo);
+            await plugin.onOperationStart?.({
+              ...opInfo,
+              status: OperationStatus.STARTED,
+              isReplay: false,
+            });
           }
         } else {
           const operationInfo = toOperationInfo(stepData);

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -92,7 +92,7 @@ export function backfillOperationInfo<T extends OperationInfo>(
   info: T,
   defaults: Partial<OperationInfo>,
 ): T {
-  info.id = defaults.id ?? "";
+  if (!info.id) info.id = defaults.id ?? "";
   if (!info.type) info.type = defaults.type ?? "";
   if (!info.subType) info.subType = defaults.subType;
   if (!info.name) info.name = defaults.name;

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -181,7 +181,7 @@ describe("createPluginRunner", () => {
       const plugin: DurableInstrumentationPlugin = {
         onOperationStart: () =>
           new Promise<void>((resolve) => {
-            resolveHook = () => {
+            resolveHook = (): void => {
               hookCompleted = true;
               resolve();
             };
@@ -316,7 +316,7 @@ describe("createPluginRunner", () => {
       const plugin: DurableInstrumentationPlugin = {
         onInvocationEnd: () =>
           new Promise<void>((resolve) => {
-            resolveHook = () => {
+            resolveHook = (): void => {
               hookCompleted = true;
               resolve();
             };


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/pull/637#issue-4669600519

*Description of changes:* We recently changed the plugin hooks to all be async. In conjunction, we are now "awaiting" all the plugin executions. This allows customers the ability to either create fire-and-forget or synchronous plugins. With this new specification, we need to go and fix the following bug: https://github.com/aws/aws-durable-execution-sdk-js/pull/633/changes#r3406736619.

I'm also ensuring that id and parentId are always hashed. I also added some typing to remove some build warnings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
