### PR TITLE
feat(sdk): group callback errors under CallbackError and add CallbackExternalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,316 @@
+# Changelog
+
+All notable changes to the AWS Durable Execution SDK for JavaScript are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0]
+
+First major release. Upgrade target for users on the `1.x` line (last release:
+`1.1.7`). `2.0.0` ships six categories of change:
+
+1. **`withRetry`** — a new helper for retrying a chunk of durable logic
+   (multi-operation blocks containing `waitForCallback`, `invoke`, etc.) with a
+   configurable backoff strategy.
+2. **Linear retry strategy** — `createLinearRetryStrategy` and the new
+   `retryPresets.linear` preset for fixed-increment backoff alongside the
+   existing exponential strategies.
+3. **Serdes upgrades** — `context.configureSerdes()` for setting default serdes
+   once, `createFileSystemSerdes` for offloading large payloads to a durable
+   mount (Amazon S3 Files, EFS), and inline previews to keep PII out of
+   `GetDurableExecutionHistory` and the AWS console.
+4. **Cost / scale knob for batch operations** — `NestingType.FLAT` on `map`
+   and `parallel` skips the per-iteration `CONTEXT` operation for up to 2x cost
+   reduction and up to 2x more iterations per execution, trading per-branch
+   observability for throughput.
+5. **More precise error types** — promise combinators and callbacks throw
+   specific error subclasses (`PromiseCombinatorError`, `CallbackExternalError`,
+   `CallbackTimeoutError`, `CallbackSubmitterError`). This is the main source of
+   breaking changes for code that branches on error type.
+6. **Observability plugins (experimental)** — a `DurableInstrumentationPlugin`
+   interface for emitting custom instrumentation. This API is experimental and
+   may change in a backward-incompatible way in any release.
+
+A number of operational fixes and security updates are also included.
+
+### ⚠ Upgrade guide (breaking changes)
+
+#### 1. Promise combinator failures now throw `PromiseCombinatorError`
+
+`context.Promise.all`, `Promise.allSettled`, `Promise.any`, and `Promise.race`
+previously rejected with `StepError`. They now reject with
+`PromiseCombinatorError`, which extends `DurableOperationError` directly — **not**
+`StepError` or `ChildContextError`.
+
+```typescript
+// v1.x — no longer matches in v2
+try {
+  await context.Promise.all([...]);
+} catch (err) {
+  if (err instanceof StepError) { /* ... */ }
+}
+
+// v2.0
+import { PromiseCombinatorError } from "@aws/durable-execution-sdk-js";
+
+try {
+  await context.Promise.all([...]);
+} catch (err) {
+  if (err instanceof PromiseCombinatorError) {
+    // err.cause is the original failure from the first rejecting branch
+  }
+}
+```
+
+If you don't care about distinguishing the operation type, catch the base class
+`DurableOperationError`.
+
+> The error-type change is a side effect of reimplementing combinators on
+> `runInChildContext` (so idle branches no longer block Lambda termination). That
+> also changes the **execution history shape** — branches now appear as `CONTEXT`
+> operations rather than `STEP` operations. See the "Changed" section below.
+
+#### 2. Callback failures now form a typed hierarchy under `CallbackError`
+
+`createCallback` and `waitForCallback` previously threw `CallbackError` for every
+failure mode. v2 organizes the specific callback errors into a hierarchy and
+adds `CallbackExternalError`, which is thrown when the external entity completes a
+callback with a failure (via `SendDurableExecutionCallbackFailure`):
+
+```
+CallbackError
+  +- CallbackExternalError   // external entity reported failure (was CallbackError)
+  +- CallbackTimeoutError    // callback timed out
+  +- CallbackSubmitterError  // waitForCallback submitter function threw
+```
+
+| Scenario                             | v1.x error      | v2 error                 |
+| ------------------------------------ | --------------- | ------------------------ |
+| Callback completed with `FAILED`     | `CallbackError` | `CallbackExternalError`  |
+| Callback timed out (`TIMED_OUT`)     | `CallbackError` | `CallbackTimeoutError`   |
+| `waitForCallback` submitter threw    | `CallbackError` | `CallbackSubmitterError` |
+| Internal error (e.g. no callback ID) | `CallbackError` | `CallbackError`          |
+
+**`instanceof CallbackError` is safe.** Because `CallbackExternalError`,
+`CallbackTimeoutError`, and `CallbackSubmitterError` all extend `CallbackError`,
+existing `catch (e) { if (e instanceof CallbackError) ... }` code keeps matching
+all callback failures. The break only affects code that relies on the **exact**
+`errorType` / `name` string being `"CallbackError"` for external failures or
+timeouts.
+
+```typescript
+// v2.0 — branch on the specific subtype, or catch the base class
+import {
+  CallbackError,
+  CallbackExternalError,
+  CallbackTimeoutError,
+  CallbackSubmitterError,
+} from "@aws/durable-execution-sdk-js";
+
+try {
+  await context.waitForCallback("approval", submitter, {
+    timeout: { hours: 1 },
+  });
+} catch (err) {
+  if (err instanceof CallbackTimeoutError) {
+    // Approver missed the deadline
+  } else if (err instanceof CallbackSubmitterError) {
+    // The submitter function (e.g. publishing the approval URL) threw
+  } else if (err instanceof CallbackExternalError) {
+    // External system completed the callback with FAILED
+  } else if (err instanceof CallbackError) {
+    // Any other callback failure (base class)
+  }
+}
+```
+
+#### 3. KMS exceptions during checkpoint / state APIs are non-retryable
+
+KMS exceptions during `CheckpointDurableExecution` and `GetDurableExecutionState`
+are now treated as non-retryable customer errors instead of being retried.
+
+#### 4. `runInChildContext` applies the serdes round-trip in all modes
+
+`runInChildContext` previously ran `deserialize(serialize(result))` only for
+small (checkpointed) payloads; large payloads (replay-children mode) and virtual
+contexts returned the raw in-memory result. With a **non-identity** serdes, the
+value a caller received depended on payload size or the virtual flag. All three
+modes now apply the same round-trip, so callers observe consistent results
+regardless of payload size. No public API change, but observed values may change
+if you use a serdes whose `deserialize(serialize(x))` differs from `x`.
+
+#### 5. `FileSystemSerdesConfig.mode` renamed to `storageMode`
+
+Only relevant if you adopted `createFileSystemSerdes` during the `2.0.0-alpha`
+line; `1.x` users are unaffected.
+
+### Added
+
+#### `withRetry` — retry a block of durable logic
+
+A new helper for retrying chunks of logic that contain operations a `step`
+cannot host (e.g. `waitForCallback`, `invoke`). Semantically a
+`runInChildContext` with a retry policy wrapped around it.
+
+```typescript
+import { withRetry, createRetryStrategy } from "@aws/durable-execution-sdk-js";
+
+const result = await withRetry(
+  context,
+  "approval",
+  (ctx, attempt) =>
+    ctx.waitForCallback(`approval-${attempt}`, submitter, {
+      timeout: { hours: 24 },
+    }),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 3,
+      initialDelay: { seconds: 2 },
+      backoffRate: 2,
+    }),
+  },
+);
+```
+
+#### `createLinearRetryStrategy` + `retryPresets.linear`
+
+Linear backoff with a configurable initial delay and increment.
+
+```typescript
+import {
+  createLinearRetryStrategy,
+  retryPresets,
+} from "@aws/durable-execution-sdk-js";
+
+// Custom: 8 attempts, starting at 2s, +3s each attempt -> 2,5,8,11,14,17,20s
+const strategy = createLinearRetryStrategy(8, 2, 3);
+await context.step("flaky", fn, { retryStrategy: strategy });
+
+// Or use the new preset (6 attempts: 1,2,3,4,5s)
+await context.step("flaky", fn, { retryStrategy: retryPresets.linear });
+```
+
+#### `context.configureSerdes()` + `SerdesConfig`
+
+Set default serdes once on the context instead of passing `serdes:` to every
+operation. Defaults flow into `step`, `runInChildContext`, `invoke`, and
+`waitForCondition`. Callbacks (`createCallback`, `waitForCallback`) require an
+**explicit** `defaultCallbackDeserializer` — they keep the passthrough
+deserializer otherwise so customer-provided callback payloads aren't accidentally
+JSON-parsed. Per-operation `serdes:` arguments still win over the default.
+
+#### `createFileSystemSerdes(basePath, config?)`
+
+A built-in `Serdes` that writes each value to a file under `basePath` and stores
+only a small file pointer in the checkpoint, keeping executions under the
+per-checkpoint size limit (~256KB) when individual operations produce large
+results. Supports `FileSystemSerdesMode.ALWAYS` (default) and
+`FileSystemSerdesMode.OVERFLOW` (inline JSON until a threshold, then spill to a
+file).
+
+> **⚠ Use a durable, shared mount.** S3 Files (Lambda S3 mount) and EFS are
+> supported. **Do not point this at Lambda's `/tmp`** — `/tmp` is
+> per-execution-environment and a replay on a different sandbox won't find the
+> file, breaking deserialization.
+
+It also accepts an optional `generatePreview` function (with the `buildPreview`
+helper plus `PreviewMode`, `FieldMatchMode`) to store a redacted inline preview
+in the checkpoint while keeping the full value on disk — useful for keeping PII
+out of `GetDurableExecutionHistory` and the AWS console.
+
+#### `NestingType` for `map` and `parallel`
+
+Trade observability for cost on batch operations. The default is
+`NestingType.NESTED` (existing behavior), so **existing code is unaffected unless
+you opt in**. `NestingType.FLAT` skips per-iteration `CONTEXT` operations for up
+to 2x cost reduction and higher per-execution scale, at the price of less
+detailed history.
+
+#### `errorMapper` on `ChildConfig`
+
+`runInChildContext`, promise combinators, and `withRetry` accept a function to
+remap the thrown error type — useful when you want a domain error class instead
+of `ChildContextError`.
+
+#### Instrumentation plugin system (experimental)
+
+> **⚠ Experimental.** This API is unstable and may change in a backward-
+> incompatible way in any future release, including minor and patch versions. It
+> is not covered by semantic versioning guarantees yet. Use with caution in
+> production and pin your SDK version if you depend on it.
+
+A new `DurableInstrumentationPlugin` interface with lifecycle hooks for
+execution, invocation, operation, and attempt-level events, composed by a plugin
+runner and wired through the entire execution path (`step`, `runInChildContext`,
+`invoke`, `wait`, `waitForCondition`, callbacks). Register plugins via the new
+`plugins` field on `DurableExecutionConfig`. Plugin errors are isolated
+(fire-and-forget) and can never alter customer output.
+
+#### Safe `DurableContext` detection
+
+`DurableContextImpl` now carries a package-namespaced
+`Symbol.for("@aws/durable-execution-sdk-js/durable-context")` brand and a
+`Symbol.toStringTag` of `"DurableContext"`, so external libraries can detect a
+durable context without importing the SDK or relying on name checks.
+
+### Changed
+
+- **Promise combinators no longer block Lambda termination during idle waits.**
+  `context.Promise.all`, `Promise.allSettled`, `Promise.any`, and `Promise.race`
+  previously ran each branch inside an internal `ctx.step`. A step keeps the
+  Lambda invocation alive, so when every branch was idle (e.g. all waiting on a
+  `wait` or `waitForCallback`) the function could not be torn down and you kept
+  paying for idle compute. The combinators are now implemented on top of
+  `runInChildContext`, which lets Lambda terminate while all branches are idle
+  and resume on a later invocation.
+
+  **Consequence — execution history shape changes.** Because each branch now runs
+  in a child context instead of a step, `GetDurableExecutionHistory` (and the AWS
+  console) now show a `CONTEXT` operation per branch instead of a `STEP`
+  operation. Anything that parses history or asserts on operation types/counts
+  for code using promise combinators must be updated. This change is also what
+  enables the typed `PromiseCombinatorError` (upgrade guide §1).
+
+- **UserAgent header** uses `aws-durable-execution-sdk-js/<version>` and appends
+  `-bundled` when running from the Lambda bundled runtime path.
+
+### Fixed
+
+- **`errorData` is preserved across nested `runInChildContext` boundaries.**
+  `DurableOperationError.toErrorObject` now walks the cause chain (bounded to 10
+  hops) to surface the first `errorData` it finds, instead of dropping it each
+  time an error is re-wrapped in a fresh `ChildContextError`.
+- **Child context result matches replay on first run**, including serdes handling
+  in batch operations.
+- **`PromiseCombinatorError` survives replay.** It was missing from
+  `DurableOperationError.fromErrorObject`, so it deserialized as `StepError` on
+  replay, breaking `instanceof` checks and error-identity determinism.
+- **`buildPreview` no longer leaks excluded subtrees.** A field excluded via
+  `FieldMatchMode.PATH` still had its descendant leaves surface under
+  `INCLUDE_ALL` mode, leaking PII into `GetDurableExecutionHistory`. Excluded
+  nodes now skip recursion entirely.
+- **`createFileSystemSerdes` OVERFLOW threshold accounts for double-encoding.**
+  The check now measures the final persisted envelope (`{ data: <json> }`, which
+  re-escapes quotes/backslashes and inflates size 10–30%) rather than the raw
+  inline JSON, so boundary payloads correctly overflow to file and stay under the
+  ~256KB checkpoint limit.
+- **Interrupted step with `shouldRetry: false` no longer crashes on replay.**
+  An `AtMostOncePerRetry` step interrupted (e.g. Lambda timeout) whose retry
+  strategy declines a retry now passes the required metadata when marking the
+  operation complete, instead of throwing `metadata required on first call` on a
+  fresh Lambda instance.
+- **eslint-plugin**: remove `context.getSourceCode()` so the plugin works on
+  ESLint v10.
+- **sdk**: resolve ESLint warnings surfaced during the build.
+- **examples**: prevent duplicate `DeleteFunction` calls during cleanup in
+  integration tests.
+
+### Security
+
+- Bump `@aws-sdk/*` deps to pull in the patched `fast-xml-parser`.
+- Resolve high-severity advisories in `fast-xml-parser`, `handlebars`, `flatted`,
+  `lodash`, `minimatch`, `picomatch`, and `vite`; update `eslint-plugin-tsdoc` to
+  `^0.5.2`.
+
+[2.0.0]: https://github.com/aws/aws-durable-execution-sdk-js/compare/sdk-1.1.7...sdk-2.0.0

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/error-instance/error-instance.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/error-instance/error-instance.test.ts
@@ -30,7 +30,8 @@ createTests({
         },
         failureError: {
           isCallbackError: true,
-          errorName: "CallbackError",
+          isCallbackExternalError: true,
+          errorName: "CallbackExternalError",
           errorMessage: "Callback failed",
         },
       });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/error-instance/error-instance.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/error-instance/error-instance.ts
