### PR TITLE
feat(otel): add OpenTelemetry instrumentation plugin for durable exec…

### DIFF
--- a/.github/workflows/lintcommit.js
+++ b/.github/workflows/lintcommit.js
@@ -32,6 +32,7 @@ const scopes = new Set([
   "ci",
   "deps",
   "deps-dev",
+  "otel",
 ]);
 
 /**

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 **/build
 /dist
 */dist
+**/dist
+**/dist-cjs
 /coverage
 **/coverage
 *.iml

--- a/package-lock.json
+++ b/package-lock.json
@@ -861,6 +861,10 @@
       "resolved": "packages/aws-durable-execution-sdk-js-insight",
       "link": true
     },
+    "node_modules/@aws/durable-execution-sdk-js-otel": {
+      "resolved": "packages/aws-durable-execution-sdk-js-otel",
+      "link": true
+    },
     "node_modules/@aws/durable-execution-sdk-js-testing": {
       "resolved": "packages/aws-durable-execution-sdk-js-testing",
       "link": true
@@ -873,6 +877,10 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aws/test-otel-plugin": {
+      "resolved": "packages/test-otel-plugin",
+      "link": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2946,6 +2954,433 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
+      "integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-exporter-base": "0.200.0",
+        "@opentelemetry/otlp-transformer": "0.200.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
+      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.74.0.tgz",
+      "integrity": "sha512-EMLUGgx2wJSXdwMEFdwd3IaW+mkUF8PENdzDFQ1FRdztzMG1d1XN76ORIjAMsXcKQISlRRcz93AWPQeBPn4EKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
+      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
+      "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/otlp-transformer": "0.200.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
+      "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/sdk-logs": "0.200.0",
+        "@opentelemetry/sdk-metrics": "2.0.0",
+        "@opentelemetry/sdk-trace-base": "2.0.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+      "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-aws-xray": {
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.2.tgz",
+      "integrity": "sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
+      "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
+      "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.8.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -2979,6 +3414,63 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -4793,7 +5285,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5535,13 +6026,21 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6045,7 +6544,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -7260,7 +7758,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8083,6 +8580,46 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8584,6 +9121,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/import-lazy": {
@@ -10114,6 +10666,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10279,11 +10837,16 @@
         "obliterator": "^1.6.1"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -10805,6 +11368,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10878,6 +11464,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -12010,7 +12609,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -14323,6 +14921,34 @@
         "node": ">=14.17"
       }
     },
