### PR TITLE
feat(sdk): add on-failure emit mode and rename emit modes

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -9,7 +9,7 @@ One line of configuration gives you full visibility into your durable workflows 
 Every time your durable function runs, Workflow Insight builds a **cumulative snapshot** of the execution (`WorkflowInsightRecord`) and sends it to one or more exporters. The record includes:
 
 - **Execution identity** — ARN, function name, region, account
-- **Status** — RUNNING, SUCCEEDED, FAILED, PENDING
+- **Status** — RUNNING, SUCCEEDED, FAILED
 - **Timing** — start/end time, total duration
 - **Input/Output** — the event and result of the execution
 - **Operations** — every step, wait, invoke, and callback with individual timing and status
@@ -34,7 +34,7 @@ interface WorkflowInsightRecord {
   accountId: string; // AWS account ID
 
   // Execution state
-  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING";
+  status: "RUNNING" | "SUCCEEDED" | "FAILED"; // suspends (waits/timers) surface as RUNNING
   startTime: string; // ISO-8601
   endTime?: string; // ISO-8601 (absent while running)
   durationMs?: number; // Total duration (absent while running)
@@ -182,8 +182,8 @@ That's it. With zero configuration, insight records appear in your function's ow
 
 ```typescript
 const insight = workflowInsight({
-  // When to emit records (default: "finished-only")
-  emitMode: "finished-only",
+  // When to emit records (default: "on-complete")
+  emitMode: "on-complete",
 
   // Sampling rate: 0.0–1.0 (default: 1.0 = all executions)
   samplingRate: 1.0,
@@ -198,10 +198,11 @@ const insight = workflowInsight({
 
 ### `emitMode`
 
-| Mode                        | Behavior                                                    | Use case                                              |
-| --------------------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| `"finished-only"` (default) | Emit one record when execution completes (SUCCEEDED/FAILED) | Low overhead; sufficient for post-hoc analysis        |
-| `"in-progress"`             | Emit on every operation change + at end                     | Real-time monitoring; see executions as they progress |
+| Mode                      | Behavior                                                    | Use case                                              |
+| ------------------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
+| `"on-complete"` (default) | Emit one record when execution completes (SUCCEEDED/FAILED) | Low overhead; sufficient for post-hoc analysis        |
+| `"on-change"`             | Emit on every operation change + at end                     | Real-time monitoring; see executions as they progress |
+| `"on-failure"`            | Emit one record only when execution ends in FAILED          | Lowest overhead; error-focused alerting and triage    |
 
 ### `samplingRate`
 
@@ -1041,7 +1042,7 @@ const insight = workflowInsight({
 **Event structure:**
 
 - Source: `aws.durable-execution.insight`
-- DetailType: `SUCCEEDED` | `FAILED` | `RUNNING` | `PENDING`
+- DetailType: `SUCCEEDED` | `FAILED` | `RUNNING`
 - Detail: full record JSON
 
 **Example rule pattern:**
@@ -1246,7 +1247,7 @@ const insight = workflowInsight({
     new DynamoDBExporter({ tableName: "insight-live" }), // Fast lookups
     new EventBridgeExporter({}), // Trigger alerts
   ],
-  emitMode: "in-progress",
+  emitMode: "on-change",
 });
 ```
 
@@ -1352,14 +1353,13 @@ The same pattern applies — the lifecycle handler reads the event and writes to
 
 ### What each status means
 
-| Status    | Origin                              | Captured by plugin?   | Captured by EventBridge? |
-| --------- | ----------------------------------- | --------------------- | ------------------------ |
-| RUNNING   | Lambda invocation                   | ✅ (in-progress mode) | ❌                       |
-| SUCCEEDED | Lambda invocation                   | ✅                    | ✅                       |
-| FAILED    | Lambda invocation                   | ✅                    | ✅                       |
-| PENDING   | Lambda invocation (wait/suspend)    | ✅                    | ❌                       |
-| STOPPED   | Backend (manual stop API)           | ❌                    | ✅                       |
-| TIMED_OUT | Backend (ExecutionTimeout exceeded) | ❌                    | ✅                       |
+| Status    | Origin                                                              | Captured by plugin? | Captured by EventBridge? |
+| --------- | ------------------------------------------------------------------- | ------------------- | ------------------------ |
+| RUNNING   | Lambda invocation (incl. wait/suspend for timers & external events) | ✅ (on-change mode) | ❌                       |
+| SUCCEEDED | Lambda invocation                                                   | ✅                  | ✅                       |
+| FAILED    | Lambda invocation                                                   | ✅                  | ✅                       |
+| STOPPED   | Backend (manual stop API)                                           | ❌                  | ✅                       |
+| TIMED_OUT | Backend (ExecutionTimeout exceeded)                                 | ❌                  | ✅                       |
 
 > **Tip:** If you use the `EventBridgeExporter` alongside this pattern, your
 > plugin-emitted events (SUCCEEDED/FAILED) and the backend-emitted events
@@ -1371,8 +1371,8 @@ The same pattern applies — the lifecycle handler reads the event and writes to
 The plugin hooks into the durable execution lifecycle:
 
 1. **`onInvocationStart`** — records execution start time
-2. **`onOperationChange`** — (in-progress mode) schedules export of a RUNNING snapshot
-3. **`onInvocationEnd`** — schedules export of the terminal snapshot (SUCCEEDED/FAILED/PENDING)
+2. **`onOperationChange`** — (on-change mode) schedules export of a RUNNING snapshot
+3. **`onInvocationEnd`** — schedules export of the snapshot, gated by `emitMode`: on terminal SUCCEEDED/FAILED (`on-complete`), FAILED only (`on-failure`), or every update including in-flight RUNNING snapshots (`on-change`)
 4. **`wrapInvocation`** — drains all pending exports before the Lambda returns
 
 Exports are **coalesced**: if updates arrive faster than the exporter can handle, intermediate snapshots are dropped (each record is a complete snapshot, so the latest one supersedes all earlier ones). This prevents overlapping export calls and keeps overhead minimal.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -41,10 +41,11 @@ interface WorkflowInsightConfig {
 
   /**
    * When to emit records.
-   * - "finished-only": emit one record when execution ends (default)
-   * - "in-progress": emit/update on every operation status change + end
+   * - "on-complete": emit one record when execution ends (default)
+   * - "on-change": emit/update on every operation status change + end
+   * - "on-failure": emit one record only when execution ends in FAILED
    */
-  emitMode?: "finished-only" | "in-progress";
+  emitMode?: "on-complete" | "on-change" | "on-failure";
 
   /**
    * Control what data is included in the emitted record.
@@ -207,7 +208,7 @@ import {
 
 const insight = workflowInsight({
   exporters: [new CloudWatchLogsExporter()],
-  emitMode: "finished-only",
+  emitMode: "on-complete",
 });
 
 export const handler = withDurableExecution(myHandler, {
@@ -239,7 +240,7 @@ const insight = workflowInsight({
       maxRecordSizeBytes: 128_000,
     }),
   ],
-  emitMode: "in-progress",
+  emitMode: "on-change",
   content: {
     input: (input) => ({
       customerId: input.customerId,
@@ -316,7 +317,7 @@ interface WorkflowInsightRecord {
   // --- Execution State ---
 
   /** Current execution status. */
-  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING";
+  status: "RUNNING" | "SUCCEEDED" | "FAILED";
 
   /** ISO-8601 timestamp when execution started. */
   startTime: string;
@@ -471,10 +472,11 @@ interface OperationRecord {
 
 ## 3. Emit Timing & Lifecycle
 
-| emitMode        | When record is emitted                                        | Record updates?                                      |
-| --------------- | ------------------------------------------------------------- | ---------------------------------------------------- |
-| `finished-only` | Once, at `onInvocationEnd` when status is SUCCEEDED or FAILED | No — single write                                    |
-| `in-progress`   | On every `onOperationChange` + at `onInvocationEnd`           | Yes — same record key, overwritten with latest state |
+| emitMode      | When record is emitted                                        | Record updates?                                      |
+| ------------- | ------------------------------------------------------------- | ---------------------------------------------------- |
+| `on-complete` | Once, at `onInvocationEnd` when status is SUCCEEDED or FAILED | No — single write                                    |
+| `on-change`   | On every `onOperationChange` + at `onInvocationEnd`           | Yes — same record key, overwritten with latest state |
+| `on-failure`  | Once, at `onInvocationEnd` when status is FAILED              | No — single write (only for failures)                |
 
 ### Critical constraint: `onInvocationEnd` must be awaited
 
@@ -492,4 +494,4 @@ The current plugin runner fires `onInvocationEnd` as fire-and-forget. For Workfl
 | Average duration of successful executions?     | `AVG(durationMs) WHERE status = 'SUCCEEDED'`                         |
 | Which step has the highest failure rate?       | Unnest operations, group by name, count failed/total                 |
 | Executions with >3 retry attempts on any step? | `WHERE ANY(operations[*].attempt > 3)`                               |
-| Currently running executions?                  | `WHERE status = 'RUNNING'` (in-progress mode only)                   |
+| Currently running executions?                  | `WHERE status = 'RUNNING'` (on-change mode only)                     |

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -43,15 +43,15 @@
 ## Emit Timing & Lifecycle
 
 - [x] Export on `onInvocationEnd`
-- [x] Export on `onOperationChange` for `in-progress` mode (gated by `emitMode`)
+- [x] Export on `onOperationChange` for `on-change` mode (gated by `emitMode`)
 - [x] Flush/await before returning via `wrapInvocation`
 - [x] Handle exporter errors gracefully (never fail the execution; `Promise.allSettled`)
 - [x] Coalesce overlapping exports — single in-flight export + latest-pending slot,
       so intermediate in-progress updates are dropped (`ExportScheduler`)
 - [x] Drain the export queue in `wrapInvocation` so the final record is delivered
-- [ ] In `finished-only` mode, emit **only** on terminal `SUCCEEDED`/`FAILED`;
-      currently `onInvocationEnd` also schedules on `PENDING` (every wait/suspend)
-      and `RETRYING`
+- [x] In `on-complete` mode, emit **only** on terminal `SUCCEEDED`/`FAILED`
+      (also added `on-failure` mode: emit only on terminal `FAILED`). Gated in
+      `onInvocationEnd`; non-terminal `PENDING`/`RETRYING` updates no longer emit.
 
 ## Record Size / Truncation
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
@@ -134,7 +134,6 @@ function severityFor(status: string): number {
     case "FAILED":
       return 17; // ERROR
     case "RUNNING":
-    case "PENDING":
       return 9; // INFO
     case "SUCCEEDED":
       return 9; // INFO

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -93,7 +93,11 @@ function parseExecutionArn(executionArn: string): ParsedArn {
 const STATUS_MAP: Record<string, WorkflowInsightRecord["status"]> = {
   SUCCEEDED: "SUCCEEDED",
   FAILED: "FAILED",
-  PENDING: "PENDING",
+  // A durable execution suspends (no compute) while waiting on a timer or an
+  // external event/callback. The runtime reports this as PENDING, but from the
+  // execution's point of view it is still in flight, so we surface it as
+  // RUNNING. RETRYING (runtime will auto-retry) is likewise still in flight.
+  PENDING: "RUNNING",
   RETRYING: "RUNNING",
 };
 
@@ -263,7 +267,7 @@ export function workflowInsight(
     config.exporters && config.exporters.length > 0
       ? config.exporters
       : [new LambdaLogExporter()];
-  const emitMode = config.emitMode ?? "finished-only";
+  const emitMode = config.emitMode ?? "on-complete";
   const scheduler = new ExportScheduler(exporters);
 
   // Per-execution state, keyed by executionArn. Prevents warm-container bleed
@@ -337,7 +341,7 @@ export function workflowInsight(
       }
       state.cachedInput = info.executionInput;
 
-      if (emitMode === "in-progress") {
+      if (emitMode === "on-change") {
         scheduler.schedule(
           buildRecord({
             executionArn: info.executionArn,
@@ -366,23 +370,46 @@ export function workflowInsight(
     },
 
     async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
-      scheduler.schedule(
-        buildRecord({
-          executionArn: info.executionArn,
-          status: mapStatus(info.status),
-          operations: buildOperationRecords(info.operations),
-          endTime: new Date(),
-          input: info.executionInput,
-          output: info.executionResult,
-          error: info.executionError,
-        }),
-      );
-      // Clear per-execution state to prevent warm-container bleed
-      execState.delete(info.executionArn);
+      const status = mapStatus(info.status);
+      const isTerminal = status === "SUCCEEDED" || status === "FAILED";
+      const isFailure = status === "FAILED";
+
+      // Decide whether this status update should produce a record.
+      // - on-change:   emit on every update (terminal or not)
+      // - on-complete: emit only on terminal SUCCEEDED/FAILED
+      // - on-failure:  emit only on terminal FAILED
+      const shouldEmit =
+        emitMode === "on-change"
+          ? true
+          : emitMode === "on-failure"
+            ? isFailure
+            : isTerminal;
+
+      if (shouldEmit) {
+        scheduler.schedule(
+          buildRecord({
+            executionArn: info.executionArn,
+            status,
+            operations: buildOperationRecords(info.operations),
+            endTime: new Date(),
+            input: info.executionInput,
+            output: info.executionResult,
+            error: info.executionError,
+          }),
+        );
+      }
+
+      // Only clear per-execution state once the execution is truly finished.
+      // onInvocationEnd also fires on non-terminal suspends (PENDING/RETRYING);
+      // clearing state there would lose the original startTime and cachedInput
+      // across resumes and corrupt duration computation.
+      if (isTerminal) {
+        execState.delete(info.executionArn);
+      }
     },
 
     async onOperationChange(info: OperationChangeInfo): Promise<void> {
-      if (emitMode !== "in-progress") {
+      if (emitMode !== "on-change") {
         return;
       }
       const state = getState(info.executionArn);

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -78,7 +78,20 @@ export interface WorkflowInsightConfig {
    */
   samplingRate?: number;
 
-  emitMode?: "finished-only" | "in-progress";
+  /**
+   * Controls when records are emitted.
+   *
+   * - `"on-change"`: emit on every operation status change and at execution
+   *   end, including while the execution is still in flight (`RUNNING`).
+   *   Highest overhead; gives real-time visibility into running executions.
+   * - `"on-complete"` (default): emit a single record when the execution
+   *   reaches a terminal status (`SUCCEEDED` or `FAILED`). No emissions on
+   *   intermediate waits/suspends.
+   * - `"on-failure"`: emit a single record only when the execution reaches a
+   *   terminal `FAILED` status. Successful executions emit nothing. Lowest
+   *   overhead; useful for error-focused alerting and triage.
+   */
+  emitMode?: "on-complete" | "on-change" | "on-failure";
 
   /**
    * Control what data is included in records (input/output transforms,
@@ -126,7 +139,7 @@ export interface WorkflowInsightRecord {
   functionQualifier: string;
   region: string;
   accountId: string;
-  status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING";
+  status: "RUNNING" | "SUCCEEDED" | "FAILED";
   startTime: string;
   endTime?: string;
   durationMs?: number;


### PR DESCRIPTION
Introduce a third emitMode for the Workflow Insight plugin and rename all three modes to a consistent, trigger-based naming scheme:

- on-change   (was in-progress):  emit on every status change + at end
- on-complete (was finished-only): emit once on terminal SUCCEEDED/FAILED
- on-failure  (new):               emit once only on terminal FAILED

Also fixes a latent bug where on-complete (the default) emitted on every PENDING/RETRYING suspend instead of only terminal statuses. Emission is now gated by mode in onInvocationEnd, and per-execution state is cleared only on terminal status so startTime/cachedInput survive across resumes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
