### PR TITLE
chore(sdk): add ESLint config and lint script to Workflow Insight

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -98,7 +98,11 @@
 
 - [x] `npm run build` passes locally (esm, cjs, types)
 - [ ] Add the insight package to root `package.json` build/test scripts
-- [ ] Wire the package into the root ESLint config (currently not linted)
+- [x] Wire the package into ESLint — added a package-local `eslint.config.js`
+      (core SDK's TypeScript rules, using only published deps — no local
+      filename-convention plugin) and a `lint` script, consistent with the other
+      packages. Lints clean (0 errors); pre-commit lint-staged now applies the
+      TS rules to insight sources.
 - [x] Package `README.md` — comprehensive docs with all exporters, config, examples
 - [ ] Add a runnable example under `aws-durable-execution-sdk-js-examples`
 

--- a/packages/aws-durable-execution-sdk-js-insight/eslint.config.js
+++ b/packages/aws-durable-execution-sdk-js-insight/eslint.config.js
@@ -1,0 +1,63 @@
+const tsParser = require("@typescript-eslint/parser");
+const typescriptEslint = require("@typescript-eslint/eslint-plugin");
+const tsdoc = require("eslint-plugin-tsdoc");
+
+module.exports = [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+      tsdoc: tsdoc,
+    },
+    rules: {
+      ...typescriptEslint.configs.recommended.rules,
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/explicit-function-return-type": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+      "no-console": "warn",
+      "no-debugger": "warn",
+      "no-duplicate-imports": "error",
+      "tsdoc/syntax": "warn",
+    },
+  },
+  {
+    files: ["src/**/*.test.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+  {
+    ignores: [
+      "dist/**/*",
+      "dist-cjs/**/*",
+      "dist-types/**/*",
+      "node_modules/**/*",
+    ],
+  },
+];

--- a/packages/aws-durable-execution-sdk-js-insight/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/package.json
@@ -32,6 +32,7 @@
     "build:esm": "rollup --config rollup.config.mjs --environment MODE:esm",
     "build:cjs": "rollup --config rollup.config.mjs --environment MODE:cjs",
     "build:types": "tsc --emitDeclarationOnly --declaration --declarationMap --outDir dist-types",
+    "lint": "eslint src --ext .ts",
     "clean": "rm -rf dist dist-cjs dist-types"
   },
   "peerDependencies": {
@@ -93,6 +94,10 @@
   },
   "devDependencies": {
     "@aws/durable-execution-sdk-js": "*",
+    "@typescript-eslint/eslint-plugin": "^8.25.0",
+    "@typescript-eslint/parser": "^8.25.0",
+    "eslint": "^9.21.0",
+    "eslint-plugin-tsdoc": "^0.5.2",
     "@aws-sdk/client-s3": "^3.658.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",


### PR DESCRIPTION
The insight package had no ESLint config, so its sources fell back to the ruleless root config and were effectively unlinted. Add a package-local flat config mirroring the core SDK's rules, plus a "lint" script and the ESLint devDependencies, consistent with the other packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
