### PR TITLE
feat(sdk): per-store operationsByName index for Workflow Insight

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -88,16 +88,23 @@ us.anthropic.claude-sonnet-4-20250514-v1:0
 
 Type a question and click **Ask**. Examples:
 
-| Question                                    | Works best with    |
-| ------------------------------------------- | ------------------ |
-| "show me the last 50 records"               | Any destination    |
-| "count executions by status"                | Any destination    |
-| "show failed executions from the last hour" | Any destination    |
-| "average duration of successful executions" | Aurora, CloudWatch |
-| "failure rate percentage"                   | Aurora             |
-| "average duration grouped by function"      | Aurora             |
-| "show executions longer than 5 seconds"     | Any destination    |
-| "find execution with name abc123"           | DynamoDB, Aurora   |
+| Question                                                | Works best with              |
+| ------------------------------------------------------- | ---------------------------- |
+| "show me the last 50 records"                           | Any destination              |
+| "count executions by status"                            | Any destination              |
+| "show failed executions from the last hour"             | Any destination              |
+| "average duration of successful executions"             | Aurora, CloudWatch           |
+| "failure rate percentage"                               | Aurora                       |
+| "average duration grouped by function"                  | Aurora                       |
+| "show executions longer than 5 seconds"                 | Any destination              |
+| "find execution with name abc123"                       | DynamoDB, Aurora             |
+| "executions where operation convert_data took under 5s" | CloudWatch, DynamoDB, Aurora |
+| "executions where the charge operation failed"          | CloudWatch, DynamoDB, Aurora |
+
+> Per-operation-name questions use the `operationsByName` index (CloudWatch
+> direct + DynamoDB) or a JSONB query over the operations array (Aurora). With
+> the `LambdaLogExporter` (nested logs) these are best-effort — the
+> `CloudWatchLogsExporter` gives the most reliable per-operation queries.
 
 ## Settings Reference
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -33,7 +33,7 @@ const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord
 - operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs, attempt, error, result }
 - operationsByName: object keyed by operation name → per-name summary:
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
-    Metric fields aggregate ALL occurrences of that name; type/subType/status/result/error reflect the LAST occurrence.
+    Metric fields aggregate ALL occurrences of that name; type/subType/status reflect the most recent occurrence; result/error are present only when the name occurs exactly once.
 - pluginVersion: string
 - sdkVersion: string
 
@@ -180,7 +180,7 @@ The partition key is "pk" (the executionArn). All record fields are stored as to
 - operations: list of maps
 - operationsByName: map keyed by operation name → per-name summary map
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
-    Metrics aggregate all occurrences; status/result/error are from the last occurrence.
+    Metrics aggregate all occurrences; status is the most recent; result/error are present only when the name occurs exactly once.
     Navigate it for per-operation-name filters, e.g. WHERE "operationsByName"."convert_data"."maxDurationMs" < 5000
 - pluginVersion: string
 - sdkVersion: string`;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -1,8 +1,13 @@
 /**
- * Prompt context for converting natural language into a CloudWatch Logs Insights
- * query. Two variants depending on how records are stored:
- * - "direct": CloudWatchLogsExporter → raw JSON, fields at top level
- * - "nested": LambdaLogExporter → records inside Lambda's JSON envelope (message field)
+ * Prompt context for converting natural language into a query. The record schema
+ * given to the model varies by destination, because the stored shape differs:
+ * - "direct" (CloudWatchLogsExporter): raw JSON, fields at top level; includes an
+ *   `operationsByName` map that is directly dot-path queryable.
+ * - "nested" (LambdaLogExporter): record inside Lambda's JSON envelope (message
+ *   field); `operationsByName` exists but isn't reliably queryable (stringified).
+ * - "dynamodb": record attributes incl. an `operationsByName` map (PartiQL nav).
+ * - "aurora": Postgres; only the canonical operations array (no operationsByName) —
+ *   query operations by name via a JSONB/JSONPath predicate on the array.
  */
 
 // ─── DIRECT (CloudWatchLogsExporter) ─────────────────────────────────────────
@@ -17,7 +22,7 @@ const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord
 - functionQualifier: string
 - region: string
 - accountId: string
-- status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING"
+- status: "RUNNING" | "SUCCEEDED" | "FAILED"
 - startTime: string (ISO-8601)
 - endTime: string (ISO-8601, optional)
 - durationMs: number (optional)
@@ -25,12 +30,18 @@ const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord
 - output: object (optional)
 - error.name: string (optional)
 - error.message: string (optional)
-- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs }
+- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs, attempt, error, result }
+- operationsByName: object keyed by operation name → per-name summary:
+    { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
+    Metric fields aggregate ALL occurrences of that name; type/subType/status/result/error reflect the LAST occurrence.
 - pluginVersion: string
 - sdkVersion: string
 
 Fields are directly queryable (no parsing needed). Nested object fields use dot notation (error.name, error.message).
-Array elements (operations.0.name) are accessible but cross-element queries are limited.`;
+For PER-OPERATION-NAME queries PREFER operationsByName — it is directly dot-path queryable, e.g.
+  filter operationsByName.convert_data.maxDurationMs < 5000
+(The operations array keeps full per-occurrence detail, but cross-element filtering on it is limited.)
+Operation names containing "." can't be used as dot-path keys — fall back to the operations array for those.`;
 
 const DIALECT_DIRECT = `Target query language: CloudWatch Logs Insights (NOT SQL).
 Rules:
@@ -62,6 +73,12 @@ A: filter recordType = "WorkflowInsight" and status = "SUCCEEDED" and durationMs
 Q: failures with a timeout error
 A: filter recordType = "WorkflowInsight" and status = "FAILED" and error.name like /Timeout/ | fields @timestamp, executionArn, error.name, error.message | sort @timestamp desc | limit 50
 
+Q: executions where operation "convert_data" took less than 5 seconds
+A: filter recordType = "WorkflowInsight" and operationsByName.convert_data.maxDurationMs < 5000 | fields @timestamp, executionArn, operationsByName.convert_data.maxDurationMs | sort @timestamp desc | limit 50
+
+Q: executions where the "charge" operation failed
+A: filter recordType = "WorkflowInsight" and operationsByName.charge.failedCount > 0 | fields @timestamp, executionArn, operationsByName.charge.error.message | sort @timestamp desc | limit 50
+
 Q: show last 100 records
 A: filter recordType = "WorkflowInsight" | fields @timestamp, status, functionName, executionArn, durationMs | sort @timestamp desc | limit 100`;
 
@@ -80,21 +97,25 @@ The "message" field contains a JSON-serialized WorkflowInsightRecord with these 
 - functionQualifier: string
 - region: string
 - accountId: string
-- status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING"
+- status: "RUNNING" | "SUCCEEDED" | "FAILED"
 - startTime: string (ISO-8601)
 - endTime: string (ISO-8601, optional)
 - durationMs: number (optional)
 - input: object (optional)
 - output: object (optional)
 - error: { name: string, message: string } (optional)
-- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs }
+- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs, attempt, error, result }
+- operationsByName: object keyed by operation name → per-name summary (type, subType, count, min/max/totalDurationMs, failedCount, maxAttempt, status, result, error)
 - pluginVersion: string
 - sdkVersion: string
 
 IMPORTANT: The "message" field is a flat JSON string, NOT a nested object.
 To access sub-fields you MUST use: parse message "\\"fieldName\\":\\"*\\"" as alias
 For numeric fields use: parse message "\\"fieldName\\":*," as alias
-Array elements (operations) cannot be individually queried — filter/parse on top-level fields only.`;
+Array elements (operations) cannot be individually queried — filter/parse on top-level fields only.
+Per-operation-name numeric filtering (operationsByName) is unreliable here because the record is a
+stringified message; for those queries prefer the CloudWatchLogsExporter (direct) destination, or do a
+coarse text match like: filter message like /"convert_data"/`;
 
 const DIALECT_NESTED = `Target query language: CloudWatch Logs Insights (NOT SQL).
 Rules:
@@ -149,7 +170,7 @@ The partition key is "pk" (the executionArn). All record fields are stored as to
 - functionQualifier: string
 - region: string
 - accountId: string
-- status: "RUNNING" | "SUCCEEDED" | "FAILED" | "PENDING"
+- status: "RUNNING" | "SUCCEEDED" | "FAILED"
 - startTime: string (ISO-8601)
 - endTime: string (ISO-8601, optional)
 - durationMs: number (optional)
@@ -157,6 +178,10 @@ The partition key is "pk" (the executionArn). All record fields are stored as to
 - output: map (optional)
 - error: map with name and message (optional)
 - operations: list of maps
+- operationsByName: map keyed by operation name → per-name summary map
+    { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
+    Metrics aggregate all occurrences; status/result/error are from the last occurrence.
+    Navigate it for per-operation-name filters, e.g. WHERE "operationsByName"."convert_data"."maxDurationMs" < 5000
 - pluginVersion: string
 - sdkVersion: string`;
 
@@ -189,7 +214,10 @@ Q: show all executions
 A: SELECT pk, status, functionName, durationMs, emittedAt FROM "TABLE_NAME" WHERE recordType = 'WorkflowInsight'
 
 Q: show executions with errors
-A: SELECT pk, status, functionName, error FROM "TABLE_NAME" WHERE recordType = 'WorkflowInsight' AND attribute_exists(error)`;
+A: SELECT pk, status, functionName, error FROM "TABLE_NAME" WHERE recordType = 'WorkflowInsight' AND attribute_exists(error)
+
+Q: executions where operation "convert_data" took less than 5 seconds
+A: SELECT pk, "operationsByName"."convert_data"."maxDurationMs" FROM "TABLE_NAME" WHERE recordType = 'WorkflowInsight' AND "operationsByName"."convert_data"."maxDurationMs" < 5000`;
 
 /** Build the system prompt handed to the model. */
 // ─── AURORA (PostgreSQL via RDS Data API) ────────────────────────────────────
@@ -198,7 +226,7 @@ const RECORD_SCHEMA_AURORA = `Records are stored in a PostgreSQL table "TABLE_NA
 - execution_arn: VARCHAR(512) PRIMARY KEY
 - execution_name: VARCHAR(256)
 - function_name: VARCHAR(128)
-- status: VARCHAR(20) — values: RUNNING, SUCCEEDED, FAILED, PENDING
+- status: VARCHAR(20) — values: RUNNING, SUCCEEDED, FAILED
 - start_time: TIMESTAMPTZ
 - end_time: TIMESTAMPTZ (NULL if still running)
 - duration_ms: BIGINT (NULL if still running)
@@ -210,6 +238,11 @@ The record_json JSONB column contains the full record including:
 - record_json->'output' — execution output (structure varies per function)
 - record_json->'error' — error details ({name, message})
 - record_json->'operations' — array of operations
+
+Note: Aurora stores only the canonical operations array (there is no
+operationsByName index here). Query operations by name with a JSONPath predicate
+against the array, e.g.
+  record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)'
 
 To access fields inside input/output, use JSONB operators:
   record_json->'input'->>'fieldName' (extracts as text)
@@ -243,7 +276,10 @@ Q: show last 100 records
 A: SELECT execution_arn, status, function_name, duration_ms, emitted_at FROM TABLE_NAME ORDER BY emitted_at DESC LIMIT 100
 
 Q: average duration grouped by function
-A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_NAME WHERE status = 'SUCCEEDED' GROUP BY function_name ORDER BY avg_ms DESC`;
+A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_NAME WHERE status = 'SUCCEEDED' GROUP BY function_name ORDER BY avg_ms DESC
+
+Q: executions where operation "convert_data" took less than 5 seconds
+A: SELECT execution_arn, function_name FROM TABLE_NAME WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)' LIMIT 50`;
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -30,18 +30,16 @@ const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord
 - output: object (optional)
 - error.name: string (optional)
 - error.message: string (optional)
-- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs, attempt, error, result }
-- operationsByName: object keyed by operation name → per-name summary:
+- operationsByName: object keyed by operation name → per-name summary (this destination carries this INSTEAD OF a raw operations array):
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
     Metric fields aggregate ALL occurrences of that name; type/subType/status reflect the most recent occurrence; result/error are present only when the name occurs exactly once.
 - pluginVersion: string
 - sdkVersion: string
 
 Fields are directly queryable (no parsing needed). Nested object fields use dot notation (error.name, error.message).
-For PER-OPERATION-NAME queries PREFER operationsByName — it is directly dot-path queryable, e.g.
+For PER-OPERATION-NAME queries use operationsByName — it is directly dot-path queryable, e.g.
   filter operationsByName.convert_data.maxDurationMs < 5000
-(The operations array keeps full per-occurrence detail, but cross-element filtering on it is limited.)
-Operation names containing "." can't be used as dot-path keys — fall back to the operations array for those.`;
+Operation names containing "." can't be used as dot-path keys.`;
 
 const DIALECT_DIRECT = `Target query language: CloudWatch Logs Insights (NOT SQL).
 Rules:
@@ -104,15 +102,13 @@ The "message" field contains a JSON-serialized WorkflowInsightRecord with these 
 - input: object (optional)
 - output: object (optional)
 - error: { name: string, message: string } (optional)
-- operations: array of { id, name, type, subType, parentId, status, startTime, endTime, durationMs, attempt, error, result }
-- operationsByName: object keyed by operation name → per-name summary (type, subType, count, min/max/totalDurationMs, failedCount, maxAttempt, status, result, error)
+- operationsByName: object keyed by operation name → per-name summary (type, subType, count, min/max/totalDurationMs, failedCount, maxAttempt, status, result, error). This destination carries this INSTEAD OF a raw operations array.
 - pluginVersion: string
 - sdkVersion: string
 
 IMPORTANT: The "message" field is a flat JSON string, NOT a nested object.
 To access sub-fields you MUST use: parse message "\\"fieldName\\":\\"*\\"" as alias
 For numeric fields use: parse message "\\"fieldName\\":*," as alias
-Array elements (operations) cannot be individually queried — filter/parse on top-level fields only.
 Per-operation-name numeric filtering (operationsByName) is unreliable here because the record is a
 stringified message; for those queries prefer the CloudWatchLogsExporter (direct) destination, or do a
 coarse text match like: filter message like /"convert_data"/`;
@@ -177,8 +173,7 @@ The partition key is "pk" (the executionArn). All record fields are stored as to
 - input: map (optional)
 - output: map (optional)
 - error: map with name and message (optional)