+    "packages/aws-durable-execution-sdk-js-otel": {
+      "name": "@aws/durable-execution-sdk-js-otel",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@eslint/compat": "^1.4.1",
+        "@eslint/js": "^9.29.0",
+        "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-jest": "^29.0.1",
+        "fast-check": "^3.23.2",
+        "jest": "^30.0.3",
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.34.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@aws/durable-execution-sdk-js": "*",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
+        "@opentelemetry/propagator-aws-xray": "^1.0.0",
+        "@opentelemetry/sdk-trace-node": "^2.6.1"
+      }
+    },
     "packages/aws-durable-execution-sdk-js-testing": {
       "name": "@aws/durable-execution-sdk-js-testing",
       "version": "1.1.1",
@@ -15979,6 +16605,32 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws/durable-execution-sdk-js": "*"
+      }
+    },
+    "packages/test-otel-plugin": {
+      "name": "@aws/test-otel-plugin",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws/durable-execution-sdk-js": "*",
+        "@aws/durable-execution-sdk-js-otel": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
+        "@opentelemetry/propagator-aws-xray": "^1.26.0",
+        "@opentelemetry/sdk-trace-node": "^2.6.1"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^28.0.9",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.2",
+        "@rollup/plugin-typescript": "^12.1.2",
+        "rollup": "^4.34.2",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
     }
   }

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -19,11 +19,8 @@ This plugin requires the [AWS Distro for OpenTelemetry (ADOT) Lambda layer](http
 
 To find the latest ADOT layer ARN for your region:
 
-1. Visit the [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda) for the list of supported regions and layer ARNs
-2. Alternatively, use the AWS CLI:
-   ```bash
-   aws lambda list-layers --compatible-runtime nodejs22.x --query "Layers[?starts_with(LayerName, 'aws-otel')]"
-   ```
+1. Visit the [ADOT Lambda Layer ARNs](https://aws-otel.github.io/docs/getting-started/lambda#aws-lambda-layer-for-opentelemetry-arns) for the list of supported regions and layer ARNs
+2. The Node.js layer name follows the format: `AWSOpenTelemetryDistroJs`
 3. Add the layer ARN to your Lambda function configuration
 
 ### AWS X-Ray Active Tracing
@@ -68,17 +65,13 @@ npm install @aws/durable-execution-sdk-js-otel
 
 This package requires the following peer dependencies:
 
-| Package                         | Version  |
-| ------------------------------- | -------- |
-| `@aws/durable-execution-sdk-js` | `*`      |
-| `@opentelemetry/api`            | `^1.0.0` |
-| `@opentelemetry/sdk-trace-node` | `^2.6.1` |
-
-Install them if not already present:
-
-```bash
-npm install @opentelemetry/api @opentelemetry/sdk-trace-node
-```
+| Package                                  | Version    |
+| ---------------------------------------- | ---------- |
+| `@aws/durable-execution-sdk-js`          | `*`        |
+| `@opentelemetry/api`                     | `^1.0.0`   |
+| `@opentelemetry/instrumentation`         | `^0.219.0` |
+| `@opentelemetry/instrumentation-aws-sdk` | `^0.74.0`  |
+| `@opentelemetry/sdk-trace-node`          | `^2.6.1`   |
 
 ## Quick Start
 
@@ -108,24 +101,12 @@ That's it. The plugin handles TracerProvider setup, deterministic ID generation,
 
 ## Configuration
 
-### Environment Variables
-
-| Variable                      | Description                                                                                   | Default           |
-| ----------------------------- | --------------------------------------------------------------------------------------------- | ----------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint for the OTLP exporter (e.g., `http://localhost:4318` for the ADOT collector sidecar) | Set by ADOT layer |
-| `OTEL_SERVICE_NAME`           | Service name for traces (e.g., your Lambda function name)                                     | —                 |
-| `OTEL_DURABLE_SAMPLING_RATE`  | Sampling rate from `0.0` (sample nothing) to `1.0` (sample all)                               | `1.0`             |
-| `AWS_LAMBDA_EXEC_WRAPPER`     | Set to `/opt/otel-handler` for the ADOT layer to instrument your function                     | —                 |
-
 ### Plugin Options
 
 ```typescript
 import { DurableExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
 
 const plugin = new DurableExecutionOtelPlugin({
-  // Override sampling rate (takes precedence over OTEL_DURABLE_SAMPLING_RATE)
-  samplingRate: 0.5,
-
   // Use a custom context extractor (default: xRayContextExtractor)
   contextExtractor: xRayContextExtractor,
 
@@ -151,13 +132,15 @@ import {
 // Default: X-Ray trace header (recommended for most Lambda deployments)
 new DurableExecutionOtelPlugin({ contextExtractor: xRayContextExtractor });
 
-// W3C Trace Context via clientContext (requires backend propagation support)
+// W3C Trace Context via clientContext (requires backend propagation support (TODO))
 new DurableExecutionOtelPlugin({ contextExtractor: w3cClientContextExtractor });
 ```
 
 ## Lambda Setup
 
-### 1. Add the ADOT Layer
+### SAM template setup
+
+#### 1. Add the ADOT Layer
 
 Add the ADOT Lambda layer to your function. The layer provides the OpenTelemetry collector that exports traces to your configured backend.
 
@@ -167,22 +150,20 @@ MyFunction:
   Type: AWS::Serverless::Function
   Properties:
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
+      - !Sub arn:aws:lambda:${AWS::Region}:615299751070:layer:AWSOpenTelemetryDistroJs:<version>
 ```
 
-> **Note:** The layer ARN varies by region and version. Refer to the [ADOT documentation](https://aws-otel.github.io/docs/getting-started/lambda) for the latest ARN in your region.
+> **Note:** The layer ARN varies by region, account, and version. Refer to the [ADOT Lambda Layer ARNs](https://aws-otel.github.io/docs/getting-started/lambda#aws-lambda-layer-for-opentelemetry-arns) for the latest ARN in your region.
 
-### 2. Set Environment Variables
+#### 2. Set Environment Variables
 
 ```yaml
 Environment:
   Variables:
-    AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
-    OTEL_SERVICE_NAME: my-durable-function
-    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+    AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
 ```
 
-### 3. Enable X-Ray Active Tracing
+#### 3. Enable X-Ray Active Tracing
 
 ```yaml
 TracingConfig:
@@ -191,9 +172,24 @@ TracingConfig:
 
 This ensures the `_X_AMZN_TRACE_ID` environment variable is set on every invocation. The durable execution backend propagates the same Root trace ID to every invocation, so all invocations of the same execution share one trace.
 
-### 4. Grant Permissions
+#### 4. Grant Permissions
 
 The function's execution role needs the `AWSXRayDaemonWriteAccess` managed policy (or equivalent permissions) if using X-Ray as the tracing backend.
+
+### AWS Console
+
+See https://aws-otel.github.io/docs/getting-started/lambda#use-the-lambda-console.
+
+### Environment Variables for ADOT layer
+
+| Variable                      | Description                                                                                   | Default           |
+| ----------------------------- | --------------------------------------------------------------------------------------------- | ----------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint for the OTLP exporter (e.g., `http://localhost:4318` for the ADOT collector sidecar) | Set by ADOT layer |
+| `AWS_LAMBDA_EXEC_WRAPPER`     | Set to `/opt/otel-instrument` for the ADOT layer to instrument your function                  | —                 |
+| `OTEL_TRACES_SAMPLER`         | Sampler to use (e.g., `traceidratio` for ratio-based sampling)                                | `always_on`       |
+| `OTEL_TRACES_SAMPLER_ARG`     | Argument for the sampler (e.g., `0.3` to sample 30% of traces)                                | —                 |
+
+See the [ADOT sampling configuration](https://aws-otel.github.io/docs/getting-started/lambda#sampling-configuration) for more details.
 
 ## Verification
 
@@ -201,16 +197,16 @@ After deploying your function with the plugin configured:
 
 1. **Invoke your durable function** — trigger at least one execution that includes multiple steps or a wait/resume cycle.
 
-2. **Check X-Ray console** — Navigate to AWS X-Ray → Traces in the AWS Console. You should see a trace with:
-   - An "invocation" span at the root
+2. **Check Cloudwatch console** — Navigate to Cloudwatch → Traces in the AWS Console. You should see a trace with:
+   - An "invocation" span per invocation
    - Child spans for each durable operation (named after your step names)
    - All invocations of the same execution grouped under one trace ID
 
-3. **Verify span links** — For operations that span multiple invocations (e.g., after a wait resumes), look for continuation spans with Links pointing back to the original operation span.
+3. **Check log correlation** — If you use `enrichLogContext()`, verify that your logs include `traceId` and `spanId` fields matching the spans in X-Ray.
 
-4. **Check log correlation** — If you use `enrichLogContext()`, verify that your logs include `traceId` and `spanId` fields matching the spans in X-Ray.
+4. **Confirm sampling** — If you set `OTEL_TRACES_SAMPLER=traceidratio` and `OTEL_TRACES_SAMPLER_ARG` to a value less than 1.0, verify that only the expected proportion of traces appear.
 
-5. **Confirm sampling** — If you set `OTEL_DURABLE_SAMPLING_RATE` to a value less than 1.0, verify that only the expected proportion of traces appear.
+5. **span links** — For operations that span multiple invocations (e.g., after a wait resumes), though span links are set, they are not visualized within CloudWatch console.
 
 ### Troubleshooting
 
@@ -218,7 +214,7 @@ After deploying your function with the plugin configured:
 | --------------------------------- | --------------------------------------------------------------- |
 | No traces appear                  | ADOT layer not configured, or `AWS_LAMBDA_EXEC_WRAPPER` not set |
 | Traces appear but are fragmented  | X-Ray active tracing not enabled on the Lambda function         |
-| Missing spans for some operations | Sampling rate set below 1.0                                     |
+| Missing spans for some operations | `OTEL_TRACES_SAMPLER_ARG` set below 1.0                         |
 | `_X_AMZN_TRACE_ID` not populated  | X-Ray active tracing not enabled                                |
 
 ## API Reference

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -1,0 +1,252 @@
+# AWS Durable Execution SDK - OpenTelemetry Plugin
+
+OpenTelemetry instrumentation plugin for AWS Durable Execution SDK. Emits distributed traces that correlate across multiple Lambda invocations of a single durable execution, producing deterministic span and trace IDs so that spans from different invocations are stitched into a single coherent trace.
+
+## Features
+
+- **Deterministic Trace IDs**: All invocations of the same durable execution share a single trace, derived from the X-Ray trace header or execution ARN
+- **Span-per-Operation**: Each durable operation (step, wait, invoke) gets its own span with accurate timing
+- **Continuation Spans**: Operations completing in a different invocation are linked back to the original span
+- **Log Correlation**: Enrich application logs with trace ID and span ID for end-to-end observability
+- **Configurable Sampling**: Control trace volume via environment variable or plugin options
+- **Self-Contained Setup**: No manual TracerProvider configuration required
+
+## Prerequisites
+
+### ADOT Lambda Layer
+
+This plugin requires the [AWS Distro for OpenTelemetry (ADOT) Lambda layer](https://aws-otel.github.io/docs/getting-started/lambda) to export traces from your Lambda function.
+
+To find the latest ADOT layer ARN for your region:
+
+1. Visit the [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda) for the list of supported regions and layer ARNs
+2. Alternatively, use the AWS CLI:
+   ```bash
+   aws lambda list-layers --compatible-runtime nodejs22.x --query "Layers[?starts_with(LayerName, 'aws-otel')]"
+   ```
+3. Add the layer ARN to your Lambda function configuration
+
+### AWS X-Ray Active Tracing
+
+Enable active tracing on your Lambda function so the `_X_AMZN_TRACE_ID` environment variable is populated at invocation time. The plugin uses this header to derive deterministic trace IDs that remain consistent across all invocations of the same durable execution.
+
+**AWS Console:** Lambda → Configuration → Monitoring and operations tools → Active tracing → Enable
+
+**AWS CLI:**
+
+```bash
+aws lambda update-function-configuration \
+  --function-name your-function-name \
+  --tracing-config Mode=Active
+```
+
+**CloudFormation / SAM:**
+
+```yaml
+MyFunction:
+  Type: AWS::Lambda::Function
+  Properties:
+    TracingConfig:
+      Mode: Active
+```
+
+**CDK:**
+
+```typescript
+new lambda.Function(this, "MyFunction", {
+  tracing: lambda.Tracing.ACTIVE,
+});
+```
+
+## Installation
+
+```bash
+npm install @aws/durable-execution-sdk-js-otel
+```
+
+### Peer Dependencies
+
+This package requires the following peer dependencies:
+
+| Package                         | Version  |
+| ------------------------------- | -------- |
+| `@aws/durable-execution-sdk-js` | `*`      |
+| `@opentelemetry/api`            | `^1.0.0` |
+| `@opentelemetry/sdk-trace-node` | `^2.6.1` |
+
+Install them if not already present:
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-trace-node
+```
+
+## Quick Start
+
+```typescript
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { DurableExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+export const handler = withDurableExecution(
+  async (event, context) => {
+    const result = await context.step("fetch-data", async () => {
+      return fetchData(event.id);
+    });
+
+    await context.wait({ seconds: 5 });
+
+    await context.step("process", async () => {
+      return process(result);
+    });
+
+    return result;
+  },
+  { plugins: [new DurableExecutionOtelPlugin()] },
+);
+```
+
+That's it. The plugin handles TracerProvider setup, deterministic ID generation, and span lifecycle internally.
+
+## Configuration
+
+### Environment Variables
+
+| Variable                      | Description                                                                                   | Default           |
+| ----------------------------- | --------------------------------------------------------------------------------------------- | ----------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint for the OTLP exporter (e.g., `http://localhost:4318` for the ADOT collector sidecar) | Set by ADOT layer |
+| `OTEL_SERVICE_NAME`           | Service name for traces (e.g., your Lambda function name)                                     | —                 |
+| `OTEL_DURABLE_SAMPLING_RATE`  | Sampling rate from `0.0` (sample nothing) to `1.0` (sample all)                               | `1.0`             |
+| `AWS_LAMBDA_EXEC_WRAPPER`     | Set to `/opt/otel-handler` for the ADOT layer to instrument your function                     | —                 |
+
+### Plugin Options
+
+```typescript
+import { DurableExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+const plugin = new DurableExecutionOtelPlugin({
+  // Override sampling rate (takes precedence over OTEL_DURABLE_SAMPLING_RATE)
+  samplingRate: 0.5,
+
+  // Use a custom context extractor (default: xRayContextExtractor)
+  contextExtractor: xRayContextExtractor,
+
+  // Provide your own TracerProvider if you already have one configured
+  tracerProvider: myTracerProvider,
+
+  // Custom instrumentation scope name (default: "aws-durable-execution-sdk-js")
+  instrumentationName: "my-service",
+});
+```
+
+### Context Extractors
+
+The plugin supports multiple strategies for extracting upstream trace context:
+
+```typescript
+import {
+  DurableExecutionOtelPlugin,
+  xRayContextExtractor,
+  w3cClientContextExtractor,
+} from "@aws/durable-execution-sdk-js-otel";
+
+// Default: X-Ray trace header (recommended for most Lambda deployments)
+new DurableExecutionOtelPlugin({ contextExtractor: xRayContextExtractor });
+
+// W3C Trace Context via clientContext (requires backend propagation support)
+new DurableExecutionOtelPlugin({ contextExtractor: w3cClientContextExtractor });
+```
+
+## Lambda Setup
+
+### 1. Add the ADOT Layer
+
+Add the ADOT Lambda layer to your function. The layer provides the OpenTelemetry collector that exports traces to your configured backend.
+
+```yaml
+# SAM template example
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-nodejs-amd64-ver-1-18-1:1
+```
+
+> **Note:** The layer ARN varies by region and version. Refer to the [ADOT documentation](https://aws-otel.github.io/docs/getting-started/lambda) for the latest ARN in your region.
+
+### 2. Set Environment Variables
+
+```yaml
+Environment:
+  Variables:
+    AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+    OTEL_SERVICE_NAME: my-durable-function
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+```
+
+### 3. Enable X-Ray Active Tracing
+
+```yaml
+TracingConfig:
+  Mode: Active
+```
+
+This ensures the `_X_AMZN_TRACE_ID` environment variable is set on every invocation. The durable execution backend propagates the same Root trace ID to every invocation, so all invocations of the same execution share one trace.
+
+### 4. Grant Permissions
+
+The function's execution role needs the `AWSXRayDaemonWriteAccess` managed policy (or equivalent permissions) if using X-Ray as the tracing backend.
+
+## Verification
+
+After deploying your function with the plugin configured:
+
+1. **Invoke your durable function** — trigger at least one execution that includes multiple steps or a wait/resume cycle.
+
+2. **Check X-Ray console** — Navigate to AWS X-Ray → Traces in the AWS Console. You should see a trace with:
+   - An "invocation" span at the root
+   - Child spans for each durable operation (named after your step names)
+   - All invocations of the same execution grouped under one trace ID
+
+3. **Verify span links** — For operations that span multiple invocations (e.g., after a wait resumes), look for continuation spans with Links pointing back to the original operation span.
+
+4. **Check log correlation** — If you use `enrichLogContext()`, verify that your logs include `traceId` and `spanId` fields matching the spans in X-Ray.
+
+5. **Confirm sampling** — If you set `OTEL_DURABLE_SAMPLING_RATE` to a value less than 1.0, verify that only the expected proportion of traces appear.
+
+### Troubleshooting
+
+| Symptom                           | Likely Cause                                                    |
+| --------------------------------- | --------------------------------------------------------------- |
+| No traces appear                  | ADOT layer not configured, or `AWS_LAMBDA_EXEC_WRAPPER` not set |
+| Traces appear but are fragmented  | X-Ray active tracing not enabled on the Lambda function         |
+| Missing spans for some operations | Sampling rate set below 1.0                                     |
+| `_X_AMZN_TRACE_ID` not populated  | X-Ray active tracing not enabled                                |
+
+## API Reference
+
+### `DurableExecutionOtelPlugin`
+
+The main plugin class. Implements `DurableInstrumentationPlugin` from `@aws/durable-execution-sdk-js`.
+
+```typescript
+new DurableExecutionOtelPlugin(config?: DurableExecutionOtelPluginConfig)
+```
+
+### `DeterministicIdGenerator`
+
+A custom OpenTelemetry `IdGenerator` that produces reproducible trace and span IDs from execution metadata. Exported for advanced use cases.
+
+### `xRayContextExtractor`
+
+Default context extractor. Reads the `_X_AMZN_TRACE_ID` environment variable to derive trace context.
+
+### `w3cClientContextExtractor`
+
+Alternative context extractor. Reads `traceparent` from `context.clientContext.custom.traceparent` (W3C Trace Context format).
+
+### `ContextExtractor`
+
+Type definition for custom context extractor functions.
+
+## License
+
+Apache-2.0

--- a/packages/aws-durable-execution-sdk-js-otel/jest.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-otel/jest.config.mjs
@@ -1,0 +1,10 @@
+import { createDefaultPreset } from "ts-jest";
+
+const defaultPreset = createDefaultPreset();
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+  ...defaultPreset,
+  testMatch: ["**/__tests__/**/*.test.ts"],
+  coverageReporters: ["cobertura", "html", "text"],
+};

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@aws/durable-execution-sdk-js-otel",
+  "description": "OpenTelemetry instrumentation plugin for AWS Durable Execution SDK",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",
+    "directory": "packages/aws-durable-execution-sdk-js-otel"
+  },
+  "homepage": "https://github.com/aws/aws-durable-execution-sdk-js/tree/main/packages/aws-durable-execution-sdk-js-otel",
+  "engines": {
+    "node": ">=22"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist-types/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist dist-cjs dist-types node_modules coverage .tsbuildinfo .rollup.cache",
+    "build": "concurrently npm:build:esm npm:build:cjs npm:build:types",
+    "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
+    "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",
+    "build:types": "tsc --project tsconfig.build.json --outDir dist-types",
+    "prepublishOnly": "npm run build && npm run test",
+    "lint": "eslint --fix",
+    "prebuild": "npm run lint",
+    "test": "tsc --noEmit && jest --config jest.config.mjs --collectCoverage --collectCoverageFrom=src/**/*.{ts,js}"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist-types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist-cjs/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "dist-cjs/",
+    "dist-types"
+  ],
+  "devDependencies": {
+    "@eslint/compat": "^1.4.1",
+    "@eslint/js": "^9.29.0",
+    "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-jest": "^29.0.1",
+    "fast-check": "^3.23.2",
+    "jest": "^30.0.3",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.34.1"
+  },
+  "peerDependencies": {
+    "@aws/durable-execution-sdk-js": "*",
+    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+    "@opentelemetry/instrumentation": "^0.219.0",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
+    "@opentelemetry/propagator-aws-xray": "^1.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.6.1"
+  },
+  "private": true
+}

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -52,10 +52,8 @@
   "peerDependencies": {
     "@aws/durable-execution-sdk-js": "*",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
     "@opentelemetry/instrumentation": "^0.219.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
-    "@opentelemetry/propagator-aws-xray": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^2.6.1"
   },
   "private": true

--- a/packages/aws-durable-execution-sdk-js-otel/rollup.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-otel/rollup.config.mjs
@@ -1,0 +1,14 @@
+// @ts-check
+
+import nodeExternals from "rollup-plugin-node-externals";
+import { createBuildOptions } from "../../rollup.config.js";
+import packageJson from "./package.json" with { type: "json" };
+
+const config = {
+  input: /** @type {Record<string, string>} */ ({
+    index: "./src/index.ts",
+  }),
+  plugins: [nodeExternals()],
+};
+
+export default createBuildOptions(config, process.env.MODE, packageJson);

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
@@ -1,0 +1,237 @@
+import type { InvocationInfo } from "@aws/durable-execution-sdk-js";
+import {
+  xRayContextExtractor,
+  w3cClientContextExtractor,
+} from "../context-extractors";
+
+const baseInfo: InvocationInfo = {
+  requestId: "req-123",
+  executionArn:
+    "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST/exec/abc",
+  isFirstInvocation: true,
+  operations: {},
+};
+
+describe("xRayContextExtractor", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns undefined when _X_AMZN_TRACE_ID is not set", () => {
+    delete process.env._X_AMZN_TRACE_ID;
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("extracts traceId and parentSpanId from valid X-Ray header", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result).toEqual({
+      traceId: "5759e988bd862e3fe1be46a994272793",
+      parentSpanId: "53995c3f42cd8ad8",
+    });
+  });
+
+  it("extracts traceId without Parent field", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result).toEqual({
+      traceId: "5759e988bd862e3fe1be46a994272793",
+      parentSpanId: undefined,
+    });
+  });
+
+  it("returns undefined for empty string", () => {
+    process.env._X_AMZN_TRACE_ID = "";
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("returns undefined for header without Root field", () => {
+    process.env._X_AMZN_TRACE_ID = "Parent=53995c3f42cd8ad8;Sampled=1";
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("returns undefined for malformed Root field (wrong hex length)", () => {
+    process.env._X_AMZN_TRACE_ID = "Root=1-5759e988-bd862e3fe1be46a9;Sampled=1";
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("returns undefined for Root field with non-hex characters", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-ZZZZZZZZZZZZZZZZZZZZZZZZ;Sampled=1";
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("handles uppercase Parent values by normalizing to lowercase", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995C3F42CD8AD8;Sampled=1";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result).toEqual({
+      traceId: "5759e988bd862e3fe1be46a994272793",
+      parentSpanId: "53995c3f42cd8ad8",
+    });
+  });
+
+  it("ignores invalid Parent field (wrong length)", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=short;Sampled=1";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result).toEqual({
+      traceId: "5759e988bd862e3fe1be46a994272793",
+      parentSpanId: undefined,
+    });
+  });
+});
+
+describe("w3cClientContextExtractor", () => {
+  it("returns undefined when info has no context", () => {
+    expect(w3cClientContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("returns undefined when clientContext is missing", () => {
+    const info = { ...baseInfo, context: {} } as unknown as InvocationInfo;
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined when clientContext.custom is missing", () => {
+    const info = {
+      ...baseInfo,
+      context: { clientContext: {} },
+    } as unknown as InvocationInfo;
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined when traceparent is missing from custom", () => {
+    const info = {
+      ...baseInfo,
+      context: { clientContext: { custom: {} } },
+    } as unknown as InvocationInfo;
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("extracts traceId, parentSpanId, and traceFlags from valid traceparent", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    const result = w3cClientContextExtractor(info);
+    expect(result).toEqual({
+      traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+      parentSpanId: "00f067aa0ba902b7",
+      traceFlags: 1,
+    });
+  });
+
+  it("parses traceFlags=00 as 0", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    const result = w3cClientContextExtractor(info);
+    expect(result?.traceFlags).toBe(0);
+  });
+
+  it("returns undefined for traceparent with wrong number of parts", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for traceparent with invalid traceId length", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent: "00-4bf92f3577b3-00f067aa0ba902b7-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for traceparent with invalid parentId length", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for traceparent with non-hex characters", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for traceparent with invalid version", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/deterministic-id-generator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/deterministic-id-generator.test.ts
@@ -1,0 +1,169 @@
+import {
+  DeterministicIdGenerator,
+  deriveTraceIdFromXRayRoot,
+  deriveTraceIdFromArn,
+  deriveSpanIdFromOperationId,
+} from "../deterministic-id-generator";
+
+describe("DeterministicIdGenerator", () => {
+  let generator: DeterministicIdGenerator;
+
+  beforeEach(() => {
+    generator = new DeterministicIdGenerator();
+  });
+
+  describe("generateTraceId", () => {
+    it("returns setTraceId value when set", () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+      generator.setTraceId(traceId);
+      expect(generator.generateTraceId()).toBe(traceId);
+    });
+
+    it("persists setTraceId across multiple calls", () => {
+      const traceId = "1234567890abcdef1234567890abcdef";
+      generator.setTraceId(traceId);
+      expect(generator.generateTraceId()).toBe(traceId);
+      expect(generator.generateTraceId()).toBe(traceId);
+      expect(generator.generateTraceId()).toBe(traceId);
+    });
+
+    it("changes when setTraceId is called again", () => {
+      const traceId1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+      const traceId2 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      generator.setTraceId(traceId1);
+      expect(generator.generateTraceId()).toBe(traceId1);
+      generator.setTraceId(traceId2);
+      expect(generator.generateTraceId()).toBe(traceId2);
+    });
+
+    it("returns a 32-char hex string as fallback when no traceId is set", () => {
+      const traceId = generator.generateTraceId();
+      expect(traceId).toMatch(/^[0-9a-f]{32}$/);
+    });
+  });
+
+  describe("generateSpanId", () => {
+    it("returns setNextSpanId value on the next call (one-shot)", () => {
+      const spanId = "abcdef1234567890";
+      generator.setNextSpanId(spanId);
+      expect(generator.generateSpanId()).toBe(spanId);
+    });
+
+    it("reverts to default after one-shot is consumed", () => {
+      const spanId = "abcdef1234567890";
+      generator.setNextSpanId(spanId);
+      expect(generator.generateSpanId()).toBe(spanId);
+      // Next call should NOT return the same value
+      const nextSpanId = generator.generateSpanId();
+      expect(nextSpanId).not.toBe(spanId);
+      expect(nextSpanId).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("returns a 16-char hex string as fallback when no spanId is set", () => {
+      const spanId = generator.generateSpanId();
+      expect(spanId).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("supports multiple sequential one-shot overrides", () => {
+      const spanId1 = "1111111111111111";
+      const spanId2 = "2222222222222222";
+
+      generator.setNextSpanId(spanId1);
+      expect(generator.generateSpanId()).toBe(spanId1);
+
+      generator.setNextSpanId(spanId2);
+      expect(generator.generateSpanId()).toBe(spanId2);
+    });
+  });
+});
+
+describe("deriveTraceIdFromXRayRoot", () => {
+  it("derives trace ID from a valid X-Ray Root field with Root= prefix", () => {
+    const root = "Root=1-5759e988-bd862e3fe1be46a994272793";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBe("5759e988bd862e3fe1be46a994272793");
+  });
+
+  it("derives trace ID from a valid X-Ray Root field without Root= prefix", () => {
+    const root = "1-5759e988-bd862e3fe1be46a994272793";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBe("5759e988bd862e3fe1be46a994272793");
+  });
+
+  it("returns undefined for invalid root (no 1- prefix after Root=)", () => {
+    const root = "Root=2-5759e988-bd862e3fe1be46a994272793";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for root with wrong hex length", () => {
+    const root = "Root=1-5759e988-bd862e3fe1be46a9";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for root with non-hex characters", () => {
+    const root = "Root=1-5759e988-ZZZZZZZZZZZZZZZZZZZZZZZZ";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBeUndefined();
+  });
+
+  it("handles another valid root", () => {
+    const root = "Root=1-67890abc-def01234567890abcdef0123";
+    const result = deriveTraceIdFromXRayRoot(root);
+    expect(result).toBe("67890abcdef01234567890abcdef0123");
+  });
+});
+
+describe("deriveTraceIdFromArn", () => {
+  it("produces a 32-char lowercase hex string", () => {
+    const arn =
+      "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-id";
+    const result = deriveTraceIdFromArn(arn);
+    expect(result).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("is deterministic (same input always produces same output)", () => {
+    const arn =
+      "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-id";
+    const result1 = deriveTraceIdFromArn(arn);
+    const result2 = deriveTraceIdFromArn(arn);
+    expect(result1).toBe(result2);
+  });
+
+  it("produces different results for different ARNs", () => {
+    const arn1 =
+      "arn:aws:lambda:us-east-1:123456789012:function:func-a:$LATEST:exec-1";
+    const arn2 =
+      "arn:aws:lambda:us-east-1:123456789012:function:func-b:$LATEST:exec-2";
+    const result1 = deriveTraceIdFromArn(arn1);
+    const result2 = deriveTraceIdFromArn(arn2);
+    expect(result1).not.toBe(result2);
+  });
+});
+
+describe("deriveSpanIdFromOperationId", () => {
+  it("produces a 16-char lowercase hex string", () => {
+    const operationId = "step-1-fetch-user";
+    const result = deriveSpanIdFromOperationId(operationId);
+    expect(result).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is deterministic (same input always produces same output)", () => {
+    const operationId = "step-1-fetch-user";
+    const result1 = deriveSpanIdFromOperationId(operationId);
+    const result2 = deriveSpanIdFromOperationId(operationId);
+    expect(result1).toBe(result2);
+  });
+
+  it("produces different results for different operation IDs", () => {
+    const result1 = deriveSpanIdFromOperationId("op-1");
+    const result2 = deriveSpanIdFromOperationId("op-2");
+    expect(result1).not.toBe(result2);
+  });
+
+  it("handles empty string", () => {
+    const result = deriveSpanIdFromOperationId("");
+    expect(result).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -214,12 +214,11 @@ describe("DurableExecutionOtelPlugin", () => {
       await plugin.onOperationEnd(makeOperationEndInfo({ id: "op-abc" }));
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const expectedSpanId = deriveSpanIdFromOperationId("op-abc");
       const opSpan = findSpan("step");
       expect(opSpan).toBeDefined();
       // When using internal provider with DeterministicIdGenerator, span ID is deterministic.
       // With external provider, we verify the durable.operation.id attribute is set correctly.
-      expect(opSpan!.attributes["durable.operation.id"]).toBe(expectedSpanId);
+      expect(opSpan!.attributes["durable.operation.id"]).toBe("op-abc");
       // Non-replay spans should NOT have links (unlike replay spans)
       expect(opSpan!.links.length).toBe(0);
     });
@@ -834,9 +833,7 @@ describe("DurableExecutionOtelPlugin", () => {
       const opSpan = findSpan("my-wait");
       expect(opSpan).toBeDefined();
       expect(opSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
-      expect(opSpan!.attributes["durable.operation.id"]).toBe(
-        deriveSpanIdFromOperationId("op-attrs"),
-      );
+      expect(opSpan!.attributes["durable.operation.id"]).toBe("op-attrs");
       expect(opSpan!.attributes["durable.operation.type"]).toBe("wait");
       expect(opSpan!.attributes["durable.operation.name"]).toBe("my-wait");
     });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -1,0 +1,1038 @@
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  NodeTracerProvider,
+} from "@opentelemetry/sdk-trace-node";
+import {
+  context,
+  trace,
+  SpanStatusCode,
+  propagation,
+} from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import { DurableExecutionOtelPlugin } from "../plugin";
+import {
+  DeterministicIdGenerator,
+  deriveSpanIdFromOperationId,
+} from "../deterministic-id-generator";
+import type {
+  InvocationInfo,
+  InvocationEndInfo,
+  OperationInfo,
+  OperationEndInfo,
+  AttemptInfo,
+  AttemptEndInfo,
+} from "@aws/durable-execution-sdk-js";
+
+let exporter: InMemorySpanExporter;
+let provider: NodeTracerProvider;
+let plugin: DurableExecutionOtelPlugin;
+
+const TEST_ARN =
+  "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123";
+const TEST_REQUEST_ID = "req-abc-123";
+
+function makeInvocationInfo(
+  overrides?: Partial<InvocationInfo>,
+): InvocationInfo {
+  return {
+    requestId: TEST_REQUEST_ID,
+    executionArn: TEST_ARN,
+    isFirstInvocation: true,
+    operations: {},
+    ...overrides,
+  };
+}
+
+function makeInvocationEndInfo(
+  overrides?: Partial<InvocationEndInfo>,
+): InvocationEndInfo {
+  return {
+    requestId: TEST_REQUEST_ID,
+    executionArn: TEST_ARN,
+    isFirstInvocation: true,
+    operations: {},
+    status: "SUCCEEDED" as any,
+    executionResult: undefined,
+    executionError: undefined,
+    executionInput: {},
+    ...overrides,
+  };
+}
+
+function makeOperationInfo(overrides?: Partial<OperationInfo>): OperationInfo {
+  return {
+    id: "op-1",
+    type: "step",
+    isReplay: false,
+    ...overrides,
+  };
+}
+
+function makeOperationEndInfo(
+  overrides?: Partial<OperationEndInfo>,
+): OperationEndInfo {
+  return {
+    id: "op-1",
+    type: "step",
+    isReplay: false,
+    ...overrides,
+  };
+}
+
+function makeAttemptInfo(overrides?: Partial<AttemptInfo>): AttemptInfo {
+  return {
+    id: "op-1",
+    type: "step",
+    isReplay: false,
+    attempt: 1,
+    ...overrides,
+  };
+}
+
+function makeAttemptEndInfo(
+  overrides?: Partial<AttemptEndInfo>,
+): AttemptEndInfo {
+  return {
+    id: "op-1",
+    type: "step",
+    isReplay: false,
+    attempt: 1,
+    outcome: "succeeded" as any,
+    ...overrides,
+  };
+}
+
+function getExportedSpans(): ReadableSpan[] {
+  return exporter.getFinishedSpans();
+}
+
+function findSpan(name: string): ReadableSpan | undefined {
+  return getExportedSpans().find((s) => s.name === name);
+}
+
+let idGenerator: DeterministicIdGenerator;
+
+beforeEach(() => {
+  exporter = new InMemorySpanExporter();
+  idGenerator = new DeterministicIdGenerator();
+  provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+    idGenerator,
+  });
+  provider.register();
+  plugin = new DurableExecutionOtelPlugin({ tracerProvider: provider });
+});
+
+afterEach(async () => {
+  await provider.shutdown();
+  exporter.reset();
+  // Reset the global API registrations
+  trace.disable();
+  context.disable();
+  propagation.disable();
+});
+
+describe("DurableExecutionOtelPlugin", () => {
+  describe("onInvocationStart", () => {
+    it("creates an invocation span with durable.execution.arn attribute", async () => {
+      const info = makeInvocationInfo();
+      await plugin.onInvocationStart(info);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const spans = getExportedSpans();
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
+        TEST_ARN,
+      );
+    });
+
+    it('creates invocation span with correct name "invocation"', async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.name).toBe("invocation");
+    });
+  });
+
+  describe("onInvocationEnd", () => {
+    it("ends all open operation spans and invocation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(makeOperationInfo({ id: "op-1" }));
+      await plugin.onOperationStart(makeOperationInfo({ id: "op-2" }));
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const spans = getExportedSpans();
+      // Should have: op-1, op-2, invocation (all ended)
+      expect(spans.length).toBe(3);
+      expect(findSpan("invocation")).toBeDefined();
+    });
+
+    it("flushes spans (they appear in exporter)", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const spans = getExportedSpans();
+      expect(spans.length).toBeGreaterThan(0);
+    });
+
+    it("clears all state for warm Lambda reuse", async () => {
+      // First invocation
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(makeOperationInfo({ id: "op-1" }));
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      exporter.reset();
+
+      // Second invocation - should not have leftover state
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ executionArn: "arn:second" }),
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ executionArn: "arn:second" }),
+      );
+
+      const spans = getExportedSpans();
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
+        "arn:second",
+      );
+      // Only 1 invocation span from second invocation, no leftover op-1
+      expect(spans.length).toBe(1);
+    });
+  });
+
+  describe("onOperationStart / onOperationEnd", () => {
+    it("non-replay operation uses deterministic span ID", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const opInfo = makeOperationInfo({ id: "op-abc", isReplay: false });
+      await plugin.onOperationStart(opInfo);
+      await plugin.onOperationEnd(makeOperationEndInfo({ id: "op-abc" }));
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const expectedSpanId = deriveSpanIdFromOperationId("op-abc");
+      const opSpan = findSpan("step");
+      expect(opSpan).toBeDefined();
+      // When using internal provider with DeterministicIdGenerator, span ID is deterministic.
+      // With external provider, we verify the durable.operation.id attribute is set correctly.
+      expect(opSpan!.attributes["durable.operation.id"]).toBe(expectedSpanId);
+      // Non-replay spans should NOT have links (unlike replay spans)
+      expect(opSpan!.links.length).toBe(0);
+    });
+
+    it("replay operation uses random span ID with Link to deterministic", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const opInfo = makeOperationInfo({
+        id: "op-replay",
+        type: "CONTEXT",
+        isReplay: true,
+      });
+      await plugin.onOperationStart(opInfo);
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-replay",
+          type: "CONTEXT",
+          isReplay: true,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const expectedDeterministicId = deriveSpanIdFromOperationId("op-replay");
+      const opSpan = findSpan("CONTEXT");
+      expect(opSpan).toBeDefined();
+      // Random span ID should differ from deterministic
+      expect(opSpan!.spanContext().spanId).not.toBe(expectedDeterministicId);
+      // Should have a Link pointing to deterministic span ID
+      expect(opSpan!.links.length).toBeGreaterThan(0);
+      expect(opSpan!.links[0].context.spanId).toBe(expectedDeterministicId);
+    });
+
+    it("uses operation name as span name when provided", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-named", name: "fetch-user" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-named", name: "fetch-user" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("fetch-user");
+      expect(opSpan).toBeDefined();
+    });
+
+    it("uses operation type as span name when no name provided", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-noname", type: "wait" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-noname", type: "wait" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("wait");
+      expect(opSpan).toBeDefined();
+    });
+  });
+
+  describe("Continuation span for cross-invocation operations", () => {
+    it("creates continuation span with Link when operation was started in prior invocation", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // onOperationEnd for an operation NOT in the map (started elsewhere)
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-cross",
+          type: "step",
+          name: "remote-op",
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const continuationSpan = findSpan("remote-op");
+      expect(continuationSpan).toBeDefined();
+      // Should have a Link pointing to deterministic span ID of op-cross
+      const expectedDeterministicId = deriveSpanIdFromOperationId("op-cross");
+      expect(continuationSpan!.links.length).toBeGreaterThan(0);
+      expect(continuationSpan!.links[0].context.spanId).toBe(
+        expectedDeterministicId,
+      );
+    });
+
+    it("continuation span uses type as name when no name provided", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-cross-2", type: "invoke" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const continuationSpan = findSpan("invoke");
+      expect(continuationSpan).toBeDefined();
+    });
+  });
+
+  describe("Parent-child resolution with parentId", () => {
+    it("operation with parentId in map becomes child of that parent span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Start parent operation
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "parent-op", name: "parent" }),
+      );
+      // Start child operation with parentId referencing parent-op
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "child-op",
+          name: "child",
+          parentId: "parent-op",
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "child-op", name: "child" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "parent-op", name: "parent" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const parentSpan = findSpan("parent");
+      const childSpan = findSpan("child");
+      expect(parentSpan).toBeDefined();
+      expect(childSpan).toBeDefined();
+      expect(childSpan!.parentSpanContext?.spanId).toBe(
+        parentSpan!.spanContext().spanId,
+      );
+    });
+
+    it("operation with parentId NOT in map becomes child of invocation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Start operation with parentId that doesn't exist in map
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "orphan-op",
+          name: "orphan",
+          parentId: "non-existent",
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "orphan-op", name: "orphan" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const invocationSpan = findSpan("invocation");
+      const orphanSpan = findSpan("orphan");
+      expect(invocationSpan).toBeDefined();
+      expect(orphanSpan).toBeDefined();
+      expect(orphanSpan!.parentSpanContext?.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
+    });
+
+    it("operation with no parentId becomes child of invocation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "root-op", name: "root-child" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "root-op", name: "root-child" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const invocationSpan = findSpan("invocation");
+      const rootOpSpan = findSpan("root-child");
+      expect(invocationSpan).toBeDefined();
+      expect(rootOpSpan).toBeDefined();
+      expect(rootOpSpan!.parentSpanContext?.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
+    });
+  });
+
+  describe("Attempt span lifecycle", () => {
+    it("creates attempt span as child of operation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-attempt", name: "my-step" }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({ id: "op-attempt", name: "my-step", attempt: 1 }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-attempt", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-attempt", name: "my-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const spans = getExportedSpans();
+      const opSpan = spans.find(
+        (s) =>
+          s.name === "my-step" && !s.attributes["durable.operation.attempt"],
+      );
+      const attemptSpan = spans.find(
+        (s) => s.attributes["durable.operation.attempt"] === 1,
+      );
+      expect(opSpan).toBeDefined();
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.parentSpanContext?.spanId).toBe(
+        opSpan!.spanContext().spanId,
+      );
+    });
+
+    it("attempt span has correct attributes", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-attr", name: "attr-step", type: "step" }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "op-attr",
+          name: "attr-step",
+          type: "step",
+          attempt: 2,
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-attr", attempt: 2 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-attr", name: "attr-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.attempt"] === 2,
+      );
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
+      expect(attemptSpan!.attributes["durable.operation.type"]).toBe("step");
+      expect(attemptSpan!.attributes["durable.operation.name"]).toBe(
+        "attr-step",
+      );
+      expect(attemptSpan!.attributes["durable.operation.attempt"]).toBe(2);
+    });
+
+    it("attempt span has Link to deterministic span ID", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-link", name: "link-step" }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({ id: "op-link", name: "link-step", attempt: 1 }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-link", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-link", name: "link-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const expectedSpanId = deriveSpanIdFromOperationId("op-link");
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.attempt"] === 1,
+      );
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.links.length).toBeGreaterThan(0);
+      expect(attemptSpan!.links[0].context.spanId).toBe(expectedSpanId);
+    });
+
+    it("onOperationAttemptEnd ends the attempt span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-end", name: "end-step" }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({ id: "op-end", name: "end-step", attempt: 1 }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-end", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-end", name: "end-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.attempt"] === 1,
+      );
+      expect(attemptSpan).toBeDefined();
+      // Span should be ended (it's in the exported list)
+      expect(attemptSpan!.endTime).toBeDefined();
+    });
+  });
+
+  describe("Error handling", () => {
+    it("onOperationEnd with error sets ERROR status and records exception", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-err", name: "err-step" }),
+      );
+      const testError = new Error("Something went wrong");
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-err",
+          name: "err-step",
+          error: testError,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("err-step");
+      expect(opSpan).toBeDefined();
+      expect(opSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(opSpan!.status.message).toBe("Something went wrong");
+      // recordException adds an event
+      const exceptionEvent = opSpan!.events.find((e) => e.name === "exception");
+      expect(exceptionEvent).toBeDefined();
+    });
+
+    it("onOperationAttemptEnd with error sets ERROR status and records exception", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-attemptErr", name: "attempt-err" }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "op-attemptErr",
+          name: "attempt-err",
+          attempt: 1,
+        }),
+      );
+      const testError = new Error("Attempt failed");
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "op-attemptErr",
+          attempt: 1,
+          error: testError,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-attemptErr", name: "attempt-err" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.attempt"] === 1,
+      );
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(attemptSpan!.status.message).toBe("Attempt failed");
+      const exceptionEvent = attemptSpan!.events.find(
+        (e) => e.name === "exception",
+      );
+      expect(exceptionEvent).toBeDefined();
+    });
+
+    it("continuation span with error sets ERROR status and records exception", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const testError = new Error("Cross-invocation failure");
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-cross-err",
+          name: "cross-err",
+          error: testError,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const continuationSpan = findSpan("cross-err");
+      expect(continuationSpan).toBeDefined();
+      expect(continuationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(continuationSpan!.status.message).toBe("Cross-invocation failure");
+      const exceptionEvent = continuationSpan!.events.find(
+        (e) => e.name === "exception",
+      );
+      expect(exceptionEvent).toBeDefined();
+    });
+  });
+
+  describe("wrapInvocation", () => {
+    it("sets active span to invocation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+
+      let capturedSpanId: string | undefined;
+      const fn = async () => {
+        const activeSpan = trace.getSpan(context.active());
+        capturedSpanId = activeSpan?.spanContext().spanId;
+        return { output: "result" } as any;
+      };
+
+      await plugin.wrapInvocation(makeInvocationInfo(), fn);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const invocationSpan = findSpan("invocation");
+      expect(capturedSpanId).toBeDefined();
+      expect(capturedSpanId).toBe(invocationSpan!.spanContext().spanId);
+    });
+
+    it("returns fn result unmodified", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const expected = { output: "test-result" } as any;
+      const fn = async () => expected;
+      const result = await plugin.wrapInvocation(makeInvocationInfo(), fn);
+      expect(result).toBe(expected);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("propagates errors from fn without catching", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const testError = new Error("wrap error");
+      const fn = async () => {
+        throw testError;
+      };
+      await expect(
+        plugin.wrapInvocation(makeInvocationInfo(), fn as any),
+      ).rejects.toThrow("wrap error");
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+  });
+
+  describe("wrapChildContextFn", () => {
+    it("sets active span to operation span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const opInfo = makeOperationInfo({ id: "op-ctx", name: "ctx-step" });
+      await plugin.onOperationStart(opInfo);
+
+      let capturedSpanId: string | undefined;
+      const fn = () => {
+        const activeSpan = trace.getSpan(context.active());
+        capturedSpanId = activeSpan?.spanContext().spanId;
+        return "child-result";
+      };
+
+      plugin.wrapChildContextFn(opInfo, fn);
+
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-ctx", name: "ctx-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("ctx-step");
+      expect(capturedSpanId).toBeDefined();
+      expect(capturedSpanId).toBe(opSpan!.spanContext().spanId);
+    });
+
+    it("returns fn result unmodified", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const opInfo = makeOperationInfo({ id: "op-ret", name: "ret-step" });
+      await plugin.onOperationStart(opInfo);
+
+      const expected = { data: 42 };
+      const fn = () => expected;
+      const result = plugin.wrapChildContextFn(opInfo, fn);
+      expect(result).toBe(expected);
+
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-ret", name: "ret-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("propagates errors from fn without catching", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const opInfo = makeOperationInfo({ id: "op-throw", name: "throw-step" });
+      await plugin.onOperationStart(opInfo);
+
+      const testError = new Error("child error");
+      const fn = () => {
+        throw testError;
+      };
+      expect(() => plugin.wrapChildContextFn(opInfo, fn)).toThrow(
+        "child error",
+      );
+
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-throw", name: "throw-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("executes fn without context modification when no span tracked", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Don't start any operation
+      const opInfo = makeOperationInfo({ id: "op-missing" });
+      const fn = () => "no-context";
+      const result = plugin.wrapChildContextFn(opInfo, fn);
+      expect(result).toBe("no-context");
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+  });
+
+  describe("wrapOperationAttemptFn", () => {
+    it("sets active span to attempt span", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-wrap-attempt", name: "wa-step" }),
+      );
+      const attemptInfo = makeAttemptInfo({
+        id: "op-wrap-attempt",
+        name: "wa-step",
+        attempt: 1,
+      });
+      await plugin.onOperationAttemptStart(attemptInfo);
+
+      let capturedSpanId: string | undefined;
+      const fn = () => {
+        const activeSpan = trace.getSpan(context.active());
+        capturedSpanId = activeSpan?.spanContext().spanId;
+        return "attempt-result";
+      };
+
+      plugin.wrapOperationAttemptFn(attemptInfo, fn);
+
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-wrap-attempt", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-wrap-attempt", name: "wa-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.attempt"] === 1,
+      );
+      expect(capturedSpanId).toBeDefined();
+      expect(capturedSpanId).toBe(attemptSpan!.spanContext().spanId);
+    });
+
+    it("returns fn result unmodified", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-ar", name: "ar-step" }),
+      );
+      const attemptInfo = makeAttemptInfo({
+        id: "op-ar",
+        name: "ar-step",
+        attempt: 1,
+      });
+      await plugin.onOperationAttemptStart(attemptInfo);
+
+      const expected = { value: "attempt" };
+      const fn = () => expected;
+      const result = plugin.wrapOperationAttemptFn(attemptInfo, fn);
+      expect(result).toBe(expected);
+
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-ar", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-ar", name: "ar-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("propagates errors from fn without catching", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-ae", name: "ae-step" }),
+      );
+      const attemptInfo = makeAttemptInfo({
+        id: "op-ae",
+        name: "ae-step",
+        attempt: 1,
+      });
+      await plugin.onOperationAttemptStart(attemptInfo);
+
+      const testError = new Error("attempt error");
+      const fn = () => {
+        throw testError;
+      };
+      expect(() => plugin.wrapOperationAttemptFn(attemptInfo, fn)).toThrow(
+        "attempt error",
+      );
+
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "op-ae", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-ae", name: "ae-step" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+  });
+
+  describe("enrichLogContext", () => {
+    it("returns traceId and spanId when span is active", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+
+      let logContext: Record<string, string | number | boolean> | undefined;
+      const fn = async () => {
+        logContext = plugin.enrichLogContext();
+        return { output: "test" } as any;
+      };
+
+      await plugin.wrapInvocation(makeInvocationInfo(), fn);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(logContext).toBeDefined();
+      expect(logContext!.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(logContext!.spanId).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it("returns undefined when no span is active", () => {
+      const result = plugin.enrichLogContext();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("Span attributes", () => {
+    it("operation span has correct attributes", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-attrs", type: "wait", name: "my-wait" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-attrs", type: "wait", name: "my-wait" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("my-wait");
+      expect(opSpan).toBeDefined();
+      expect(opSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
+      expect(opSpan!.attributes["durable.operation.id"]).toBe(
+        deriveSpanIdFromOperationId("op-attrs"),
+      );
+      expect(opSpan!.attributes["durable.operation.type"]).toBe("wait");
+      expect(opSpan!.attributes["durable.operation.name"]).toBe("my-wait");
+    });
+
+    it("operation span omits durable.operation.name when no name provided", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-noname2", type: "invoke" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ id: "op-noname2", type: "invoke" }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("invoke");
+      expect(opSpan).toBeDefined();
+      expect(opSpan!.attributes["durable.operation.name"]).toBeUndefined();
+    });
+  });
+
+  describe("Span filtering for WAIT, CHAINED_INVOKE, and CALLBACK types", () => {
+    describe("onOperationStart with isReplay=true skips filtered types", () => {
+      it("does not create a span for WAIT type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-wait-replay",
+            type: "WAIT",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const waitSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "WAIT",
+        );
+        expect(waitSpan).toBeUndefined();
+      });
+
+      it("does not create a span for CHAINED_INVOKE type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-invoke-replay",
+            type: "CHAINED_INVOKE",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const invokeSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "CHAINED_INVOKE",
+        );
+        expect(invokeSpan).toBeUndefined();
+      });
+
+      it("does not create a span for CALLBACK type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-callback-replay",
+            type: "CALLBACK",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const callbackSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "CALLBACK",
+        );
+        expect(callbackSpan).toBeUndefined();
+      });
+
+      it("still creates a span for CONTEXT type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-context-replay",
+            type: "CONTEXT",
+            isReplay: true,
+          }),
+        );
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({ id: "op-context-replay", type: "CONTEXT" }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const contextSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "CONTEXT",
+        );
+        expect(contextSpan).toBeDefined();
+      });
+    });
+
+    describe("onOperationEnd never creates spans for filtered types on replay", () => {
+      it("does not create a continuation span for WAIT type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-wait-end",
+            type: "WAIT",
+            name: "my-wait",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const waitSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "WAIT",
+        );
+        expect(waitSpan).toBeUndefined();
+      });
+
+      it("does not create a continuation span for INVOKE type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-invoke-end",
+            type: "INVOKE",
+            name: "my-invoke",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const invokeSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "INVOKE",
+        );
+        expect(invokeSpan).toBeUndefined();
+      });
+
+      it("does not create a continuation span for CALLBACK type on replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-callback-end",
+            type: "CALLBACK",
+            name: "my-callback",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const callbackSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "CALLBACK",
+        );
+        expect(callbackSpan).toBeUndefined();
+      });
+
+      it("does not create a continuation span for step type on replay either", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-step-end",
+            type: "step",
+            name: "cross-step",
+            isReplay: true,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const continuationSpan = findSpan("cross-step");
+        expect(continuationSpan).toBeUndefined();
+      });
+
+      it("still creates a span for WAIT type when not a replay", async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-wait-nonreplay",
+            type: "WAIT",
+            isReplay: false,
+          }),
+        );
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-wait-nonreplay",
+            type: "WAIT",
+            isReplay: false,
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+        const spans = getExportedSpans();
+        const waitSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "WAIT",
+        );
+        expect(waitSpan).toBeDefined();
+      });
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
@@ -1,0 +1,158 @@
+import type { InvocationInfo } from "@aws/durable-execution-sdk-js";
+
+/**
+ * Result type returned by context extractors.
+ */
+export type ContextExtractorResult =
+  | {
+      traceId: string;
+      parentSpanId?: string;
+      traceFlags?: number;
+    }
+  | undefined;
+
+/**
+ * A function that extracts upstream trace context from the invocation environment.
+ */
+export type ContextExtractor = (info: InvocationInfo) => ContextExtractorResult;
+
+/**
+ * Reads the X-Ray trace header from the `_X_AMZN_TRACE_ID` environment variable.
+ *
+ * The durable execution backend propagates the same Root trace ID to every
+ * invocation, so all invocations of the same execution share one traceId.
+ *
+ * X-Ray Header format:
+ *   Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1
+ *
+ * - Extract Root value, strip "1-" prefix and all "-" to get 32-char hex traceId
+ * - Extract Parent value for parentSpanId (16-char hex)
+ *
+ * Returns undefined when _X_AMZN_TRACE_ID is missing or malformed.
+ */
+export function xRayContextExtractor(
+  _info: InvocationInfo,
+): ContextExtractorResult {
+  const header = process.env._X_AMZN_TRACE_ID;
+  if (!header) {
+    return undefined;
+  }
+
+  // Parse the header into key-value pairs separated by semicolons
+  const fields = new Map<string, string>();
+  for (const part of header.split(";")) {
+    const eqIdx = part.indexOf("=");
+    if (eqIdx > 0) {
+      const key = part.slice(0, eqIdx).trim();
+      const value = part.slice(eqIdx + 1).trim();
+      fields.set(key, value);
+    }
+  }
+
+  const root = fields.get("Root");
+  if (!root) {
+    return undefined;
+  }
+
+  // Root format: 1-5759e988-bd862e3fe1be46a994272793
+  // Strip the "1-" prefix and remove all dashes to get 32-char hex
+  const rootValue = root.startsWith("1-") ? root.slice(2) : root;
+  const traceId = rootValue.replace(/-/g, "").toLowerCase();
+
+  // Validate: must be exactly 32 hex characters
+  if (!/^[0-9a-f]{32}$/.test(traceId)) {
+    return undefined;
+  }
+
+  const parent = fields.get("Parent");
+  let parentSpanId: string | undefined;
+  if (parent && /^[0-9a-f]{16}$/.test(parent.toLowerCase())) {
+    parentSpanId = parent.toLowerCase();
+  }
+
+  return { traceId, parentSpanId };
+}
+
+/**
+ * Minimal interface for the Lambda context's clientContext that may be
+ * available on the InvocationInfo when the function is invoked via
+ * the AWS Mobile SDK or when the backend propagates clientContext.
+ */
+interface InvocationInfoWithClientContext extends InvocationInfo {
+  context?: {
+    clientContext?: {
+      custom?: Record<string, string>;
+    };
+  };
+}
+
+/**
+ * Reads W3C traceparent from `context.clientContext.custom.traceparent`.
+ *
+ * W3C traceparent format:
+ *   00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+ *   Format: version-traceId-parentId-traceFlags
+ *
+ * - traceId is 32 hex chars
+ * - parentId is 16 hex chars
+ * - flags is 2 hex chars (parsed to number)
+ *
+ * Returns undefined when clientContext or traceparent is missing or malformed.
+ */
+export function w3cClientContextExtractor(
+  info: InvocationInfo,
+): ContextExtractorResult {
+  const extendedInfo = info as InvocationInfoWithClientContext;
+  const traceparent = extendedInfo.context?.clientContext?.custom?.traceparent;
+
+  if (!traceparent) {
+    return undefined;
+  }
+
+  return parseW3CTraceparent(traceparent);
+}
+
+/**
+ * Parses a W3C traceparent header value.
+ *
+ * Format: version-traceId-parentId-flags
+ * Example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+ */
+function parseW3CTraceparent(traceparent: string): ContextExtractorResult {
+  const parts = traceparent.split("-");
+
+  // Must have exactly 4 parts: version, traceId, parentId, flags
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const [version, traceId, parentId, flags] = parts;
+
+  // Version must be 2 hex chars
+  if (!/^[0-9a-f]{2}$/.test(version)) {
+    return undefined;
+  }
+
+  // TraceId must be 32 hex chars
+  if (!/^[0-9a-f]{32}$/.test(traceId)) {
+    return undefined;
+  }
+
+  // ParentId must be 16 hex chars
+  if (!/^[0-9a-f]{16}$/.test(parentId)) {
+    return undefined;
+  }
+
+  // Flags must be 2 hex chars
+  if (!/^[0-9a-f]{2}$/.test(flags)) {
+    return undefined;
+  }
+
+  const traceFlags = parseInt(flags, 16);
+
+  return {
+    traceId,
+    parentSpanId: parentId,
+    traceFlags,
+  };
+}

