### PR TITLE
feat(sdk): add plugin hooks to invoke

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -16,6 +16,7 @@ describe("DurableContext executionContext property", () => {
       tenantId: undefined,
       pendingCompletions: new Set(),
       getStepData: jest.fn(),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
     };
 
     const mockLambdaContext: Context = {

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -336,6 +336,7 @@ export class DurableContextImpl<
         this._parentId,
         this.checkAndUpdateReplayMode.bind(this),
         () => this._defaultSerdes,
+        this.durableExecution.plugin,
       );
       return invokeHandler<I, O>(
         ...([

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -540,8 +540,8 @@ describe("DurableContext", () => {
       await context.invoke("func", {});
 
       // New invoke handler uses centralized termination, no hasRunningOperations parameter
-      // Verify it was called with the new signature (context, checkpoint, createStepId, parentId, checkAndUpdateReplayMode, getDefaultSerdes)
-      expect(createInvokeHandler.mock.calls[0].length).toBe(6);
+      // Verify it was called with the new signature (context, checkpoint, createStepId, parentId, checkAndUpdateReplayMode, getDefaultSerdes, plugin)
+      expect(createInvokeHandler.mock.calls[0].length).toBe(7);
     });
 
     it("should call map handler", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
@@ -142,6 +142,7 @@ describe("initializeExecutionContext", () => {
         durableExecutionArn: mockDurableExecutionArn,
         pendingCompletions: expect.any(Set),
         getStepData: expect.any(Function),
+        isOperationUpdatedBetweenInvocation: expect.any(Function),
         tenantId: mockLambdaContext.tenantId,
         requestId: mockLambdaContext.awsRequestId,
       },

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -79,6 +79,9 @@ export const initializeExecutionContext = async (
 
   log("📝", "Loaded step data:", stepData);
 
+  // Build the set of operation IDs that were updated between invocations
+  const updatedOperationIds = new Set<string>(event.UpdatedOperationIds || []);
+
   return {
     executionContext: {
       durableExecutionClient,
@@ -89,6 +92,9 @@ export const initializeExecutionContext = async (
       pendingCompletions: new Set<string>(),
       getStepData(stepId: string): Operation | undefined {
         return getStepDataUtil(stepData, stepId);
+      },
+      isOperationUpdatedBetweenInvocation(hashedOperationId: string): boolean {
+        return updatedOperationIds.has(hashedOperationId);
       },
       tenantId: context.tenantId,
       requestId: context.awsRequestId,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler-two-phase.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler-two-phase.test.ts
@@ -36,6 +36,7 @@ describe("Invoke Handler Two-Phase Execution", () => {
         terminate: jest.fn(),
       },
       durableExecutionArn: "test-arn",
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
     } as any;
 
     mockCheckpoint = {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.plugin.test.ts
@@ -91,7 +91,7 @@ describe("InvokeHandler - plugin hooks", () => {
 
     await expect(handler("test-function", { test: "data" })).rejects.toThrow();
 
-    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(0);
     expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.plugin.test.ts
@@ -1,0 +1,176 @@
+import { createInvokeHandler } from "./invoke-handler";
+import { ExecutionContext } from "../../types";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
+import { DurableInstrumentationPlugin } from "../../types/plugin";
+
+jest.mock("../../utils/logger/logger");
+jest.mock("../../errors/serdes-errors/serdes-errors");
+
+import {
+  safeSerialize,
+  safeDeserialize,
+} from "../../errors/serdes-errors/serdes-errors";
+
+const mockSafeSerialize = safeSerialize as jest.MockedFunction<
+  typeof safeSerialize
+>;
+const mockSafeDeserialize = safeDeserialize as jest.MockedFunction<
+  typeof safeDeserialize
+>;
+
+describe("InvokeHandler - plugin hooks", () => {
+  let mockContext: ExecutionContext;
+  let mockCheckpoint: Checkpoint;
+  let mockCreateStepId: jest.Mock;
+  let mockPlugin: jest.Mocked<DurableInstrumentationPlugin>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateStepId = jest.fn().mockReturnValue("test-step-1");
+    mockCheckpoint = {
+      checkpoint: jest.fn().mockResolvedValue(undefined),
+      markOperationState: jest.fn(),
+      markOperationAwaited: jest.fn(),
+      waitForStatusChange: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    mockContext = {
+      getStepData: jest.fn().mockReturnValue(undefined),
+      terminationManager: { terminate: jest.fn() },
+      durableExecutionArn: "test-arn",
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
+    } as any;
+    mockPlugin = {
+      onOperationStart: jest.fn(),
+      onOperationEnd: jest.fn(),
+      onOperationAttemptStart: jest.fn(),
+      onOperationAttemptEnd: jest.fn(),
+    };
+    mockSafeSerialize.mockResolvedValue('{"serialized":"data"}');
+    mockSafeDeserialize.mockResolvedValue({ result: "success" });
+  });
+
+  it("should call onOperationEnd on replay succeeded", async () => {
+    (mockContext.getStepData as jest.Mock).mockReturnValue({
+      Status: OperationStatus.SUCCEEDED,
+      ChainedInvokeDetails: { Result: '{"result":"success"}' },
+    });
+
+    const handler = createInvokeHandler(
+      mockContext,
+      mockCheckpoint,
+      mockCreateStepId,
+      undefined,
+      jest.fn(),
+      undefined,
+      mockPlugin,
+    );
+
+    await handler("test-function", { test: "data" });
+
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onOperationStart and onOperationEnd on replay failed", async () => {
+    (mockContext.getStepData as jest.Mock).mockReturnValue({
+      Status: OperationStatus.FAILED,
+      ChainedInvokeDetails: {
+        Error: { ErrorMessage: "invoke failed" },
+      },
+    });
+
+    const handler = createInvokeHandler(
+      mockContext,
+      mockCheckpoint,
+      mockCreateStepId,
+      undefined,
+      jest.fn(),
+      undefined,
+      mockPlugin,
+    );
+
+    await expect(handler("test-function", { test: "data" })).rejects.toThrow();
+
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call plugin hooks on phase 2 succeeded", async () => {
+    (mockContext.getStepData as jest.Mock)
+      .mockReturnValueOnce(undefined) // phase 1: no existing step data → triggers checkpoint
+      .mockReturnValueOnce(undefined) // phase 1: getStepData after checkpoint (for toOperationInfo)
+      .mockReturnValueOnce({
+        // phase 2: after waitForStatusChange
+        Status: OperationStatus.SUCCEEDED,
+        ChainedInvokeDetails: { Result: '{"result":"success"}' },
+      });
+
+    const handler = createInvokeHandler(
+      mockContext,
+      mockCheckpoint,
+      mockCreateStepId,
+      undefined,
+      jest.fn(),
+      undefined,
+      mockPlugin,
+    );
+
+    await handler("test-function", { test: "data" });
+
+    // Phase 1: onOperationStart (new invoke started)
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    // Phase 2: onOperationEnd (invoke completed)
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call plugin hooks with error on phase 2 failed", async () => {
+    (mockContext.getStepData as jest.Mock)
+      .mockReturnValueOnce(undefined) // phase 1: no existing step data → triggers checkpoint
+      .mockReturnValueOnce(undefined) // phase 1: getStepData after checkpoint (for toOperationInfo)
+      .mockReturnValueOnce({
+        // phase 2: after waitForStatusChange
+        Status: OperationStatus.FAILED,
+        ChainedInvokeDetails: {
+          Error: { ErrorMessage: "invoke failed" },
+        },
+      });
+
+    const handler = createInvokeHandler(
+      mockContext,
+      mockCheckpoint,
+      mockCreateStepId,
+      undefined,
+      jest.fn(),
+      undefined,
+      mockPlugin,
+    );
+
+    await expect(handler("test-function", { test: "data" })).rejects.toThrow();
+
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+  });
+
+  it("should not throw when plugin hooks are undefined", async () => {
+    (mockContext.getStepData as jest.Mock).mockReturnValue({
+      Status: OperationStatus.SUCCEEDED,
+      ChainedInvokeDetails: { Result: '{"result":"success"}' },
+    });
+
+    const handler = createInvokeHandler(
+      mockContext,
+      mockCheckpoint,
+      mockCreateStepId,
+      undefined,
+      jest.fn(),
+      undefined,
+      {},
+    );
+
+    const result = await handler("test-function", { test: "data" });
+    expect(result).toEqual({ result: "success" });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.test.ts
@@ -47,6 +47,7 @@ describe("InvokeHandler", () => {
         terminate: jest.fn(),
       },
       durableExecutionArn: "test-arn",
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
     } as any;
 
     mockSafeSerialize.mockResolvedValue('{"serialized":"data"}');
@@ -199,9 +200,14 @@ describe("InvokeHandler", () => {
 
     it("should wait for status change when operation is still in progress", async () => {
       // Phase 1: first check (null)
+      // After checkpoint: STARTED
       // Phase 2: after waitForStatusChange (SUCCEEDED)
       (mockContext.getStepData as jest.Mock)
         .mockReturnValueOnce(null) // Phase 1 - initial check, triggers checkpoint
+        .mockReturnValueOnce({
+          Status: OperationStatus.STARTED,
+          ChainedInvokeDetails: {},
+        }) // After checkpoint - for plugin onOperationStart
         .mockReturnValueOnce({
           Status: OperationStatus.SUCCEEDED,
           ChainedInvokeDetails: { Result: '{"result":"success"}' },

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -128,10 +128,6 @@ export const createInvokeHandler = (
         backfillOperationInfo(operationInfo, opInfo);
         const isUpdatedBetweenInvocation =
           context.isOperationUpdatedBetweenInvocation(opInfo.id);
-        await plugin.onOperationStart?.({
-          ...operationInfo,
-          isReplay: !isUpdatedBetweenInvocation,
-        });
         await plugin.onOperationEnd?.({
           ...operationInfo,
           isReplay: !isUpdatedBetweenInvocation,
@@ -168,10 +164,6 @@ export const createInvokeHandler = (
         backfillOperationInfo(operationInfo, opInfo);
         const isUpdatedBetweenInvocation =
           context.isOperationUpdatedBetweenInvocation(opInfo.id);
-        await plugin.onOperationStart?.({
-          ...operationInfo,
-          isReplay: !isUpdatedBetweenInvocation,
-        });
         await plugin.onOperationEnd?.({
           ...operationInfo,
           isReplay: !isUpdatedBetweenInvocation,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -19,6 +19,12 @@ import {
   safeDeserialize,
 } from "../../errors/serdes-errors/serdes-errors";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
+import { DurableInstrumentationPlugin } from "../../types/plugin";
+import {
+  backfillOperationInfo,
+  toOperationInfo,
+} from "../../utils/operation/operation";
+import { hashId } from "../../utils/step-id-utils/step-id-utils";
 
 export const createInvokeHandler = (
   context: ExecutionContext,
@@ -28,6 +34,7 @@ export const createInvokeHandler = (
   checkAndUpdateReplayMode?: () => void,
 
   getDefaultSerdes?: () => AnySerdes,
+  plugin: DurableInstrumentationPlugin = {},
 ): {
   <I, O>(
     funcId: string,
@@ -70,6 +77,14 @@ export const createInvokeHandler = (
 
     const stepId = createStepId();
 
+    const opInfo = {
+      id: hashId(stepId),
+      name: name,
+      type: OperationType.CHAINED_INVOKE,
+      subType: OperationSubType.CHAINED_INVOKE,
+      parentId: parentId ? hashId(parentId) : undefined,
+    };
+
     // Phase 1: Start invoke operation
     let isCompleted = false;
 
@@ -109,6 +124,19 @@ export const createInvokeHandler = (
           },
         );
 
+        const operationInfo = toOperationInfo(stepData);
+        backfillOperationInfo(operationInfo, opInfo);
+        const isUpdatedBetweenInvocation =
+          context.isOperationUpdatedBetweenInvocation(opInfo.id);
+        await plugin.onOperationStart?.({
+          ...operationInfo,
+          isReplay: !isUpdatedBetweenInvocation,
+        });
+        await plugin.onOperationEnd?.({
+          ...operationInfo,
+          isReplay: !isUpdatedBetweenInvocation,
+        });
+
         isCompleted = true;
         return;
       }
@@ -120,6 +148,7 @@ export const createInvokeHandler = (
         stepData?.Status === OperationStatus.STOPPED
       ) {
         log("❌", "Invoke already failed:", { stepId });
+        checkAndUpdateReplayMode?.();
 
         checkpoint.markOperationState(
           stepId,
@@ -134,6 +163,19 @@ export const createInvokeHandler = (
             },
           },
         );
+
+        const operationInfo = toOperationInfo(stepData);
+        backfillOperationInfo(operationInfo, opInfo);
+        const isUpdatedBetweenInvocation =
+          context.isOperationUpdatedBetweenInvocation(opInfo.id);
+        await plugin.onOperationStart?.({
+          ...operationInfo,
+          isReplay: !isUpdatedBetweenInvocation,
+        });
+        await plugin.onOperationEnd?.({
+          ...operationInfo,
+          isReplay: !isUpdatedBetweenInvocation,
+        });
 
         isCompleted = true;
         return;
@@ -164,6 +206,14 @@ export const createInvokeHandler = (
             ...(config?.tenantId && { TenantId: config.tenantId }),
           },
         });
+        stepData = context.getStepData(stepId);
+        const operationInfo = toOperationInfo(stepData);
+        backfillOperationInfo(operationInfo, opInfo);
+        await plugin.onOperationStart?.({ ...operationInfo, isReplay: false });
+      } else {
+        const operationInfo = toOperationInfo(stepData);
+        backfillOperationInfo(operationInfo, opInfo);
+        await plugin.onOperationStart?.({ ...operationInfo, isReplay: true });
       }
 
       // Mark as IDLE_NOT_AWAITED
@@ -237,6 +287,9 @@ export const createInvokeHandler = (
           stepId,
           OperationLifecycleState.COMPLETED,
         );
+        const operationInfo = toOperationInfo(stepData);
+        backfillOperationInfo(operationInfo, opInfo);
+        await plugin.onOperationEnd?.({ ...operationInfo, isReplay: false });
 
         const invokeDetails = stepData.ChainedInvokeDetails;
         return await safeDeserialize(
@@ -255,14 +308,24 @@ export const createInvokeHandler = (
 
       checkpoint.markOperationState(stepId, OperationLifecycleState.COMPLETED);
 
-      const invokeDetails = stepData?.ChainedInvokeDetails;
-      if (invokeDetails?.Error) {
+      const invokeError = stepData?.ChainedInvokeDetails?.Error;
+      const operationInfo = toOperationInfo(stepData);
+      backfillOperationInfo(operationInfo, opInfo);
+      await plugin.onOperationEnd?.({
+        ...operationInfo,
+        isReplay: false,
+        error: invokeError?.ErrorMessage
+          ? new Error(invokeError.ErrorMessage)
+          : new Error("Invoke failed"),
+      });
+
+      if (invokeError) {
         throw new InvokeError(
-          invokeDetails.Error.ErrorMessage || "Invoke failed",
-          invokeDetails.Error.ErrorMessage
-            ? new Error(invokeDetails.Error.ErrorMessage)
+          invokeError.ErrorMessage || "Invoke failed",
+          invokeError.ErrorMessage
+            ? new Error(invokeError.ErrorMessage)
             : undefined,
-          invokeDetails.Error.ErrorData,
+          invokeError.ErrorData,
         );
       } else {
         throw new InvokeError("Invoke failed");

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-integration.test.ts
@@ -92,6 +92,7 @@ describe("Run In Child Context Integration Tests", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(mockExecutionContext._stepData, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
     } satisfies ExecutionContext;

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
@@ -57,6 +57,7 @@ describe("TerminationManager Checkpoint Integration", () => {
       tenantId: "",
       pendingCompletions: new Set(),
       getStepData: jest.fn(),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
     } satisfies ExecutionContext;
 
     mockLogger = createDefaultLogger(mockContext);

--- a/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
@@ -80,6 +80,9 @@ export function createTestDurableContext(options?: {
     getStepData(stepId: string): Operation | undefined {
       return getStepDataUtil(stepData, stepId);
     },
+    isOperationUpdatedBetweenInvocation(): boolean {
+      return false;
+    },
     requestId: "mock-request-id",
     tenantId: undefined,
   };

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-context.ts
@@ -30,6 +30,7 @@ export const createMockExecutionContext = (
     getStepData: jest.fn((stepId: string) => {
       return getStepDataUtil(defaultMockContext._stepData, stepId);
     }),
+    isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
     ...overrides,
   } as unknown as jest.Mocked<ExecutionContext>;
 

--- a/packages/aws-durable-execution-sdk-js/src/types/core.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/core.ts
@@ -42,6 +42,20 @@ export interface DurableExecutionInvocationInput {
   CheckpointToken: string;
 
   /**
+   * Operation IDs (hashed) that were updated between the previous invocation and this one.
+   *
+   * These are operations whose status changed externally (e.g., a wait timer expired,
+   * a callback was received, or a chained invoke completed) since the last checkpoint.
+   * This allows the SDK to distinguish between:
+   * - First-time observation of a completion (isReplay: false for onOperationEnd)
+   * - Replayed observation of a previously seen completion (isReplay: true for onOperationEnd)
+   *
+   * When undefined (e.g., first invocation), all pre-existing completed operations are
+   * treated as replay.
+   */
+  UpdatedOperationIds?: string[];
+
+  /**
    * Execution state including operation history and pagination information.
    *
    * Contains the full context needed to resume execution including:
@@ -327,4 +341,14 @@ export interface ExecutionContext {
   tenantId: string | undefined;
   pendingCompletions: Set<string>; // Track stepIds with pending SUCCEED/FAIL
   getStepData(stepId: string): Operation | undefined;
+
+  /**
+   * Check if an operation (by hashed ID) was updated between the previous invocation
+   * and this one. This indicates the operation's status changed externally (e.g., a wait
+   * expired, callback received, or chained invoke completed) since the last checkpoint.
+   *
+   * Returns true if the operation ID is in the UpdatedOperationIds from the invocation input.
+   * Returns false if UpdatedOperationIds is not present (first invocation) or the ID is not listed.
+   */
+  isOperationUpdatedBetweenInvocation(hashedOperationId: string): boolean;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
@@ -45,6 +45,7 @@ describe("CheckpointManager - StepData Update", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
     };

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
@@ -36,6 +36,7 @@ describe("CheckpointManager Termination Behavior", () => {
       terminationManager: new TerminationManager(),
       durableExecutionArn: "test-arn",
       getStepData: jest.fn(),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: "",
       pendingCompletions: new Set(),

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -83,6 +83,7 @@ describe("CheckpointManager", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
     } satisfies ExecutionContext;
@@ -753,6 +754,7 @@ describe("deleteCheckpointHandler", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData1, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
     } satisfies ExecutionContext;
@@ -767,6 +769,7 @@ describe("deleteCheckpointHandler", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData2, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
     } satisfies ExecutionContext;
@@ -1033,6 +1036,7 @@ describe("createCheckpointHandler", () => {
       getStepData: jest.fn((stepId: string) => {
         return getStepData(stepData, stepId);
       }),
+      isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
     } satisfies ExecutionContext;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/pull/637#issue-4669600519

*Description of changes:* Add onOperationStart and onOperationEnd plugin hooks to invoke-handler. Use hashId for operation IDs in plugin info objects and await all plugin hook calls.

Add UpdatedOperationIds to DurableExecutionInvocationInput and isOperationUpdatedBetweenInvocation to ExecutionContext to distinguish first-time observation of external completions from replays in onOperationEnd calls.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
