### PR TITLE
feat(sdk): add PluginOperationStatus as const object (tree-shakeable, backward-compatible)

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -28,7 +28,10 @@ import {
 import { runWithContext } from "../../utils/context-tracker/context-tracker";
 import { DurablePromise } from "../../types/durable-promise";
 import { DurableLogger } from "../../types/durable-logger";
-import { DurableInstrumentationPlugin } from "../../types/plugin";
+import {
+  DurableInstrumentationPlugin,
+  PluginOperationStatus,
+} from "../../types/plugin";
 import {
   backfillOperationInfo,
   toOperationInfo,
@@ -342,7 +345,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
     });
     await plugin.onOperationStart?.({
       ...opInfo,
-      status: OperationStatus.STARTED,
+      status: PluginOperationStatus.STARTED,
       isReplay: false,
     });
   } else {
@@ -438,7 +441,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       backfillOperationInfo(onOperationEndInfo, opInfo);
       await plugin.onOperationEnd?.({
         ...onOperationEndInfo,
-        status: OperationStatus.SUCCEEDED,
+        status: PluginOperationStatus.SUCCEEDED,
         isReplay: false,
       });
 
@@ -504,7 +507,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       backfillOperationInfo(onOperationEndInfo, opInfo);
       await plugin.onOperationEnd?.({
         ...onOperationEndInfo,
-        status: OperationStatus.FAILED,
+        status: PluginOperationStatus.FAILED,
         isReplay: false,
         error: reconstructedError,
       });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -39,6 +39,7 @@ import {
   DurableInstrumentationPlugin,
   AttemptEndInfoOutcome,
   CustomerFnResult,
+  PluginOperationStatus,
 } from "../../types/plugin";
 import {
   toAttemptEndInfo,
@@ -288,7 +289,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
             backfillOperationInfo(operationInfo, opInfo);
             await plugin.onOperationStart?.({
               ...opInfo,
-              status: OperationStatus.STARTED,
+              status: PluginOperationStatus.STARTED,
               isReplay: isRetryAttempt,
             });
           }

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -32,6 +32,7 @@ import { DurableLogger } from "../../types/durable-logger";
 import {
   DurableInstrumentationPlugin,
   AttemptEndInfoOutcome,
+  PluginOperationStatus,
 } from "../../types/plugin";
 import {
   toAttemptInfo,
@@ -216,7 +217,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
           backfillOperationInfo(operationInfo, opInfo);
           await plugin.onOperationStart?.({
             ...opInfo,
-            status: OperationStatus.STARTED,
+            status: PluginOperationStatus.STARTED,
             isReplay: isRetryAttempt,
           });
         } else {

--- a/packages/aws-durable-execution-sdk-js/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js/src/index.ts
@@ -95,6 +95,7 @@ export {
   OperationChangeInfo,
   OperationInfo,
   OperationEndInfo,
+  PluginOperationStatus,
   AttemptInfo,
   AttemptEndInfo,
   AttemptEndInfoOutcome,

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -9,12 +9,37 @@ import { DurableExecutionInvocationOutput } from "./core";
  *
  * @experimental This enum is experimental and may be changed or removed in future releases.
  */
-export enum PluginInvocationStatus {
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  PENDING = "PENDING",
-  RETRYING = "RETRYING",
-}
+export const PluginInvocationStatus = {
+  SUCCEEDED: "SUCCEEDED",
+  FAILED: "FAILED",
+  PENDING: "PENDING",
+  RETRYING: "RETRYING",
+} as const;
+
+export type PluginInvocationStatus =
+  (typeof PluginInvocationStatus)[keyof typeof PluginInvocationStatus];
+
+/**
+ * Status values for durable operations.
+ *
+ * These represent the lifecycle states that an operation can be in
+ * during durable execution.
+ *
+ * @experimental This enum is experimental and may be changed or removed in future releases.
+ */
+export const PluginOperationStatus = {
+  STARTED: "STARTED",
+  READY: "READY",
+  PENDING: "PENDING",
+  SUCCEEDED: "SUCCEEDED",
+  FAILED: "FAILED",
+  TIMED_OUT: "TIMED_OUT",
+  STOPPED: "STOPPED",
+  CANCELLED: "CANCELLED",
+} as const;
+
+export type PluginOperationStatus =
+  (typeof PluginOperationStatus)[keyof typeof PluginOperationStatus];
 
 /**
  * Information about a durable operation.
@@ -27,7 +52,7 @@ export interface OperationInfo {
   type: string;
   subType?: string;
   parentId?: string;
-  status?: string;
+  status?: PluginOperationStatus;
   startTimestamp?: Date;
   endTimestamp?: Date;
   result?: string;
@@ -57,11 +82,14 @@ export interface AttemptInfo extends OperationInfo {
  *
  * @experimental This enum is experimental and may be changed or removed in future releases.
  */
-export enum AttemptEndInfoOutcome {
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  RETRYING = "RETRYING",
-}
+export const AttemptEndInfoOutcome = {
+  SUCCEEDED: "SUCCEEDED",
+  FAILED: "FAILED",
+  RETRYING: "RETRYING",
+} as const;
+
+export type AttemptEndInfoOutcome =
+  (typeof AttemptEndInfoOutcome)[keyof typeof AttemptEndInfoOutcome];
 
 /**
  * Information provided when an operation attempt ends.
@@ -69,10 +97,7 @@ export enum AttemptEndInfoOutcome {
  * @experimental This interface is experimental and may be changed or removed in future releases.
  */
 export interface AttemptEndInfo extends AttemptInfo {
-  outcome:
-    | AttemptEndInfoOutcome.SUCCEEDED
-    | AttemptEndInfoOutcome.FAILED
-    | AttemptEndInfoOutcome.RETRYING;
+  outcome: AttemptEndInfoOutcome;
   error?: Error;
   nextAttemptDelaySeconds?: number;
 }


### PR DESCRIPTION
## Issue #, if available:
N/A

## Description of changes:

This is an alternative to #664 that delivers the same feature while keeping the public API **tree-shakeable _and_ backward compatible**.

### What it does
1. Adds a `PluginOperationStatus` type that mirrors `OperationStatus` from `@aws-sdk/client-lambda` (`STARTED`, `READY`, `PENDING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, `STOPPED`, `CANCELLED`).
2. Types `OperationInfo.status` as `PluginOperationStatus` and wires the enum into `onOperationStart` / `onOperationEnd` in the step, wait-for-condition, and run-in-child-context handlers.
3. Converts `PluginInvocationStatus` and `AttemptEndInfoOutcome` to the same pattern for consistency.

### Why `as const` objects instead of `const enum`
`const enum` is fully erased at compile time and emits **no runtime object**, which:
- breaks plain-JS consumers and `Object.values(...)` (the symbol is `undefined` at runtime),
- breaks transpile-only / `isolatedModules` toolchains (Babel, esbuild, SWC) — including this repo's own `-otel` and `-testing` packages,
- is a **breaking change** for the already-published `PluginInvocationStatus` and `AttemptEndInfoOutcome` enums.

Using an `as const` object + derived union type (the exact pattern AWS SDK v3 uses for `OperationStatus`) keeps the values tree-shakeable (a plain object literal, not the un-shakeable `enum` IIFE) while still emitting a real runtime export, so existing consumers keep working.

### Bonus
Because `OperationStatus` is assignable to the resulting string union, the `as PluginOperationStatus` cast in `toOperationInfo` is no longer needed and was removed (`operation.ts` now matches `main`).

### Verification
- `npm run build` (rollup esm + cjs + tsc types) — confirmed `exports.PluginOperationStatus` is present in the runtime CJS bundle.
- `tsc --noEmit` for the SDK package and the `-otel` / `-testing` consumer packages (which use `isolatedModules`).
- `jest`: 1012 tests / 86 suites passing.
- `eslint`: no new issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
