### PR TITLE
feat(sdk): add executionInput to InvocationInfo (plugin interface)

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
@@ -9,6 +9,7 @@ const baseInfo: InvocationInfo = {
   executionArn:
     "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST/exec/abc",
   isFirstInvocation: true,
+  executionInput: {},
   operations: {},
 };
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -39,6 +39,7 @@ function makeInvocationInfo(
     requestId: TEST_REQUEST_ID,
     executionArn: TEST_ARN,
     isFirstInvocation: true,
+    executionInput: {},
     operations: {},
     ...overrides,
   };
@@ -51,6 +52,7 @@ function makeInvocationEndInfo(
     requestId: TEST_REQUEST_ID,
     executionArn: TEST_ARN,
     isFirstInvocation: true,
+    executionInput: {},
     operations: {},
     status: "SUCCEEDED" as any,
     executionResult: undefined,

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -57,7 +57,6 @@ function makeInvocationEndInfo(
     status: "SUCCEEDED" as any,
     executionResult: undefined,
     executionError: undefined,
-    executionInput: {},
     ...overrides,
   };
 }

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -52,7 +52,7 @@ function makeInvocationEndInfo(
     requestId: TEST_REQUEST_ID,
     executionArn: TEST_ARN,
     isFirstInvocation: true,
-    executionInput: {},
+    executionInput: {}, // required by InvocationInfo (parent type)
     operations: {},
     status: "SUCCEEDED" as any,
     executionResult: undefined,

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -95,6 +95,7 @@ export interface InvocationBaseInfo {
  */
 export interface InvocationInfo extends InvocationBaseInfo {
   isFirstInvocation: boolean;
+  executionInput: unknown;
   operations: Record<string, OperationInfo>;
 }
 
@@ -108,7 +109,6 @@ export interface InvocationEndInfo extends InvocationInfo {
   status: PluginInvocationStatus;
   executionResult?: unknown;
   executionError?: Error;
-  executionInput: unknown;
   operations: Record<string, OperationInfo>;
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -25,6 +25,7 @@ describe("createPluginRunner", () => {
     requestId: "req-1",
     executionArn: "arn:aws:lambda:us-east-1:123:function:fn:1/exec/abc",
     isFirstInvocation: true,
+    executionInput: { test: true },
     operations: {},
   };
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -86,6 +86,7 @@ describe("plugin hooks", () => {
       requestId: "req-123",
       executionArn: "arn:test",
       isFirstInvocation: true,
+      executionInput: expect.anything(),
       operations: expect.any(Object),
     });
   });
@@ -106,6 +107,7 @@ describe("plugin hooks", () => {
       requestId: "req-123",
       executionArn: "arn:test",
       isFirstInvocation: false,
+      executionInput: expect.anything(),
       operations: expect.any(Object),
     });
   });

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -68,11 +68,19 @@ async function runHandler<
     executionContext.requestId,
   );
 
+  // Extract customerHandlerEvent early so it's available for plugins in onInvocationStart
+  const initialExecutionEvent =
+    executionContext._stepData[Object.keys(executionContext._stepData)[0]];
+  const customerHandlerEvent = JSON.parse(
+    initialExecutionEvent?.ExecutionDetails?.InputPayload ?? "{}",
+  );
+
   const invocationInfo: InvocationInfo = {
     requestId: executionContext.requestId,
     executionArn: executionContext.durableExecutionArn,
     isFirstInvocation:
       durableExecutionMode === DurableExecutionMode.ExecutionMode,
+    executionInput: customerHandlerEvent,
     operations: toOperationInfoMap(executionContext._stepData),
   };
   await plugin.onInvocationStart?.(invocationInfo);
@@ -100,14 +108,6 @@ async function runHandler<
     ) as Logger,
     undefined,
     durableExecution,
-  );
-
-  // Extract customerHandlerEvent from the complete operations array (after pagination)
-  // This ensures we get the full payload even for large payloads that are paginated
-  const initialExecutionEvent =
-    executionContext._stepData[Object.keys(executionContext._stepData)[0]];
-  const customerHandlerEvent = JSON.parse(
-    initialExecutionEvent?.ExecutionDetails?.InputPayload ?? "{}",
   );
 
   const executeInvocation =


### PR DESCRIPTION
## Summary

Moves `executionInput` from `InvocationEndInfo` up to `InvocationInfo` so plugins receive the execution input on `onInvocationStart` — not only at invocation end.

## Motivation

Observability plugins (like Workflow Insight) need to include the execution input in their first emitted record. Currently `executionInput` is only available in `onInvocationEnd`, which means:
- The initial RUNNING record has no input
- If the execution suspends (wait/callback) before completing, no record ever has the input