### PR TITLE
fix(testing-sdk): bump to 1.1.2 and publish core SDK peer-compat fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5737,6 +5737,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
@@ -17931,7 +17938,7 @@
     },
     "packages/aws-durable-execution-sdk-js-testing": {
       "name": "@aws/durable-execution-sdk-js-testing",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.1014.0",
@@ -17946,11 +17953,13 @@
         "@eslint/js": "^9.29.0",
         "@rollup/plugin-replace": "^6.0.3",
         "@types/aws-lambda": "^8.10.150",
+        "@types/semver": "^7.5.8",
         "@types/sinonjs__fake-timers": "^15.0.1",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jest": "^29.0.1",
         "jest": "^30.0.3",
+        "semver": "^7.5.4",
         "tsx": "^4.20.5",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.1"

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/durable-execution-sdk-js-testing",
   "description": "AWS Durable Execution Testing SDK for TypeScript",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -47,11 +47,13 @@
     "@eslint/js": "^9.29.0",
     "@rollup/plugin-replace": "^6.0.3",
     "@types/aws-lambda": "^8.10.150",
+    "@types/semver": "^7.5.8",
     "@types/sinonjs__fake-timers": "^15.0.1",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jest": "^29.0.1",
     "jest": "^30.0.3",
+    "semver": "^7.5.4",
     "tsx": "^4.20.5",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.1"

--- a/packages/aws-durable-execution-sdk-js-testing/src/__tests__/peer-compatibility.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/__tests__/peer-compatibility.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { satisfies, validRange } from "semver";
+
+/**
+ * Regression guard for https://github.com/aws/aws-durable-execution-sdk-js/issues/674.
+ *
+ * The testing SDK declares a peer dependency on the core SDK
+ * (`@aws/durable-execution-sdk-js`). Inside this monorepo the two packages are
+ * linked via npm workspaces, so the peer range is never actually resolved —
+ * meaning a range that would fail a real `npm install` (e.g. `^1.0.1` while the
+ * core SDK is `2.0.0`) passes CI unnoticed. That is exactly how the published
+ * `1.1.1` shipped an incompatible `^1.0.1` peer range.
+ *
+ * This test reads both manifests off disk and asserts the core SDK's current
+ * version actually satisfies the declared peer range, catching the drift
+ * without needing to publish or install from the registry.
+ */
+describe("peer dependency compatibility with the core SDK", () => {
+  const CORE_PKG_NAME = "@aws/durable-execution-sdk-js";
+
+  const readPkg = (...segments: string[]): Record<string, unknown> =>
+    JSON.parse(readFileSync(join(__dirname, ...segments), "utf-8")) as Record<
+      string,
+      unknown
+    >;
+
+  // src/__tests__ -> package root
+  const testingPkg = readPkg("..", "..", "package.json");
+  // sibling package in the monorepo
+  const corePkg = readPkg(
+    "..",
+    "..",
+    "..",
+    "aws-durable-execution-sdk-js",
+    "package.json",
+  );
+
+  const peerDeps = (testingPkg.peerDependencies ?? {}) as Record<
+    string,
+    string
+  >;
+  const peerRange = peerDeps[CORE_PKG_NAME];
+  const coreVersion = corePkg.version as string;
+
+  it("declares a peer dependency on the core SDK", () => {
+    expect(peerRange).toBeDefined();
+  });
+
+  it("declares a valid semver range for the core SDK peer dependency", () => {
+    expect(validRange(peerRange)).not.toBeNull();
+  });
+
+  it("accepts the core SDK's current version", () => {
+    expect(coreVersion).toBeTruthy();
+    // includePrerelease so alpha/beta core versions (e.g. 2.0.0-alpha.1) are
+    // matched by ranges like ">=2.0.0" during pre-release development.
+    expect(satisfies(coreVersion, peerRange, { includePrerelease: true })).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
The published `@aws/durable-execution-sdk-js-testing@1.1.1` declares a peer dependency of `@aws/durable-execution-sdk-js@^1.0.1`, which fails to resolve against the core SDK v2.0.0 (issue #674). The source was already widened to `*`, but the version was never bumped, so the fix could not be republished over the existing 1.1.1 on npm.

Changes:
- Bump the testing package version 1.1.1 -> 1.1.2 so the already-correct `*` peer range can be published to the registry.
- Add a regression test (src/__tests__/peer-compatibility.test.ts) that reads both manifests off disk and asserts the core SDK's current version satisfies the declared peer range. Workspace symlinking masks this class of bug, so the test guards against it without needing a registry install.
- Add `semver` and `@types/semver` devDependencies used by the test.

Verified: full testing suite passes (1167 passed); the test fails as expected when the peer range is reverted to `^1.0.1`.

*Issue #, if available:* #674

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
