### PR TITLE
fix(sdk): add plugin interface hook tests for isReplay

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.plugin.test.ts
@@ -73,12 +73,21 @@ describe("RunInChildContext Handler - plugin hooks", () => {
     await flushMicrotasks();
 
     expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledWith(
+      expect.objectContaining({ isReplay: false }),
+    );
     expect(mockPlugin.wrapChildContextFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapChildContextFn).toHaveBeenCalledWith(
-      expect.objectContaining({ name: TEST_CONSTANTS.CHILD_CONTEXT_NAME }),
+      expect.objectContaining({
+        name: TEST_CONSTANTS.CHILD_CONTEXT_NAME,
+        isReplay: false,
+      }),
       expect.any(Function),
     );
     expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ isReplay: false }),
+    );
     expect(mockPlugin.onOperationEnd).toHaveBeenCalledWith(
       expect.not.objectContaining({ error: expect.anything() }),
     );
@@ -105,14 +114,20 @@ describe("RunInChildContext Handler - plugin hooks", () => {
     await flushMicrotasks();
 
     expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(1);
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledWith(
+      expect.objectContaining({ isReplay: false }),
+    );
     expect(mockPlugin.wrapChildContextFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapChildContextFn).toHaveBeenCalledWith(
-      expect.objectContaining({ name: TEST_CONSTANTS.CHILD_CONTEXT_NAME }),
+      expect.objectContaining({
+        name: TEST_CONSTANTS.CHILD_CONTEXT_NAME,
+        isReplay: false,
+      }),
       expect.any(Function),
     );
     expect(mockPlugin.onOperationEnd).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationEnd).toHaveBeenCalledWith(
-      expect.objectContaining({ error: expect.any(Error) }),
+      expect.objectContaining({ isReplay: false, error: expect.any(Error) }),
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -93,12 +93,12 @@ describe("Step Handler - plugin hooks", () => {
 
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
 
@@ -106,6 +106,7 @@ describe("Step Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );
@@ -135,13 +136,14 @@ describe("Step Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.FAILED,
         error: stepError,
       }),
@@ -186,19 +188,20 @@ describe("Step Handler - plugin hooks", () => {
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
 
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.RETRYING,
         error: expect.any(Error),
         nextAttemptDelaySeconds: 0,
@@ -208,6 +211,7 @@ describe("Step Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -104,12 +104,12 @@ describe("WaitForCondition Handler - plugin hooks", () => {
 
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
 
@@ -117,6 +117,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );
@@ -158,13 +159,14 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledWith(
-      expect.objectContaining({ attempt: 1 }),
+      expect.objectContaining({ attempt: 1, isReplay: false }),
       expect.any(Function),
     );
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledWith(
       expect.objectContaining({
         attempt: 1,
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.FAILED,
         error: checkError,
       }),
@@ -211,6 +213,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.RETRYING,
         nextAttemptDelaySeconds: 5,
       }),
@@ -219,6 +222,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        isReplay: false,
         outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/545

*Description of changes:* Add missing isReplay assertion for handler plugin tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
