### PR TITLE
fix(sdk): onOperationStart is called with isReplay true for subsequen…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14541,7 +14541,7 @@
     },
     "packages/aws-durable-execution-sdk-js-otel": {
       "name": "@aws/durable-execution-sdk-js-otel",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/compat": "^1.4.1",

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -7,6 +7,8 @@ import {
   DurableInstrumentationPlugin,
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+import { hashId } from "../../utils/step-id-utils/step-id-utils";
 
 jest.mock("../../utils/logger/logger");
 jest.mock("../../errors/serdes-errors/serdes-errors");
@@ -267,5 +269,92 @@ describe("Step Handler - plugin hooks", () => {
 
     const result = await stepHandler("my-step", stepFn);
     expect(result).toBe("result");
+  });
+
+  it("should call onOperationStart with isReplay true on subsequent retry attempts", async () => {
+    const stepId = "step-1";
+    const hashedStepId = hashId(stepId);
+
+    // Track getStepData calls to return appropriate state at each point
+    // in the retry lifecycle.
+    // The default semantics is AtLeastOncePerRetry:
+    //   executeStepLogic call 1:
+    //     1. top of executeStepLogic: null (not started yet)
+    //     2. try block (computing currentAttempt): null (Attempt 0 → currentAttempt=1)
+    //     3. catch block (computing currentAttempt after error): null
+    //     4. after RETRY checkpoint: { Attempt: 1 }
+    //     5. for NextAttemptTimestamp: { Attempt: 1 }
+    //   waitForRetryTimer resolves, then executeStepLogic call 2:
+    //     6. top of executeStepLogic: { Attempt: 1, Status: PENDING } — not STARTED
+    //     7. try block (computing currentAttempt): { Attempt: 1 }
+    //     8. after SUCCEED checkpoint: { Status: SUCCEEDED, Attempt: 1 }
+    let getStepDataCallCount = 0;
+    (mockContext.getStepData as jest.Mock).mockImplementation(() => {
+      getStepDataCallCount++;
+      if (getStepDataCallCount <= 3) {
+        return null;
+      }
+      if (getStepDataCallCount <= 7) {
+        return {
+          Id: hashedStepId,
+          Status: OperationStatus.PENDING,
+          StepDetails: {
+            Attempt: 1,
+          },
+        };
+      }
+      return {
+        Id: hashedStepId,
+        Status: OperationStatus.SUCCEEDED,
+        StepDetails: {
+          Attempt: 1,
+          Result: JSON.stringify("recovered"),
+        },
+      };
+    });
+
+    mockPlugin.onOperationStart = jest.fn();
+
+    let callCount = 0;
+    const stepFn = jest.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error("transient failure");
+      }
+      return "recovered";
+    });
+
+    const stepHandler = createStepHandler(
+      mockContext,
+      mockCheckpoint,
+      mockParentContext,
+      createStepId,
+      createDefaultLogger(),
+      undefined,
+      undefined,
+      mockPlugin,
+    );
+
+    const result = await stepHandler("my-step", stepFn, {
+      retryStrategy: (_error, attempt) => ({
+        shouldRetry: attempt < 3,
+        delay: { seconds: 0 },
+      }),
+    });
+
+    expect(result).toBe("recovered");
+
+    // onOperationStart should be called twice:
+    // 1st: isReplay false (first attempt, Attempt=0 from null)
+    // 2nd: isReplay true (retry attempt, Attempt=1)
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(2);
+    expect(mockPlugin.onOperationStart).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ isReplay: false }),
+    );
+    expect(mockPlugin.onOperationStart).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ isReplay: true }),
+    );
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -269,11 +269,13 @@ export const createStepHandler = <Logger extends DurableLogger>(
             stepData = context.getStepData(stepId);
             const operationInfo = toOperationInfo(stepData);
             backfillOperationInfo(operationInfo, opInfo);
+            const isRetryAttempt = (stepData?.StepDetails?.Attempt || 0) >= 1;
             await plugin.onOperationStart?.({
               ...operationInfo,
-              isReplay: false,
+              isReplay: isRetryAttempt,
             });
           } else {
+            const isRetryAttempt = (stepData?.StepDetails?.Attempt || 0) >= 1;
             checkpoint.checkpoint(stepId, {
               Id: stepId,
               ParentId: parentId,
@@ -287,7 +289,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
             await plugin.onOperationStart?.({
               ...opInfo,
               status: OperationStatus.STARTED,
-              isReplay: false,
+              isReplay: isRetryAttempt,
             });
           }
         } else {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -11,6 +11,8 @@ import {
   DurableInstrumentationPlugin,
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
+import { OperationStatus } from "@aws-sdk/client-lambda";
+import { hashId } from "../../utils/step-id-utils/step-id-utils";
 
 jest.mock("../../utils/logger/logger");
 jest.mock("../../errors/serdes-errors/serdes-errors");
@@ -292,5 +294,82 @@ describe("WaitForCondition Handler - plugin hooks", () => {
 
     const result = await handler(checkFunc, config);
     expect(result).toBe("done");
+  });
+
+  it("should call onOperationStart with isReplay true on subsequent retry attempts", async () => {
+    const stepId = "step-1";
+    const hashedStepId = hashId(stepId);
+
+    // Simulate the getStepData progression:
+    // 1st call (top of executeCheckLogic, first attempt): null (not started)
+    // After RETRY checkpoint and re-entering executeCheckLogic via recursion:
+    // subsequent calls return data with Attempt: 1 and status STARTED
+    let getStepDataCallCount = 0;
+    (mockContext.getStepData as jest.Mock).mockImplementation(() => {
+      getStepDataCallCount++;
+      if (getStepDataCallCount <= 2) {
+        // First attempt: no step data
+        return null;
+      }
+      // After RETRY checkpoint: return data indicating a retry with Attempt: 1
+      // Status STARTED means the operation was already started (enters isReplay: true branch)
+      return {
+        Id: hashedStepId,
+        Status: OperationStatus.STARTED,
+        StepDetails: {
+          Attempt: 1,
+          Result: JSON.stringify("state-after-first-attempt"),
+        },
+      };
+    });
+
+    (mockPlugin.wrapOperationAttemptFn as jest.Mock).mockImplementation(
+      (_info: unknown, fn: () => unknown) => fn(),
+    );
+    mockPlugin.onOperationStart = jest.fn();
+
+    let checkCallCount = 0;
+    mockRunWithContext.mockImplementation(async (_stepId, _parentId, fn) => {
+      checkCallCount++;
+      return checkCallCount;
+    });
+
+    const handler = createWaitForConditionHandler(
+      mockContext,
+      mockCheckpoint,
+      createStepId,
+      createDefaultLogger(),
+      undefined,
+      undefined,
+      mockPlugin,
+    );
+
+    const checkFunc: WaitForConditionCheckFunc<number, DurableLogger> =
+      jest.fn();
+    const config: WaitForConditionConfig<number> = {
+      waitStrategy: jest
+        .fn()
+        .mockReturnValueOnce({
+          shouldContinue: true,
+          delay: { seconds: 5 },
+        })
+        .mockReturnValue({ shouldContinue: false }),
+      initialState: 0,
+    };
+
+    await handler("my-condition", checkFunc, config);
+
+    // onOperationStart should be called twice:
+    // 1st: isReplay false (first attempt, Attempt=0)
+    // 2nd: isReplay true (second attempt, status is STARTED so enters the else branch)
+    expect(mockPlugin.onOperationStart).toHaveBeenCalledTimes(2);
+    expect(mockPlugin.onOperationStart).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ isReplay: false }),
+    );
+    expect(mockPlugin.onOperationStart).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ isReplay: true }),
+    );
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -203,6 +203,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
 
         // Checkpoint START if not already started
         if (stepData?.Status !== OperationStatus.STARTED) {
+          const isRetryAttempt = (stepData?.StepDetails?.Attempt || 0) >= 1;
           checkpoint.checkpoint(stepId, {
             Id: stepId,
             ParentId: parentId,
@@ -216,7 +217,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
           await plugin.onOperationStart?.({
             ...opInfo,
             status: OperationStatus.STARTED,
-            isReplay: false,
+            isReplay: isRetryAttempt,
           });
         } else {
           const operationInfo = toOperationInfo(stepData);


### PR DESCRIPTION
…t attempts

*Issue #, if available:* 

*Description of changes:* Step and wait-for-condition attempts across different invocations were being exported as spans within the same invocation in CloudWatch traces during manual testing. The reason is because the isReplay flag was not accurate for subsequent retry attempts of an operation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
