### PR TITLE
fix(sdk): preserve errorData across nested runInChildContext boundaries

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.history.json
@@ -1,0 +1,335 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "b75544b4-3b69-4fd5-b475-715f8412a7c7",
+    "EventTimestamp": "2026-06-17T22:08:58.473Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "outer-child",
+    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "inner-child",
+    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 2,
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 6,
+    "EventTimestamp": "2026-06-17T22:08:58.502Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:08:58.473Z",
+      "EndTimestamp": "2026-06-17T22:08:58.502Z",
+      "Error": {},
+      "RequestId": "1fc1a044-acdb-459a-b8ec-3ee022a434a0"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 7,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:00.483Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:00.483Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 3,
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-06-17T22:09:00.504Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:09:00.481Z",
+      "EndTimestamp": "2026-06-17T22:09:00.504Z",
+      "Error": {},
+      "RequestId": "121a7c17-ad54-4ccc-987f-1d9407c80dd1"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:03.488Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:03.488Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 14,
+        "CurrentAttempt": 2
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 12,
+    "EventTimestamp": "2026-06-17T22:09:03.510Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:09:03.485Z",
+      "EndTimestamp": "2026-06-17T22:09:03.510Z",
+      "Error": {},
+      "RequestId": "0bba8e55-a8c9-47ba-a2bc-36daa015af69"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 13,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:17.491Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 14,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:17.491Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 1,
+        "CurrentAttempt": 3
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 15,
+    "EventTimestamp": "2026-06-17T22:09:17.512Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:09:17.489Z",
+      "EndTimestamp": "2026-06-17T22:09:17.512Z",
+      "Error": {},
+      "RequestId": "d46d80c9-8a8c-4b91-bec5-a96ec1bf377a"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 16,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:18.495Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 17,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:18.495Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "NextAttemptDelaySeconds": 9,
+        "CurrentAttempt": 4
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 18,
+    "EventTimestamp": "2026-06-17T22:09:18.515Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:09:18.492Z",
+      "EndTimestamp": "2026-06-17T22:09:18.515Z",
+      "Error": {},
+      "RequestId": "0c9f4173-a871-449f-b789-cb1a5ca099d2"
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 19,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:27.500Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 20,
+    "Id": "2f221a18eb863803",
+    "Name": "throw-with-error-data",
+    "EventTimestamp": "2026-06-17T22:09:27.500Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 5
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "RunInChildContext",
+    "EventId": 21,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "inner-child",
+    "EventTimestamp": "2026-06-17T22:09:27.502Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "CallbackError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "RunInChildContext",
+    "EventId": 22,
+    "Id": "c4ca4238a0b92382",
+    "Name": "outer-child",
+    "EventTimestamp": "2026-06-17T22:09:27.502Z",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "ChildContextError",
+          "ErrorMessage": "cb failed",
+          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 23,
+    "EventTimestamp": "2026-06-17T22:09:27.503Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-06-17T22:09:27.496Z",
+      "EndTimestamp": "2026-06-17T22:09:27.503Z",
+      "Error": {},
+      "RequestId": "2eaf128e-bfc1-4786-b8e6-a0e498031006"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 24,
+    "Id": "b75544b4-3b69-4fd5-b475-715f8412a7c7",
+    "EventTimestamp": "2026-06-17T22:09:27.503Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"found\":true,\"errorData\":\"{\\\"reason\\\":\\\"operator-cancelled\\\"}\"}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.history.json
@@ -2,8 +2,8 @@
   {
     "EventType": "ExecutionStarted",
     "EventId": 1,
-    "Id": "b75544b4-3b69-4fd5-b475-715f8412a7c7",
-    "EventTimestamp": "2026-06-17T22:08:58.473Z",
+    "Id": "d2f727a9-6125-4787-a12b-c713269d8a98",
+    "EventTimestamp": "2026-06-17T22:56:19.890Z",
     "ExecutionStartedDetails": {
       "Input": {
         "Payload": "{}"
@@ -16,7 +16,7 @@
     "EventId": 2,
     "Id": "c4ca4238a0b92382",
     "Name": "outer-child",
-    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "EventTimestamp": "2026-06-17T22:56:19.896Z",
     "ContextStartedDetails": {}
   },
   {
@@ -25,7 +25,7 @@
     "EventId": 3,
     "Id": "ea66c06c1e1c05fa",
     "Name": "inner-child",
-    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "EventTimestamp": "2026-06-17T22:56:19.896Z",
     "ParentId": "c4ca4238a0b92382",
     "ContextStartedDetails": {}
   },
@@ -35,7 +35,7 @@
     "EventId": 4,
     "Id": "2f221a18eb863803",
     "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "EventTimestamp": "2026-06-17T22:56:19.896Z",
     "ParentId": "ea66c06c1e1c05fa",
     "StepStartedDetails": {}
   },
@@ -45,7 +45,7 @@
     "EventId": 5,
     "Id": "2f221a18eb863803",
     "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:08:58.479Z",
+    "EventTimestamp": "2026-06-17T22:56:19.896Z",
     "ParentId": "ea66c06c1e1c05fa",
     "StepFailedDetails": {
       "Error": {
@@ -56,232 +56,17 @@
         }
       },
       "RetryDetails": {
-        "NextAttemptDelaySeconds": 2,
         "CurrentAttempt": 1
-      }
-    }
-  },
-  {
-    "EventType": "InvocationCompleted",
-    "EventId": 6,
-    "EventTimestamp": "2026-06-17T22:08:58.502Z",
-    "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:08:58.473Z",
-      "EndTimestamp": "2026-06-17T22:08:58.502Z",
-      "Error": {},
-      "RequestId": "1fc1a044-acdb-459a-b8ec-3ee022a434a0"
-    }
-  },
-  {
-    "EventType": "StepStarted",
-    "SubType": "Step",
-    "EventId": 7,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:00.483Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepStartedDetails": {}
-  },
-  {
-    "EventType": "StepFailed",
-    "SubType": "Step",
-    "EventId": 8,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:00.483Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepFailedDetails": {
-      "Error": {
-        "Payload": {
-          "ErrorType": "CallbackError",
-          "ErrorMessage": "cb failed",
-          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
-        }
-      },
-      "RetryDetails": {
-        "NextAttemptDelaySeconds": 3,
-        "CurrentAttempt": 1
-      }
-    }
-  },
-  {
-    "EventType": "InvocationCompleted",
-    "EventId": 9,
-    "EventTimestamp": "2026-06-17T22:09:00.504Z",
-    "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:09:00.481Z",
-      "EndTimestamp": "2026-06-17T22:09:00.504Z",
-      "Error": {},
-      "RequestId": "121a7c17-ad54-4ccc-987f-1d9407c80dd1"
-    }
-  },
-  {
-    "EventType": "StepStarted",
-    "SubType": "Step",
-    "EventId": 10,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:03.488Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepStartedDetails": {}
-  },
-  {
-    "EventType": "StepFailed",
-    "SubType": "Step",
-    "EventId": 11,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:03.488Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepFailedDetails": {
-      "Error": {
-        "Payload": {
-          "ErrorType": "CallbackError",
-          "ErrorMessage": "cb failed",
-          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
-        }
-      },
-      "RetryDetails": {
-        "NextAttemptDelaySeconds": 14,
-        "CurrentAttempt": 2
-      }
-    }
-  },
-  {
-    "EventType": "InvocationCompleted",
-    "EventId": 12,
-    "EventTimestamp": "2026-06-17T22:09:03.510Z",
-    "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:09:03.485Z",
-      "EndTimestamp": "2026-06-17T22:09:03.510Z",
-      "Error": {},
-      "RequestId": "0bba8e55-a8c9-47ba-a2bc-36daa015af69"
-    }
-  },
-  {
-    "EventType": "StepStarted",
-    "SubType": "Step",
-    "EventId": 13,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:17.491Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepStartedDetails": {}
-  },
-  {
-    "EventType": "StepFailed",
-    "SubType": "Step",
-    "EventId": 14,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:17.491Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepFailedDetails": {
-      "Error": {
-        "Payload": {
-          "ErrorType": "CallbackError",
-          "ErrorMessage": "cb failed",
-          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
-        }
-      },
-      "RetryDetails": {
-        "NextAttemptDelaySeconds": 1,
-        "CurrentAttempt": 3
-      }
-    }
-  },
-  {
-    "EventType": "InvocationCompleted",
-    "EventId": 15,
-    "EventTimestamp": "2026-06-17T22:09:17.512Z",
-    "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:09:17.489Z",
-      "EndTimestamp": "2026-06-17T22:09:17.512Z",
-      "Error": {},
-      "RequestId": "d46d80c9-8a8c-4b91-bec5-a96ec1bf377a"
-    }
-  },
-  {
-    "EventType": "StepStarted",
-    "SubType": "Step",
-    "EventId": 16,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:18.495Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepStartedDetails": {}
-  },
-  {
-    "EventType": "StepFailed",
-    "SubType": "Step",
-    "EventId": 17,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:18.495Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepFailedDetails": {
-      "Error": {
-        "Payload": {
-          "ErrorType": "CallbackError",
-          "ErrorMessage": "cb failed",
-          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
-        }
-      },
-      "RetryDetails": {
-        "NextAttemptDelaySeconds": 9,
-        "CurrentAttempt": 4
-      }
-    }
-  },
-  {
-    "EventType": "InvocationCompleted",
-    "EventId": 18,
-    "EventTimestamp": "2026-06-17T22:09:18.515Z",
-    "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:09:18.492Z",
-      "EndTimestamp": "2026-06-17T22:09:18.515Z",
-      "Error": {},
-      "RequestId": "0c9f4173-a871-449f-b789-cb1a5ca099d2"
-    }
-  },
-  {
-    "EventType": "StepStarted",
-    "SubType": "Step",
-    "EventId": 19,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:27.500Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepStartedDetails": {}
-  },
-  {
-    "EventType": "StepFailed",
-    "SubType": "Step",
-    "EventId": 20,
-    "Id": "2f221a18eb863803",
-    "Name": "throw-with-error-data",
-    "EventTimestamp": "2026-06-17T22:09:27.500Z",
-    "ParentId": "ea66c06c1e1c05fa",
-    "StepFailedDetails": {
-      "Error": {
-        "Payload": {
-          "ErrorType": "CallbackError",
-          "ErrorMessage": "cb failed",
-          "ErrorData": "{\"reason\":\"operator-cancelled\"}"
-        }
-      },
-      "RetryDetails": {
-        "CurrentAttempt": 5
       }
     }
   },
   {
     "EventType": "ContextFailed",
     "SubType": "RunInChildContext",
-    "EventId": 21,
+    "EventId": 6,
     "Id": "ea66c06c1e1c05fa",
     "Name": "inner-child",
-    "EventTimestamp": "2026-06-17T22:09:27.502Z",
+    "EventTimestamp": "2026-06-17T22:56:19.898Z",
     "ParentId": "c4ca4238a0b92382",
     "ContextFailedDetails": {
       "Error": {
@@ -296,10 +81,10 @@
   {
     "EventType": "ContextFailed",
     "SubType": "RunInChildContext",
-    "EventId": 22,
+    "EventId": 7,
     "Id": "c4ca4238a0b92382",
     "Name": "outer-child",
-    "EventTimestamp": "2026-06-17T22:09:27.502Z",
+    "EventTimestamp": "2026-06-17T22:56:19.898Z",
     "ContextFailedDetails": {
       "Error": {
         "Payload": {
@@ -312,20 +97,20 @@
   },
   {
     "EventType": "InvocationCompleted",
-    "EventId": 23,
-    "EventTimestamp": "2026-06-17T22:09:27.503Z",
+    "EventId": 8,
+    "EventTimestamp": "2026-06-17T22:56:19.898Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-17T22:09:27.496Z",
-      "EndTimestamp": "2026-06-17T22:09:27.503Z",
+      "StartTimestamp": "2026-06-17T22:56:19.890Z",
+      "EndTimestamp": "2026-06-17T22:56:19.898Z",
       "Error": {},
-      "RequestId": "2eaf128e-bfc1-4786-b8e6-a0e498031006"
+      "RequestId": "a3ce8bf4-4cfa-4603-9cea-7c0f99f18262"
     }
   },
   {
     "EventType": "ExecutionSucceeded",
-    "EventId": 24,
-    "Id": "b75544b4-3b69-4fd5-b475-715f8412a7c7",
-    "EventTimestamp": "2026-06-17T22:09:27.503Z",
+    "EventId": 9,
+    "Id": "d2f727a9-6125-4787-a12b-c713269d8a98",
+    "EventTimestamp": "2026-06-17T22:56:19.899Z",
     "ExecutionSucceededDetails": {
       "Result": {
         "Payload": "{\"found\":true,\"errorData\":\"{\\\"reason\\\":\\\"operator-cancelled\\\"}\"}"

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.test.ts
@@ -1,0 +1,21 @@
+import { handler } from "./run-in-child-context-error-data-propagation";
+import { createTests } from "../../../utils/test-helper";
+
+const SENTINEL = JSON.stringify({ reason: "operator-cancelled" });
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should preserve errorData across nested runInChildContext boundaries", async () => {
+      const execution = await runner.run();
+      const result = execution.getResult() as any;
+
+      // This is the key assertion for issue #524:
+      // errorData must survive 2+ runInChildContext boundary crossings
+      expect(result.found).toBe(true);
+      expect(result.errorData).toBe(SENTINEL);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.ts
@@ -1,6 +1,5 @@
 import {
   CallbackError,
-  ChildContextError,
   DurableContext,
   DurableOperationError,
   withDurableExecution,
@@ -24,9 +23,15 @@ export const handler = withDurableExecution(
           await outerChild.runInChildContext(
             "inner-child",
             async (innerChild: DurableContext) => {
-              await innerChild.step("throw-with-error-data", async () => {
-                throw new CallbackError("cb failed", undefined, SENTINEL);
-              });
+              await innerChild.step(
+                "throw-with-error-data",
+                async () => {
+                  throw new CallbackError("cb failed", undefined, SENTINEL);
+                },
+                // Fail fast: skip retries so the test doesn't wait out the
+                // default retry window (important for cloud integ tests).
+                { retryStrategy: () => ({ shouldRetry: false }) },
+              );
             },
           );
         },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/run-in-child-context/error-data-propagation/run-in-child-context-error-data-propagation.ts
@@ -1,0 +1,51 @@
+import {
+  CallbackError,
+  ChildContextError,
+  DurableContext,
+  DurableOperationError,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Run in Child Context - Error Data Propagation",
+  description:
+    "Demonstrates that errorData is preserved when errors cross multiple runInChildContext boundaries (issue #524)",
+};
+
+const SENTINEL = JSON.stringify({ reason: "operator-cancelled" });
+
+export const handler = withDurableExecution(
+  async (_event, context: DurableContext) => {
+    try {
+      await context.runInChildContext(
+        "outer-child",
+        async (outerChild: DurableContext) => {
+          await outerChild.runInChildContext(
+            "inner-child",
+            async (innerChild: DurableContext) => {
+              await innerChild.step("throw-with-error-data", async () => {
+                throw new CallbackError("cb failed", undefined, SENTINEL);
+              });
+            },
+          );
+        },
+      );
+    } catch (error) {
+      // Walk the cause chain to find errorData
+      let node: unknown = error;
+      for (let i = 0; i < 10 && node; i++) {
+        if (
+          node instanceof DurableOperationError &&
+          typeof node.errorData === "string"
+        ) {
+          return { found: true, errorData: node.errorData };
+        }
+        node = (node as any).cause;
+      }
+      return { found: false, errorData: undefined };
+    }
+
+    return { found: false, errorData: undefined };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -91,13 +91,29 @@ export abstract class DurableOperationError extends Error {
   }
 
   /**
-   * Convert to ErrorObject for serialization
+   * Convert to ErrorObject for serialization.
+   * When errorData is undefined, walks the cause chain to surface the first
+   * errorData found — prevents loss across runInChildContext boundaries.
    */
   toErrorObject(): ErrorObject {
+    let errorData = this.errorData;
+    if (errorData === undefined) {
+      let node: unknown = this.cause;
+      for (let i = 0; i < 10 && node; i++) {
+        if (
+          node instanceof DurableOperationError &&
+          typeof node.errorData === "string"
+        ) {
+          errorData = node.errorData;
+          break;
+        }
+        node = node instanceof Error ? node.cause : undefined;
+      }
+    }
     return {
       ErrorType: this.errorType,
       ErrorMessage: this.message,
-      ErrorData: this.errorData,
+      ErrorData: errorData,
       StackTrace: STORE_STACK_TRACES
         ? this.cause?.stack?.split(/\r?\n/) || this.stack?.split(/\r?\n/)
         : undefined,


### PR DESCRIPTION
DurableOperationError.toErrorObject only copied this.errorData, so when an error carrying errorData crossed two or more runInChildContext boundaries the payload was lost. Each boundary wraps the error in a fresh ChildContextError whose own errorData is undefined, overwriting the deeper value on serialization.

toErrorObject now walks the cause chain (bounded to 10 hops) when its own errorData is undefined and surfaces the first DurableOperationError.errorData it finds. No public API or type changes.

Adds a run-in-child-context/error-data-propagation example and test that throws a CallbackError with errorData through two nested child contexts and asserts the payload is still recoverable at the catch site.

*Issue #, if available:*
#524


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