-- operations: list of maps
-- operationsByName: map keyed by operation name → per-name summary map
+- operationsByName: map keyed by operation name → per-name summary map (stored INSTEAD OF a raw operations list)
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
     Metrics aggregate all occurrences; status is the most recent; result/error are present only when the name occurs exactly once.
     Navigate it for per-operation-name filters, e.g. WHERE "operationsByName"."convert_data"."maxDurationMs" < 5000

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -1081,6 +1081,7 @@ const insight = workflowInsight({
     new FirehoseExporter({
       deliveryStreamName: "workflow-insight-stream",
       region: "us-east-1", // optional
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });
@@ -1110,6 +1111,7 @@ const insight = workflowInsight({
       eventBusName: "default", // optional (default)
       source: "aws.durable-execution.insight", // optional (default)
       region: "us-east-1", // optional
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });
@@ -1150,6 +1152,7 @@ const insight = workflowInsight({
         "https://sqs.us-east-1.amazonaws.com/123456789012/insight-queue.fifo",
       messageGroupId: undefined, // optional (default: executionArn)
       region: "us-east-1", // optional
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });
@@ -1295,6 +1298,7 @@ const insight = workflowInsight({
     new FileExporter({
       directory: "/mnt/efs/workflow-insight",
       mode: "ndjson", // optional (default)
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -293,14 +293,14 @@ so name-based queries become a simple dot-path:
 fields executionArn | filter operationsByName.convert_data.maxDurationMs < 5000
 ```
 
-Each entry aggregates metrics across all occurrences of the name and snapshots
-the last occurrence's detail:
+Each entry aggregates metrics across all occurrences of the name; `result`/`error`
+are kept only when the name ran exactly once:
 
 ```json
 "operationsByName": {
-  "convert_data": {
+  "insert_to_db": {
     "type": "STEP", "subType": "Step",
-    "count": 2, "minDurationMs": 4200, "maxDurationMs": 8100, "totalDurationMs": 12300,
+    "count": 1, "minDurationMs": 6200, "maxDurationMs": 6200, "totalDurationMs": 6200,
     "failedCount": 0, "maxAttempt": 1,
     "status": "SUCCEEDED",
     "result": { "rows": 1200 }
@@ -311,9 +311,11 @@ the last occurrence's detail:
 Notes:
 
 - **Metrics** (`count`, `min`/`max`/`totalDurationMs`, `failedCount`, `maxAttempt`)
-  span all occurrences; `type`/`subType`/`status`/`result`/`error` reflect the
-  **last** occurrence (a run is either a success with `result` or a failure with
-  `error`).
+  span all occurrences; `type`/`subType`/`status` reflect the most recently seen
+  occurrence.
+- **`result`/`error` are included only when the name occurs exactly once.** For a
+  repeated name (loops/retries/map) they're dropped — there's no single
+  representative value — but `failedCount` still flags failures.
 - Operations **without a name are excluded** (they can't be keyed or queried).
 - Operation names containing `.` don't work as dot-path keys; use the canonical
   `operations` array for those.

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -1219,6 +1219,7 @@ const insight = workflowInsight({
       endpoint: "https://otlp.datadoghq.com/v1/logs",
       headers: { "DD-API-KEY": process.env.DD_API_KEY! },
       protocol: "http/json", // optional (default)
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });
@@ -1228,7 +1229,10 @@ const insight = workflowInsight({
 
 - Resource: `service.name`, `cloud.region`, `cloud.account.id`, `faas.name`, `faas.version`
 - Log attributes: `workflow.execution_arn`, `workflow.status`, `workflow.duration_ms`
-- Log body: full record JSON
+- Log body: full record JSON. `operationsFormat` controls how operations appear
+  in the body — the `operations` array (default), the `operationsByName` map, or
+  both. (Operations are only in the body, never attributes, so this never affects
+  attribute cardinality.)
 - Severity: ERROR for FAILED, INFO otherwise
 
 **No dependencies** — uses native `fetch`.
@@ -1254,12 +1258,17 @@ const insight = workflowInsight({
       headers: { Authorization: "Bearer " + process.env.TOKEN },
       method: "POST", // optional (default)
       timeoutMs: 5000, // optional (default: 10000)
+      operationsFormat: "array", // optional: "array" (default) | "by-name" | "both"
     }),
   ],
 });
 ```
 
 **No dependencies** — uses native `fetch` with configurable timeout.
+
+`operationsFormat` controls how operations are rendered in the posted body:
+the canonical `operations` array (default), the name-keyed `operationsByName`
+map, or both — pick what your endpoint consumes.
 
 **When to use:** Custom backends, internal microservices, SaaS integrations without dedicated exporters, prototyping.
 

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -318,8 +318,11 @@ Notes:
   repeated name (loops/retries/map) they're dropped — there's no single
   representative value — but `failedCount` still flags failures.
 - Operations **without a name are excluded** (they can't be keyed or queried).
-- Operation names containing `.` don't work as dot-path keys; use the canonical
-  `operations` array for those.
+- **Choosing query-safe operation names is your responsibility.** The name is used
+  verbatim as the map key — the library does no sanitization or escaping. A name
+  containing `.` (or other characters a destination treats specially in field
+  paths) may not be addressable via dot-path in some stores (notably CloudWatch
+  Logs Insights). Prefer simple names like `charge-card`.
 - The array remains the source of truth; array-native exporters (S3/Athena,
   OpenSearch, Aurora, Redshift) emit only the array. See
   [`docs/operations-shape.md`](./docs/operations-shape.md).

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -318,11 +318,13 @@ Notes:
   repeated name (loops/retries/map) they're dropped — there's no single
   representative value — but `failedCount` still flags failures.
 - Operations **without a name are excluded** (they can't be keyed or queried).
-- **Choosing query-safe operation names is your responsibility.** The name is used
-  verbatim as the map key — the library does no sanitization or escaping. A name
-  containing `.` (or other characters a destination treats specially in field
-  paths) may not be addressable via dot-path in some stores (notably CloudWatch
-  Logs Insights). Prefer simple names like `charge-card`.
+- **Choosing store-safe operation names is your responsibility.** Names are used
+  verbatim as keys/identifiers — the library never sanitizes or escapes them. Any
+  character your target store treats specially (e.g. `.` in CloudWatch Logs
+  Insights / OpenSearch field paths, reserved or quoting characters in
+  DynamoDB attribute names and SQL identifiers, etc.) can make an operation hard
+  or impossible to query there. Stick to simple, portable names — letters,
+  digits, `-`, `_` — to stay safe across destinations.
 - The array remains the source of truth; array-native exporters (S3/Athena,
   OpenSearch, Aurora, Redshift) emit only the array. See
   [`docs/operations-shape.md`](./docs/operations-shape.md).

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -272,6 +272,55 @@ content: {
 > using the default JSON serialization, or whose serialized form your transform
 > can handle. Input/output transforms are not affected by this.
 
+## Querying by operation name (`operationsByName`)
+
+`operations` is a canonical **array** — lossless (it keeps every occurrence of a
+repeated step name), and queryable in the analytical stores that support nested
+data (Athena `UNNEST`, Postgres/Redshift JSON path, OpenSearch `nested`):
+
+```sql
+-- Postgres (JSONB): executions where "convert_data" ran under 5s
+WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)';
+```
+
+Point-access stores that can't filter "the array element named X" —
+**CloudWatch Logs** (`LambdaLogExporter`, `CloudWatchLogsExporter`) and
+**DynamoDB** (`DynamoDBExporter`) — additionally emit an `operationsByName` map
+so name-based queries become a simple dot-path:
+
+```
+# CloudWatch Logs Insights
+fields executionArn | filter operationsByName.convert_data.maxDurationMs < 5000
+```
+
+Each entry aggregates metrics across all occurrences of the name and snapshots
+the last occurrence's detail:
+
+```json
+"operationsByName": {
+  "convert_data": {
+    "type": "STEP", "subType": "Step",
+    "count": 2, "minDurationMs": 4200, "maxDurationMs": 8100, "totalDurationMs": 12300,
+    "failedCount": 0, "maxAttempt": 1,
+    "status": "SUCCEEDED",
+    "result": { "rows": 1200 }
+  }
+}
+```
+
+Notes:
+
+- **Metrics** (`count`, `min`/`max`/`totalDurationMs`, `failedCount`, `maxAttempt`)
+  span all occurrences; `type`/`subType`/`status`/`result`/`error` reflect the
+  **last** occurrence (a run is either a success with `result` or a failure with
+  `error`).
+- Operations **without a name are excluded** (they can't be keyed or queried).
+- Operation names containing `.` don't work as dot-path keys; use the canonical
+  `operations` array for those.
+- The array remains the source of truth; array-native exporters (S3/Athena,
+  OpenSearch, Aurora, Redshift) emit only the array. See
+  [`docs/operations-shape.md`](./docs/operations-shape.md).
+
 ## Exporters
 
 ### Comparison Table

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -285,8 +285,9 @@ WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationM
 
 Point-access stores that can't filter "the array element named X" —
 **CloudWatch Logs** (`LambdaLogExporter`, `CloudWatchLogsExporter`) and
-**DynamoDB** (`DynamoDBExporter`) — additionally emit an `operationsByName` map
-so name-based queries become a simple dot-path:
+**DynamoDB** (`DynamoDBExporter`) — emit an `operationsByName` map **instead of
+the `operations` array**, so name-based queries become a simple dot-path (these
+stores trade the per-occurrence array detail for queryability):
 
 ```
 # CloudWatch Logs Insights

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -59,9 +59,11 @@ or the `operationsByName` map — never both.
 
 - Keyed by the **raw operation name**. Unnamed operations are excluded (a
   customer can't identify or query them anyway).
-  - Caveat: names containing `.` (or other path-breaking characters) don't work
-    as dot-path keys in CloudWatch/OpenSearch/DynamoDB. No sanitization is done;
-    the canonical array is the fallback. Recommend avoiding `.` in step names.
+  - Caveat: **choosing a query-safe name is the developer's responsibility.** The
+    name is used verbatim as the key — the plugin does no sanitization or escaping.
+    A name containing `.` (or other characters a destination treats specially in
+    field paths) may not be addressable via dot-path in some stores (notably
+    CloudWatch Logs Insights; DynamoDB PartiQL can quote it). Prefer simple names.
 - Value = a per-name summary, built in a **single pass** over the array
   (insert-or-update; no grouping or sorting):
   - **Aggregated across ALL occurrences** (multiplicity-independent, safe for

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -50,14 +50,18 @@ never named, so surfacing it adds noise without value.
   - Caveat: names containing `.` (or other path-breaking characters) don't work
     as dot-path keys in CloudWatch/OpenSearch/DynamoDB. No sanitization is done;
     the canonical array is the fallback. Recommend avoiding `.` in step names.
-- Value = a per-name summary combining two kinds of fields:
+- Value = a per-name summary, built in a **single pass** over the array
+  (insert-or-update; no grouping or sorting):
   - **Aggregated across ALL occurrences** (multiplicity-independent, safe for
     filtering): `count`, `minDurationMs`, `maxDurationMs`, `totalDurationMs`,
     `failedCount`, `maxAttempt`.
-  - **Snapshot of the LAST occurrence** (by `startTime`; fallback insertion
-    order): `type`, `subType`, `status`, and `result` **XOR** `error`.
-    - A single occurrence is either a success (has `result`) or a failure (has
-      `error`), so the last occurrence naturally contributes one of them.
+  - **Most recently seen occurrence**: `type`, `subType`, `status` (the runtime
+    appends newer operations to the end of the array, so the last one processed
+    wins).
+  - **`result` / `error`** are included only when the name occurs **exactly
+    once** in the execution. On the first repeat they are dropped — a repeated
+    name has no single representative value, and this keeps the logic trivial (no
+    "which occurrence?" choice).
     - `result` is present only when the operation opted in via
       `content.operations.overrides[].result`. `error` is gated by
       `content.operations.includeErrors`.
@@ -65,20 +69,20 @@ never named, so surfacing it adds noise without value.
       (and override-transformed) value — with a custom/overflow Serdes it may be
       a non-JSON string or a storage pointer, not the original object.
 
-Rule of thumb: **aggregate metrics across all runs; snapshot the last run's
-`type`/`subType`/`status`/`result`/`error`.**
+Rule of thumb: **aggregate metrics across all runs; keep `result`/`error` only
+for names that ran once.**
 
 ### Example value
 
 ```json
 "operationsByName": {
-  "convert_data": {
+  "insert_to_db": {
     "type": "STEP",
     "subType": "Step",
-    "count": 2,
-    "minDurationMs": 4200,
-    "maxDurationMs": 8100,
-    "totalDurationMs": 12300,
+    "count": 1,
+    "minDurationMs": 6200,
+    "maxDurationMs": 6200,
+    "totalDurationMs": 6200,
     "failedCount": 0,
     "maxAttempt": 1,
     "status": "SUCCEEDED",
@@ -93,11 +97,14 @@ Rule of thumb: **aggregate metrics across all runs; snapshot the last run's
     "totalDurationMs": 450,
     "failedCount": 1,
     "maxAttempt": 3,
-    "status": "FAILED",
-    "error": { "name": "StepError", "message": "declined" }
+    "status": "SUCCEEDED"
   }
 }
 ```
+
+`insert_to_db` ran once → its `result` is kept. `charge` ran three times → no
+single `result`/`error`, just the aggregate metrics (`failedCount: 1` still flags
+that one run failed).
 
 ## Query example: "executions where operation `convert_data` took < 5s"
 
@@ -151,7 +158,9 @@ operationsByName.convert_data.maxDurationMs < :v   (:v = 5000)
 
 - `totalDurationMs`: **included** (enables cumulative-cost queries `min`/`max` don't).
 - `subType`: **included** (carries customer-defined child-context labels).
-- Representative detail: **last** occurrence (by `startTime`, insertion-order tiebreak).
+- Representative detail: `result`/`error` kept only for **single-occurrence**
+  names (dropped on the first repeat); `type`/`subType`/`status` reflect the
+  most recently seen occurrence. Single-pass, no sorting.
 - `operationsByName` is emitted **always** by the three point-access exporters
   (no toggle) — bounded by distinct names, so the size cost is small.
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -1,0 +1,164 @@
+# Operation shape: canonical array + per-store `operationsByName` index
+
+> Status: **implemented.** `operations` stays a canonical array; the
+> `LambdaLogExporter`, `CloudWatchLogsExporter`, and `DynamoDBExporter` emit a
+> derived `operationsByName` index via `buildOperationsByName`.
+
+## Decision
+
+`WorkflowInsightRecord.operations` stays a **canonical JSON array** of
+`OperationRecord`. It is the lossless source of truth. Exporters that target
+point-access stores additionally emit a derived, name-keyed **`operationsByName`**
+index; array-native stores keep only the array.
+
+**Unnamed operations are excluded everywhere.** An operation with no `name` is
+dropped from the canonical array (current behavior) and, consequently, from the
+`operationsByName` index — a customer can't identify or query an operation they
+never named, so surfacing it adds noise without value.
+
+## Why the array is canonical
+
+- **Duplicate operation names are legitimate.** The same step name runs many
+  times via loops, retries, and `map`/`parallel` (e.g. the agentic-loop pattern
+  reuses `context.step("invoke-model", …)` every iteration). A flat
+  `name → object` map silently collapses these (last-wins) and loses data.
+- **It queries well in every real query engine.** See examples below —
+  Athena, Postgres, MySQL, Redshift, and OpenSearch all filter array-of-object
+  data natively (via `UNNEST`, JSONPath, SUPER, or `nested`).
+- **Dynamic keys break schema stores.** Keying by arbitrary operation names
+  causes OpenSearch mapping/field explosion and an unstable Athena schema. The
+  array keeps one stable structure regardless of operation names.
+- **Lossless superset → exporters specialize.** Reshaping an array into a
+  name-keyed map is trivial inside an exporter; the reverse (map → array) is
+  impossible once duplicates were collapsed. So the canonical model is the
+  array, and per-store shaping lives at the edge.
+
+## Per-store shaping (in exporters)
+
+- **CloudWatch Logs Insights** (`LambdaLogExporter`, `CloudWatchLogsExporter`)
+  and **DynamoDB** (`DynamoDBExporter`) are point-access stores that cannot
+  filter "the array element named X" well. These additionally emit
+  `operationsByName` for dot-path queries. They emit **array + `operationsByName`**.
+- **Array-native stores** — `S3Exporter` (Athena), `OpenSearchExporter`
+  (`nested`), `AuroraExporter`, `RedshiftExporter` (SUPER) — keep the **array only**.
+- **Custom exporters** may reshape however they want.
+
+## `operationsByName` specification
+
+- Keyed by the **raw operation name**. Unnamed operations are excluded (a
+  customer can't identify or query them anyway).
+  - Caveat: names containing `.` (or other path-breaking characters) don't work
+    as dot-path keys in CloudWatch/OpenSearch/DynamoDB. No sanitization is done;
+    the canonical array is the fallback. Recommend avoiding `.` in step names.
+- Value = a per-name summary combining two kinds of fields:
+  - **Aggregated across ALL occurrences** (multiplicity-independent, safe for
+    filtering): `count`, `minDurationMs`, `maxDurationMs`, `totalDurationMs`,
+    `failedCount`, `maxAttempt`.
+  - **Snapshot of the LAST occurrence** (by `startTime`; fallback insertion
+    order): `type`, `subType`, `status`, and `result` **XOR** `error`.
+    - A single occurrence is either a success (has `result`) or a failure (has
+      `error`), so the last occurrence naturally contributes one of them.
+    - `result` is present only when the operation opted in via
+      `content.operations.overrides[].result`. `error` is gated by
+      `content.operations.includeErrors`.
+    - **SerDes caveat** applies to `result`: it is the checkpointed, serialized
+      (and override-transformed) value — with a custom/overflow Serdes it may be
+      a non-JSON string or a storage pointer, not the original object.
+
+Rule of thumb: **aggregate metrics across all runs; snapshot the last run's
+`type`/`subType`/`status`/`result`/`error`.**
+
+### Example value
+
+```json
+"operationsByName": {
+  "convert_data": {
+    "type": "STEP",
+    "subType": "Step",
+    "count": 2,
+    "minDurationMs": 4200,
+    "maxDurationMs": 8100,
+    "totalDurationMs": 12300,
+    "failedCount": 0,
+    "maxAttempt": 1,
+    "status": "SUCCEEDED",
+    "result": { "rows": 1200 }
+  },
+  "charge": {
+    "type": "STEP",
+    "subType": "Step",
+    "count": 3,
+    "minDurationMs": 90,
+    "maxDurationMs": 210,
+    "totalDurationMs": 450,
+    "failedCount": 1,
+    "maxAttempt": 3,
+    "status": "FAILED",
+    "error": { "name": "StepError", "message": "declined" }
+  }
+}
+```
+
+## Query example: "executions where operation `convert_data` took < 5s"
+
+**Array-native stores** (query the canonical array):
+
+```sql
+-- Athena (Trino)
+SELECT execution_arn FROM workflow_insight
+WHERE any_match(operations, op -> op.name = 'convert_data' AND op.durationMs < 5000);
+
+-- Postgres (JSONB), GIN-indexable
+WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)';
+
+-- Redshift (SUPER)
+SELECT DISTINCT w.execution_arn FROM workflow_insight w, w.record_json.operations op
+WHERE op.name::varchar = 'convert_data' AND op.durationMs::int < 5000;
+```
+
+```json
+// OpenSearch (nested)
+{
+  "query": {
+    "nested": {
+      "path": "operations",
+      "query": {
+        "bool": {
+          "must": [
+            { "term": { "operations.name": "convert_data" } },
+            { "range": { "operations.durationMs": { "lt": 5000 } } }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+**Point-access stores** (query `operationsByName`):
+
+```
+# CloudWatch Logs Insights
+fields executionArn | filter operationsByName.convert_data.maxDurationMs < 5000
+
+# DynamoDB (FilterExpression — expressible, still a Scan)
+operationsByName.convert_data.maxDurationMs < :v   (:v = 5000)
+```
+
+(`maxDurationMs < 5000` = every run under 5s; `minDurationMs < 5000` = at least one run under 5s.)
+
+## Decisions (resolved)
+
+- `totalDurationMs`: **included** (enables cumulative-cost queries `min`/`max` don't).
+- `subType`: **included** (carries customer-defined child-context labels).
+- Representative detail: **last** occurrence (by `startTime`, insertion-order tiebreak).
+- `operationsByName` is emitted **always** by the three point-access exporters
+  (no toggle) — bounded by distinct names, so the size cost is small.
+
+## Implementation plan
+
+1. Shared, unit-tested `buildOperationsByName(operations)` helper.
+2. Wire it into `LambdaLogExporter`, `CloudWatchLogsExporter`, `DynamoDBExporter`
+   (emit array + `operationsByName`).
+3. Leave array-native exporters unchanged.
+4. Document the per-store shape and example queries in the README.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -8,8 +8,8 @@
 
 `WorkflowInsightRecord.operations` stays a **canonical JSON array** of
 `OperationRecord`. It is the lossless source of truth. Exporters that target
-point-access stores additionally emit a derived, name-keyed **`operationsByName`**
-index; array-native stores keep only the array.
+point-access stores emit a derived, name-keyed **`operationsByName`** index
+instead of the array; array-native stores keep the array.
 
 **Unnamed operations are excluded everywhere.** An operation with no `name` is
 dropped from the canonical array (current behavior) and, consequently, from the
@@ -37,11 +37,16 @@ never named, so surfacing it adds noise without value.
 
 - **CloudWatch Logs Insights** (`LambdaLogExporter`, `CloudWatchLogsExporter`)
   and **DynamoDB** (`DynamoDBExporter`) are point-access stores that cannot
-  filter "the array element named X" well. These additionally emit
-  `operationsByName` for dot-path queries. They emit **array + `operationsByName`**.
+  filter "the array element named X" well. These emit **`operationsByName`
+  instead of the `operations` array** — the map is dot-path queryable. (Trade-off:
+  these stores no longer carry the per-occurrence array detail.)
 - **Array-native stores** — `S3Exporter` (Athena), `OpenSearchExporter`
-  (`nested`), `AuroraExporter`, `RedshiftExporter` (SUPER) — keep the **array only**.
+  (`nested`), `AuroraExporter`, `RedshiftExporter` (SUPER) — keep the
+  **`operations` array** (no `operationsByName`).
 - **Custom exporters** may reshape however they want.
+
+Each store therefore carries exactly one operations representation: the array,
+or the `operationsByName` map — never both.
 
 ## `operationsByName` specification
 
@@ -168,6 +173,6 @@ operationsByName.convert_data.maxDurationMs < :v   (:v = 5000)
 
 1. Shared, unit-tested `buildOperationsByName(operations)` helper.
 2. Wire it into `LambdaLogExporter`, `CloudWatchLogsExporter`, `DynamoDBExporter`
-   (emit array + `operationsByName`).
+   (emit `operationsByName` instead of the `operations` array).
 3. Leave array-native exporters unchanged.
 4. Document the per-store shape and example queries in the README.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -45,6 +45,13 @@ never named, so surfacing it adds noise without value.
   **`operations` array** (no `operationsByName`).
 - **Custom exporters** may reshape however they want.
 
+- **Flexible sinks** — `HttpExporter` and `OTelExporter` target arbitrary,
+  user-defined consumers, so they take an `operationsFormat` option:
+  `"array"` (default, lossless) · `"by-name"` · `"both"`. Defaulting to `"array"`
+  keeps the safe, dynamic-key-free shape; users who know their consumer can opt
+  into the map. (`"both"` is allowed here because these sinks have no
+  store-shape constraint.)
+
 Each store therefore carries exactly one operations representation: the array,
 or the `operationsByName` map — never both.
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -59,11 +59,12 @@ or the `operationsByName` map — never both.
 
 - Keyed by the **raw operation name**. Unnamed operations are excluded (a
   customer can't identify or query them anyway).
-  - Caveat: **choosing a query-safe name is the developer's responsibility.** The
-    name is used verbatim as the key — the plugin does no sanitization or escaping.
-    A name containing `.` (or other characters a destination treats specially in
-    field paths) may not be addressable via dot-path in some stores (notably
-    CloudWatch Logs Insights; DynamoDB PartiQL can quote it). Prefer simple names.
+  - Caveat: **choosing a store-safe name is the developer's responsibility.** The
+    name is used verbatim as the key — the plugin never sanitizes or escapes it.
+    Any character the target store treats specially (e.g. `.` in CloudWatch/
+    OpenSearch field paths, reserved/quoting characters in DynamoDB attribute
+    names or SQL identifiers) can make an operation hard or impossible to query
+    there. Stick to simple, portable names (letters, digits, `-`, `_`).
 - Value = a per-name summary, built in a **single pass** over the array
   (insert-or-update; no grouping or sorting):
   - **Aggregated across ALL occurrences** (multiplicity-independent, safe for

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -45,12 +45,16 @@ never named, so surfacing it adds noise without value.
   **`operations` array** (no `operationsByName`).
 - **Custom exporters** may reshape however they want.
 
-- **Flexible sinks** — `HttpExporter` and `OTelExporter` target arbitrary,
-  user-defined consumers, so they take an `operationsFormat` option:
-  `"array"` (default, lossless) · `"by-name"` · `"both"`. Defaulting to `"array"`
-  keeps the safe, dynamic-key-free shape; users who know their consumer can opt
-  into the map. (`"both"` is allowed here because these sinks have no
+- **Flexible sinks** — `HttpExporter`, `OTelExporter`, `SQSExporter`,
+  `EventBridgeExporter`, `FirehoseExporter`, and `FileExporter` route the record
+  JSON to an arbitrary, user-defined consumer, so they take an `operationsFormat`
+  option: `"array"` (default, lossless) · `"by-name"` · `"both"`. Defaulting to
+  `"array"` keeps the safe, dynamic-key-free shape; users who know their consumer
+  can opt into the map. (`"both"` is allowed here because these sinks have no
   store-shape constraint.)
+- **`TimestreamExporter`** is dimensional (fixed dimensions + typed measures, plus
+  a `recordJson` catch-all and an array-derived `operationCount`), not a JSON-blob
+  router, so it has no `operationsFormat` option.
 
 Each store therefore carries exactly one operations representation: the array,
 or the `operationsByName` map — never both.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/operations-shape.md
@@ -69,8 +69,9 @@ or the `operationsByName` map — never both.
     OpenSearch field paths, reserved/quoting characters in DynamoDB attribute
     names or SQL identifiers) can make an operation hard or impossible to query
     there. Stick to simple, portable names (letters, digits, `-`, `_`).
-- Value = a per-name summary, built in a **single pass** over the array
-  (insert-or-update; no grouping or sorting):
+- Value = a per-name summary, built by aggregating in one pass over the
+  operations (insert-or-update into a map), then materializing the smaller
+  distinct-name map — no grouping or sorting:
   - **Aggregated across ALL occurrences** (multiplicity-independent, safe for
     filtering): `count`, `minDurationMs`, `maxDurationMs`, `totalDurationMs`,
     `failedCount`, `maxAttempt`.
@@ -179,7 +180,7 @@ operationsByName.convert_data.maxDurationMs < :v   (:v = 5000)
 - `subType`: **included** (carries customer-defined child-context labels).
 - Representative detail: `result`/`error` kept only for **single-occurrence**
   names (dropped on the first repeat); `type`/`subType`/`status` reflect the
-  most recently seen occurrence. Single-pass, no sorting.
+  most recently seen occurrence. No sorting.
 - `operationsByName` is emitted **always** by the three point-access exporters
   (no toggle) — bounded by distinct names, so the size cost is small.
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -46,6 +46,8 @@
 - [x] Unit tests for `buildOperationsByName` (duplicate names, last-occurrence
       result/error, failedCount, missing durations)
 - [x] Document per-store shape + example queries in the README
+- [x] `operationsFormat` option (`array` | `by-name` | `both`, default `array`) on
+      `HttpExporter` and `OTelExporter` for arbitrary/flexible destinations
 
 ## Content Filtering
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -36,12 +36,12 @@
 ## Query Ergonomics — per-store operation shaping
 
 > Design agreed in `operations-shape.md`. `operations` stays a canonical array;
-> point-access stores additionally emit a name-keyed `operationsByName` index.
+> point-access stores emit a name-keyed `operationsByName` index instead of the array.
 
 - [x] Add shared `buildOperationsByName(operations)` helper (per-name summary:
       aggregate `count`/`min`/`max`/`totalDurationMs`/`failedCount`/`maxAttempt`
       across occurrences + last-occurrence `type`/`subType`/`status`/`result`|`error`)
-- [x] Emit `operationsByName` (alongside the array) from `LambdaLogExporter`,
+- [x] Emit `operationsByName` (instead of the array) from `LambdaLogExporter`,
       `CloudWatchLogsExporter`, and `DynamoDBExporter`
 - [x] Unit tests for `buildOperationsByName` (duplicate names, last-occurrence
       result/error, failedCount, missing durations)

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -46,8 +46,10 @@
 - [x] Unit tests for `buildOperationsByName` (duplicate names, last-occurrence
       result/error, failedCount, missing durations)
 - [x] Document per-store shape + example queries in the README
-- [x] `operationsFormat` option (`array` | `by-name` | `both`, default `array`) on
-      `HttpExporter` and `OTelExporter` for arbitrary/flexible destinations
+- [x] `operationsFormat` option (`array` | `by-name` | `both`, default `array`) on the
+      flexible-sink exporters — `HttpExporter`, `OTelExporter`, `SQSExporter`,
+      `EventBridgeExporter`, `FirehoseExporter`, `FileExporter`. (Timestream is
+      dimensional, so it's excluded.)
 
 ## Content Filtering
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -33,6 +33,20 @@
       `content.operations.overrides[].result` transform (omitted by default to
       avoid unbounded payloads).
 
+## Query Ergonomics — per-store operation shaping
+
+> Design agreed in `operations-shape.md`. `operations` stays a canonical array;
+> point-access stores additionally emit a name-keyed `operationsByName` index.
+
+- [x] Add shared `buildOperationsByName(operations)` helper (per-name summary:
+      aggregate `count`/`min`/`max`/`totalDurationMs`/`failedCount`/`maxAttempt`
+      across occurrences + last-occurrence `type`/`subType`/`status`/`result`|`error`)
+- [x] Emit `operationsByName` (alongside the array) from `LambdaLogExporter`,
+      `CloudWatchLogsExporter`, and `DynamoDBExporter`
+- [x] Unit tests for `buildOperationsByName` (duplicate names, last-occurrence
+      result/error, failedCount, missing durations)
+- [x] Document per-store shape + example queries in the README
+
 ## Content Filtering
 
 - [x] Apply `content.input` transform (boolean or function)

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
@@ -5,6 +5,7 @@ import {
   ResourceAlreadyExistsException,
 } from "@aws-sdk/client-cloudwatch-logs";
 import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import { withOperationsByName } from "../operations-index";
 
 /**
  * Configuration for the CloudWatch Logs exporter.
@@ -63,7 +64,7 @@ export class CloudWatchLogsExporter implements InsightExporter {
         logEvents: [
           {
             timestamp: Date.now(),
-            message: JSON.stringify(record),
+            message: JSON.stringify(withOperationsByName(record)),
           },
         ],
       }),

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import { withOperationsByName } from "../operations-index";
 
 /**
  * Configuration for the DynamoDB exporter.
@@ -54,7 +55,7 @@ export class DynamoDBExporter implements InsightExporter {
 
   async export(record: WorkflowInsightRecord): Promise<void> {
     const item: Record<string, unknown> = {
-      ...record,
+      ...withOperationsByName(record),
       [this.partitionKey]: record.executionArn,
     };
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
@@ -2,7 +2,12 @@ import {
   EventBridgeClient,
   PutEventsCommand,
 } from "@aws-sdk/client-eventbridge";
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the EventBridge exporter.
@@ -23,6 +28,13 @@ export interface EventBridgeExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * How operations are rendered in the event detail: the canonical `operations`
+   * array (`"array"`, default), the `operationsByName` map (`"by-name"`), or
+   * `"both"`. Choose based on what your rule targets consume.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -41,11 +53,13 @@ export interface EventBridgeExporterConfig {
 export class EventBridgeExporter implements InsightExporter {
   private readonly eventBusName: string;
   private readonly source: string;
+  private readonly operationsFormat: OperationsFormat;
   private readonly client: EventBridgeClient;
 
   constructor(config: EventBridgeExporterConfig = {}) {
     this.eventBusName = config.eventBusName ?? "default";
     this.source = config.source ?? "aws.durable-execution.insight";
+    this.operationsFormat = config.operationsFormat ?? "array";
     this.client = new EventBridgeClient(
       config.region ? { region: config.region } : {},
     );
@@ -59,7 +73,9 @@ export class EventBridgeExporter implements InsightExporter {
             EventBusName: this.eventBusName,
             Source: this.source,
             DetailType: record.status,
-            Detail: JSON.stringify(record),
+            Detail: JSON.stringify(
+              applyOperationsFormat(record, this.operationsFormat),
+            ),
             Time: new Date(record.emittedAt),
           },
         ],

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
@@ -1,6 +1,11 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the file exporter.
@@ -20,6 +25,13 @@ export interface FileExporterConfig {
    * Default: "ndjson"
    */
   mode?: "ndjson" | "json";
+
+  /**
+   * How operations are rendered in the written record: the canonical `operations`
+   * array (`"array"`, default), the `operationsByName` map (`"by-name"`), or
+   * `"both"`.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -39,26 +51,30 @@ export interface FileExporterConfig {
 export class FileExporter implements InsightExporter {
   private readonly directory: string;
   private readonly mode: "ndjson" | "json";
+  private readonly operationsFormat: OperationsFormat;
   private dirCreated = false;
 
   constructor(config: FileExporterConfig) {
     this.directory = config.directory;
     this.mode = config.mode ?? "ndjson";
+    this.operationsFormat = config.operationsFormat ?? "array";
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {
     await this.ensureDir();
 
+    const formatted = applyOperationsFormat(record, this.operationsFormat);
+
     if (this.mode === "ndjson") {
       const date = record.emittedAt.slice(0, 10); // YYYY-MM-DD
       const filePath = join(this.directory, `${date}.ndjson`);
-      await appendFile(filePath, JSON.stringify(record) + "\n", "utf-8");
+      await appendFile(filePath, JSON.stringify(formatted) + "\n", "utf-8");
     } else {
       const fileName =
         sanitize(record.executionName ?? record.executionArn) + ".json";
       const filePath = join(this.directory, fileName);
       const { writeFile } = await import("node:fs/promises");
-      await writeFile(filePath, JSON.stringify(record, null, 2), "utf-8");
+      await writeFile(filePath, JSON.stringify(formatted, null, 2), "utf-8");
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
@@ -1,5 +1,10 @@
 import { FirehoseClient, PutRecordCommand } from "@aws-sdk/client-firehose";
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the Kinesis Firehose exporter.
@@ -11,6 +16,13 @@ export interface FirehoseExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * How operations are rendered in each NDJSON record: the canonical `operations`
+   * array (`"array"`, default), the `operationsByName` map (`"by-name"`), or
+   * `"both"`. Choose based on the downstream destination's consumer.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -27,17 +39,21 @@ export interface FirehoseExporterConfig {
  */
 export class FirehoseExporter implements InsightExporter {
   private readonly deliveryStreamName: string;
+  private readonly operationsFormat: OperationsFormat;
   private readonly client: FirehoseClient;
 
   constructor(config: FirehoseExporterConfig) {
     this.deliveryStreamName = config.deliveryStreamName;
+    this.operationsFormat = config.operationsFormat ?? "array";
     this.client = new FirehoseClient(
       config.region ? { region: config.region } : {},
     );
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {
-    const data = JSON.stringify(record) + "\n";
+    const data =
+      JSON.stringify(applyOperationsFormat(record, this.operationsFormat)) +
+      "\n";
 
     await this.client.send(
       new PutRecordCommand({

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
@@ -1,4 +1,9 @@
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the HTTP/Webhook exporter.
@@ -19,6 +24,13 @@ export interface HttpExporterConfig {
 
   /** Request timeout in milliseconds. Default: 10000 (10s). */
   timeoutMs?: number;
+
+  /**
+   * How operations are rendered in the posted record: the canonical
+   * `operations` array (`"array"`, default), the name-keyed `operationsByName`
+   * map (`"by-name"`), or `"both"`. Choose based on what your endpoint consumes.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -36,12 +48,14 @@ export class HttpExporter implements InsightExporter {
   private readonly method: "POST" | "PUT";
   private readonly headers: Record<string, string>;
   private readonly timeoutMs: number;
+  private readonly operationsFormat: OperationsFormat;
 
   constructor(config: HttpExporterConfig) {
     this.url = config.url;
     this.method = config.method ?? "POST";
     this.headers = config.headers ?? {};
     this.timeoutMs = config.timeoutMs ?? 10_000;
+    this.operationsFormat = config.operationsFormat ?? "array";
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {
@@ -55,7 +69,9 @@ export class HttpExporter implements InsightExporter {
           "Content-Type": "application/json",
           ...this.headers,
         },
-        body: JSON.stringify(record),
+        body: JSON.stringify(
+          applyOperationsFormat(record, this.operationsFormat),
+        ),
         signal: controller.signal,
       });
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
@@ -1,4 +1,9 @@
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the OpenTelemetry log exporter.
@@ -21,6 +26,14 @@ export interface OTelExporterConfig {
    * Default: "http/json"
    */
   protocol?: "http/json" | "http/protobuf";
+
+  /**
+   * How operations are rendered in the log body: the canonical `operations`
+   * array (`"array"`, default), the name-keyed `operationsByName` map
+   * (`"by-name"`), or `"both"`. Operations are only in the log body (not
+   * attributes), so this has no effect on attribute cardinality.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -40,6 +53,7 @@ export interface OTelExporterConfig {
 export class OTelExporter implements InsightExporter {
   private readonly endpoint: string;
   private readonly headers: Record<string, string>;
+  private readonly operationsFormat: OperationsFormat;
 
   constructor(config: OTelExporterConfig) {
     if (config.protocol === "http/protobuf") {
@@ -49,6 +63,7 @@ export class OTelExporter implements InsightExporter {
     }
     this.endpoint = config.endpoint;
     this.headers = config.headers ?? {};
+    this.operationsFormat = config.operationsFormat ?? "array";
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {
@@ -102,7 +117,11 @@ export class OTelExporter implements InsightExporter {
                   timeUnixNano: toNano(record.emittedAt),
                   severityNumber: severityFor(record.status),
                   severityText: record.status,
-                  body: { stringValue: JSON.stringify(record) },
+                  body: {
+                    stringValue: JSON.stringify(
+                      applyOperationsFormat(record, this.operationsFormat),
+                    ),
+                  },
                   attributes: [
                     kv("workflow.execution_arn", record.executionArn),
                     kv("workflow.execution_name", record.executionName ?? ""),

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
@@ -1,5 +1,10 @@
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import type { InsightExporter, WorkflowInsightRecord } from "../types";
+import type {
+  InsightExporter,
+  OperationsFormat,
+  WorkflowInsightRecord,
+} from "../types";
+import { applyOperationsFormat } from "../operations-index";
 
 /**
  * Configuration for the SQS exporter.
@@ -17,6 +22,13 @@ export interface SQSExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * How operations are rendered in the message body: the canonical `operations`
+   * array (`"array"`, default), the `operationsByName` map (`"by-name"`), or
+   * `"both"`. Choose based on what your consumer expects.
+   */
+  operationsFormat?: OperationsFormat;
 }
 
 /**
@@ -35,12 +47,14 @@ export class SQSExporter implements InsightExporter {
   private readonly queueUrl: string;
   private readonly messageGroupId?: string;
   private readonly isFifo: boolean;
+  private readonly operationsFormat: OperationsFormat;
   private readonly client: SQSClient;
 
   constructor(config: SQSExporterConfig) {
     this.queueUrl = config.queueUrl;
     this.messageGroupId = config.messageGroupId;
     this.isFifo = config.queueUrl.endsWith(".fifo");
+    this.operationsFormat = config.operationsFormat ?? "array";
     this.client = new SQSClient(config.region ? { region: config.region } : {});
   }
 
@@ -48,7 +62,9 @@ export class SQSExporter implements InsightExporter {
     await this.client.send(
       new SendMessageCommand({
         QueueUrl: this.queueUrl,
-        MessageBody: JSON.stringify(record),
+        MessageBody: JSON.stringify(
+          applyOperationsFormat(record, this.operationsFormat),
+        ),
         MessageGroupId: this.isFifo
           ? (this.messageGroupId ?? record.executionArn)
           : undefined,

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -24,6 +24,7 @@ export type {
   WorkflowInsightRecord,
   OperationRecord,
   OperationSummary,
+  OperationsFormat,
   ContentConfig,
   OperationOverride,
 } from "./types";
@@ -31,6 +32,7 @@ export type {
 export {
   buildOperationsByName,
   withOperationsByName,
+  applyOperationsFormat,
 } from "./operations-index";
 
 export { S3Exporter } from "./exporters/s3-exporter";

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -16,15 +16,22 @@ import type {
   JsonValue,
   InsightExporter,
 } from "./types";
+import { withOperationsByName } from "./operations-index";
 
 export type {
   InsightExporter,
   WorkflowInsightConfig,
   WorkflowInsightRecord,
   OperationRecord,
+  OperationSummary,
   ContentConfig,
   OperationOverride,
 } from "./types";
+
+export {
+  buildOperationsByName,
+  withOperationsByName,
+} from "./operations-index";
 
 export { S3Exporter } from "./exporters/s3-exporter";
 export type { S3ExporterConfig } from "./exporters/s3-exporter";
@@ -255,7 +262,7 @@ function buildOperationRecords(
  */
 export class LambdaLogExporter implements InsightExporter {
   async export(record: WorkflowInsightRecord): Promise<void> {
-    console.log(JSON.stringify(record));
+    console.log(JSON.stringify(withOperationsByName(record)));
   }
 }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -128,15 +128,18 @@ describe("buildOperationsByName", () => {
 });
 
 describe("withOperationsByName", () => {
-  it("attaches operationsByName without mutating the original record", () => {
+  it("replaces operations with operationsByName without mutating the original", () => {
     const record = {
       operations: [op({ id: "o1", name: "step-a", durationMs: 5 })],
     } as unknown as WorkflowInsightRecord;
 
-    const augmented = withOperationsByName(record);
-    expect(augmented.operationsByName["step-a"].count).toBe(1);
+    const out = withOperationsByName(record);
+    expect(out.operationsByName["step-a"].count).toBe(1);
+    // the array is dropped from the emitted record...
     expect(
-      (record as unknown as { operationsByName?: unknown }).operationsByName,
+      (out as unknown as { operations?: unknown }).operations,
     ).toBeUndefined();
+    // ...but the original record is not mutated.
+    expect(record.operations).toHaveLength(1);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -11,14 +11,13 @@ function op(
 }
 
 describe("buildOperationsByName", () => {
-  it("aggregates metrics across occurrences and snapshots the last occurrence", () => {
+  it("aggregates metrics across occurrences and drops result/error for repeated names", () => {
     const byName = buildOperationsByName([
       op({
         id: "o1",
         name: "charge",
         subType: "Step",
         status: "FAILED",
-        startTime: "2026-01-01T00:00:01.000Z",
         durationMs: 100,
         attempt: 1,
         error: { name: "StepError", message: "e1" },
@@ -28,7 +27,6 @@ describe("buildOperationsByName", () => {
         name: "charge",
         subType: "Step",
         status: "SUCCEEDED",
-        startTime: "2026-01-01T00:00:03.000Z",
         durationMs: 210,
         attempt: 2,
         result: { ok: true },
@@ -44,15 +42,22 @@ describe("buildOperationsByName", () => {
       totalDurationMs: 310,
       failedCount: 1,
       maxAttempt: 2,
-      status: "SUCCEEDED", // last occurrence (later startTime) succeeded
-      result: { ok: true }, // from the last occurrence
-      // no error: last occurrence succeeded
+      status: "SUCCEEDED", // most recently seen occurrence
+      // no result/error: the name repeated
     });
+    expect(byName.charge.result).toBeUndefined();
+    expect(byName.charge.error).toBeUndefined();
   });
 
-  it("uses the same uniform shape for a single occurrence", () => {
+  it("keeps result for a single-occurrence operation", () => {
     const byName = buildOperationsByName([
-      op({ id: "o1", name: "insert", status: "SUCCEEDED", durationMs: 6200 }),
+      op({
+        id: "o1",
+        name: "insert",
+        status: "SUCCEEDED",
+        durationMs: 6200,
+        result: { rows: 3 },
+      }),
     ]);
     expect(byName.insert).toEqual({
       type: "STEP",
@@ -62,7 +67,26 @@ describe("buildOperationsByName", () => {
       totalDurationMs: 6200,
       failedCount: 0,
       status: "SUCCEEDED",
+      result: { rows: 3 },
     });
+  });
+
+  it("keeps error for a single failed occurrence", () => {
+    const byName = buildOperationsByName([
+      op({
+        id: "o1",
+        name: "convert",
+        status: "FAILED",
+        error: { name: "StepError", message: "boom" },
+      }),
+    ]);
+    expect(byName.convert.status).toBe("FAILED");
+    expect(byName.convert.failedCount).toBe(1);
+    expect(byName.convert.error).toEqual({
+      name: "StepError",
+      message: "boom",
+    });
+    expect(byName.convert.result).toBeUndefined();
   });
 
   it("excludes operations without a name", () => {
@@ -82,38 +106,24 @@ describe("buildOperationsByName", () => {
     expect(byName["wait-1"].totalDurationMs).toBeUndefined();
   });
 
-  it("surfaces the last occurrence's error (and no result) when it failed", () => {
+  it("initializes duration aggregates when only a later occurrence has a duration", () => {
     const byName = buildOperationsByName([
-      op({
-        id: "o1",
-        name: "convert",
-        status: "SUCCEEDED",
-        startTime: "2026-01-01T00:00:01.000Z",
-        result: { a: 1 },
-      }),
-      op({
-        id: "o2",
-        name: "convert",
-        status: "FAILED",
-        startTime: "2026-01-01T00:00:05.000Z",
-        error: { name: "StepError", message: "boom" },
-      }),
+      op({ id: "o1", name: "x", status: "SUCCEEDED" }),
+      op({ id: "o2", name: "x", status: "SUCCEEDED", durationMs: 50 }),
     ]);
-    expect(byName.convert.status).toBe("FAILED");
-    expect(byName.convert.failedCount).toBe(1);
-    expect(byName.convert.error).toEqual({
-      name: "StepError",
-      message: "boom",
-    });
-    expect(byName.convert.result).toBeUndefined();
+    expect(byName.x.count).toBe(2);
+    expect(byName.x.minDurationMs).toBe(50);
+    expect(byName.x.maxDurationMs).toBe(50);
+    expect(byName.x.totalDurationMs).toBe(50);
   });
 
-  it("breaks startTime ties by insertion order (later index wins)", () => {
+  it("updates status/type to the most recently seen occurrence", () => {
     const byName = buildOperationsByName([
-      op({ id: "o1", name: "x", status: "SUCCEEDED", result: { first: true } }),
-      op({ id: "o2", name: "x", status: "SUCCEEDED", result: { last: true } }),
+      op({ id: "o1", name: "x", type: "STEP", status: "SUCCEEDED" }),
+      op({ id: "o2", name: "x", type: "STEP", status: "FAILED" }),
     ]);
-    expect(byName.x.result).toEqual({ last: true });
+    expect(byName.x.status).toBe("FAILED");
+    expect(byName.x.failedCount).toBe(1);
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyOperationsFormat,
   buildOperationsByName,
   withOperationsByName,
 } from "./operations-index";
@@ -141,5 +142,40 @@ describe("withOperationsByName", () => {
     ).toBeUndefined();
     // ...but the original record is not mutated.
     expect(record.operations).toHaveLength(1);
+  });
+});
+
+describe("applyOperationsFormat", () => {
+  const record = {
+    operations: [
+      op({ id: "o1", name: "step-a", durationMs: 5 }),
+      op({ id: "o2", name: "step-a", durationMs: 7 }),
+    ],
+  } as unknown as WorkflowInsightRecord;
+
+  it("array: returns the record unchanged", () => {
+    const out = applyOperationsFormat(record, "array") as WorkflowInsightRecord;
+    expect(out.operations).toHaveLength(2);
+    expect(
+      (out as unknown as { operationsByName?: unknown }).operationsByName,
+    ).toBeUndefined();
+  });
+
+  it("by-name: replaces the array with the map", () => {
+    const out = applyOperationsFormat(record, "by-name") as {
+      operations?: unknown;
+      operationsByName: Record<string, { count: number }>;
+    };
+    expect(out.operations).toBeUndefined();
+    expect(out.operationsByName["step-a"].count).toBe(2);
+  });
+
+  it("both: keeps the array and adds the map", () => {
+    const out = applyOperationsFormat(record, "both") as {
+      operations: unknown[];
+      operationsByName: Record<string, { count: number }>;
+    };
+    expect(out.operations).toHaveLength(2);
+    expect(out.operationsByName["step-a"].count).toBe(2);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -1,0 +1,132 @@
+import {
+  buildOperationsByName,
+  withOperationsByName,
+} from "./operations-index";
+import type { OperationRecord, WorkflowInsightRecord } from "./types";
+
+function op(
+  partial: Partial<OperationRecord> & { id: string },
+): OperationRecord {
+  return { type: "STEP", status: "SUCCEEDED", ...partial } as OperationRecord;
+}
+
+describe("buildOperationsByName", () => {
+  it("aggregates metrics across occurrences and snapshots the last occurrence", () => {
+    const byName = buildOperationsByName([
+      op({
+        id: "o1",
+        name: "charge",
+        subType: "Step",
+        status: "FAILED",
+        startTime: "2026-01-01T00:00:01.000Z",
+        durationMs: 100,
+        attempt: 1,
+        error: { name: "StepError", message: "e1" },
+      }),
+      op({
+        id: "o2",
+        name: "charge",
+        subType: "Step",
+        status: "SUCCEEDED",
+        startTime: "2026-01-01T00:00:03.000Z",
+        durationMs: 210,
+        attempt: 2,
+        result: { ok: true },
+      }),
+    ]);
+
+    expect(byName.charge).toEqual({
+      type: "STEP",
+      subType: "Step",
+      count: 2,
+      minDurationMs: 100,
+      maxDurationMs: 210,
+      totalDurationMs: 310,
+      failedCount: 1,
+      maxAttempt: 2,
+      status: "SUCCEEDED", // last occurrence (later startTime) succeeded
+      result: { ok: true }, // from the last occurrence
+      // no error: last occurrence succeeded
+    });
+  });
+
+  it("uses the same uniform shape for a single occurrence", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "insert", status: "SUCCEEDED", durationMs: 6200 }),
+    ]);
+    expect(byName.insert).toEqual({
+      type: "STEP",
+      count: 1,
+      minDurationMs: 6200,
+      maxDurationMs: 6200,
+      totalDurationMs: 6200,
+      failedCount: 0,
+      status: "SUCCEEDED",
+    });
+  });
+
+  it("excludes operations without a name", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", status: "SUCCEEDED" }),
+      op({ id: "o2", name: "named", status: "SUCCEEDED" }),
+    ]);
+    expect(Object.keys(byName)).toEqual(["named"]);
+  });
+
+  it("omits duration fields when no occurrence has a duration", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "wait-1", type: "WAIT", status: "SUCCEEDED" }),
+    ]);
+    expect(byName["wait-1"].minDurationMs).toBeUndefined();
+    expect(byName["wait-1"].maxDurationMs).toBeUndefined();
+    expect(byName["wait-1"].totalDurationMs).toBeUndefined();
+  });
+
+  it("surfaces the last occurrence's error (and no result) when it failed", () => {
+    const byName = buildOperationsByName([
+      op({
+        id: "o1",
+        name: "convert",
+        status: "SUCCEEDED",
+        startTime: "2026-01-01T00:00:01.000Z",
+        result: { a: 1 },
+      }),
+      op({
+        id: "o2",
+        name: "convert",
+        status: "FAILED",
+        startTime: "2026-01-01T00:00:05.000Z",
+        error: { name: "StepError", message: "boom" },
+      }),
+    ]);
+    expect(byName.convert.status).toBe("FAILED");
+    expect(byName.convert.failedCount).toBe(1);
+    expect(byName.convert.error).toEqual({
+      name: "StepError",
+      message: "boom",
+    });
+    expect(byName.convert.result).toBeUndefined();
+  });
+
+  it("breaks startTime ties by insertion order (later index wins)", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "x", status: "SUCCEEDED", result: { first: true } }),
+      op({ id: "o2", name: "x", status: "SUCCEEDED", result: { last: true } }),
+    ]);
+    expect(byName.x.result).toEqual({ last: true });
+  });
+});
+
+describe("withOperationsByName", () => {
+  it("attaches operationsByName without mutating the original record", () => {
+    const record = {
+      operations: [op({ id: "o1", name: "step-a", durationMs: 5 })],
+    } as unknown as WorkflowInsightRecord;
+
+    const augmented = withOperationsByName(record);
+    expect(augmented.operationsByName["step-a"].count).toBe(1);
+    expect(
+      (record as unknown as { operationsByName?: unknown }).operationsByName,
+    ).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -127,6 +127,15 @@ describe("buildOperationsByName", () => {
     expect(byName.x.failedCount).toBe(1);
   });
 
+  it("reflects the latest occurrence's subType (clears a stale earlier one)", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "x", subType: "Batch", status: "SUCCEEDED" }),
+      op({ id: "o2", name: "x", status: "SUCCEEDED" }), // no subType
+    ]);
+    expect(byName.x.count).toBe(2);
+    expect(byName.x.subType).toBeUndefined();
+  });
+
   it("does not pollute Object.prototype for a '__proto__' operation name", () => {
     const byName = buildOperationsByName([
       op({ id: "o1", name: "__proto__", status: "SUCCEEDED", durationMs: 5 }),

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -126,6 +126,23 @@ describe("buildOperationsByName", () => {
     expect(byName.x.status).toBe("FAILED");
     expect(byName.x.failedCount).toBe(1);
   });
+
+  it("does not pollute Object.prototype for a '__proto__' operation name", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "__proto__", status: "SUCCEEDED", durationMs: 5 }),
+      // second occurrence exercises the update + delete path
+      op({ id: "o2", name: "__proto__", status: "FAILED", durationMs: 9 }),
+    ]);
+
+    // Object.prototype must be untouched.
+    expect(({} as Record<string, unknown>).count).toBeUndefined();
+    expect(({} as Record<string, unknown>).status).toBeUndefined();
+
+    // The summary is stored as an own data property, not on the prototype.
+    const desc = Object.getOwnPropertyDescriptor(byName, "__proto__");
+    expect(desc?.value?.count).toBe(2);
+    expect(desc?.value?.status).toBe("FAILED");
+  });
 });
 
 describe("withOperationsByName", () => {

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.test.ts
@@ -118,6 +118,15 @@ describe("buildOperationsByName", () => {
     expect(byName.x.totalDurationMs).toBe(50);
   });
 
+  it("initializes maxAttempt when only a later occurrence has an attempt", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "x", status: "SUCCEEDED" }), // no attempt
+      op({ id: "o2", name: "x", status: "SUCCEEDED", attempt: 4 }),
+    ]);
+    expect(byName.x.count).toBe(2);
+    expect(byName.x.maxAttempt).toBe(4);
+  });
+
   it("updates status/type to the most recently seen occurrence", () => {
     const byName = buildOperationsByName([
       op({ id: "o1", name: "x", type: "STEP", status: "SUCCEEDED" }),
@@ -151,6 +160,23 @@ describe("buildOperationsByName", () => {
     const desc = Object.getOwnPropertyDescriptor(byName, "__proto__");
     expect(desc?.value?.count).toBe(2);
     expect(desc?.value?.status).toBe("FAILED");
+  });
+
+  it("serializes a '__proto__' entry through JSON without polluting (round-trip)", () => {
+    const byName = buildOperationsByName([
+      op({ id: "o1", name: "__proto__", status: "SUCCEEDED", durationMs: 5 }),
+    ]);
+
+    const json = JSON.stringify(byName);
+    // The entry is actually emitted (so it reaches CloudWatch/etc., not dropped).
+    expect(json).toContain('"__proto__"');
+
+    const parsed = JSON.parse(json);
+    // Round-trip must not pollute Object.prototype...
+    expect(({} as Record<string, unknown>).count).toBeUndefined();
+    // ...and the summary is recoverable as an own property.
+    const desc = Object.getOwnPropertyDescriptor(parsed, "__proto__");
+    expect(desc?.value?.count).toBe(1);
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -60,7 +60,10 @@ export function buildOperationsByName(
     existing.failedCount += failed;
     existing.type = op.type;
     existing.status = op.status;
+    // Reflect the latest occurrence: set subType if present, otherwise clear the
+    // stale earlier value (keeps parity with type/status, which are always set).
     if (op.subType !== undefined) existing.subType = op.subType;
+    else delete existing.subType;
     if (duration !== undefined) {
       existing.minDurationMs =
         existing.minDurationMs === undefined

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -7,7 +7,9 @@ import type {
 
 /**
  * Builds a name-keyed index of operation summaries from the canonical operations
- * array, in a single pass. Operations without a name are skipped (they can't be
+ * array in one pass over the operations (aggregating into a Map), then a second
+ * pass over the smaller distinct-name Map to materialize the result. Operations
+ * without a name are skipped (they can't be
  * keyed or queried).
  *
  * For each named operation: if the name is not yet in the index, insert a

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -5,74 +5,79 @@ import type {
 } from "./types";
 
 /**
- * Picks the "last" occurrence of a same-named group: the one with the greatest
- * `startTime` (ISO-8601 strings sort chronologically). Missing timestamps sort
- * earliest, and ties resolve to the later array index (insertion order).
- */
-function latestOccurrence(group: OperationRecord[]): OperationRecord {
-  let last = group[0];
-  for (let i = 1; i < group.length; i++) {
-    if ((group[i].startTime ?? "") >= (last.startTime ?? "")) {
-      last = group[i];
-    }
-  }
-  return last;
-}
-
-function summarize(group: OperationRecord[]): OperationSummary {
-  const durations = group
-    .map((o) => o.durationMs)
-    .filter((d): d is number => typeof d === "number");
-  const attempts = group
-    .map((o) => o.attempt)
-    .filter((a): a is number => typeof a === "number");
-  const last = latestOccurrence(group);
-
-  const summary: OperationSummary = {
-    type: last.type,
-    count: group.length,
-    failedCount: group.filter((o) => o.status === "FAILED").length,
-    status: last.status,
-  };
-
-  if (last.subType !== undefined) summary.subType = last.subType;
-  if (durations.length > 0) {
-    summary.minDurationMs = Math.min(...durations);
-    summary.maxDurationMs = Math.max(...durations);
-    summary.totalDurationMs = durations.reduce((a, b) => a + b, 0);
-  }
-  if (attempts.length > 0) summary.maxAttempt = Math.max(...attempts);
-  // A single occurrence is either a success (result) or a failure (error), so
-  // the last occurrence naturally contributes at most one of these.
-  if (last.result !== undefined) summary.result = last.result;
-  if (last.error !== undefined) summary.error = last.error;
-
-  return summary;
-}
-
-/**
  * Builds a name-keyed index of operation summaries from the canonical operations
- * array. Operations without a name are skipped (they can't be keyed or queried).
+ * array, in a single pass. Operations without a name are skipped (they can't be
+ * keyed or queried).
  *
- * Metric fields aggregate across all occurrences of a name; `type`/`subType`/
- * `status`/`result`/`error` come from the last occurrence. See
- * `docs/operations-shape.md`.
+ * For each named operation: if the name is not yet in the index, insert a
+ * summary (including its `result`/`error`); if it is already present (a repeated
+ * name — loops/retries/map), update the aggregate metrics and **drop
+ * `result`/`error`**, since there is no single representative value for a name
+ * that ran more than once. Scalar fields (`type`, `subType`, `status`) reflect
+ * the most recently seen occurrence (the runtime appends newer operations to the
+ * end of the array). See `docs/operations-shape.md`.
  */
 export function buildOperationsByName(
   operations: OperationRecord[],
 ): Record<string, OperationSummary> {
-  const groups = new Map<string, OperationRecord[]>();
+  const byName: Record<string, OperationSummary> = {};
+
   for (const op of operations) {
     if (!op.name) continue;
-    const existing = groups.get(op.name);
-    if (existing) existing.push(op);
-    else groups.set(op.name, [op]);
+
+    const duration =
+      typeof op.durationMs === "number" ? op.durationMs : undefined;
+    const attempt = typeof op.attempt === "number" ? op.attempt : undefined;
+    const failed = op.status === "FAILED" ? 1 : 0;
+
+    const existing = byName[op.name];
+    if (!existing) {
+      const summary: OperationSummary = {
+        type: op.type,
+        count: 1,
+        failedCount: failed,
+        status: op.status,
+      };
+      if (op.subType !== undefined) summary.subType = op.subType;
+      if (duration !== undefined) {
+        summary.minDurationMs = duration;
+        summary.maxDurationMs = duration;
+        summary.totalDurationMs = duration;
+      }
+      if (attempt !== undefined) summary.maxAttempt = attempt;
+      if (op.result !== undefined) summary.result = op.result;
+      if (op.error !== undefined) summary.error = op.error;
+      byName[op.name] = summary;
+      continue;
+    }
+
+    // Repeated name: aggregate and drop the per-occurrence result/error.
+    existing.count += 1;
+    existing.failedCount += failed;
+    existing.type = op.type;
+    existing.status = op.status;
+    if (op.subType !== undefined) existing.subType = op.subType;
+    if (duration !== undefined) {
+      existing.minDurationMs =
+        existing.minDurationMs === undefined
+          ? duration
+          : Math.min(existing.minDurationMs, duration);
+      existing.maxDurationMs =
+        existing.maxDurationMs === undefined
+          ? duration
+          : Math.max(existing.maxDurationMs, duration);
+      existing.totalDurationMs = (existing.totalDurationMs ?? 0) + duration;
+    }
+    if (attempt !== undefined) {
+      existing.maxAttempt =
+        existing.maxAttempt === undefined
+          ? attempt
+          : Math.max(existing.maxAttempt, attempt);
+    }
+    delete existing.result;
+    delete existing.error;
   }
 
-  const byName: Record<string, OperationSummary> = {};
-  for (const [name, group] of groups) {
-    byName[name] = summarize(group);
-  }
   return byName;
 }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -21,7 +21,10 @@ import type {
 export function buildOperationsByName(
   operations: OperationRecord[],
 ): Record<string, OperationSummary> {
-  const byName: Record<string, OperationSummary> = {};
+  // Accumulate in a Map: operation names are arbitrary strings, and indexing a
+  // plain object with e.g. "__proto__" would read/mutate Object.prototype.
+  // Map get/set are entry operations and immune to prototype pollution.
+  const groups = new Map<string, OperationSummary>();
 
   for (const op of operations) {
     if (!op.name) continue;
@@ -31,7 +34,7 @@ export function buildOperationsByName(
     const attempt = typeof op.attempt === "number" ? op.attempt : undefined;
     const failed = op.status === "FAILED" ? 1 : 0;
 
-    const existing = byName[op.name];
+    const existing = groups.get(op.name);
     if (!existing) {
       const summary: OperationSummary = {
         type: op.type,
@@ -48,7 +51,7 @@ export function buildOperationsByName(
       if (attempt !== undefined) summary.maxAttempt = attempt;
       if (op.result !== undefined) summary.result = op.result;
       if (op.error !== undefined) summary.error = op.error;
-      byName[op.name] = summary;
+      groups.set(op.name, summary);
       continue;
     }
 
@@ -79,6 +82,18 @@ export function buildOperationsByName(
     delete existing.error;
   }
 
+  // Materialize as a plain object. `defineProperty` creates an own data property
+  // even for a key like "__proto__", so a malicious name can't reach the
+  // Object.prototype setter.
+  const byName: Record<string, OperationSummary> = {};
+  for (const [name, summary] of groups) {
+    Object.defineProperty(byName, name, {
+      value: summary,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
   return byName;
 }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -82,17 +82,18 @@ export function buildOperationsByName(
 }
 
 /**
- * Returns the record augmented with an `operationsByName` index. Used by
- * point-access exporters (CloudWatch Logs, DynamoDB) whose stores can't filter
- * "the array element named X" but can dot-path into a name-keyed map.
+ * Returns the record with its `operations` array **replaced** by a name-keyed
+ * `operationsByName` index. Used by point-access exporters (CloudWatch Logs,
+ * DynamoDB) whose stores can't filter "the array element named X" but can
+ * dot-path into a name-keyed map — so they carry the index instead of the array
+ * (array-native exporters keep the `operations` array unchanged).
  */
-export function withOperationsByName(
-  record: WorkflowInsightRecord,
-): WorkflowInsightRecord & {
+export function withOperationsByName(record: WorkflowInsightRecord): Omit<
+  WorkflowInsightRecord,
+  "operations"
+> & {
   operationsByName: Record<string, OperationSummary>;
 } {
-  return {
-    ...record,
-    operationsByName: buildOperationsByName(record.operations),
-  };
+  const { operations, ...rest } = record;
+  return { ...rest, operationsByName: buildOperationsByName(operations) };
 }

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -1,6 +1,7 @@
 import type {
   OperationRecord,
   OperationSummary,
+  OperationsFormat,
   WorkflowInsightRecord,
 } from "./types";
 
@@ -96,4 +97,39 @@ export function withOperationsByName(record: WorkflowInsightRecord): Omit<
 } {
   const { operations, ...rest } = record;
   return { ...rest, operationsByName: buildOperationsByName(operations) };
+}
+
+/** The record as rendered by {@link applyOperationsFormat}. */
+export type FormattedRecord =
+  | WorkflowInsightRecord
+  | (Omit<WorkflowInsightRecord, "operations"> & {
+      operationsByName: Record<string, OperationSummary>;
+    })
+  | (WorkflowInsightRecord & {
+      operationsByName: Record<string, OperationSummary>;
+    });
+
+/**
+ * Renders a record's operations according to an {@link OperationsFormat}. Used by
+ * flexible-destination exporters (HTTP, OTel) that can carry either shape:
+ * - `"array"`  → the record unchanged (canonical operations array).
+ * - `"by-name"`→ `operations` replaced by the `operationsByName` map.
+ * - `"both"`   → the array plus an added `operationsByName` map.
+ */
+export function applyOperationsFormat(
+  record: WorkflowInsightRecord,
+  format: OperationsFormat,
+): FormattedRecord {
+  switch (format) {
+    case "by-name":
+      return withOperationsByName(record);
+    case "both":
+      return {
+        ...record,
+        operationsByName: buildOperationsByName(record.operations),
+      };
+    case "array":
+    default:
+      return record;
+  }
 }

--- a/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/operations-index.ts
@@ -1,0 +1,93 @@
+import type {
+  OperationRecord,
+  OperationSummary,
+  WorkflowInsightRecord,
+} from "./types";
+
+/**
+ * Picks the "last" occurrence of a same-named group: the one with the greatest
+ * `startTime` (ISO-8601 strings sort chronologically). Missing timestamps sort
+ * earliest, and ties resolve to the later array index (insertion order).
+ */
+function latestOccurrence(group: OperationRecord[]): OperationRecord {
+  let last = group[0];
+  for (let i = 1; i < group.length; i++) {
+    if ((group[i].startTime ?? "") >= (last.startTime ?? "")) {
+      last = group[i];
+    }
+  }
+  return last;
+}
+
+function summarize(group: OperationRecord[]): OperationSummary {
+  const durations = group
+    .map((o) => o.durationMs)
+    .filter((d): d is number => typeof d === "number");
+  const attempts = group
+    .map((o) => o.attempt)
+    .filter((a): a is number => typeof a === "number");
+  const last = latestOccurrence(group);
+
+  const summary: OperationSummary = {
+    type: last.type,
+    count: group.length,
+    failedCount: group.filter((o) => o.status === "FAILED").length,
+    status: last.status,
+  };
+
+  if (last.subType !== undefined) summary.subType = last.subType;
+  if (durations.length > 0) {
+    summary.minDurationMs = Math.min(...durations);
+    summary.maxDurationMs = Math.max(...durations);
+    summary.totalDurationMs = durations.reduce((a, b) => a + b, 0);
+  }
+  if (attempts.length > 0) summary.maxAttempt = Math.max(...attempts);
+  // A single occurrence is either a success (result) or a failure (error), so
+  // the last occurrence naturally contributes at most one of these.
+  if (last.result !== undefined) summary.result = last.result;
+  if (last.error !== undefined) summary.error = last.error;
+
+  return summary;
+}
+
+/**
+ * Builds a name-keyed index of operation summaries from the canonical operations
+ * array. Operations without a name are skipped (they can't be keyed or queried).
+ *
+ * Metric fields aggregate across all occurrences of a name; `type`/`subType`/
+ * `status`/`result`/`error` come from the last occurrence. See
+ * `docs/operations-shape.md`.
+ */
+export function buildOperationsByName(
+  operations: OperationRecord[],
+): Record<string, OperationSummary> {
+  const groups = new Map<string, OperationRecord[]>();
+  for (const op of operations) {
+    if (!op.name) continue;
+    const existing = groups.get(op.name);
+    if (existing) existing.push(op);
+    else groups.set(op.name, [op]);
+  }
+
+  const byName: Record<string, OperationSummary> = {};
+  for (const [name, group] of groups) {
+    byName[name] = summarize(group);
+  }
+  return byName;
+}
+
+/**
+ * Returns the record augmented with an `operationsByName` index. Used by
+ * point-access exporters (CloudWatch Logs, DynamoDB) whose stores can't filter
+ * "the array element named X" but can dot-path into a name-keyed map.
+ */
+export function withOperationsByName(
+  record: WorkflowInsightRecord,
+): WorkflowInsightRecord & {
+  operationsByName: Record<string, OperationSummary>;
+} {
+  return {
+    ...record,
+    operationsByName: buildOperationsByName(record.operations),
+  };
+}

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -145,6 +145,41 @@ export interface OperationRecord {
 }
 
 /**
+ * A per-operation-name summary emitted (as an `operationsByName` map) by
+ * point-access exporters (CloudWatch Logs, DynamoDB) to make name-based queries
+ * ergonomic. The canonical `operations` array remains the lossless source of
+ * truth; see `docs/operations-shape.md`.
+ *
+ * Metric fields aggregate across ALL occurrences of the name; `type`, `subType`,
+ * `status`, and `result`/`error` reflect the LAST occurrence (by `startTime`).
+ *
+ * @experimental This interface is experimental and may change in future releases.
+ */
+export interface OperationSummary {
+  type: string;
+  subType?: string;
+  /** Number of occurrences of this operation name in the execution. */
+  count: number;
+  /** Min/max/total duration across occurrences that have a duration. */
+  minDurationMs?: number;
+  maxDurationMs?: number;
+  totalDurationMs?: number;
+  /** How many occurrences ended in FAILED. */
+  failedCount: number;
+  /** Highest attempt number seen across occurrences. */
+  maxAttempt?: number;
+  /** Status of the last occurrence. */
+  status: string;
+  /** Result of the last occurrence (present only if that op opted results in). */
+  result?: OperationResult;
+  /** Error of the last occurrence (present only if it failed and errors are included). */
+  error?: {
+    name: string;
+    message: string;
+  };
+}
+
+/**
  * The curated execution record emitted to destinations.
  * @experimental This interface is experimental and may change in future releases.
  */

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -151,7 +151,9 @@ export interface OperationRecord {
  * truth; see `docs/operations-shape.md`.
  *
  * Metric fields aggregate across ALL occurrences of the name; `type`, `subType`,
- * `status`, and `result`/`error` reflect the LAST occurrence (by `startTime`).
+ * and `status` reflect the most recently seen occurrence. `result` and `error`
+ * are included only when the name occurs exactly ONCE in the execution — for a
+ * repeated name there is no single representative value, so both are omitted.
  *
  * @experimental This interface is experimental and may change in future releases.
  */
@@ -168,11 +170,11 @@ export interface OperationSummary {
   failedCount: number;
   /** Highest attempt number seen across occurrences. */
   maxAttempt?: number;
-  /** Status of the last occurrence. */
+  /** Status of the most recently seen occurrence. */
   status: string;
-  /** Result of the last occurrence (present only if that op opted results in). */
+  /** Result — only present when this name occurs exactly once (and opted results in). */
   result?: OperationResult;
-  /** Error of the last occurrence (present only if it failed and errors are included). */
+  /** Error — only present when this name occurs exactly once (and it failed, errors included). */
   error?: {
     name: string;
     message: string;

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -145,6 +145,16 @@ export interface OperationRecord {
 }
 
 /**
+ * How an exporter renders operations in the emitted record:
+ * - `"array"`: the canonical `operations` array (lossless; default).
+ * - `"by-name"`: replace it with the `operationsByName` map (name-keyed summary).
+ * - `"both"`: include the `operations` array and the `operationsByName` map.
+ *
+ * @experimental This type is experimental and may change in future releases.
+ */
+export type OperationsFormat = "array" | "by-name" | "both";
+
+/**
  * A per-operation-name summary emitted (as an `operationsByName` map) by
  * point-access exporters (CloudWatch Logs, DynamoDB) to make name-based queries
  * ergonomic. The canonical `operations` array remains the lossless source of


### PR DESCRIPTION
Lets users query executions by a *named operation's* metrics. `operations` stays a
canonical **array** in array-native stores; point-access stores (CloudWatch,
DynamoDB) carry a name-keyed **`operationsByName`** map instead; and the flexible
HTTP/OTel exporters make the choice configurable. Each store carries exactly one
operations representation.

Operation names repeat (loops/retries/`map` — the agentic-loop reuses
`context.step("invoke-model", …)`), so a name-keyed map can't be the canonical shape
without losing data, and dynamic keys break schema stores (OpenSearch mapping
explosion, unstable Athena schema). So the array is canonical; the map is a
per-exporter projection. Full rationale + multi-store query examples in
`docs/operations-shape.md`.

### What changed

  **Plugin core**
  - New `OperationSummary` / `OperationsFormat` types and
    `buildOperationsByName()` / `withOperationsByName()` / `applyOperationsFormat()`.
  - `buildOperationsByName` Aggregates in one pass over the operations, then materializes the smaller distinct-name map - no grouping or sorting:
    - Metrics aggregate across all occurrences: `count`, `min`/`max`/`totalDurationMs`,
      `failedCount`, `maxAttempt`.
    - `type`/`subType`/`status` reflect the most recently seen occurrence.
    - `result`/`error` kept **only when a name occurs exactly once**; dropped on the
      first repeat (`failedCount` still flags failures).
    - Unnamed operations excluded.

  **Exporters (per-store shaping)**
  - CloudWatch (`LambdaLogExporter`, `CloudWatchLogsExporter`) and `DynamoDBExporter`
    emit `operationsByName` **instead of** the array.
  - Array-native exporters (S3/Athena, OpenSearch, Aurora, Redshift) keep the array.
  - `HttpExporter` and `OTelExporter` take an **`operationsFormat`** option
    (`"array"` default | `"by-name"` | `"both"`) since their consumers are arbitrary.

  **VS Code extension (NL→query)**
  - Destination-specific schema handed to the model: `operationsByName` (dot-path) for
    CloudWatch-direct + DynamoDB; JSONB/JSONPath over the array for Aurora; best-effort
    note for the nested `LambdaLogExporter`. Added per-operation-name few-shots +
    README example questions.
  - Removed the stale `PENDING` status from all schema variants.
