### PR TITLE
feat(sdk): surface operation error and attempt on OperationInfo

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -19,12 +19,18 @@
 ## Operation-Level Detail Capture
 
 > The `OperationRecord` contract includes `attempt`, per-operation `error`, and
-> (via content overrides) `result`. `OperationInfo` from `onOperationChange`
-> does not carry these — capturing them requires additional lifecycle hooks.
+> `result`. These are all present in the checkpointed `Operation` data; the core
+> SDK's `toOperationInfo()` now surfaces them on `OperationInfo`, so they arrive
+> via `onOperationChange` with no extra lifecycle hooks needed.
 
-- [ ] Capture per-operation `error` (wire `onOperationEnd`)
-- [ ] Capture per-operation `attempt` count (wire `onOperationAttemptEnd`)
-- [ ] Capture per-operation `result` (needed for `content.operations.overrides`)
+- [x] Capture per-operation `error` — SDK `toOperationInfo` maps `*Details.Error`
+      onto `OperationInfo.error` (via `DurableOperationError.fromErrorObject`);
+      plugin serializes it into `OperationRecord.error`.
+- [x] Capture per-operation `attempt` count — SDK maps `StepDetails.Attempt`
+      onto `OperationInfo.attempt`; plugin serializes it into `OperationRecord.attempt`.
+- [~] Capture per-operation `result` — now available on `OperationInfo.result`
+  (SDK already mapped it), but not yet emitted in `OperationRecord`; defer to
+  Content Filtering since raw results are unbounded and need override/size gating.
 
 ## Content Filtering
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -147,6 +147,10 @@ function toOperationRecord(op: OperationInfo): OperationRecord {
     startTime: toIsoString(op.startTimestamp),
     endTime: toIsoString(op.endTimestamp),
     durationMs,
+    attempt: op.attempt,
+    error: op.error
+      ? { name: op.error.name, message: op.error.message }
+      : undefined,
   };
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -56,6 +56,17 @@ export interface OperationInfo {
   startTimestamp?: Date;
   endTimestamp?: Date;
   result?: string;
+  /**
+   * The error the operation failed with, reconstructed from the checkpointed
+   * error data. Present on failed operations regardless of which lifecycle
+   * hook surfaced this info (e.g. also available via `onOperationChange`).
+   */
+  error?: Error;
+  /**
+   * The current attempt number for the operation (1-based), when applicable
+   * (e.g. steps). Sourced from the checkpointed step details.
+   */
+  attempt?: number;
   isReplay: boolean;
 }
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -6,6 +6,7 @@ import {
   AttemptEndInfo,
   AttemptEndInfoOutcome,
 } from "../../types/plugin";
+import { DurableOperationError } from "../../errors/durable-error/durable-error";
 
 /**
  * Converts an Operation to an OperationInfo.
@@ -13,6 +14,12 @@ import {
  * @experimental This function is experimental and may be changed or removed in future releases.
  */
 export function toOperationInfo(operation?: Operation): OperationInfo {
+  const errorObject =
+    operation?.StepDetails?.Error ??
+    operation?.CallbackDetails?.Error ??
+    operation?.ContextDetails?.Error ??
+    operation?.ChainedInvokeDetails?.Error;
+
   return {
     id: operation?.Id ?? "",
     name: operation?.Name,
@@ -27,6 +34,10 @@ export function toOperationInfo(operation?: Operation): OperationInfo {
       operation?.CallbackDetails?.Result ??
       operation?.ContextDetails?.Result ??
       operation?.ChainedInvokeDetails?.Result,
+    error: errorObject
+      ? DurableOperationError.fromErrorObject(errorObject)
+      : undefined,
+    attempt: operation?.StepDetails?.Attempt,
     isReplay: false,
   };
 }


### PR DESCRIPTION
The checkpointed Operation already carries per-operation Error (on Step/ Callback/Context/ChainedInvoke details) and Attempt (on StepDetails), but toOperationInfo() only mapped Result, so onOperationChange consumers could never see them.

- Add error?: Error and attempt?: number to the public (experimental) OperationInfo type.
- Map them in toOperationInfo(): attempt from StepDetails.Attempt, error via DurableOperationError.fromErrorObject() using the same *Details fan-out as result. No new lifecycle hooks required.
- Workflow Insight plugin now serializes attempt and error { name, message } into OperationRecord (stack trace and errorData intentionally omitted).

result remains available on OperationInfo but is not yet emitted in the record; deferred to content filtering due to unbounded size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
