### PR TITLE
feat(sdk): align linear retry strategy with exponential helper

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -79,7 +79,10 @@ export {
   createRetryStrategy,
   RetryStrategyConfig,
 } from "./utils/retry/retry-config";
-export { createLinearRetryStrategy } from "./utils/retry/linear-retry-strategy/linear-retry-strategy";
+export {
+  createLinearRetryStrategy,
+  LinearRetryStrategyConfig,
+} from "./utils/retry/linear-retry-strategy/linear-retry-strategy";
 export { retryPresets } from "./utils/retry/retry-presets/retry-presets";
 export { withRetry, WithRetryConfig, RetryableFunc } from "./utils/with-retry";
 export { DurableExecutionInvocationInputWithClient } from "./utils/durable-execution-invocation-input/durable-execution-invocation-input";

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.test.ts
@@ -1,8 +1,14 @@
 import { createLinearRetryStrategy } from "./linear-retry-strategy";
+import { JitterStrategy } from "../../../types";
 
 describe("createLinearRetryStrategy", () => {
   it("should create linear backoff delays", () => {
-    const strategy = createLinearRetryStrategy(5, 2, 3);
+    const strategy = createLinearRetryStrategy({
+      maxAttempts: 5,
+      initialDelay: { seconds: 2 },
+      increment: { seconds: 3 },
+      jitter: JitterStrategy.NONE,
+    });
 
     expect(strategy(new Error("test"), 1)).toEqual({
       shouldRetry: true,
@@ -21,7 +27,7 @@ describe("createLinearRetryStrategy", () => {
   });
 
   it("should stop retrying after max attempts", () => {
-    const strategy = createLinearRetryStrategy(3);
+    const strategy = createLinearRetryStrategy({ maxAttempts: 3 });
 
     expect(strategy(new Error("test"), 3)).toEqual({
       shouldRetry: false,
@@ -29,7 +35,7 @@ describe("createLinearRetryStrategy", () => {
   });
 
   it("should use default values", () => {
-    const strategy = createLinearRetryStrategy();
+    const strategy = createLinearRetryStrategy({ jitter: JitterStrategy.NONE });
 
     expect(strategy(new Error("test"), 1)).toEqual({
       shouldRetry: true,
@@ -39,6 +45,162 @@ describe("createLinearRetryStrategy", () => {
     expect(strategy(new Error("test"), 2)).toEqual({
       shouldRetry: true,
       delay: { seconds: 2 },
+    });
+  });
+
+  it("should default to 6 max attempts", () => {
+    const strategy = createLinearRetryStrategy({ jitter: JitterStrategy.NONE });
+
+    expect(strategy(new Error("test"), 5).shouldRetry).toBe(true);
+    expect(strategy(new Error("test"), 6).shouldRetry).toBe(false);
+  });
+
+  it("should cap delay at maxDelay", () => {
+    const strategy = createLinearRetryStrategy({
+      maxAttempts: 10,
+      initialDelay: { seconds: 5 },
+      increment: { seconds: 10 },
+      maxDelay: { seconds: 20 },
+      jitter: JitterStrategy.NONE,
+    });
+
+    // 5 + 10 * (1-1) = 5
+    expect(strategy(new Error("test"), 1).delay).toEqual({ seconds: 5 });
+    // 5 + 10 * (2-1) = 15
+    expect(strategy(new Error("test"), 2).delay).toEqual({ seconds: 15 });
+    // 5 + 10 * (3-1) = 25, capped to 20
+    expect(strategy(new Error("test"), 3).delay).toEqual({ seconds: 20 });
+    // 5 + 10 * (4-1) = 35, capped to 20
+    expect(strategy(new Error("test"), 4).delay).toEqual({ seconds: 20 });
+  });
+
+  it("should support Duration units other than seconds", () => {
+    const strategy = createLinearRetryStrategy({
+      maxAttempts: 5,
+      initialDelay: { minutes: 1 },
+      increment: { minutes: 1 },
+      jitter: JitterStrategy.NONE,
+    });
+
+    expect(strategy(new Error("test"), 1).delay).toEqual({ seconds: 60 });
+    expect(strategy(new Error("test"), 2).delay).toEqual({ seconds: 120 });
+  });
+
+  describe("jitter", () => {
+    it("should apply FULL jitter within bounds", () => {
+      const strategy = createLinearRetryStrategy({
+        initialDelay: { seconds: 10 },
+        increment: { seconds: 0 },
+        jitter: JitterStrategy.FULL,
+      });
+
+      for (let i = 0; i < 20; i++) {
+        const decision = strategy(new Error("test"), 1);
+        expect(decision.shouldRetry).toBe(true);
+        if (decision.shouldRetry) {
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1);
+          expect(decision.delay!.seconds).toBeLessThanOrEqual(10);
+          expect(Number.isInteger(decision.delay!.seconds)).toBe(true);
+        }
+      }
+    });
+
+    it("should apply HALF jitter within bounds", () => {
+      const strategy = createLinearRetryStrategy({
+        initialDelay: { seconds: 10 },
+        increment: { seconds: 0 },
+        jitter: JitterStrategy.HALF,
+      });
+
+      for (let i = 0; i < 20; i++) {
+        const decision = strategy(new Error("test"), 1);
+        expect(decision.shouldRetry).toBe(true);
+        if (decision.shouldRetry) {
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(5);
+          expect(decision.delay!.seconds).toBeLessThanOrEqual(10);
+        }
+      }
+    });
+
+    it("should default jitter to FULL", () => {
+      const strategy = createLinearRetryStrategy({
+        initialDelay: { seconds: 10 },
+        increment: { seconds: 0 },
+      });
+
+      for (let i = 0; i < 20; i++) {
+        const decision = strategy(new Error("test"), 1);
+        if (decision.shouldRetry) {
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1);
+          expect(decision.delay!.seconds).toBeLessThanOrEqual(10);
+        }
+      }
+    });
+
+    it("should always return integer delays >= 1", () => {
+      const strategy = createLinearRetryStrategy({
+        initialDelay: { seconds: 0.3 },
+        increment: { seconds: 0.4 },
+        jitter: JitterStrategy.FULL,
+      });
+
+      for (let i = 0; i < 20; i++) {
+        const decision = strategy(new Error("test"), 1);
+        expect(decision.shouldRetry).toBe(true);
+        if (decision.shouldRetry) {
+          expect(Number.isInteger(decision.delay!.seconds)).toBe(true);
+          expect(decision.delay!.seconds).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
+  });
+
+  describe("error filtering", () => {
+    it("should retry all errors by default", () => {
+      const strategy = createLinearRetryStrategy({
+        jitter: JitterStrategy.NONE,
+      });
+      expect(strategy(new Error("anything"), 1).shouldRetry).toBe(true);
+      expect(strategy(new Error("another"), 1).shouldRetry).toBe(true);
+    });
+
+    it("should filter retryable errors by message pattern", () => {
+      const strategy = createLinearRetryStrategy({
+        retryableErrors: [/timeout/i, "rate limit"],
+        jitter: JitterStrategy.NONE,
+      });
+
+      expect(strategy(new Error("Request timeout"), 1).shouldRetry).toBe(true);
+      expect(strategy(new Error("hit rate limit"), 1).shouldRetry).toBe(true);
+      expect(strategy(new Error("invalid input"), 1).shouldRetry).toBe(false);
+    });
+
+    it("should filter retryable errors by error type", () => {
+      class TimeoutError extends Error {}
+      class ValidationError extends Error {}
+
+      const strategy = createLinearRetryStrategy({
+        retryableErrorTypes: [TimeoutError],
+        jitter: JitterStrategy.NONE,
+      });
+
+      expect(strategy(new TimeoutError("timed out"), 1).shouldRetry).toBe(true);
+      expect(strategy(new ValidationError("bad"), 1).shouldRetry).toBe(false);
+      expect(strategy(new Error("generic"), 1).shouldRetry).toBe(false);
+    });
+
+    it("should combine error filters with OR logic", () => {
+      class TimeoutError extends Error {}
+
+      const strategy = createLinearRetryStrategy({
+        retryableErrors: [/network/i],
+        retryableErrorTypes: [TimeoutError],
+        jitter: JitterStrategy.NONE,
+      });
+
+      expect(strategy(new TimeoutError("timed out"), 1).shouldRetry).toBe(true);
+      expect(strategy(new Error("Network failure"), 1).shouldRetry).toBe(true);
+      expect(strategy(new Error("invalid input"), 1).shouldRetry).toBe(false);
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/linear-retry-strategy/linear-retry-strategy.ts
@@ -1,25 +1,191 @@
-import { RetryDecision } from "../../../types";
+import { RetryDecision, JitterStrategy, Duration } from "../../../types";
+import { durationToSeconds } from "../../duration/duration";
+import {
+  finalizeDelaySeconds,
+  isErrorRetryable,
+  resolveRetryableErrors,
+} from "../retry-common/retry-common";
 
 /**
- * Creates a linear backoff retry strategy
- * @param maxAttempts - Maximum number of attempts (default: 6)
- * @param initialDelay - Initial delay in seconds (default: 1)
- * @param increment - Linear increment per attempt in seconds (default: 1)
- * @returns Retry strategy with linear backoff
+ * Configuration options for creating a linear backoff retry strategy.
+ *
+ * @remarks
+ * When neither `retryableErrors` nor `retryableErrorTypes` is specified, all errors are retried by default.
+ * When either is specified, only errors matching the specified criteria are retried.
+ * When both are specified, errors matching either criteria are retried (OR logic).
+ *
+ * @example
+ * ```typescript
+ * // Retry all errors (default behavior), 1s, 2s, 3s, 4s, 5s delays
+ * createLinearRetryStrategy()
+ *
+ * // Custom delays starting at 2s, growing by 3s each attempt, capped at 30s
+ * createLinearRetryStrategy({
+ *   maxAttempts: 5,
+ *   initialDelay: { seconds: 2 },
+ *   increment: { seconds: 3 },
+ *   maxDelay: { seconds: 30 },
+ * })
+ *
+ * // Retry only specific error types
+ * createLinearRetryStrategy({ retryableErrorTypes: [TimeoutError, NetworkError] })
+ * ```
+ *
+ * @public
+ */
+interface LinearRetryStrategyConfig {
+  /**
+   * Maximum number of total attempts (including initial attempt).
+   * @defaultValue 6
+   */
+  maxAttempts?: number;
+
+  /**
+   * Initial delay before the first retry.
+   * @defaultValue \{ seconds: 1 \}
+   */
+  initialDelay?: Duration;
+
+  /**
+   * Linear increment added to the delay for each subsequent retry.
+   * @defaultValue \{ seconds: 1 \}
+   */
+  increment?: Duration;
+
+  /**
+   * Maximum delay between retries. The linearly growing delay is capped at this value.
+   * @defaultValue \{ minutes: 5 \}
+   */
+  maxDelay?: Duration;
+
+  /**
+   * Jitter strategy to apply to retry delays.
+   * @defaultValue JitterStrategy.FULL
+   * @see {@link JitterStrategy}
+   */
+  jitter?: JitterStrategy;
+
+  /**
+   * List of error message patterns (strings or RegExp) that are retryable.
+   *
+   * @remarks
+   * - If undefined and `retryableErrorTypes` is also undefined: all errors are retried (default)
+   * - If specified: only errors with messages matching these patterns are retried
+   * - Strings are matched using `includes()`, RegExp patterns use `test()`
+   * - Combined with `retryableErrorTypes` using OR logic
+   *
+   * @defaultValue All errors when both filters are undefined, otherwise empty array
+   */
+  retryableErrors?: (string | RegExp)[];
+
+  /**
+   * List of error class types that are retryable.
+   *
+   * @remarks
+   * - If undefined and `retryableErrors` is also undefined: all errors are retried (default)
+   * - If specified: only errors that are instances of these types are retried
+   * - Combined with `retryableErrors` using OR logic
+   *
+   * @defaultValue Empty array
+   */
+  retryableErrorTypes?: (new () => Error)[];
+}
+
+const DEFAULT_CONFIG: Required<LinearRetryStrategyConfig> = {
+  maxAttempts: 6,
+  initialDelay: { seconds: 1 },
+  increment: { seconds: 1 },
+  maxDelay: { minutes: 5 },
+  jitter: JitterStrategy.FULL,
+  retryableErrors: [/.*/], // By default, retry all errors
+  retryableErrorTypes: [],
+};
+
+/**
+ * Creates a retry strategy function with linear backoff and configurable jitter.
+ *
+ * @param config - Configuration options for the retry strategy
+ * @returns A function that determines whether to retry and calculates delay based on error and attempt count
+ *
+ * @remarks
+ * The returned function takes an error and attempt count, and returns a {@link RetryDecision} indicating
+ * whether to retry and the delay before the next attempt.
+ *
+ * **Delay Calculation:**
+ * - Base delay = `initialDelay + increment × (attemptsMade - 1)`
+ * - Capped at `maxDelay`
+ * - Jitter applied based on `jitter` strategy
+ * - Final delay rounded to nearest second, minimum 1 second
+ *
+ * **Error Filtering:**
+ * - If neither `retryableErrors` nor `retryableErrorTypes` is specified: all errors are retried
+ * - If either is specified: only matching errors are retried
+ * - If both are specified: errors matching either criteria are retried (OR logic)
+ *
+ * @example
+ * ```typescript
+ * // Defaults: retry all errors, 6 attempts, 1s, 2s, 3s, 4s, 5s delays (before jitter)
+ * const linearRetry = createLinearRetryStrategy();
+ *
+ * // Use in step configuration
+ * await context.step('api-call', async () => {
+ *   return await callExternalAPI();
+ * }, { retryStrategy: createLinearRetryStrategy({ jitter: JitterStrategy.NONE }) });
+ * ```
+ *
+ * @see {@link LinearRetryStrategyConfig} for configuration options
+ * @see {@link JitterStrategy} for jitter strategies
+ * @see {@link RetryDecision} for return type
+ *
+ * @public
  */
 export const createLinearRetryStrategy = (
-  maxAttempts: number = 6,
-  initialDelay: number = 1,
-  increment: number = 1,
+  config: LinearRetryStrategyConfig = {},
 ) => {
+  const { retryableErrors, retryableErrorTypes } = resolveRetryableErrors(
+    config.retryableErrors,
+    config.retryableErrorTypes,
+  );
+
+  const finalConfig: Required<LinearRetryStrategyConfig> = {
+    ...DEFAULT_CONFIG,
+    ...config,
+    retryableErrors,
+    retryableErrorTypes,
+  };
+
   return (error: Error, attemptsMade: number): RetryDecision => {
-    if (attemptsMade >= maxAttempts) {
+    // Check if we've exceeded max attempts
+    if (attemptsMade >= finalConfig.maxAttempts) {
       return { shouldRetry: false };
     }
 
-    return {
-      shouldRetry: true,
-      delay: { seconds: initialDelay + increment * (attemptsMade - 1) },
-    };
+    // Check if error is retryable based on message patterns and/or types
+    if (
+      !isErrorRetryable(
+        error,
+        finalConfig.retryableErrors,
+        finalConfig.retryableErrorTypes,
+      )
+    ) {
+      return { shouldRetry: false };
+    }
+
+    // Calculate delay with linear backoff
+    const initialDelaySeconds = durationToSeconds(finalConfig.initialDelay);
+    const incrementSeconds = durationToSeconds(finalConfig.increment);
+    const maxDelaySeconds = durationToSeconds(finalConfig.maxDelay);
+
+    const baseDelay = Math.min(
+      initialDelaySeconds + incrementSeconds * (attemptsMade - 1),
+      maxDelaySeconds,
+    );
+
+    // Apply jitter and normalize to an integer >= 1 second
+    const finalDelay = finalizeDelaySeconds(baseDelay, finalConfig.jitter);
+
+    return { shouldRetry: true, delay: { seconds: finalDelay } };
   };
 };
+
+export type { LinearRetryStrategyConfig };

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-common/retry-common.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-common/retry-common.ts
@@ -1,0 +1,114 @@
+import { JitterStrategy } from "../../../types";
+
+/**
+ * Applies a jitter strategy to a delay value.
+ *
+ * @param delay - Base delay in seconds (before jitter)
+ * @param strategy - Jitter strategy to apply
+ * @returns Delay in seconds with jitter applied
+ *
+ * @remarks
+ * - {@link JitterStrategy.NONE}: returns the delay unchanged
+ * - {@link JitterStrategy.FULL}: random value between 0 and `delay`
+ * - {@link JitterStrategy.HALF}: random value between `delay / 2` and `delay`
+ * - Any unrecognized value: returns the delay unchanged
+ *
+ * @internal
+ */
+export const applyJitter = (
+  delay: number,
+  strategy: JitterStrategy,
+): number => {
+  switch (strategy) {
+    case JitterStrategy.NONE:
+      return delay;
+    case JitterStrategy.FULL:
+      // Random between 0 and delay
+      return Math.random() * delay;
+    case JitterStrategy.HALF:
+      // Random between delay/2 and delay
+      return delay / 2 + Math.random() * (delay / 2);
+    default:
+      return delay;
+  }
+};
+
+/**
+ * Resolves the effective retryable-error filters, applying the shared default
+ * behavior: when neither filter is specified, all errors are retried.
+ *
+ * @param retryableErrors - User-supplied message patterns, if any
+ * @param retryableErrorTypes - User-supplied error class types, if any
+ * @returns The resolved, non-undefined filters to evaluate against errors
+ *
+ * @remarks
+ * - If neither filter is specified: `retryableErrors` defaults to a match-all pattern (retry all)
+ * - If only `retryableErrorTypes` is specified: `retryableErrors` defaults to `[]`
+ * - If only `retryableErrors` is specified: `retryableErrorTypes` defaults to `[]`
+ *
+ * @internal
+ */
+export const resolveRetryableErrors = (
+  retryableErrors?: (string | RegExp)[],
+  retryableErrorTypes?: (new () => Error)[],
+): {
+  retryableErrors: (string | RegExp)[];
+  retryableErrorTypes: (new () => Error)[];
+} => {
+  const shouldUseDefaultErrors =
+    retryableErrors === undefined && retryableErrorTypes === undefined;
+
+  return {
+    retryableErrors: retryableErrors ?? (shouldUseDefaultErrors ? [/.*/] : []),
+    retryableErrorTypes: retryableErrorTypes ?? [],
+  };
+};
+
+/**
+ * Determines whether an error is retryable based on message patterns and/or
+ * error types. The two filters are combined using OR logic.
+ *
+ * @param error - The error thrown by the operation
+ * @param retryableErrors - Message patterns (strings matched with `includes`, RegExp with `test`)
+ * @param retryableErrorTypes - Error class types matched with `instanceof`
+ * @returns `true` if the error matches either filter
+ *
+ * @internal
+ */
+export const isErrorRetryable = (
+  error: Error,
+  retryableErrors: (string | RegExp)[],
+  retryableErrorTypes: (new () => Error)[],
+): boolean => {
+  const isRetryableErrorMessage = retryableErrors.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(error.message);
+    }
+    return error.message.includes(pattern);
+  });
+
+  const isRetryableErrorType = retryableErrorTypes.some(
+    (ErrorType) => error instanceof ErrorType,
+  );
+
+  return isRetryableErrorMessage || isRetryableErrorType;
+};
+
+/**
+ * Applies jitter and normalizes a base delay into a whole number of seconds
+ * that is always at least 1.
+ *
+ * @param baseDelaySeconds - Base delay in seconds (before jitter), already capped
+ * @param jitter - Jitter strategy to apply
+ * @returns Integer delay in seconds, minimum 1
+ *
+ * @internal
+ */
+export const finalizeDelaySeconds = (
+  baseDelaySeconds: number,
+  jitter: JitterStrategy,
+): number => {
+  const delayWithJitter = applyJitter(baseDelaySeconds, jitter);
+  // Ensure delay is an integer >= 1
+  return Math.max(1, Math.round(delayWithJitter));
+};

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts
@@ -1,5 +1,10 @@
 import { RetryDecision, JitterStrategy, Duration } from "../../../types";
 import { durationToSeconds } from "../../duration/duration";
+import {
+  finalizeDelaySeconds,
+  isErrorRetryable,
+  resolveRetryableErrors,
+} from "../retry-common/retry-common";
 
 /**
  * Configuration options for creating a retry strategy
@@ -116,21 +121,6 @@ const DEFAULT_CONFIG: Required<RetryStrategyConfig> = {
   retryableErrorTypes: [],
 };
 
-const applyJitter = (delay: number, strategy: JitterStrategy): number => {
-  switch (strategy) {
-    case JitterStrategy.NONE:
-      return delay;
-    case JitterStrategy.FULL:
-      // Random between 0 and delay
-      return Math.random() * delay;
-    case JitterStrategy.HALF:
-      // Random between delay/2 and delay
-      return delay / 2 + Math.random() * (delay / 2);
-    default:
-      return delay;
-  }
-};
-
 /**
  * Creates a retry strategy function with exponential backoff and configurable jitter
  *
@@ -196,16 +186,16 @@ const applyJitter = (delay: number, strategy: JitterStrategy): number => {
  * @public
  */
 export const createRetryStrategy = (config: RetryStrategyConfig = {}) => {
-  // Only apply default retryableErrors if user didn't specify either filter
-  const shouldUseDefaultErrors =
-    config.retryableErrors === undefined &&
-    config.retryableErrorTypes === undefined;
+  const { retryableErrors, retryableErrorTypes } = resolveRetryableErrors(
+    config.retryableErrors,
+    config.retryableErrorTypes,
+  );
 
   const finalConfig: Required<RetryStrategyConfig> = {
     ...DEFAULT_CONFIG,
     ...config,
-    retryableErrors:
-      config.retryableErrors ?? (shouldUseDefaultErrors ? [/.*/] : []),
+    retryableErrors,
+    retryableErrorTypes,
   };
 
   return (error: Error, attemptsMade: number): RetryDecision => {
@@ -214,22 +204,14 @@ export const createRetryStrategy = (config: RetryStrategyConfig = {}) => {
       return { shouldRetry: false };
     }
 
-    // Check if error is retryable based on error message
-    const isRetryableErrorMessage = finalConfig.retryableErrors.some(
-      (pattern) => {
-        if (pattern instanceof RegExp) {
-          return pattern.test(error.message);
-        }
-        return error.message.includes(pattern);
-      },
-    );
-
-    // Check if error is retryable based on error type
-    const isRetryableErrorType = finalConfig.retryableErrorTypes.some(
-      (ErrorType) => error instanceof ErrorType,
-    );
-
-    if (!isRetryableErrorMessage && !isRetryableErrorType) {
+    // Check if error is retryable based on message patterns and/or types
+    if (
+      !isErrorRetryable(
+        error,
+        finalConfig.retryableErrors,
+        finalConfig.retryableErrorTypes,
+      )
+    ) {
       return { shouldRetry: false };
     }
 
@@ -242,11 +224,8 @@ export const createRetryStrategy = (config: RetryStrategyConfig = {}) => {
       maxDelaySeconds,
     );
 
-    // Apply jitter
-    const delayWithJitter = applyJitter(baseDelay, finalConfig.jitter);
-
-    // Ensure delay is an integer >= 1
-    const finalDelay = Math.max(1, Math.round(delayWithJitter));
+    // Apply jitter and normalize to an integer >= 1 second
+    const finalDelay = finalizeDelaySeconds(baseDelay, finalConfig.jitter);
 
     return { shouldRetry: true, delay: { seconds: finalDelay } };
   };

--- a/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-presets/retry-presets.ts
@@ -45,9 +45,15 @@ export const retryPresets = {
    * Linear retry strategy with fixed increment
    * - 6 total attempts (1 initial + 5 retries)
    * - Delays: 1s, 2s, 3s, 4s, 5s
+   * - Jitter: NONE (deterministic delays)
    * - Total max wait time: 15 seconds
    */
-  linear: createLinearRetryStrategy(6, 1, 1),
+  linear: createLinearRetryStrategy({
+    maxAttempts: 6,
+    initialDelay: { seconds: 1 },
+    increment: { seconds: 1 },
+    jitter: JitterStrategy.NONE,
+  }),
 
   /**
    * No retry strategy - fails immediately on first error


### PR DESCRIPTION
Bring createLinearRetryStrategy to parity with createRetryStrategy by switching it to a config-object API and adding the capabilities it was missing. Both helpers now share a common module so their behavior cannot drift apart.

Changes:
- Add src/utils/retry/retry-common with shared applyJitter, resolveRetryableErrors, isErrorRetryable, and finalizeDelaySeconds (jitter + integer/min-1s clamp).
- Refactor createRetryStrategy to delegate to the shared module (no behavior change).
- Rewrite createLinearRetryStrategy with a LinearRetryStrategyConfig object using Duration values, and add maxDelay capping, jitter (default FULL), and retryableErrors/retryableErrorTypes filtering.
- Update retryPresets.linear to the new API with jitter NONE to keep its documented deterministic 1s-5s delays.
- Export LinearRetryStrategyConfig from the package entry point.
- Expand linear retry tests: maxDelay, non-second Duration units, all jitter modes, integer/min-1 clamping, and error filtering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