--- a/packages/aws-durable-execution-sdk-js-otel/src/deterministic-id-generator.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/deterministic-id-generator.ts
@@ -1,0 +1,125 @@
+import { createHash } from "crypto";
+import type { IdGenerator } from "@opentelemetry/sdk-trace-node";
+
+/**
+ * A custom OpenTelemetry IdGenerator that produces deterministic trace and span IDs
+ * derived from execution metadata (X-Ray headers, execution ARNs, operation IDs)
+ * rather than random values.
+ *
+ * This ensures that spans from different Lambda invocations of the same durable
+ * execution are stitched into a single coherent trace.
+ */
+export class DeterministicIdGenerator implements IdGenerator {
+  private traceId: string | undefined;
+  private nextSpanId: string | undefined;
+
+  /**
+   * Set the trace ID for all subsequent generateTraceId() calls.
+   * This is persistent until setTraceId is called again.
+   */
+  setTraceId(traceId: string): void {
+    this.traceId = traceId;
+  }
+
+  /**
+   * Set the span ID to return on the next single generateSpanId() call.
+   * This is a one-shot override: it is consumed on the next call and then
+   * reverts to default behavior.
+   */
+  setNextSpanId(spanId: string): void {
+    this.nextSpanId = spanId;
+  }
+
+  /**
+   * Generate a 32-char lowercase hex trace ID.
+   *
+   * If setTraceId has been called, returns that value persistently.
+   * Otherwise returns a random 32-char hex string as fallback.
+   */
+  generateTraceId(): string {
+    if (this.traceId) {
+      return this.traceId;
+    }
+    // Fallback: generate a random trace ID
+    return createHash("sha256")
+      .update(Math.random().toString())
+      .digest("hex")
+      .slice(0, 32);
+  }
+
+  /**
+   * Generate a 16-char lowercase hex span ID.
+   *
+   * If setNextSpanId has been called, returns that value once (one-shot)
+   * and then clears it. Otherwise returns a random 16-char hex string.
+   */
+  generateSpanId(): string {
+    if (this.nextSpanId) {
+      const spanId = this.nextSpanId;
+      this.nextSpanId = undefined;
+      return spanId;
+    }
+    // Fallback: generate a random span ID
+    return createHash("sha256")
+      .update(Math.random().toString())
+      .digest("hex")
+      .slice(0, 16);
+  }
+}
+
+/**
+ * Derive a deterministic trace ID from an X-Ray Root field.
+ * Strips the `Root=1-` prefix and all `-` separators to produce
+ * a valid 32-character lowercase hex OpenTelemetry trace ID.
+ *
+ * @param xRayRoot - The Root field value, e.g. "1-5759e988-bd862e3fe1be46a994272793"
+ * @returns A 32-char lowercase hex string, or undefined if the input is invalid
+ */
+export function deriveTraceIdFromXRayRoot(
+  xRayRoot: string,
+): string | undefined {
+  // Strip "Root=" prefix if present
+  let root = xRayRoot;
+  if (root.startsWith("Root=")) {
+    root = root.slice(5);
+  }
+
+  // Strip the version prefix "1-"
+  if (root.startsWith("1-")) {
+    root = root.slice(2);
+  } else {
+    return undefined;
+  }
+
+  // Remove all dashes
+  const hex = root.replace(/-/g, "");
+
+  // Validate: must be exactly 32 lowercase hex characters
+  if (hex.length !== 32 || !/^[0-9a-f]{32}$/.test(hex)) {
+    return undefined;
+  }
+
+  return hex;
+}
+
+/**
+ * Derive a deterministic trace ID from an execution ARN by hashing it
+ * with SHA-256 and truncating to the first 32 lowercase hex characters.
+ *
+ * @param executionArn - The execution ARN string
+ * @returns A 32-char lowercase hex string
+ */
+export function deriveTraceIdFromArn(executionArn: string): string {
+  return createHash("sha256").update(executionArn).digest("hex").slice(0, 32);
+}
+
+/**
+ * Derive a deterministic span ID from an operation ID by hashing it
+ * with SHA-256 and truncating to the first 16 lowercase hex characters.
+ *
+ * @param operationId - The operation ID string
+ * @returns A 16-char lowercase hex string
+ */
+export function deriveSpanIdFromOperationId(operationId: string): string {
+  return createHash("sha256").update(operationId).digest("hex").slice(0, 16);
+}

