### PR TITLE
feat(sdk): sanitize filesystem serdes paths and add pathEncoding option

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -63,6 +63,7 @@ export {
 export {
   createFileSystemSerdes,
   FileSystemSerdesMode,
+  FileSystemPathEncoding,
   FileSystemSerdesConfig,
   FieldMatchMode,
   PreviewMode,

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.test.ts
@@ -2,11 +2,13 @@ import { SerdesContext } from "./serdes";
 import {
   createFileSystemSerdes,
   FileSystemSerdesMode,
+  FileSystemPathEncoding,
   PreviewMode,
   FieldMatchMode,
   buildPreview,
 } from "./filesystem-serdes";
 import { TEST_CONSTANTS } from "../../testing/test-constants";
+import { createHash } from "node:crypto";
 
 jest.mock("node:fs/promises", () => ({
   mkdir: jest.fn().mockResolvedValue(undefined),
@@ -142,6 +144,134 @@ describe("createFileSystemSerdes", () => {
       // The serialized result should overflow to file, not inline
       expect(mockWriteFile).toHaveBeenCalled();
       expect(JSON.parse(result!)).toEqual({ file: EXPECTED_FILE });
+    });
+  });
+});
+
+describe("createFileSystemSerdes path encoding", () => {
+  // An entity ID that is unsafe as a raw file name: a slash would create or
+  // escape directories, and "../" would traverse outside the per-execution dir.
+  const unsafeContext: SerdesContext = {
+    entityId: "../invoices/2026",
+    durableExecutionArn: TEST_CONSTANTS.DURABLE_EXECUTION_ARN,
+  };
+
+  // A realistic durable execution ARN:
+  // arn:aws:lambda:<region>:<account>:function:<fn>:<version>/durable-execution/<executionName>/<invocationId>
+  const FUNCTION_NAME = "payment-processor";
+  const EXECUTION_NAME = "045e664f-c7e6-4487-be17-30efc3c6880a";
+  const INVOCATION_ID = "d6a8ddb8-0286-39d6-89bd-8f13b33d4722";
+  const REALISTIC_ARN = `arn:aws:lambda:us-east-1:123456789012:function:${FUNCTION_NAME}:54/durable-execution/${EXECUTION_NAME}/${INVOCATION_ID}`;
+  const realisticContext: SerdesContext = {
+    entityId: TEST_CONSTANTS.STEP_ID,
+    durableExecutionArn: REALISTIC_ARN,
+  };
+
+  describe("URI encoding (default)", () => {
+    it("derives a compact directory from the ARN's function name, execution name and invocation id", async () => {
+      const serdes = createFileSystemSerdes(BASE_PATH);
+      const result = await serdes.serialize({ id: 1 }, realisticContext);
+
+      const expectedDir = `${BASE_PATH}/${FUNCTION_NAME}/${EXECUTION_NAME}/${INVOCATION_ID}`;
+      const expectedFile = `${expectedDir}/${TEST_CONSTANTS.STEP_ID}.json`;
+
+      expect(mockMkdir).toHaveBeenCalledWith(expectedDir, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expectedFile,
+        JSON.stringify({ id: 1 }),
+        "utf-8",
+      );
+      // The whole ARN must NOT appear as a single encoded directory segment.
+      expect(expectedDir).not.toContain("%3A");
+      expect(JSON.parse(result!)).toEqual({ file: expectedFile });
+    });
+
+    it("falls back to encoding the whole ARN when it is not a durable-execution ARN", async () => {
+      const serdes = createFileSystemSerdes(BASE_PATH);
+      await serdes.serialize({ id: 1 }, mockContext);
+
+      // TEST ARN is not in the expected shape, so the whole ARN is encoded into
+      // a single directory segment (legacy layout) and the file name is unchanged.
+      expect(mockMkdir).toHaveBeenCalledWith(EXPECTED_DIR, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        EXPECTED_FILE,
+        JSON.stringify({ id: 1 }),
+        "utf-8",
+      );
+    });
+
+    it("encodes the entityId so an unsafe name stays a single flat file", async () => {
+      const serdes = createFileSystemSerdes(BASE_PATH);
+      const result = await serdes.serialize({ id: 1 }, unsafeContext);
+
+      const expectedFile = `${EXPECTED_DIR}/${encodeURIComponent(
+        unsafeContext.entityId,
+      )}.json`;
+
+      // The written path must be the flat encoded file directly under the
+      // ARN directory — no extra directories, no traversal.
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expectedFile,
+        JSON.stringify({ id: 1 }),
+        "utf-8",
+      );
+      expect(expectedFile.startsWith(`${EXPECTED_DIR}/`)).toBe(true);
+      expect(expectedFile).not.toContain("/../");
+      expect(JSON.parse(result!)).toEqual({ file: expectedFile });
+    });
+
+    it("matches the legacy raw layout for IDs that need no encoding", async () => {
+      const serdes = createFileSystemSerdes(BASE_PATH);
+      await serdes.serialize({ id: 1 }, mockContext);
+
+      // STEP_ID has no special chars, so encodeURIComponent is a no-op and the
+      // on-disk path is unchanged from the pre-fix behavior.
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        EXPECTED_FILE,
+        JSON.stringify({ id: 1 }),
+        "utf-8",
+      );
+    });
+  });
+
+  describe("HASH encoding", () => {
+    const serdes = createFileSystemSerdes(BASE_PATH, {
+      pathEncoding: FileSystemPathEncoding.HASH,
+    });
+
+    const sha256 = (v: string): string =>
+      createHash("sha256").update(v).digest("hex");
+
+    it("hashes the whole ARN directory and the entityId file name", async () => {
+      const result = await serdes.serialize({ id: 1 }, realisticContext);
+
+      const expectedDir = `${BASE_PATH}/${sha256(REALISTIC_ARN)}`;
+      const expectedFile = `${expectedDir}/${sha256(
+        TEST_CONSTANTS.STEP_ID,
+      )}.json`;
+
+      expect(mockMkdir).toHaveBeenCalledWith(expectedDir, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expectedFile,
+        JSON.stringify({ id: 1 }),
+        "utf-8",
+      );
+      expect(JSON.parse(result!)).toEqual({ file: expectedFile });
+    });
+
+    it("produces fixed-length (64 hex char) segment names", async () => {
+      await serdes.serialize(
+        { id: 1 },
+        {
+          entityId: "x".repeat(10_000),
+          durableExecutionArn: REALISTIC_ARN,
+        },
+      );
+
+      const writtenPath = mockWriteFile.mock.calls[0][0] as string;
+      const fileName = writtenPath.split("/").pop()!;
+      expect(fileName).toBe(`${sha256("x".repeat(10_000))}.json`);
+      expect(fileName.length).toBe(64 + ".json".length);
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/serdes/filesystem-serdes.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import { SerdesContext, AnySerdes } from "./serdes";
 import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
 export {
@@ -31,6 +32,32 @@ export enum FileSystemSerdesMode {
 }
 
 /**
+ * Controls how the durable execution ARN and entity ID are turned into the
+ * on-disk directory and file names.
+ *
+ * - `URI`: The per-execution directory is a compact, human-navigable path built
+ *   from the ARN's function name, execution name and invocation id
+ *   (`<functionName>/<executionName>/<invocationId>`); the file name is the
+ *   entity ID encoded with `encodeURIComponent`. Names stay readable, but a very
+ *   long entity ID may exceed the filesystem's per-name length limit (commonly
+ *   255 bytes). If the ARN does not match the expected durable-execution shape,
+ *   the whole ARN is `encodeURIComponent`-encoded into a single directory
+ *   segment instead.
+ *
+ * - `HASH`: The ARN (directory) and entity ID (file name) are each replaced by
+ *   their SHA-256 hex digest. Names are a fixed length (64 chars) and always
+ *   filesystem-safe regardless of the characters or length of the original
+ *   value, at the cost of no longer being human-readable when browsing the
+ *   mount.
+ *
+ * @public
+ */
+export enum FileSystemPathEncoding {
+  URI = "URI",
+  HASH = "HASH",
+}
+
+/**
  * Configuration options for {@link createFileSystemSerdes}.
  *
  * @public
@@ -41,6 +68,17 @@ export interface FileSystemSerdesConfig {
    * @defaultValue `FileSystemSerdesMode.ALWAYS`
    */
   storageMode?: FileSystemSerdesMode;
+  /**
+   * Controls how the durable execution ARN (directory) and entity ID (file
+   * name) are encoded into path segments.
+   *
+   * Use `FileSystemPathEncoding.HASH` when entity IDs may contain characters
+   * that are unsafe in a file name (for example `/`) or may be long enough to
+   * exceed the filesystem's name-length limit.
+   *
+   * @defaultValue `FileSystemPathEncoding.URI`
+   */
+  pathEncoding?: FileSystemPathEncoding;
   /**
    * Optional function that generates a preview object from the value.
    * When provided, the preview is stored inline in the checkpoint envelope
@@ -78,15 +116,108 @@ type FileSystemEnvelope =
   | { data: string }
   | { file: string; preview?: Record<string, unknown> };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * Encodes a path segment (the execution ARN or entity ID) into a name that is
+ * safe to use on the filesystem.
+ *
+ * @internal
+ */
+function encodeSegment(
+  value: string,
+  encoding: FileSystemPathEncoding,
+): string {
+  return encoding === FileSystemPathEncoding.HASH
+    ? createHash("sha256").update(value).digest("hex")
+    : encodeURIComponent(value);
+}
+
+/**
+ * The parts of a durable execution ARN that identify a single execution.
+ *
+ * These values are stable for the lifetime of an execution — they do not
+ * change across the multiple Lambda invocations (replays) of that execution —
+ * and are already filesystem-safe (function name charset plus UUIDs).
+ *
+ * @internal
+ */
+interface DurableExecutionArnParts {
+  functionName: string;
+  executionName: string;
+  invocationId: string;
+}
+
+/**
+ * Matches a durable execution ARN of the form:
+ *
+ *   arn:<partition>:lambda:<region>:<account>:function:<functionName>:<version>/durable-execution/<executionName>/<invocationId>
+ *
+ * @internal
+ */
+const DURABLE_EXECUTION_ARN_PATTERN =
+  /^arn:[^:]*:lambda:[^:]*:[^:]*:function:([^:/]+):[^:/]+\/durable-execution\/([^/]+)\/([^/]+)$/;
+
+/** @internal */
+function parseDurableExecutionArn(
+  arn: string,
+): DurableExecutionArnParts | undefined {
+  const match = DURABLE_EXECUTION_ARN_PATTERN.exec(arn);
+  if (!match) return undefined;
+  return {
+    functionName: match[1],
+    executionName: match[2],
+    invocationId: match[3],
+  };
+}
+
+/**
+ * Resolves the per-execution directory under `basePath`.
+ *
+ * In `URI` mode the directory is a compact, human-navigable path built from the
+ * execution's function name, execution name and invocation id (all stable for
+ * the lifetime of the execution and already filesystem-safe). If the ARN does
+ * not match the expected shape (for example a local/test ARN), the whole ARN is
+ * URI-encoded into a single segment instead.
+ *
+ * In `HASH` mode the whole ARN is hashed into a single fixed-length segment.
+ *
+ * @internal
+ */
+function resolveExecutionDir(
+  basePath: string,
+  arn: string,
+  pathEncoding: FileSystemPathEncoding,
+): string {
+  if (pathEncoding === FileSystemPathEncoding.URI) {
+    const parts = parseDurableExecutionArn(arn);
+    if (parts) {
+      return join(
+        basePath,
+        parts.functionName,
+        parts.executionName,
+        parts.invocationId,
+      );
+    }
+  }
+  return join(basePath, encodeSegment(arn, pathEncoding));
+}
+
 async function writeToFile(
   basePath: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   context: SerdesContext,
+  pathEncoding: FileSystemPathEncoding,
 ): Promise<string> {
-  const dir = join(basePath, encodeURIComponent(context.durableExecutionArn));
+  const dir = resolveExecutionDir(
+    basePath,
+    context.durableExecutionArn,
+    pathEncoding,
+  );
   await mkdir(dir, { recursive: true });
-  const filePath = join(dir, `${context.entityId}.json`);
+  const filePath = join(
+    dir,
+    `${encodeSegment(context.entityId, pathEncoding)}.json`,
+  );
   await writeFile(filePath, JSON.stringify(value), "utf-8");
   return filePath;
 }
@@ -153,6 +284,7 @@ export function createFileSystemSerdes(
   config: FileSystemSerdesConfig = {},
 ): AnySerdes {
   const storageMode = config.storageMode ?? FileSystemSerdesMode.ALWAYS;
+  const pathEncoding = config.pathEncoding ?? FileSystemPathEncoding.URI;
   return {
     serialize: async (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -162,7 +294,12 @@ export function createFileSystemSerdes(
       if (value === undefined) return undefined;
 
       if (storageMode === FileSystemSerdesMode.ALWAYS) {
-        const filePath = await writeToFile(basePath, value, context);
+        const filePath = await writeToFile(
+          basePath,
+          value,
+          context,
+          pathEncoding,
+        );
         const preview = config.generatePreview?.(value);
         const envelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }
@@ -176,7 +313,12 @@ export function createFileSystemSerdes(
         data: inlineJson,
       } as FileSystemEnvelope);
       if (Buffer.byteLength(envelope, "utf-8") > OVERFLOW_THRESHOLD_BYTES) {
-        const filePath = await writeToFile(basePath, value, context);
+        const filePath = await writeToFile(
+          basePath,
+          value,
+          context,
+          pathEncoding,
+        );
         const preview = config.generatePreview?.(value);
         const fileEnvelope: FileSystemEnvelope = preview
           ? { file: filePath, preview }


### PR DESCRIPTION
The filesystem serdes derived the on-disk directory from `encodeURIComponent(durableExecutionArn)` but used the raw `entityId` for the file name (`${entityId}.json`). An entity ID containing characters such as `/` or `..` could therefore escape or fail to create the intended directory. This is latent today (entity IDs are counter-based step IDs) but becomes a real problem once user-controlled operation names flow into the entity ID. 

Changes:
- Always sanitize the entity ID before using it as a file name.
- Add a `pathEncoding` config option (new public `FileSystemPathEncoding` enum) to choose how the ARN and entity ID are turned into path segments:
  - `URI` (default): the per-execution directory is a compact, human-navigable path parsed from the ARN — `<functionName>/<executionName>/<invocationId>` (these are stable across an execution's invocations and already filesystem-safe), and the file name is `encodeURIComponent(entityId)`. Falls back to encoding the whole ARN when it is not a durable-execution ARN.
  - `HASH`: the whole ARN (directory) and the entity ID (file name) are each replaced by their SHA-256 hex digest — fixed length and always safe, regardless of the characters or length of the original value.
- Export `FileSystemPathEncoding` from the package index.
- Add unit tests covering the compact directory layout, the non-standard ARN fallback, entity-ID sanitization, and the HASH layout.

*Issue #, if available:*
#625

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
