### PR TITLE
feat(sdk): add CDK stack for Insight destination infrastructure

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -205,6 +205,8 @@ const insight = workflowInsight({
 
 ### `samplingRate`
 
+> **Not yet implemented.** Reserved for a future release. Setting this currently has no effect.
+
 A number between 0 and 1. The decision is per-execution (all-or-nothing):
 
 ```typescript
@@ -224,6 +226,8 @@ exporters: [
 ```
 
 ### `content` (advanced)
+
+> **Not yet implemented.** Reserved for a future release. Setting this currently has no effect.
 
 Control what data is included in records:
 
@@ -613,6 +617,123 @@ aws timestream-write create-table \
 
 ---
 
+### CDK Infrastructure (Automated Setup)
+
+> **Note:** This CDK stack is designed for **getting started and testing**. It uses minimal configurations (single-AZ, no backups, `RemovalPolicy.DESTROY`) to keep costs low and teardown easy. For production, build your own infrastructure with proper security, redundancy, monitoring, and cost controls tailored to your workload.
+
+Instead of creating resources manually, you can use the included CDK stack to deploy all destination infrastructure, IAM permissions, and an example Lambda function with a single command.
+
+**Location:** `cdk/` directory within this package.
+
+#### Quick Start
+
+```bash
+cd packages/aws-durable-execution-sdk-js-insight/cdk
+npm install
+npx cdk deploy
+```
+
+> The CDK package depends on the `@aws/durable-execution-sdk-js` and
+> `@aws/durable-execution-sdk-js-insight` workspace packages (the example
+> Lambda imports them). The `deploy`, `synth`, `test`, and `typecheck` scripts
+> automatically build these dependencies first via a `build:deps` pre-step, so
+> no manual ordering is required. (If you prefer to build manually, run
+> `npm run build:deps`.)
+
+#### Configuration (`cdk/config.json`)
+
+Edit `config.json` to enable/disable destinations and configure settings:
+
+```json
+{
+  "destinations": {
+    "cloudwatchLogs": {
+      "enabled": true,
+      "logGroupName": "/workflow-insight/demo",
+      "retentionDays": 30
+    },
+    "dynamodb": { "enabled": true, "tableName": "workflow-insight" },
+    "aurora": {
+      "enabled": true,
+      "tableName": "workflow_insight",
+      "databaseName": "postgres",
+      "minCapacity": 0.5,
+      "maxCapacity": 1
+    },
+    "s3": { "enabled": false, "bucketName": "workflow-insight-records" },
+    "redshift": {
+      "enabled": false,
+      "namespaceName": "insight-namespace",
+      "workgroupName": "insight-workgroup",
+      "databaseName": "dev",
+      "tableName": "workflow_insight",
+      "schema": "public"
+    },
+    "opensearch": { "enabled": false, "domainName": "workflow-insight" },
+    "firehose": {
+      "enabled": false,
+      "streamName": "workflow-insight",
+      "bufferIntervalSeconds": 60,
+      "bufferSizeMB": 1
+    },
+    "sqs": { "enabled": false, "queueName": "workflow-insight", "fifo": false },
+    "eventbridge": { "enabled": false, "eventBusName": "default" },
+    "timestream": {
+      "enabled": false,
+      "databaseName": "workflow-insight",
+      "tableName": "records",
+      "memoryRetentionHours": 24,
+      "magneticRetentionDays": 365
+    }
+  },
+  "lambda": {
+    "roleNames": [],
+    "discoverDurableFunctions": false,
+    "createExampleFunction": true,
+    "autoInvoke": { "enabled": false, "rateMinutes": 5 }
+  }
+}
+```
+
+#### Lambda Settings
+
+| Setting                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `roleNames`                | Array of **existing** IAM role names to attach the Insight permissions policy to. Default: `[]` (empty). The example function's role is added automatically when `createExampleFunction` is `true`, so you can leave this empty to start. Add your own durable function roles here to grant them access.                                                                                                                                                                      |
+| `discoverDurableFunctions` | When `true`, the CDK app lists all Lambda functions **at synth time** and identifies durable functions by the presence of `DurableConfig` (the native Lambda API field). The Insight permissions policy is attached directly to their exact execution-role ARNs — no runtime Lambda or `iam:PutRolePolicy` grant is used. Requires AWS credentials at synth time (same model as CDK context lookups), and `cdk synth`/`deploy` will reflect the account state at that moment. |
+| `createExampleFunction`    | Deploys an insurance claim processing workflow (with retry policies and random transient failures) pre-configured with the Insight plugin pointing to all enabled destinations                                                                                                                                                                                                                                                                                                |
+| `autoInvoke.enabled`       | Deploys a dispatcher Lambda + EventBridge rule that invokes the example function on a schedule with randomized input. **Default: `false`.** Enabling creates ongoing costs (Lambda invocations, Aurora ACU time, DynamoDB writes). Disable or destroy the stack when not actively testing.                                                                                                                                                                                    |
+| `autoInvoke.rateMinutes`   | How often the dispatcher triggers (default: 5 minutes)                                                                                                                                                                                                                                                                                                                                                                                                                        |
+
+#### What Gets Deployed
+
+When `createExampleFunction` and `autoInvoke` are both enabled, the stack creates:
+
+1. **Destination resources** — tables, clusters, queues, etc. for each enabled destination
+2. **IAM policy** — a single managed policy (`WorkflowInsightDestinations`) attached to all target roles
+3. **Example function** (`insight-example-workflow`) — a 6-step insurance claim workflow with:
+   - Retry policy (4 attempts, 1s initial backoff, coefficient 2, max 5s)
+   - ~30% random transient failure rate per step (generates retry attempt data)
+   - Three possible outcomes: APPROVED, REJECTED, or MORE_DOCUMENTS_REQUIRED
+4. **Dispatcher** (`insight-example-dispatcher`) — generates random claims with: `customerName`, `insuranceClaimNumber`, `claimAmount`, `claimType`
+5. **EventBridge rule** (`insight-example-dispatch`) — triggers the dispatcher every N minutes
+
+After deployment, data starts flowing automatically to all enabled destinations.
+
+#### Aurora Table Auto-Creation
+
+When Aurora is enabled, the stack deploys a custom resource that creates the `workflow_insight` table automatically via the RDS Data API. No manual SQL needed.
+
+#### Tear Down
+
+```bash
+npx cdk destroy
+```
+
+This removes all created resources (tables, clusters, functions, rules). Resources use `RemovalPolicy.DESTROY` by default for clean teardown.
+
+---
+
 ### Exporter Usage & Examples
 
 Detailed configuration, code examples, and use-case guidance for each exporter.
@@ -819,6 +940,8 @@ const insight2 = workflowInsight({
 **IAM required:** `redshift-data:ExecuteStatement` (+ `redshift-serverless:GetCredentials` or `redshift:GetClusterCredentialsWithIAM`).
 
 **When to use:** Large-scale cross-function analytics, BI dashboards, data warehouse integration.
+
+**Note:** The `record_json` column uses Redshift's SUPER type with `JSON_PARSE()` for navigable nested queries. SUPER values are limited to ~1 MB — executions with unusually large input/output payloads may fail the insert.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/.gitignore
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+cdk.out/
+cdk.context.json
+dist/
+package-lock.json
+*.js
+*.d.ts
+*.js.map
+!cdk.json

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/app.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/app.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import * as cdk from "aws-cdk-lib";
+import { LambdaClient, paginateListFunctions } from "@aws-sdk/client-lambda";
+import { InsightDestinationsStack } from "./stack";
+import * as config from "./config.json";
+
+/**
+ * Discover the execution-role ARNs of all durable functions in the account
+ * by listing functions and checking for the native DurableConfig field.
+ * Runs at synth time so the resolved ARNs can scope IAM/OpenSearch policies
+ * precisely (no runtime Lambda / iam:PutRolePolicy needed).
+ */
+async function discoverDurableFunctionRoles(
+  region?: string,
+): Promise<string[]> {
+  const client = new LambdaClient(region ? { region } : {});
+  const roleArns = new Set<string>();
+  for await (const page of paginateListFunctions({ client }, {})) {
+    for (const fn of page.Functions ?? []) {
+      // DurableConfig IS part of the FunctionConfiguration returned by
+      // ListFunctions (see the documented Response Syntax for ListFunctions).
+      // The API's "subset of fields" caveat only excludes State, StateReason,
+      // StateReasonCode, LastUpdateStatus, LastUpdateStatusReason,
+      // LastUpdateStatusReasonCode, and RuntimeVersionConfig — none of which
+      // we depend on here. So filtering on DurableConfig is reliable and does
+      // not require a per-function GetFunction call.
+      if (fn.Role && fn.DurableConfig) {
+        roleArns.add(fn.Role);
+      }
+    }
+  }
+  return Array.from(roleArns);
+}
+
+async function main(): Promise<void> {
+  const app = new cdk.App();
+  const region = process.env.CDK_DEFAULT_REGION;
+
+  // Account and region are resolved from the AWS credentials/profile in use
+  // when running `cdk synth`/`cdk deploy` (CDK CLI populates CDK_DEFAULT_*).
+  // Override with `cdk deploy --region <region>` or AWS_REGION / AWS_PROFILE.
+  let discoveredRoleArns: string[] = [];
+  if (config.lambda.discoverDurableFunctions) {
+    discoveredRoleArns = await discoverDurableFunctionRoles(region);
+    console.log(
+      `Discovered ${discoveredRoleArns.length} durable function role(s) at synth time.`,
+    );
+  }
+
+  new InsightDestinationsStack(app, "InsightDestinationsStack", {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region,
+    },
+    discoveredRoleArns,
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/cdk.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node app.ts",
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
@@ -1,0 +1,67 @@
+{
+  "destinations": {
+    "cloudwatchLogs": {
+      "enabled": true,
+      "logGroupName": "/workflow-insight/demo",
+      "retentionDays": 30
+    },
+    "dynamodb": {
+      "enabled": true,
+      "tableName": "workflow-insight"
+    },
+    "aurora": {
+      "enabled": true,
+      "tableName": "workflow_insight",
+      "databaseName": "postgres",
+      "minCapacity": 0.5,
+      "maxCapacity": 1
+    },
+    "s3": {
+      "enabled": false,
+      "bucketName": "workflow-insight-records"
+    },
+    "redshift": {
+      "enabled": false,
+      "namespaceName": "insight-namespace",
+      "workgroupName": "insight-workgroup",
+      "databaseName": "dev",
+      "tableName": "workflow_insight",
+      "schema": "public"
+    },
+    "opensearch": {
+      "enabled": false,
+      "domainName": "workflow-insight"
+    },
+    "firehose": {
+      "enabled": false,
+      "streamName": "workflow-insight",
+      "bufferIntervalSeconds": 60,
+      "bufferSizeMB": 1
+    },
+    "sqs": {
+      "enabled": false,
+      "queueName": "workflow-insight",
+      "fifo": false
+    },
+    "eventbridge": {
+      "enabled": false,
+      "eventBusName": "default"
+    },
+    "timestream": {
+      "enabled": false,
+      "databaseName": "workflow-insight",
+      "tableName": "records",
+      "memoryRetentionHours": 24,
+      "magneticRetentionDays": 365
+    }
+  },
+  "lambda": {
+    "roleNames": [],
+    "discoverDurableFunctions": false,
+    "createExampleFunction": true,
+    "autoInvoke": {
+      "enabled": false,
+      "rateMinutes": 5
+    }
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/dispatcher/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/dispatcher/index.ts
@@ -1,0 +1,78 @@
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+
+const client = new LambdaClient({});
+const FUNCTION_NAME = process.env.TARGET_FUNCTION_NAME!;
+
+const CUSTOMERS = [
+  "Alice Johnson",
+  "Bob Martinez",
+  "Carol Williams",
+  "David Chen",
+  "Emma Thompson",
+  "Frank O'Brien",
+  "Grace Kim",
+  "Henry Patel",
+];
+
+const CLAIM_TYPES = [
+  "auto-collision",
+  "auto-theft",
+  "home-fire",
+  "home-flood",
+  "home-burglary",
+  "health-emergency",
+  "health-routine",
+  "life-disability",
+  "travel-cancellation",
+  "travel-medical",
+];
+
+function randomItem<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function randomClaimNumber(): string {
+  const prefix = "CLM";
+  const year = new Date().getFullYear();
+  const seq = Math.floor(Math.random() * 900000) + 100000;
+  return `${prefix}-${year}-${seq}`;
+}
+
+function randomAmount(type: string): number {
+  const ranges: Record<string, [number, number]> = {
+    "auto-collision": [2000, 45000],
+    "auto-theft": [5000, 60000],
+    "home-fire": [10000, 250000],
+    "home-flood": [5000, 150000],
+    "home-burglary": [1000, 50000],
+    "health-emergency": [500, 100000],
+    "health-routine": [100, 5000],
+    "life-disability": [10000, 500000],
+    "travel-cancellation": [200, 15000],
+    "travel-medical": [500, 75000],
+  };
+  const [min, max] = ranges[type] ?? [1000, 50000];
+  return Math.round((Math.random() * (max - min) + min) * 100) / 100;
+}
+
+export async function handler() {
+  const claimType = randomItem(CLAIM_TYPES);
+  const payload = {
+    customerName: randomItem(CUSTOMERS),
+    insuranceClaimNumber: randomClaimNumber(),
+    claimAmount: randomAmount(claimType),
+    claimType,
+  };
+
+  console.log(`Dispatching to ${FUNCTION_NAME}:`, JSON.stringify(payload));
+
+  await client.send(
+    new InvokeCommand({
+      FunctionName: FUNCTION_NAME,
+      InvocationType: "Event", // async — don't wait for result
+      Payload: Buffer.from(JSON.stringify(payload)),
+    }),
+  );
+
+  return { dispatched: payload };
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
@@ -1,0 +1,271 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  createRetryStrategy,
+} from "@aws/durable-execution-sdk-js";
+import {
+  workflowInsight,
+  CloudWatchLogsExporter,
+  DynamoDBExporter,
+  AuroraExporter,
+} from "@aws/durable-execution-sdk-js-insight";
+
+/**
+ * Example durable function: Insurance Claim Processing workflow.
+ *
+ * Demonstrates a multi-step claim workflow with:
+ * - Retry strategy with short backoff on each step
+ * - Random transient failures (~30% chance per step)
+ * - Claim decision logic: APPROVED / REJECTED / MORE_DOCUMENTS_REQUIRED
+ */
+
+const exporters = [
+  ...(process.env.INSIGHT_LOG_GROUP
+    ? [
+        new CloudWatchLogsExporter({
+          logGroupName: process.env.INSIGHT_LOG_GROUP,
+          region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+  ...(process.env.INSIGHT_DYNAMODB_TABLE
+    ? [
+        new DynamoDBExporter({
+          tableName: process.env.INSIGHT_DYNAMODB_TABLE,
+          sortKey: undefined, // upsert mode: one item per execution
+          region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+  ...(process.env.INSIGHT_AURORA_RESOURCE_ARN
+    ? [
+        new AuroraExporter({
+          resourceArn: process.env.INSIGHT_AURORA_RESOURCE_ARN,
+          secretArn: process.env.INSIGHT_AURORA_SECRET_ARN!,
+          database: process.env.INSIGHT_AURORA_DATABASE ?? "postgres",
+          table: process.env.INSIGHT_AURORA_TABLE ?? "workflow_insight",
+          engine: "postgresql",
+          region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+];
+
+/** Simulates a transient failure ~30% of the time */
+function maybeFailTransient(stepName: string): void {
+  if (Math.random() < 0.3) {
+    throw new Error(
+      `Transient failure in ${stepName}: service temporarily unavailable`,
+    );
+  }
+}
+
+type ClaimDecision = "APPROVED" | "REJECTED" | "MORE_DOCUMENTS_REQUIRED";
+
+const retryStrategy = createRetryStrategy({
+  maxAttempts: 4,
+  initialDelay: { seconds: 1 },
+  maxDelay: { seconds: 5 },
+  backoffRate: 2,
+});
+
+export const handler = withDurableExecution(
+  async (
+    event: {
+      customerName: string;
+      insuranceClaimNumber: string;
+      claimAmount: number;
+      claimType: string;
+    },
+    context: DurableContext,
+  ) => {
+    // Step 1: Validate the claim
+    const validation = await context.step(
+      "validateClaim",
+      async () => {
+        maybeFailTransient("validateClaim");
+
+        const isValid = event.claimAmount > 0 && event.claimAmount < 1_000_000;
+        const riskScore = Math.round(Math.random() * 100);
+        const missingDocs =
+          event.claimAmount > 25_000 && Math.random() < 0.4
+            ? ["police-report", "photo-evidence"]
+            : [];
+
+        return {
+          valid: isValid,
+          riskScore,
+          flagged: event.claimAmount > 50_000,
+          missingDocuments: missingDocs,
+        };
+      },
+      { retryStrategy },
+    );
+
+    // Early exit: invalid claim
+    if (!validation.valid) {
+      return {
+        claimNumber: event.insuranceClaimNumber,
+        customerName: event.customerName,
+        claimType: event.claimType,
+        decision: "REJECTED" as ClaimDecision,
+        reason: "Invalid claim amount",
+        validation,
+      };
+    }
+
+    // Early exit: missing documentation
+    if (validation.missingDocuments.length > 0) {
+      const docRequest = await context.step(
+        "requestDocuments",
+        async () => {
+          maybeFailTransient("requestDocuments");
+          return {
+            requestId: `DOC-${Date.now()}`,
+            documentsRequested: validation.missingDocuments,
+            deadline: new Date(
+              Date.now() + 7 * 24 * 60 * 60 * 1000,
+            ).toISOString(),
+            notifiedVia: "email",
+          };
+        },
+        { retryStrategy },
+      );
+
+      return {
+        claimNumber: event.insuranceClaimNumber,
+        customerName: event.customerName,
+        claimType: event.claimType,
+        decision: "MORE_DOCUMENTS_REQUIRED" as ClaimDecision,
+        reason: `Missing: ${validation.missingDocuments.join(", ")}`,
+        validation,
+        documentRequest: docRequest,
+      };
+    }
+
+    // Step 2: Check policy coverage
+    const coverage = await context.step(
+      "checkPolicyCoverage",
+      async () => {
+        maybeFailTransient("checkPolicyCoverage");
+        return {
+          policyId: `POL-${event.customerName.replace(/\s/g, "").substring(0, 6).toUpperCase()}-001`,
+          covered: Math.random() > 0.15, // 15% chance not covered
+          deductible: event.claimAmount > 10_000 ? 1000 : 500,
+          maxPayout: 500_000,
+        };
+      },
+      { retryStrategy },
+    );
+
+    // Reject if not covered
+    if (!coverage.covered) {
+      return {
+        claimNumber: event.insuranceClaimNumber,
+        customerName: event.customerName,
+        claimType: event.claimType,
+        decision: "REJECTED" as ClaimDecision,
+        reason: "Claim type not covered under current policy",
+        validation,
+        coverage,
+      };
+    }
+
+    // Step 3: Fraud detection
+    const fraudCheck = await context.step(
+      "fraudDetection",
+      async () => {
+        maybeFailTransient("fraudDetection");
+        const fraudScore = validation.riskScore * 0.6 + Math.random() * 40;
+        return {
+          score: Math.round(fraudScore),
+          flagged: fraudScore > 80,
+          checks: ["identity-verified", "claim-history", "pattern-analysis"],
+        };
+      },
+      { retryStrategy },
+    );
+
+    // Reject if fraud detected
+    if (fraudCheck.flagged) {
+      return {
+        claimNumber: event.insuranceClaimNumber,
+        customerName: event.customerName,
+        claimType: event.claimType,
+        decision: "REJECTED" as ClaimDecision,
+        reason: "Fraud detection flagged",
+        validation,
+        coverage,
+        fraudCheck,
+      };
+    }
+
+    // Step 4: Assess and calculate payout
+    const assessment = await context.step(
+      "assessClaim",
+      async () => {
+        maybeFailTransient("assessClaim");
+        const approvedAmount = Math.min(
+          event.claimAmount - coverage.deductible,
+          coverage.maxPayout,
+        );
+        return {
+          assessorId: `ASR-${Math.floor(Math.random() * 9000) + 1000}`,
+          approvedAmount: Math.max(0, approvedAmount),
+          adjustmentReason:
+            validation.riskScore > 70 ? "high-risk-adjustment" : "standard",
+        };
+      },
+      { retryStrategy },
+    );
+
+    // Step 5: Process payment
+    const payment = await context.step(
+      "processPayment",
+      async () => {
+        maybeFailTransient("processPayment");
+        return {
+          paymentId: `PAY-${Date.now()}`,
+          amount: assessment.approvedAmount,
+          method:
+            assessment.approvedAmount > 10_000 ? "wire-transfer" : "check",
+          scheduledDate: new Date(
+            Date.now() + 3 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        };
+      },
+      { retryStrategy },
+    );
+
+    // Step 6: Notify customer
+    const notification = await context.step(
+      "notifyCustomer",
+      async () => {
+        maybeFailTransient("notifyCustomer");
+        return {
+          notificationId: `NTF-${Date.now()}`,
+          channel: "email",
+          sentAt: new Date().toISOString(),
+          message: `Claim ${event.insuranceClaimNumber} approved for $${assessment.approvedAmount.toFixed(2)}`,
+        };
+      },
+      { retryStrategy },
+    );
+
+    return {
+      claimNumber: event.insuranceClaimNumber,
+      customerName: event.customerName,
+      claimType: event.claimType,
+      decision: "APPROVED" as ClaimDecision,
+      validation,
+      coverage,
+      fraudCheck,
+      assessment,
+      payment,
+      notification,
+    };
+  },
+  {
+    plugins: [workflowInsight({ exporters })],
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aws/durable-execution-sdk-js-insight-cdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CDK stack to deploy Workflow Insight destination infrastructure",
+  "scripts": {
+    "build:deps": "npm --prefix ../../aws-durable-execution-sdk-js run build && npm --prefix .. run build",
+    "build": "tsc -p tsconfig.build.json",
+    "pretypecheck": "npm run build:deps",
+    "typecheck": "tsc --noEmit",
+    "pretest": "npm run build:deps",
+    "test": "jest",
+    "presynth": "npm run build:deps",
+    "synth": "cdk synth",
+    "predeploy": "npm run build:deps",
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy"
+  },
+  "dependencies": {
+    "@aws-sdk/client-lambda": "^3.1076.0",
+    "@aws-sdk/client-redshift-data": "^3.1076.0",
+    "@aws/durable-execution-sdk-js": "file:../../aws-durable-execution-sdk-js",
+    "@aws/durable-execution-sdk-js-insight": "file:..",
+    "aws-cdk-lib": "^2.150.0",
+    "constructs": "^10.3.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.162",
+    "@types/jest": "^29.5.0",
+    "aws-cdk": "^2.150.0",
+    "esbuild": "^0.24.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "typescript": "^5.5.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/*.test.ts"
+    ],
+    "modulePathIgnorePatterns": [
+      "cdk.out"
+    ]
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/redshift-create-table.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/redshift-create-table.ts
@@ -1,0 +1,85 @@
+import type {
+  CdkCustomResourceEvent,
+  CdkCustomResourceResponse,
+} from "aws-lambda";
+import {
+  RedshiftDataClient,
+  ExecuteStatementCommand,
+  DescribeStatementCommand,
+} from "@aws-sdk/client-redshift-data";
+
+const client = new RedshiftDataClient({});
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_WAIT_MS = 120_000; // 2 minutes max
+
+/**
+ * CDK Provider-compatible custom resource that creates a Redshift table
+ * and polls DescribeStatement until the SQL finishes or fails.
+ *
+ * Unlike the RDS Data API (synchronous), Redshift Data API is async —
+ * ExecuteStatement returns immediately. This handler polls to confirm
+ * the CREATE TABLE actually succeeded.
+ */
+export async function handler(
+  event: CdkCustomResourceEvent,
+): Promise<CdkCustomResourceResponse> {
+  const requestType = event.RequestType;
+
+  if (requestType === "Delete") {
+    return {
+      PhysicalResourceId: event.PhysicalResourceId ?? "redshift-create-table",
+      Data: { status: "SKIPPED" },
+    };
+  }
+
+  // Create or Update: execute the SQL and wait for completion
+  const workgroupName = event.ResourceProperties.WorkgroupName;
+  const database = event.ResourceProperties.Database;
+  const sql = event.ResourceProperties.Sql;
+
+  const executeResp = await client.send(
+    new ExecuteStatementCommand({
+      WorkgroupName: workgroupName,
+      Database: database,
+      Sql: sql,
+    }),
+  );
+
+  const statementId = executeResp.Id!;
+  console.log(`ExecuteStatement submitted: ${statementId}`);
+
+  // Poll until finished
+  const startTime = Date.now();
+  while (Date.now() - startTime < MAX_WAIT_MS) {
+    await sleep(POLL_INTERVAL_MS);
+
+    const desc = await client.send(
+      new DescribeStatementCommand({ Id: statementId }),
+    );
+
+    const status = desc.Status;
+    console.log(`Statement ${statementId}: ${status}`);
+
+    if (status === "FINISHED") {
+      return {
+        PhysicalResourceId: `redshift-create-table-${workgroupName}-${database}`,
+        Data: { status: "FINISHED", statementId },
+      };
+    }
+
+    if (status === "FAILED" || status === "ABORTED") {
+      throw new Error(
+        `Redshift CREATE TABLE failed: ${desc.Error ?? "unknown error"} (statement: ${statementId})`,
+      );
+    }
+  }
+
+  throw new Error(
+    `Redshift CREATE TABLE timed out after ${MAX_WAIT_MS / 1000}s (statement: ${statementId})`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
@@ -1,0 +1,68 @@
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import { InsightDestinationsStack } from "./stack";
+
+/**
+ * Basic smoke test: ensures the stack synthesizes without errors.
+ * Catches structural issues like missing cfn-response protocols,
+ * broken custom resources, or invalid construct trees.
+ *
+ * NOTE: These assertions are coupled to the default values in config.json
+ * (e.g., table names, enabled destinations, resource counts). If you change
+ * config.json (e.g., enable Redshift), some tests may need updating.
+ * This is intentional for a demo stack — the tests validate the committed
+ * default configuration works end-to-end.
+ */
+describe("InsightDestinationsStack", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new InsightDestinationsStack(app, "TestStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  it("synthesizes without errors", () => {
+    expect(template).toBeDefined();
+  });
+
+  it("creates a CloudWatch log group", () => {
+    template.hasResourceProperties("AWS::Logs::LogGroup", {
+      LogGroupName: "/workflow-insight/demo",
+    });
+  });
+
+  it("creates a DynamoDB table with pk key", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "workflow-insight",
+      KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+    });
+  });
+
+  it("creates an Aurora Serverless v2 cluster with Data API", () => {
+    template.hasResourceProperties("AWS::RDS::DBCluster", {
+      EnableHttpEndpoint: true,
+    });
+  });
+
+  it("creates the Aurora table via custom resource", () => {
+    template.resourceCountIs("Custom::AWS", 1);
+  });
+
+  it("creates an IAM policy for destinations", () => {
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyName: "WorkflowInsightDestinations",
+    });
+  });
+
+  it("creates the example Lambda function", () => {
+    // Physical name is auto-generated (no fixed FunctionName), so assert on
+    // the runtime + handler instead.
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Runtime: "nodejs22.x",
+      Handler: "index.handler",
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -1,0 +1,624 @@
+import * as cdk from "aws-cdk-lib";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as opensearch from "aws-cdk-lib/aws-opensearchservice";
+import * as firehose from "aws-cdk-lib/aws-kinesisfirehose";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as timestream from "aws-cdk-lib/aws-timestream";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNode from "aws-cdk-lib/aws-lambda-nodejs";
+import * as cr from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+import * as path from "path";
+import * as config from "./config.json";
+
+/**
+ * Props for the Insight destinations stack.
+ */
+export interface InsightDestinationsStackProps extends cdk.StackProps {
+  /**
+   * Role ARNs of durable functions discovered at synth time (via ListFunctions
+   * in app.ts). Populated only when config.lambda.discoverDurableFunctions is true.
+   * The Insight permissions policy is attached directly to these roles.
+   */
+  discoveredRoleArns?: string[];
+}
+
+export class InsightDestinationsStack extends cdk.Stack {
+  constructor(
+    scope: Construct,
+    id: string,
+    props?: InsightDestinationsStackProps,
+  ) {
+    super(scope, id, props);
+
+    const policyStatements: iam.PolicyStatement[] = [];
+
+    // Example function's execution role is created up front (when enabled) so
+    // its ARN is available to destination access policies (e.g. OpenSearch).
+    // No explicit roleName — CDK auto-generates a unique name so the stack can
+    // be deployed multiple times without collisions.
+    const exampleRole = config.lambda.createExampleFunction
+      ? new iam.Role(this, "ExampleFunctionRole", {
+          assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+          managedPolicies: [
+            iam.ManagedPolicy.fromAwsManagedPolicyName(
+              "service-role/AWSLambdaBasicExecutionRole",
+            ),
+          ],
+        })
+      : undefined;
+
+    // --- CloudWatch Logs ---
+    let logGroup: logs.LogGroup | undefined;
+    if (config.destinations.cloudwatchLogs.enabled) {
+      logGroup = new logs.LogGroup(this, "InsightLogGroup", {
+        logGroupName: config.destinations.cloudwatchLogs.logGroupName,
+        retention: config.destinations.cloudwatchLogs
+          .retentionDays as logs.RetentionDays,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "logs:DescribeLogStreams",
+          ],
+          resources: [logGroup.logGroupArn, `${logGroup.logGroupArn}:*`],
+        }),
+      );
+    }
+
+    // --- DynamoDB ---
+    let ddbTable: dynamodb.Table | undefined;
+    if (config.destinations.dynamodb.enabled) {
+      ddbTable = new dynamodb.Table(this, "InsightTable", {
+        tableName: config.destinations.dynamodb.tableName,
+        partitionKey: {
+          name: "pk",
+          type: dynamodb.AttributeType.STRING,
+        },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["dynamodb:PutItem", "dynamodb:UpdateItem"],
+          resources: [ddbTable.tableArn],
+        }),
+      );
+    }
+
+    // --- Aurora Serverless v2 ---
+    let auroraCluster: rds.DatabaseCluster | undefined;
+    if (config.destinations.aurora.enabled) {
+      const vpc = new ec2.Vpc(this, "InsightVpc", {
+        maxAzs: 2,
+        natGateways: 0,
+        subnetConfiguration: [
+          {
+            name: "isolated",
+            subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          },
+        ],
+      });
+
+      auroraCluster = new rds.DatabaseCluster(this, "InsightAuroraCluster", {
+        engine: rds.DatabaseClusterEngine.auroraPostgres({
+          version: rds.AuroraPostgresEngineVersion.VER_16_4,
+        }),
+        serverlessV2MinCapacity: config.destinations.aurora.minCapacity,
+        serverlessV2MaxCapacity: config.destinations.aurora.maxCapacity,
+        writer: rds.ClusterInstance.serverlessV2("writer"),
+        defaultDatabaseName: config.destinations.aurora.databaseName,
+        enableDataApi: true,
+        vpc,
+        vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+
+      // Custom Resource to create the table via RDS Data API
+      // Table name is interpolated from operator-controlled config (not user input).
+      const createTableSql = `
+        CREATE TABLE IF NOT EXISTS ${config.destinations.aurora.tableName} (
+          execution_arn VARCHAR(256) PRIMARY KEY,
+          execution_name VARCHAR(128),
+          function_name VARCHAR(128),
+          status VARCHAR(20),
+          start_time TIMESTAMPTZ,
+          end_time TIMESTAMPTZ,
+          duration_ms BIGINT,
+          record_json JSONB,
+          emitted_at TIMESTAMPTZ
+        );
+      `;
+
+      new cr.AwsCustomResource(this, "AuroraCreateTable", {
+        onCreate: {
+          service: "RDSDataService",
+          action: "executeStatement",
+          parameters: {
+            resourceArn: auroraCluster.clusterArn,
+            secretArn: auroraCluster.secret!.secretArn,
+            database: config.destinations.aurora.databaseName,
+            sql: createTableSql,
+          },
+          physicalResourceId: cr.PhysicalResourceId.of(
+            `aurora-create-table-${config.destinations.aurora.tableName}`,
+          ),
+        },
+        onUpdate: {
+          service: "RDSDataService",
+          action: "executeStatement",
+          parameters: {
+            resourceArn: auroraCluster.clusterArn,
+            secretArn: auroraCluster.secret!.secretArn,
+            database: config.destinations.aurora.databaseName,
+            sql: createTableSql,
+          },
+          physicalResourceId: cr.PhysicalResourceId.of(
+            `aurora-create-table-${config.destinations.aurora.tableName}`,
+          ),
+        },
+        policy: cr.AwsCustomResourcePolicy.fromStatements([
+          new iam.PolicyStatement({
+            actions: ["rds-data:ExecuteStatement"],
+            resources: [auroraCluster.clusterArn],
+          }),
+          new iam.PolicyStatement({
+            actions: ["secretsmanager:GetSecretValue"],
+            resources: [auroraCluster.secret!.secretArn],
+          }),
+        ]),
+      });
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: [
+            "rds-data:ExecuteStatement",
+            "rds-data:BatchExecuteStatement",
+          ],
+          resources: [auroraCluster.clusterArn],
+        }),
+        new iam.PolicyStatement({
+          actions: ["secretsmanager:GetSecretValue"],
+          resources: [auroraCluster.secret!.secretArn],
+        }),
+      );
+
+      new cdk.CfnOutput(this, "AuroraClusterArn", {
+        value: auroraCluster.clusterArn,
+      });
+      new cdk.CfnOutput(this, "AuroraSecretArn", {
+        value: auroraCluster.secret!.secretArn,
+      });
+    }
+
+    // --- S3 ---
+    if (config.destinations.s3.enabled) {
+      const bucket = new s3.Bucket(this, "InsightBucket", {
+        bucketName: config.destinations.s3.bucketName,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        autoDeleteObjects: true,
+      });
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["s3:PutObject"],
+          resources: [`${bucket.bucketArn}/*`],
+        }),
+      );
+    }
+
+    // --- Redshift Serverless ---
+    if (config.destinations.redshift.enabled) {
+      const namespace = new cdk.CfnResource(this, "RedshiftNamespace", {
+        type: "AWS::RedshiftServerless::Namespace",
+        properties: {
+          NamespaceName: config.destinations.redshift.namespaceName,
+          DbName: config.destinations.redshift.databaseName,
+          AdminUsername: "admin",
+          ManageAdminPassword: true,
+        },
+      });
+
+      const workgroup = new cdk.CfnResource(this, "RedshiftWorkgroup", {
+        type: "AWS::RedshiftServerless::Workgroup",
+        properties: {
+          WorkgroupName: config.destinations.redshift.workgroupName,
+          NamespaceName: config.destinations.redshift.namespaceName,
+          BaseCapacity: 8,
+          PubliclyAccessible: false,
+        },
+      });
+      workgroup.addDependency(namespace);
+
+      // Custom Resource to create the table via Redshift Data API
+      // Table/schema names are interpolated from operator-controlled config (not user input).
+      const fqTable = `${config.destinations.redshift.schema}.${config.destinations.redshift.tableName}`;
+      const createRedshiftTableSql = `
+        CREATE TABLE IF NOT EXISTS ${fqTable} (
+          execution_arn VARCHAR(512) PRIMARY KEY,
+          execution_name VARCHAR(256),
+          function_name VARCHAR(128),
+          status VARCHAR(20),
+          start_time VARCHAR(30),
+          end_time VARCHAR(30),
+          duration_ms BIGINT,
+          record_json SUPER,
+          emitted_at VARCHAR(30)
+        );
+      `;
+
+      // Use a Provider-backed custom resource that polls DescribeStatement
+      // until the CREATE TABLE completes. The Redshift Data API is async —
+      // ExecuteStatement returns immediately without confirming success.
+      const redshiftTableFn = new lambdaNode.NodejsFunction(
+        this,
+        "RedshiftCreateTableHandler",
+        {
+          runtime: lambda.Runtime.NODEJS_22_X,
+          handler: "handler",
+          entry: path.join(__dirname, "redshift-create-table.ts"),
+          timeout: cdk.Duration.minutes(3),
+          initialPolicy: [
+            new iam.PolicyStatement({
+              actions: [
+                "redshift-data:ExecuteStatement",
+                "redshift-data:DescribeStatement",
+              ],
+              resources: ["*"],
+            }),
+            new iam.PolicyStatement({
+              actions: ["redshift-serverless:GetCredentials"],
+              resources: [
+                `arn:${this.partition}:redshift-serverless:${this.region}:${this.account}:workgroup/*`,
+              ],
+            }),
+          ],
+          bundling: {
+            format: lambdaNode.OutputFormat.ESM,
+            mainFields: ["module", "main"],
+            banner:
+              'import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+            minify: true,
+          },
+        },
+      );
+
+      const redshiftTableProvider = new cr.Provider(
+        this,
+        "RedshiftCreateTableProvider",
+        { onEventHandler: redshiftTableFn },
+      );
+
+      const redshiftCreateTable = new cdk.CustomResource(
+        this,
+        "RedshiftCreateTable",
+        {
+          serviceToken: redshiftTableProvider.serviceToken,
+          properties: {
+            WorkgroupName: config.destinations.redshift.workgroupName,
+            Database: config.destinations.redshift.databaseName,
+            Sql: createRedshiftTableSql,
+          },
+        },
+      );
+      redshiftCreateTable.node.addDependency(workgroup);
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["redshift-data:ExecuteStatement"],
+          resources: [
+            `arn:${this.partition}:redshift-serverless:${this.region}:${this.account}:workgroup/*`,
+          ],
+        }),
+        new iam.PolicyStatement({
+          actions: ["redshift-serverless:GetCredentials"],
+          resources: [
+            `arn:${this.partition}:redshift-serverless:${this.region}:${this.account}:workgroup/*`,
+          ],
+        }),
+      );
+    }
+
+    // --- OpenSearch ---
+    if (config.destinations.opensearch.enabled) {
+      const domain = new opensearch.Domain(this, "InsightOpenSearch", {
+        domainName: config.destinations.opensearch.domainName,
+        version: opensearch.EngineVersion.OPENSEARCH_2_11,
+        capacity: {
+          dataNodeInstanceType: "t3.small.search",
+          dataNodes: 1,
+        },
+        ebs: {
+          volumeSize: 10,
+        },
+        encryptionAtRest: { enabled: true },
+        nodeToNodeEncryption: true,
+        enforceHttps: true,
+        accessPolicies: [
+          new iam.PolicyStatement({
+            actions: ["es:ESHttpPut", "es:ESHttpPost", "es:ESHttpGet"],
+            principals: [new iam.AnyPrincipal()],
+            resources: [
+              `arn:${this.partition}:es:${this.region}:${this.account}:domain/${config.destinations.opensearch.domainName}/*`,
+            ],
+            conditions: {
+              StringLike: {
+                // All principal ARNs are known at synth time (explicit roleNames,
+                // synth-time discovered roles, and the example function role).
+                "aws:PrincipalArn": [
+                  ...config.lambda.roleNames.map(
+                    (r) =>
+                      `arn:${this.partition}:iam::${this.account}:role/${r}`,
+                  ),
+                  ...(props?.discoveredRoleArns ?? []),
+                  ...(exampleRole ? [exampleRole.roleArn] : []),
+                ],
+              },
+            },
+          }),
+        ],
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["es:ESHttpPut", "es:ESHttpPost"],
+          resources: [`${domain.domainArn}/*`],
+        }),
+      );
+    }
+
+    // --- Firehose ---
+    if (config.destinations.firehose.enabled) {
+      const firehoseBucket = new s3.Bucket(this, "FirehoseBucket", {
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        autoDeleteObjects: true,
+      });
+
+      const firehoseRole = new iam.Role(this, "FirehoseRole", {
+        assumedBy: new iam.ServicePrincipal("firehose.amazonaws.com"),
+      });
+      firehoseBucket.grantReadWrite(firehoseRole);
+
+      const stream = new firehose.CfnDeliveryStream(
+        this,
+        "InsightFirehoseStream",
+        {
+          deliveryStreamName: config.destinations.firehose.streamName,
+          extendedS3DestinationConfiguration: {
+            bucketArn: firehoseBucket.bucketArn,
+            roleArn: firehoseRole.roleArn,
+            bufferingHints: {
+              intervalInSeconds:
+                config.destinations.firehose.bufferIntervalSeconds,
+              sizeInMBs: config.destinations.firehose.bufferSizeMB,
+            },
+          },
+        },
+      );
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["firehose:PutRecord", "firehose:PutRecordBatch"],
+          resources: [stream.attrArn],
+        }),
+      );
+    }
+
+    // --- SQS ---
+    if (config.destinations.sqs.enabled) {
+      const queueProps: sqs.QueueProps = {
+        queueName: config.destinations.sqs.fifo
+          ? `${config.destinations.sqs.queueName}.fifo`
+          : config.destinations.sqs.queueName,
+        fifo: config.destinations.sqs.fifo,
+        contentBasedDeduplication: config.destinations.sqs.fifo
+          ? true
+          : undefined,
+      };
+
+      const queue = new sqs.Queue(this, "InsightQueue", queueProps);
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["sqs:SendMessage"],
+          resources: [queue.queueArn],
+        }),
+      );
+    }
+
+    // --- EventBridge ---
+    if (config.destinations.eventbridge.enabled) {
+      let eventBusArn: string;
+
+      if (config.destinations.eventbridge.eventBusName === "default") {
+        eventBusArn = `arn:${this.partition}:events:${this.region}:${this.account}:event-bus/default`;
+      } else {
+        const bus = new events.EventBus(this, "InsightEventBus", {
+          eventBusName: config.destinations.eventbridge.eventBusName,
+        });
+        eventBusArn = bus.eventBusArn;
+      }
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["events:PutEvents"],
+          resources: [eventBusArn],
+        }),
+      );
+    }
+
+    // --- Timestream ---
+    if (config.destinations.timestream.enabled) {
+      const db = new timestream.CfnDatabase(this, "InsightTimestreamDb", {
+        databaseName: config.destinations.timestream.databaseName,
+      });
+
+      const table = new timestream.CfnTable(this, "InsightTimestreamTable", {
+        databaseName: config.destinations.timestream.databaseName,
+        tableName: config.destinations.timestream.tableName,
+        retentionProperties: {
+          MemoryStoreRetentionPeriodInHours: String(
+            config.destinations.timestream.memoryRetentionHours,
+          ),
+          MagneticStoreRetentionPeriodInDays: String(
+            config.destinations.timestream.magneticRetentionDays,
+          ),
+        },
+      });
+      table.addDependency(db);
+
+      policyStatements.push(
+        new iam.PolicyStatement({
+          actions: ["timestream:WriteRecords"],
+          resources: [
+            `arn:${this.partition}:timestream:${this.region}:${this.account}:database/${config.destinations.timestream.databaseName}/table/${config.destinations.timestream.tableName}`,
+          ],
+        }),
+        // DescribeEndpoints requires resource: "*" (API does not support resource-level permissions)
+        new iam.PolicyStatement({
+          actions: ["timestream:DescribeEndpoints"],
+          resources: ["*"],
+        }),
+      );
+    }
+
+    // --- Resolve target roles ---
+    const targetRoles: iam.IRole[] = [];
+
+    // Explicitly listed role names
+    if (config.lambda.roleNames.length > 0) {
+      for (const roleName of config.lambda.roleNames) {
+        targetRoles.push(
+          iam.Role.fromRoleName(this, `Role-${roleName}`, roleName),
+        );
+      }
+    }
+
+    // Discover durable functions and grant to their roles.
+    // Discovery runs at synth time (see app.ts) via ListFunctions, so the
+    // exact role ARNs are known here and the policy is attached directly —
+    // no runtime Lambda or iam:PutRolePolicy grant required.
+    const discoveredRoleArns = props?.discoveredRoleArns ?? [];
+    for (const roleArn of discoveredRoleArns) {
+      const roleName = roleArn.split("/").pop()!;
+      targetRoles.push(
+        iam.Role.fromRoleArn(this, `DiscoveredRole-${roleName}`, roleArn, {
+          mutable: true,
+        }),
+      );
+    }
+
+    // --- Create example durable function ---
+    if (config.lambda.createExampleFunction && exampleRole) {
+      targetRoles.push(exampleRole);
+
+      const envVars: Record<string, string> = {};
+      if (config.destinations.cloudwatchLogs.enabled) {
+        envVars.INSIGHT_LOG_GROUP =
+          config.destinations.cloudwatchLogs.logGroupName;
+      }
+      if (config.destinations.dynamodb.enabled) {
+        envVars.INSIGHT_DYNAMODB_TABLE = config.destinations.dynamodb.tableName;
+      }
+      if (config.destinations.aurora.enabled && auroraCluster) {
+        envVars.INSIGHT_AURORA_RESOURCE_ARN = auroraCluster.clusterArn;
+        envVars.INSIGHT_AURORA_SECRET_ARN = auroraCluster.secret!.secretArn;
+        envVars.INSIGHT_AURORA_DATABASE =
+          config.destinations.aurora.databaseName;
+        envVars.INSIGHT_AURORA_TABLE = config.destinations.aurora.tableName;
+      }
+
+      const exampleFn = new lambdaNode.NodejsFunction(
+        this,
+        "InsightExampleFunction",
+        {
+          runtime: lambda.Runtime.NODEJS_22_X,
+          handler: "handler",
+          entry: path.join(__dirname, "example-function", "index.ts"),
+          role: exampleRole,
+          timeout: cdk.Duration.seconds(30),
+          environment: envVars,
+          bundling: {
+            format: lambdaNode.OutputFormat.ESM,
+            mainFields: ["module", "main"],
+            banner:
+              'import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+            minify: true,
+            sourceMap: true,
+          },
+        },
+      );
+
+      new cdk.CfnOutput(this, "ExampleFunctionArn", {
+        value: exampleFn.functionArn,
+      });
+      new cdk.CfnOutput(this, "ExampleFunctionName", {
+        value: exampleFn.functionName,
+      });
+
+      // --- Auto-invoke: dispatcher Lambda + EventBridge schedule ---
+      if (config.lambda.autoInvoke.enabled) {
+        const dispatcherFn = new lambdaNode.NodejsFunction(
+          this,
+          "InsightDispatcherFunction",
+          {
+            runtime: lambda.Runtime.NODEJS_22_X,
+            handler: "handler",
+            entry: path.join(__dirname, "dispatcher", "index.ts"),
+            timeout: cdk.Duration.seconds(15),
+            environment: {
+              TARGET_FUNCTION_NAME: exampleFn.functionName,
+            },
+            bundling: {
+              format: lambdaNode.OutputFormat.ESM,
+              mainFields: ["module", "main"],
+              banner:
+                'import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+              minify: true,
+            },
+          },
+        );
+
+        // Grant the dispatcher permission to invoke the example function
+        exampleFn.grantInvoke(dispatcherFn);
+
+        // EventBridge rule to trigger the dispatcher on a schedule
+        const rule = new events.Rule(this, "InsightDispatchRule", {
+          schedule: events.Schedule.rate(
+            cdk.Duration.minutes(config.lambda.autoInvoke.rateMinutes),
+          ),
+        });
+        rule.addTarget(new targets.LambdaFunction(dispatcherFn));
+
+        new cdk.CfnOutput(this, "DispatcherFunctionName", {
+          value: dispatcherFn.functionName,
+        });
+        new cdk.CfnOutput(this, "DispatchRuleName", {
+          value: rule.ruleName,
+        });
+      }
+    }
+
+    // --- Attach all policy statements to target roles ---
+    if (policyStatements.length > 0 && targetRoles.length > 0) {
+      new iam.Policy(this, "InsightDestinationPolicy", {
+        policyName: "WorkflowInsightDestinations",
+        statements: policyStatements,
+        roles: targetRoles,
+      });
+    }
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.build.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "cdk.out",
+    "**/*.test.ts",
+    "example-function/**",
+    "dispatcher/**",
+    "discover-roles.ts",
+    "redshift-create-table.ts"
+  ]
+}

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -52,8 +52,6 @@
 - [ ] In `finished-only` mode, emit **only** on terminal `SUCCEEDED`/`FAILED`;
       currently `onInvocationEnd` also schedules on `PENDING` (every wait/suspend)
       and `RETRYING`
-- [ ] Replay-safe emission — avoid duplicate/redundant exports across replays
-      (in-progress mode re-fires `onOperationChange` for already-completed ops)
 
 ## Record Size / Truncation
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
@@ -135,12 +135,12 @@ export class RedshiftExporter implements InsightExporter {
       status = :status,
       end_time = ${endTimeExpr},
       duration_ms = ${durationExpr},
-      record_json = :record_json,
+      record_json = JSON_PARSE(:record_json),
       emitted_at = :emitted_at
     WHEN NOT MATCHED THEN INSERT
       (execution_arn, execution_name, function_name, status, start_time, end_time, duration_ms, record_json, emitted_at)
     VALUES
-      (:execution_arn, ${execNameExpr}, :function_name, :status, :start_time, ${endTimeExpr}, ${durationExpr}, :record_json, :emitted_at)`;
+      (:execution_arn, ${execNameExpr}, :function_name, :status, :start_time, ${endTimeExpr}, ${durationExpr}, JSON_PARSE(:record_json), :emitted_at)`;
 
     await this.client.send(
       new ExecuteStatementCommand({

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -247,6 +247,18 @@ const SDK_VERSION = "2.0.0-alpha.1";
 export function workflowInsight(
   config: WorkflowInsightConfig,
 ): DurableInstrumentationPlugin {
+  // Warn about unimplemented config options
+  if (config.samplingRate !== undefined) {
+    console.warn(
+      "[workflow-insight] samplingRate is not yet implemented and has no effect.",
+    );
+  }
+  if (config.content !== undefined) {
+    console.warn(
+      "[workflow-insight] content filtering is not yet implemented and has no effect.",
+    );
+  }
+
   const exporters =
     config.exporters && config.exporters.length > 0
       ? config.exporters

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -38,8 +38,10 @@ export interface OperationOverride {
 }
 
 /**
- * Controls what data is included in the emitted record.
- * @experimental This interface is experimental and may change in future releases.
+ * Controls what data is included in emitted records.
+ *
+ * @experimental **Not yet implemented.** This interface is reserved for a future release.
+ * Configuring it currently has no effect on emitted records.
  */
 export interface ContentConfig {
   input?: boolean | ((input: ExecutionInput) => ExecutionInput);
@@ -66,8 +68,25 @@ export interface InsightExporter {
  */
 export interface WorkflowInsightConfig {
   exporters?: InsightExporter[];
+
+  /**
+   * Sampling rate: 0.0–1.0. When set, only a fraction of executions emit records.
+   * The decision is per-execution (all-or-nothing).
+   *
+   * @experimental **Not yet implemented.** This field is reserved for a future release.
+   * Setting it currently has no effect.
+   */
   samplingRate?: number;
+
   emitMode?: "finished-only" | "in-progress";
+
+  /**
+   * Control what data is included in records (input/output transforms,
+   * operation overrides, error inclusion).
+   *
+   * @experimental **Not yet implemented.** This field is reserved for a future release.
+   * Setting it currently has no effect.
+   */
   content?: ContentConfig;
 }
 


### PR DESCRIPTION
Config-driven CDK stack that deploys destination resources for the Workflow Insight plugin. Supports 10 destinations (CloudWatch Logs, DynamoDB, Aurora, S3, Redshift, OpenSearch, Firehose, SQS, EventBridge, Timestream) with enable/disable toggles.

**Note:** First revision, will update it after testing each destination throughfully.

Features:
- roleNames: array of existing Lambda roles to grant permissions
- discoverDurableFunctions: auto-discover and grant to all durable fns
- createExampleFunction: deploys insurance claim processing workflow with retry policies and random transient failures for demo data
- autoInvoke: EventBridge rule + dispatcher Lambda that generates random claim inputs (customerName, claimNumber, amount, type)
- Aurora custom resource for automatic table creation
- Single managed IAM policy with all required permissions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
