### PR TITLE
fix(sdk): prevent buildPreview from leaking excluded subtrees

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.test.ts
@@ -1,0 +1,46 @@
+import { buildPreview, PreviewMode, FieldMatchMode } from "./preview";
+
+describe("buildPreview - issue #621: PATH exclude should drop entire subtree", () => {
+  it("excludes entire subtree when using FieldMatchMode.PATH on an object field", () => {
+    const value = {
+      orderId: "o-1",
+      customer: { address: { city: "Seattle", zip: "98109" } },
+    };
+
+    const preview = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "customer.address", match: FieldMatchMode.PATH }],
+    });
+
+    // The subtree under customer.address must not appear
+    expect(preview).toEqual({ orderId: "o-1" });
+  });
+
+  it("excludes deeply nested subtree with FieldMatchMode.PATH", () => {
+    const value = {
+      id: "1",
+      a: { b: { c: { secret: "hidden" }, d: "visible" } },
+    };
+
+    const preview = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "a.b.c", match: FieldMatchMode.PATH }],
+    });
+
+    expect(preview).toEqual({ id: "1", a: { b: { d: "visible" } } });
+  });
+
+  it("excludes entire object field (not just its key) with PATH mode", () => {
+    const value = {
+      public: "ok",
+      pii: { ssn: "123-45-6789", dob: "1990-01-01" },
+    };
+
+    const preview = buildPreview(value, {
+      mode: PreviewMode.INCLUDE_ALL,
+      exclude: [{ name: "pii", match: FieldMatchMode.PATH }],
+    });
+
+    expect(preview).toEqual({ public: "ok" });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/preview.ts
@@ -147,7 +147,9 @@ export function buildPreview(
             : isMatched(path, config.include)));
 
       if (!visible) {
-        collect(obj[key], path);
+        if (!excluded) {
+          collect(obj[key], path);
+        }
         continue;
       }
 


### PR DESCRIPTION
When a field is excluded via FieldMatchMode.PATH, the collect function still recursed into its children. Descendant leaves then appeared visible under INCLUDE_ALL mode, leaking PII into GetDurableExecutionHistory.

Skip recursion entirely for excluded nodes so the whole subtree is dropped, consistent with the "exclude always wins" rule.

Adds unit tests covering PATH-mode subtree exclusion.

*Issue #, if available:*
#621 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
