### PR TITLE
fix(sdk): add PromiseCombinatorError case to fromErrorObject

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -75,6 +75,12 @@ export abstract class DurableOperationError extends Error {
           cause,
           errorObject.ErrorData,
         );
+      case "PromiseCombinatorError":
+        return new PromiseCombinatorError(
+          errorObject.ErrorMessage || "Promise combinator failed",
+          cause,
+          errorObject.ErrorData,
+        );
       default:
         return new StepError(
           errorObject.ErrorMessage || "Unknown error",

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/error-determinism.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/error-determinism.integration.test.ts
@@ -2,6 +2,7 @@ import {
   StepError,
   CallbackError,
   InvokeError,
+  PromiseCombinatorError,
   DurableOperationError,
 } from "./durable-error";
 import { ErrorObject } from "@aws-sdk/client-lambda";
@@ -162,6 +163,39 @@ describe("Error Determinism Integration Tests", () => {
         '{"functionName": "myFunction", "requestId": "abc-123"}',
       );
       expect(reconstructed.cause?.message).toBe("Lambda invocation failed");
+    });
+  });
+
+  describe("PromiseCombinatorError Determinism", () => {
+    it("should reconstruct PromiseCombinatorError from serialized ErrorObject", () => {
+      const errorObject: ErrorObject = {
+        ErrorType: "PromiseCombinatorError",
+        ErrorMessage: "All promises were rejected",
+        ErrorData: '{"failedCount": 3}',
+      };
+
+      const reconstructed = DurableOperationError.fromErrorObject(errorObject);
+
+      expect(reconstructed instanceof PromiseCombinatorError).toBe(true);
+      expect(reconstructed.errorType).toBe("PromiseCombinatorError");
+      expect(reconstructed.message).toBe("All promises were rejected");
+      expect(reconstructed.errorData).toBe('{"failedCount": 3}');
+    });
+
+    it("should preserve PromiseCombinatorError identity across serialize/deserialize", () => {
+      const original = new PromiseCombinatorError(
+        "All promises failed",
+        new Error("underlying cause"),
+        '{"count": 2}',
+      );
+
+      const serialized = original.toErrorObject();
+      expect(serialized.ErrorType).toBe("PromiseCombinatorError");
+
+      const deserialized = DurableOperationError.fromErrorObject(serialized);
+      expect(deserialized instanceof PromiseCombinatorError).toBe(true);
+      expect(deserialized.message).toBe("All promises failed");
+      expect(deserialized.errorData).toBe('{"count": 2}');
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -47,6 +47,7 @@ export {
   InvokeError,
   ChildContextError,
   WaitForConditionError,
+  PromiseCombinatorError,
 } from "./errors/durable-error/durable-error";
 export {
   defaultSerdes,


### PR DESCRIPTION
PromiseCombinatorError was missing from the switch in DurableOperationError.fromErrorObject, causing it to deserialize as StepError on replay. This broke instanceof checks and introduced non-deterministic error identity.

Changes:
- Add case "PromiseCombinatorError" to fromErrorObject switch
- Export PromiseCombinatorError from package index
- Add integration tests for round-trip serialization


*Issue #, if available:*
#622 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
