### PR TITLE
fix(sdk): enforce read-only queries in VS Code extension

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -5,6 +5,7 @@ import { runLogsInsightsQuery } from "./logsInsights";
 import { runDynamoDBQuery } from "./dynamodb";
 import { runAuroraQuery } from "./aurora";
 import { ensureLimit } from "./schema";
+import { assertReadOnly } from "./queryValidator";
 
 type InboundMessage =
   | { type: "ready" }
@@ -193,6 +194,7 @@ class ExplorerPanel {
         if (cfg.destinationType === "dynamodb") {
           if (!cfg.dynamodbTableName)
             throw new Error("No DynamoDB table configured.");
+          assertReadOnly(generated.query, "PartiQL");
           const table = await runDynamoDBQuery({
             region: cfg.region,
             credentials,
@@ -211,6 +213,7 @@ class ExplorerPanel {
         if (cfg.destinationType === "aurora") {
           if (!cfg.auroraResourceArn || !cfg.auroraSecretArn)
             throw new Error("Aurora not configured.");
+          assertReadOnly(generated.query, "PostgreSQL");
           const table = await runAuroraQuery({
             region: cfg.region,
             credentials,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryValidator.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryValidator.ts
@@ -1,0 +1,47 @@
+/**
+ * Validates that a SQL/PartiQL query is read-only (SELECT only).
+ * Rejects any statement that could mutate data.
+ *
+ * This is a defense-in-depth measure since queries are LLM-generated
+ * and could be hallucinated or prompt-injected. Customers should also
+ * configure their DB credentials with read-only permissions.
+ */
+
+const DANGEROUS_KEYWORDS =
+  /^\s*(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|MERGE|REPLACE|GRANT|REVOKE|EXEC|EXECUTE|CALL|COPY|UNLOAD)\b/i;
+const VALID_SELECT = /^\s*(SELECT|WITH)\b/i;
+
+/**
+ * Throws if the query is not a single read-only SELECT (or WITH...SELECT).
+ */
+export function assertReadOnly(query: string, engine: string): void {
+  const trimmed = query.trim();
+
+  if (!trimmed) {
+    throw new Error("Empty query.");
+  }
+
+  // Check for dangerous keywords at statement start
+  if (DANGEROUS_KEYWORDS.test(trimmed)) {
+    throw new Error(
+      `Refused to execute ${engine} query: only SELECT statements are allowed. ` +
+        `Got: "${trimmed.substring(0, 40)}..."`,
+    );
+  }
+
+  // Must start with SELECT or WITH (for CTEs)
+  if (!VALID_SELECT.test(trimmed)) {
+    throw new Error(
+      `Refused to execute ${engine} query: must start with SELECT or WITH. ` +
+        `Got: "${trimmed.substring(0, 40)}..."`,
+    );
+  }
+
+  // Reject multiple statements (semicolon followed by non-whitespace)
+  const withoutStrings = trimmed.replace(/'[^']*'/g, ""); // strip string literals
+  if (/;\s*\S/.test(withoutStrings)) {
+    throw new Error(
+      `Refused to execute ${engine} query: multiple statements not allowed.`,
+    );
+  }
+}


### PR DESCRIPTION
LLM-generated queries are executed against the customer's database with potentially write-capable credentials. A hallucinated or prompt-injected DELETE/DROP/UPDATE would execute unchecked.

Added assertReadOnly() that validates before execution:
- Must start with SELECT or WITH (CTEs)
- Rejects INSERT/UPDATE/DELETE/DROP/ALTER/CREATE/TRUNCATE/MERGE/etc.
- Rejects multiple statements (semicolon injection)

Applied to both Aurora (PostgreSQL) and DynamoDB (PartiQL) paths. CloudWatch Logs Insights is inherently read-only.

Defense-in-depth: customers should also configure read-only DB credentials for the extension.