@@ -1,5 +1,6 @@
 import {
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
   DurableContext,
   withDurableExecution,
@@ -47,6 +48,7 @@ export const handler = withDurableExecution(
         },
         failureError: {
           isCallbackError: errors[1] instanceof CallbackError,
+          isCallbackExternalError: errors[1] instanceof CallbackExternalError,
           errorName: errors[1]?.constructor.name,
           errorMessage: errors[1]?.message,
         },

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/create-callback/failures/create-callback-failures.test.ts
@@ -29,7 +29,7 @@ createTests({
       // Expect the actual error message sent via sendCallbackFailure
       expect(result.getError()).toEqual({
         errorMessage: "External API failure",
-        errorType: "CallbackError",
+        errorType: "CallbackExternalError",
         stackTrace: undefined,
       });
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/error-instance-failure/error-instance-failure.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/error-instance-failure/error-instance-failure.test.ts
@@ -9,7 +9,7 @@ createTests({
   handler,
   invocationType: InvocationType.Event,
   tests: (runner, { assertEventSignatures }) => {
-    it("should catch CallbackError for callback failure", async () => {
+    it("should catch CallbackExternalError for callback failure", async () => {
       const executionPromise = runner.run({ payload: {} });
 
       const callback = runner.getOperationByIndex(0);
@@ -20,7 +20,8 @@ createTests({
       const errorCheck = result.getResult() as any;
 
       expect(errorCheck.isCallbackError).toBe(true);
-      expect(errorCheck.errorName).toBe("CallbackError");
+      expect(errorCheck.isCallbackExternalError).toBe(true);
+      expect(errorCheck.errorName).toBe("CallbackExternalError");
       expect(errorCheck.errorMessage).toBe("Callback failed");
 
       assertEventSignatures(result, "failure", {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/error-instance-failure/error-instance-failure.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/error-instance-failure/error-instance-failure.ts
@@ -1,5 +1,6 @@
 import {
   CallbackError,
+  CallbackExternalError,
   DurableContext,
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
@@ -7,7 +8,8 @@ import { ExampleConfig } from "../../../types";
 
 export const config: ExampleConfig = {
   name: "Wait for Callback - Error Instance Failure",
-  description: "Verifies CallbackError instanceof check works across replays",
+  description:
+    "Verifies CallbackExternalError instanceof check works across replays",
 };
 
 export const handler = withDurableExecution(
@@ -28,6 +30,7 @@ export const handler = withDurableExecution(
 
     return await context.step("check-error-type", async () => ({
       isCallbackError: error instanceof CallbackError,
+      isCallbackExternalError: error instanceof CallbackExternalError,
       errorName: error?.constructor.name,
       errorMessage: error?.message,
     }));

--- a/packages/aws-durable-execution-sdk-js/src/errors/callback-error/callback-error.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/callback-error/callback-error.test.ts
@@ -1,4 +1,10 @@
-import { CallbackError } from "../../errors/durable-error/durable-error";
+import {
+  CallbackError,
+  CallbackExternalError,
+  CallbackTimeoutError,
+  CallbackSubmitterError,
+  DurableOperationError,
+} from "../../errors/durable-error/durable-error";
 import { ErrorObject } from "@aws-sdk/client-lambda";
 
 describe("CallbackError", () => {
@@ -80,5 +86,63 @@ describe("CallbackError", () => {
       expect(error.cause!.name).toBe("Error");
       expect(error.cause!.stack).toBeUndefined();
     });
+  });
+});
+
+describe("Callback error hierarchy", () => {
+  it("CallbackExternalError should be a CallbackError", () => {
+    const error = new CallbackExternalError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(DurableOperationError);
+    expect(error).toBeInstanceOf(CallbackError);
+    expect(error).toBeInstanceOf(CallbackExternalError);
+    expect(error.name).toBe("CallbackExternalError");
+    expect(error.errorType).toBe("CallbackExternalError");
+    expect(error.message).toBe("Callback failed");
+  });
+
+  it("CallbackTimeoutError should be a CallbackError", () => {
+    const error = new CallbackTimeoutError();
+
+    expect(error).toBeInstanceOf(CallbackError);
+    expect(error).toBeInstanceOf(CallbackTimeoutError);
+    expect(error.errorType).toBe("CallbackTimeoutError");
+    expect(error.message).toBe("Callback timed out");
+  });
+
+  it("CallbackSubmitterError should be a CallbackError", () => {
+    const error = new CallbackSubmitterError();
+
+    expect(error).toBeInstanceOf(CallbackError);
+    expect(error).toBeInstanceOf(CallbackSubmitterError);
+    expect(error.errorType).toBe("CallbackSubmitterError");
+    expect(error.message).toBe("Callback submitter failed");
+  });
+
+  it("base CallbackError should not be an instance of its subclasses", () => {
+    const error = new CallbackError();
+
+    expect(error).toBeInstanceOf(CallbackError);
+    expect(error).not.toBeInstanceOf(CallbackExternalError);
+    expect(error).not.toBeInstanceOf(CallbackTimeoutError);
+    expect(error).not.toBeInstanceOf(CallbackSubmitterError);
+    expect(error.errorType).toBe("CallbackError");
+  });
+
+  it("should reconstruct CallbackExternalError from ErrorObject preserving the subtype", () => {
+    const errorObject: ErrorObject = {
+      ErrorType: "CallbackExternalError",
+      ErrorMessage: "External system reported failure",
+      ErrorData: "external-data",
+    };
+
+    const error = DurableOperationError.fromErrorObject(errorObject);
+
+    expect(error).toBeInstanceOf(CallbackExternalError);
+    expect(error).toBeInstanceOf(CallbackError);
+    expect(error.errorType).toBe("CallbackExternalError");
+    expect(error.message).toBe("External system reported failure");
+    expect(error.errorData).toBe("external-data");
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -45,6 +45,12 @@ export abstract class DurableOperationError extends Error {
           cause,
           errorObject.ErrorData,
         );
+      case "CallbackExternalError":
+        return new CallbackExternalError(
+          errorObject.ErrorMessage || "Callback failed",
+          cause,
+          errorObject.ErrorData,
+        );
       case "CallbackTimeoutError":
         return new CallbackTimeoutError(
           errorObject.ErrorMessage || "Callback timed out",
@@ -134,11 +140,39 @@ export class StepError extends DurableOperationError {
 }
 
 /**
- * Error thrown when a callback operation fails
+ * Base error for all callback operation failures.
+ *
+ * Acts as the parent class for the more specific callback errors, so callers
+ * can catch every callback-related failure with a single
+ * `instanceof CallbackError` check:
+ *
+ * ```
+ * CallbackError
+ *   +- CallbackExternalError   // external entity reported failure
+ *   +- CallbackTimeoutError    // callback timed out
+ *   +- CallbackSubmitterError  // submitter function failed
+ * ```
+ *
+ * It is also thrown directly for internal callback failures that do not fall
+ * into one of the more specific categories (e.g. a missing callback ID).
+ *
  * @public
  */
 export class CallbackError extends DurableOperationError {
-  readonly errorType = "CallbackError";
+  readonly errorType: string = "CallbackError";
+
+  constructor(message?: string, cause?: Error, errorData?: string) {
+    super(message || "Callback failed", cause, errorData);
+  }
+}
+
+/**
+ * Error thrown when the external entity completes a callback with a failure
+ * (e.g. via SendDurableExecutionCallbackFailure) instead of a success.
+ * @public
+ */
+export class CallbackExternalError extends CallbackError {
+  readonly errorType = "CallbackExternalError";
 
   constructor(message?: string, cause?: Error, errorData?: string) {
     super(message || "Callback failed", cause, errorData);
@@ -149,7 +183,7 @@ export class CallbackError extends DurableOperationError {
  * Error thrown when a callback operation times out
  * @public
  */
-export class CallbackTimeoutError extends DurableOperationError {
+export class CallbackTimeoutError extends CallbackError {
   readonly errorType = "CallbackTimeoutError";
 
   constructor(message?: string, cause?: Error, errorData?: string) {
@@ -161,7 +195,7 @@ export class CallbackTimeoutError extends DurableOperationError {
  * Error thrown when a callback submitter fails
  * @public
  */
-export class CallbackSubmitterError extends DurableOperationError {
+export class CallbackSubmitterError extends CallbackError {
   readonly errorType = "CallbackSubmitterError";
 
   constructor(message?: string, cause?: Error, errorData?: string) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback-promise.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback-promise.test.ts
@@ -1,7 +1,11 @@
 import { createCallbackPromise } from "./callback-promise";
 import { ExecutionContext, OperationLifecycleState } from "../../types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
-import { CallbackError } from "../../errors/durable-error/durable-error";
+import {
+  CallbackError,
+  CallbackExternalError,
+  CallbackTimeoutError,
+} from "../../errors/durable-error/durable-error";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
 import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
 
@@ -129,11 +133,12 @@ describe("createCallbackPromise", () => {
       mockCheckAndUpdateReplayMode,
     );
 
-    await expect(promise).rejects.toThrow(CallbackError);
+    await expect(promise).rejects.toThrow(CallbackExternalError);
 
     try {
       await promise;
     } catch (error) {
+      expect(error).toBeInstanceOf(CallbackExternalError);
       expect(error).toBeInstanceOf(CallbackError);
       expect((error as CallbackError).message).toBe("Custom error message");
       expect((error as CallbackError).cause?.name).toBe("CustomError");
@@ -162,7 +167,7 @@ describe("createCallbackPromise", () => {
       mockCheckAndUpdateReplayMode,
     );
 
-    await expect(promise).rejects.toThrow(CallbackError);
+    await expect(promise).rejects.toThrow(CallbackExternalError);
     await expect(promise).rejects.toThrow("Callback failed");
   });
 
@@ -182,7 +187,9 @@ describe("createCallbackPromise", () => {
       mockCheckAndUpdateReplayMode,
     );
 
+    await expect(promise).rejects.toThrow(CallbackTimeoutError);
+    await expect(promise).rejects.toThrow("Callback timed out");
+    // CallbackTimeoutError is part of the CallbackError hierarchy
     await expect(promise).rejects.toThrow(CallbackError);
-    await expect(promise).rejects.toThrow("Callback failed");
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback-promise.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback-promise.ts
@@ -5,7 +5,11 @@ import {
 } from "../../types";
 import { OperationStatus } from "@aws-sdk/client-lambda";
 import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
-import { CallbackError } from "../../errors/durable-error/durable-error";
+import {
+  CallbackError,
+  CallbackExternalError,
+  CallbackTimeoutError,
+} from "../../errors/durable-error/durable-error";
 import { Serdes } from "../../utils/serdes/serdes";
 import { log } from "../../utils/logger/logger";
 import { Checkpoint } from "../../utils/checkpoint/checkpoint-helper";
@@ -73,19 +77,29 @@ export const createCallbackPromise = <T>(
 
     const callbackData = stepData?.CallbackDetails;
     const error = callbackData?.Error;
+    const isTimeout = stepData?.Status === OperationStatus.TIMED_OUT;
 
     const callbackError = error
-      ? (() => {
+      ? ((): CallbackError => {
           const cause = new Error(error.ErrorMessage);
           cause.name = error.ErrorType || "Error";
           cause.stack = error.StackTrace?.join("\n");
-          return new CallbackError(
+          if (isTimeout) {
+            return new CallbackTimeoutError(
+              error.ErrorMessage || "Callback timed out",
+              cause,
+              error.ErrorData,
+            );
+          }
+          return new CallbackExternalError(
             error.ErrorMessage || "Callback failed",
             cause,
             error.ErrorData,
           );
         })()
-      : new CallbackError("Callback failed");
+      : isTimeout
+        ? new CallbackTimeoutError("Callback timed out")
+        : new CallbackExternalError("Callback failed");
 
     const operationInfo = toOperationInfo(stepData);
     backfillOperationInfo(operationInfo, opInfo);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.test.ts
@@ -14,6 +14,7 @@ import { hashId } from "../../utils/step-id-utils/step-id-utils";
 import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
 import {
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
 } from "../../errors/durable-error/durable-error";
 
@@ -282,7 +283,7 @@ describe("Callback Handler", () => {
     {
       status: OperationStatus.FAILED,
       statusName: "failed",
-      expectedErrorClass: CallbackError,
+      expectedErrorClass: CallbackExternalError,
       testData: {
         callbackId: "callback-failed-123",
         errorData: "Error data",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -13,6 +13,7 @@ import { Serdes, AnySerdesDeserializer } from "../../utils/serdes/serdes";
 import { safeDeserialize } from "../../errors/serdes-errors/serdes-errors";
 import {
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
 } from "../../errors/durable-error/durable-error";
 import { validateReplayConsistency } from "../../utils/replay-validation/replay-validation";
@@ -242,7 +243,7 @@ export const createCallback = (
         const isTimeout = stepData?.Status === OperationStatus.TIMED_OUT;
 
         const callbackError = error
-          ? ((): CallbackError | CallbackTimeoutError => {
+          ? ((): CallbackError => {
               const cause = new Error(error.ErrorMessage);
               cause.name = error.ErrorType || "Error";
               cause.stack = error.StackTrace?.join("\n");
@@ -255,7 +256,7 @@ export const createCallback = (
                 );
               }
 
-              return new CallbackError(
+              return new CallbackExternalError(
                 error.ErrorMessage || "Callback failed",
                 cause,
                 error.ErrorData,
@@ -263,7 +264,7 @@ export const createCallback = (
             })()
           : isTimeout
             ? new CallbackTimeoutError("Callback timed out")
-            : new CallbackError("Callback failed");
+            : new CallbackExternalError("Callback failed");
 
         const rejectedPromise = new DurablePromise(async (): Promise<T> => {
           throw callbackError;

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
@@ -13,6 +13,7 @@ import { Serdes, SerdesContext } from "../../utils/serdes/serdes";
 const KNOWN_DURABLE_ERROR_TYPES = new Set([
   "StepError",
   "CallbackError",
+  "CallbackExternalError",
   "CallbackTimeoutError",
   "CallbackSubmitterError",
   "InvokeError",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -146,9 +146,10 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
             serdes: createPassThroughSerdes(),
           }),
           errorMapper: (originalError) => {
-            // Pass through callback errors directly (both timeout and failure)
+            // Pass through callback errors directly (timeout, external failure, base)
             if (
               originalError.errorType === "CallbackTimeoutError" ||
+              originalError.errorType === "CallbackExternalError" ||
               originalError.errorType === "CallbackError"
             ) {
               return originalError;

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -42,6 +42,7 @@ export {
   DurableOperationError,
   StepError,
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
   CallbackSubmitterError,
   InvokeError,


### PR DESCRIPTION
Reorganize the callback error types into a hierarchy so a single `instanceof CallbackError` check matches every callback failure, and add `CallbackExternalError` for the case where the external entity completes a callback with a failure (SendDurableExecutionCallbackFailure).

CallbackError
  +- CallbackExternalError   // external entity reported failure
  +- CallbackTimeoutError    // callback timed out
  +- CallbackSubmitterError  // waitForCallback submitter threw

Changes:
- CallbackTimeoutError and CallbackSubmitterError now extend CallbackError instead of DurableOperationError directly; add CallbackExternalError as a third subclass and export it from the package index.
- createCallback / callback-promise now throw CallbackExternalError on an external FAILED status and CallbackTimeoutError on TIMED_OUT (the live-wait path previously threw a generic CallbackError even on timeout).
- Register CallbackExternalError in DurableOperationError.fromErrorObject and in the batch-result known-error set so it round-trips correctly on replay.
- waitForCallback's child-context errorMapper passes CallbackExternalError through alongside the other callback errors.
- Update SDK unit tests and the callback examples to assert the new types.
- Add CHANGELOG.md documenting the 2.0.0 release.

BREAKING CHANGE: an externally-failed callback now reports errorType/name "CallbackExternalError" instead of "CallbackError", and a callback that times out while being awaited now throws CallbackTimeoutError. Code using `instanceof CallbackError` is unaffected; only exact errorType/name string comparisons need updating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