--- a/packages/aws-durable-execution-sdk-js-otel/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/index.ts
@@ -1,0 +1,23 @@
+// Public exports for @aws/durable-execution-sdk-js-otel
+
+// Plugin
+export { DurableExecutionOtelPlugin } from "./plugin";
+export type { DurableExecutionOtelPluginConfig } from "./plugin";
+
+// ID Generator
+export {
+  DeterministicIdGenerator,
+  deriveTraceIdFromXRayRoot,
+  deriveTraceIdFromArn,
+  deriveSpanIdFromOperationId,
+} from "./deterministic-id-generator";
+
+// Context Extractors
+export {
+  xRayContextExtractor,
+  w3cClientContextExtractor,
+} from "./context-extractors";
+export type {
+  ContextExtractor,
+  ContextExtractorResult,
+} from "./context-extractors";

--- a/packages/aws-durable-execution-sdk-js-otel/src/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/plugin.ts
@@ -170,7 +170,7 @@ export class DurableExecutionOtelPlugin implements DurableInstrumentationPlugin 
 
     const attributes: Record<string, string> = {
       "durable.execution.arn": this.executionArn,
-      "durable.operation.id": deterministicSpanId,
+      "durable.operation.id": info.id,
       "durable.operation.type": info.type,
     };
     if (info.name) {
@@ -276,7 +276,7 @@ export class DurableExecutionOtelPlugin implements DurableInstrumentationPlugin 
 
       const attributes: Record<string, string> = {
         "durable.execution.arn": this.executionArn,
-        "durable.operation.id": deterministicSpanId,
+        "durable.operation.id": info.id,
         "durable.operation.type": info.type,
       };
       if (info.name) {
@@ -328,7 +328,7 @@ export class DurableExecutionOtelPlugin implements DurableInstrumentationPlugin 
 
     const attributes: Record<string, string | number> = {
       "durable.execution.arn": this.executionArn,
-      "durable.operation.id": deterministicSpanId,
+      "durable.operation.id": info.id,
       "durable.operation.type": info.type,
       "durable.operation.attempt": info.attempt,
     };

--- a/packages/aws-durable-execution-sdk-js-otel/src/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/plugin.ts
@@ -1,0 +1,397 @@
+import type {
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  InvocationEndInfo,
+  OperationInfo,
+  OperationEndInfo,
+  AttemptInfo,
+  AttemptEndInfo,
+  OperationChangeInfo,
+} from "@aws/durable-execution-sdk-js";
+import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
+import type { TracerProvider, Tracer, Span } from "@opentelemetry/api";
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import {
+  DeterministicIdGenerator,
+  deriveTraceIdFromArn,
+  deriveSpanIdFromOperationId,
+} from "./deterministic-id-generator";
+import { xRayContextExtractor } from "./context-extractors";
+import type { ContextExtractor } from "./context-extractors";
+
+/**
+ * Configuration options for the DurableExecutionOtelPlugin.
+ */
+export interface DurableExecutionOtelPluginConfig {
+  /** Custom TracerProvider. If omitted, the plugin creates one internally. */
+  tracerProvider?: TracerProvider;
+  /** Context extractor function. Defaults to xRayContextExtractor. */
+  contextExtractor?: ContextExtractor;
+  /** Instrumentation scope name. Defaults to "aws-durable-execution-sdk-js". */
+  instrumentationName?: string;
+}
+
+const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
+
+/**
+ * OpenTelemetry instrumentation plugin for durable executions.
+ *
+ * Implements the DurableInstrumentationPlugin interface to emit distributed
+ * traces that correlate across multiple Lambda invocations of a single
+ * durable execution.
+ */
+export class DurableExecutionOtelPlugin implements DurableInstrumentationPlugin {
+  private readonly tracerProvider: TracerProvider;
+  private readonly tracer: Tracer;
+  private readonly idGenerator: DeterministicIdGenerator;
+  private readonly contextExtractor: ContextExtractor;
+
+  // Per-invocation state
+  private spanMap: Map<string, Span> = new Map();
+  private spanStack: Span[] = [];
+  private invocationSpan: Span | undefined;
+  private executionArn: string = "";
+  private attemptSpan: Span | undefined;
+
+  constructor(config?: DurableExecutionOtelPluginConfig) {
+    const instrumentationName =
+      config?.instrumentationName ?? DEFAULT_INSTRUMENTATION_NAME;
+
+    this.idGenerator = new DeterministicIdGenerator();
+    this.contextExtractor = config?.contextExtractor ?? xRayContextExtractor;
+
+    if (config?.tracerProvider) {
+      this.tracerProvider = config.tracerProvider;
+    } else {
+      this.tracerProvider = trace.getTracerProvider();
+      registerInstrumentations({
+        tracerProvider: this.tracerProvider,
+        instrumentations: [
+          new AwsInstrumentation({
+            suppressInternalInstrumentation: true,
+            sqsExtractContextPropagationFromPayload: true,
+          }),
+        ],
+      });
+    }
+
+    this.tracer = this.tracerProvider.getTracer(instrumentationName);
+
+    // Monkey-patch the tracer's ID generator so spans use deterministic IDs.
+    // The _idGenerator field is internal to @opentelemetry/sdk-trace-base's Tracer class.
+    (this.tracer as any)._idGenerator = this.idGenerator;
+  }
+
+  async onInvocationStart(info: InvocationInfo): Promise<void> {
+    // 1. Store the execution ARN
+    this.executionArn = info.executionArn;
+
+    // 2. Invoke the context extractor
+    const extractedContext = this.contextExtractor(info);
+
+    // 3. Set the trace ID on the ID generator
+    if (extractedContext?.traceId) {
+      this.idGenerator.setTraceId(extractedContext.traceId);
+    } else {
+      // Fallback: derive trace ID from ARN
+      const derivedId = deriveTraceIdFromArn(info.executionArn);
+      this.idGenerator.setTraceId(derivedId);
+    }
+
+    // 4. Create the invocation span
+    this.invocationSpan = this.tracer.startSpan("invocation", {
+      attributes: {
+        "durable.execution.arn": info.executionArn,
+      },
+    });
+  }
+
+  wrapInvocation(
+    _info: InvocationInfo,
+    fn: () => Promise<DurableExecutionInvocationOutput>,
+  ): Promise<DurableExecutionInvocationOutput> {
+    if (!this.invocationSpan) {
+      return fn();
+    }
+    return context.with(
+      trace.setSpan(context.active(), this.invocationSpan),
+      fn,
+    );
+  }
+
+  async onInvocationEnd(_info: InvocationEndInfo): Promise<void> {
+    // 1. End all spans in the stack in reverse order
+    while (this.spanStack.length > 0) {
+      const span = this.spanStack.pop()!;
+      span.end();
+    }
+
+    // 2. End the invocation span if it exists
+    if (this.invocationSpan) {
+      this.invocationSpan.end();
+    }
+
+    // 3. Force flush the tracer provider
+    if ("forceFlush" in this.tracerProvider) {
+      try {
+        await (
+          this.tracerProvider as { forceFlush: () => Promise<void> }
+        ).forceFlush();
+      } catch {
+        // Gracefully handle flush errors
+      }
+    }
+
+    // 4. Clear all per-invocation state
+    this.spanMap.clear();
+    this.spanStack = [];
+    this.invocationSpan = undefined;
+    this.executionArn = "";
+    this.attemptSpan = undefined;
+  }
+
+  async onOperationStart(info: OperationInfo): Promise<void> {
+    const deterministicSpanId = deriveSpanIdFromOperationId(info.id);
+    const spanName = info.name ?? info.type;
+
+    // Resolve parent span: use parentId from map, or fall back to invocation span
+    let parentSpan: Span | undefined;
+    if (info.parentId && this.spanMap.has(info.parentId)) {
+      parentSpan = this.spanMap.get(info.parentId);
+    } else {
+      parentSpan = this.invocationSpan;
+    }
+
+    const parentContext = parentSpan
+      ? trace.setSpan(context.active(), parentSpan)
+      : context.active();
+
+    const attributes: Record<string, string> = {
+      "durable.execution.arn": this.executionArn,
+      "durable.operation.id": deterministicSpanId,
+      "durable.operation.type": info.type,
+    };
+    if (info.name) {
+      attributes["durable.operation.name"] = info.name;
+    }
+
+    let span: Span | undefined;
+
+    if (!info.isReplay) {
+      // Non-replay: use deterministic span ID
+      this.idGenerator.setNextSpanId(deterministicSpanId);
+      span = this.tracer.startSpan(
+        spanName,
+        {
+          attributes,
+          startTime: info.startTimestamp,
+        },
+        parentContext,
+      );
+    } else if (info.type === "CONTEXT" || info.type === "STEP") {
+      // Replay: use random span ID, add Link to deterministic span
+      const traceId =
+        this.invocationSpan?.spanContext().traceId ??
+        this.idGenerator.generateTraceId();
+      span = this.tracer.startSpan(
+        spanName,
+        {
+          attributes,
+          startTime: info.startTimestamp,
+          links: [
+            {
+              context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
+            },
+          ],
+        },
+        parentContext,
+      );
+    }
+
+    // Push to map and stack
+    if (span != undefined) {
+      this.spanMap.set(info.id, span);
+      this.spanStack.push(span);
+    }
+  }
+
+  wrapChildContextFn(info: OperationInfo, fn: () => unknown): unknown {
+    const span = this.spanMap.get(info.id);
+    if (!span) {
+      return fn();
+    }
+    return context.with(trace.setSpan(context.active(), span), fn);
+  }
+
+  async onOperationEnd(info: OperationEndInfo): Promise<void> {
+    // Skip span creation for WAIT, INVOKE, CHAINED_INVOKE, and CALLBACK operations on replay
+    if (
+      info.isReplay &&
+      (info.type === "WAIT" ||
+        info.type === "INVOKE" ||
+        info.type === "CHAINED_INVOKE" ||
+        info.type === "CALLBACK")
+    ) {
+      return;
+    }
+
+    const deterministicSpanId = deriveSpanIdFromOperationId(info.id);
+
+    if (this.spanMap.has(info.id)) {
+      // Operation was started in this invocation
+      const span = this.spanMap.get(info.id)!;
+
+      // Record error if present
+      if (info.error) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.error.message,
+        });
+        span.recordException(info.error);
+      }
+
+      // End the span
+      span.end(info.endTimestamp);
+
+      // Remove from map
+      this.spanMap.delete(info.id);
+
+      // Remove from stack (find by reference)
+      const stackIndex = this.spanStack.indexOf(span);
+      if (stackIndex !== -1) {
+        this.spanStack.splice(stackIndex, 1);
+      }
+    } else if (!info.isReplay) {
+      // Operation was started in a prior invocation — create Continuation_Span
+      const spanName = info.name ?? info.type;
+      const traceId =
+        this.invocationSpan?.spanContext().traceId ??
+        this.idGenerator.generateTraceId();
+
+      const parentContext = this.invocationSpan
+        ? trace.setSpan(context.active(), this.invocationSpan)
+        : context.active();
+
+      const attributes: Record<string, string> = {
+        "durable.execution.arn": this.executionArn,
+        "durable.operation.id": deterministicSpanId,
+        "durable.operation.type": info.type,
+      };
+      if (info.name) {
+        attributes["durable.operation.name"] = info.name;
+      }
+
+      const continuationSpan = this.tracer.startSpan(
+        spanName,
+        {
+          attributes,
+          startTime: info.startTimestamp,
+          links: [
+            {
+              context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
+            },
+          ],
+        },
+        parentContext,
+      );
+
+      // Record error if present
+      if (info.error) {
+        continuationSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.error.message,
+        });
+        continuationSpan.recordException(info.error);
+      }
+
+      // Immediately end
+      continuationSpan.end(info.endTimestamp);
+    }
+  }
+
+  async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
+    const deterministicSpanId = deriveSpanIdFromOperationId(info.id);
+    const spanName = info.name ?? info.type;
+
+    // Find the parent Operation_Span for this operation
+    const parentSpan = this.spanMap.get(info.id);
+    const parentContext = parentSpan
+      ? trace.setSpan(context.active(), parentSpan)
+      : context.active();
+
+    // Get current trace ID for the link
+    const currentTraceId =
+      this.invocationSpan?.spanContext().traceId ??
+      this.idGenerator.generateTraceId();
+
+    const attributes: Record<string, string | number> = {
+      "durable.execution.arn": this.executionArn,
+      "durable.operation.id": deterministicSpanId,
+      "durable.operation.type": info.type,
+      "durable.operation.attempt": info.attempt,
+    };
+    if (info.name) {
+      attributes["durable.operation.name"] = info.name;
+    }
+
+    // Create Attempt_Span as child of Operation_Span with Link to deterministic span
+    const attemptSpan = this.tracer.startSpan(
+      spanName,
+      {
+        attributes,
+        startTime: info.startTimestamp,
+        links: [
+          {
+            context: {
+              traceId: currentTraceId,
+              spanId: deterministicSpanId,
+              traceFlags: 1,
+            },
+          },
+        ],
+      },
+      parentContext,
+    );
+
+    this.attemptSpan = attemptSpan;
+  }
+
+  wrapOperationAttemptFn(_info: AttemptInfo, fn: () => unknown): unknown {
+    if (!this.attemptSpan) {
+      return fn();
+    }
+    return context.with(trace.setSpan(context.active(), this.attemptSpan), fn);
+  }
+
+  async onOperationAttemptEnd(info: AttemptEndInfo): Promise<void> {
+    if (this.attemptSpan) {
+      if (info.error) {
+        this.attemptSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.error.message,
+        });
+        this.attemptSpan.recordException(info.error);
+      }
+      this.attemptSpan.end(info.endTimestamp);
+      this.attemptSpan = undefined;
+    }
+  }
+
+  async onOperationChange(_info: OperationChangeInfo): Promise<void> {
+    // No-op for this plugin
+  }
+
+  enrichLogContext(): Record<string, string | number | boolean> | undefined {
+    const span = trace.getSpan(context.active());
+    if (!span) {
+      return undefined;
+    }
+    const spanContext = span.spanContext();
+    return {
+      traceId: spanContext.traceId,
+      spanId: spanContext.spanId,
+    };
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-otel/tsconfig.build.json
+++ b/packages/aws-durable-execution-sdk-js-otel/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "incremental": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/aws-durable-execution-sdk-js-otel/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-otel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./dist",
+    "sourceMap": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "isolatedModules": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
…utions

*Issue #, if available:*

*Description of changes:*

Add aws-durable-execution-sdk-js-otel package that implements the DurableInstrumentationPlugin interface to emit distributed traces correlating across multiple Lambda invocations of a single durable execution.

Key features:
- Deterministic trace/span ID generation from execution ARN
- Context extraction from X-Ray trace headers
- Span lifecycle management for operations, attempts, and invocations
- Continuation spans for operations spanning multiple invocations
- Replay-aware span creation (skips redundant spans on replay)

I've tested this manually. Will follow up with integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
