### PR TITLE
chore(otel): Remove RETRYING from AttemptEndInfoOutcome

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -642,45 +642,6 @@ describe("OtelPlugin", () => {
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe("FAILED");
     });
-
-    it("attempt span includes durable.attempt.outcome attribute on failed attempt", async () => {
-      await plugin.onInvocationStart(makeInvocationInfo());
-      await plugin.onOperationStart(
-        makeOperationInfo({
-          id: "op-outcome-retry",
-          name: "retry-step",
-          type: "step",
-        }),
-      );
-      await plugin.onOperationAttemptStart(
-        makeAttemptInfo({
-          id: "op-outcome-retry",
-          name: "retry-step",
-          type: "step",
-          attempt: 1,
-        }),
-      );
-      await plugin.onOperationAttemptEnd(
-        makeAttemptEndInfo({
-          id: "op-outcome-retry",
-          attempt: 1,
-          outcome: "FAILED" as any,
-          error: new Error("transient failure"),
-        }),
-      );
-      await plugin.onOperationEnd(
-        makeOperationEndInfo({ id: "op-outcome-retry", name: "retry-step" }),
-      );
-      await plugin.onInvocationEnd(makeInvocationEndInfo());
-
-      const attemptSpan = getExportedSpans().find(
-        (s) =>
-          s.attributes["durable.operation.id"] === "op-outcome-retry" &&
-          s.attributes["durable.operation.attempt"] === 1,
-      );
-      expect(attemptSpan).toBeDefined();
-      expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe("FAILED");
-    });
   });
 
   describe("Error handling", () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -643,7 +643,7 @@ describe("OtelPlugin", () => {
       expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe("FAILED");
     });
 
-    it("attempt span includes durable.attempt.outcome attribute on retrying", async () => {
+    it("attempt span includes durable.attempt.outcome attribute on failed attempt", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onOperationStart(
         makeOperationInfo({
@@ -664,7 +664,7 @@ describe("OtelPlugin", () => {
         makeAttemptEndInfo({
           id: "op-outcome-retry",
           attempt: 1,
-          outcome: "RETRYING" as any,
+          outcome: "FAILED" as any,
           error: new Error("transient failure"),
         }),
       );
@@ -679,9 +679,7 @@ describe("OtelPlugin", () => {
           s.attributes["durable.operation.attempt"] === 1,
       );
       expect(attemptSpan).toBeDefined();
-      expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe(
-        "RETRYING",
-      );
+      expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe("FAILED");
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -152,7 +152,7 @@ describe("Step Handler - plugin hooks", () => {
     );
   });
 
-  it("should call onOperationAttemptEnd with retrying outcome when step fails and will retry", async () => {
+  it("should call onOperationAttemptEnd with failed outcome when step fails and will retry", async () => {
     let callCount = 0;
     const stepFn = jest.fn().mockImplementation(async () => {
       callCount++;
@@ -182,7 +182,7 @@ describe("Step Handler - plugin hooks", () => {
 
     expect(result).toBe("recovered");
 
-    // First attempt: start + retrying end
+    // First attempt: start + failed end
     // Second attempt: start + succeeded end
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(2);
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(2);
@@ -204,7 +204,7 @@ describe("Step Handler - plugin hooks", () => {
       1,
       expect.objectContaining({
         isReplay: false,
-        outcome: AttemptEndInfoOutcome.RETRYING,
+        outcome: AttemptEndInfoOutcome.FAILED,
         error: expect.any(Error),
         nextAttemptDelaySeconds: 0,
       }),

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -206,7 +206,6 @@ describe("Step Handler - plugin hooks", () => {
         isReplay: false,
         outcome: AttemptEndInfoOutcome.FAILED,
         error: expect.any(Error),
-        nextAttemptDelaySeconds: 0,
       }),
     );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -451,7 +451,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
           stepData = context.getStepData(stepId);
           const attemptEndInfo = toAttemptEndInfo(
             stepData,
-            AttemptEndInfoOutcome.RETRYING,
+            AttemptEndInfoOutcome.FAILED,
             {
               attempt: currentAttempt,
               error: error instanceof Error ? error : new Error(String(error)),

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -455,7 +455,6 @@ export const createStepHandler = <Logger extends DurableLogger>(
             {
               attempt: currentAttempt,
               error: error instanceof Error ? error : new Error(String(error)),
-              nextAttemptDelaySeconds,
             },
           );
           backfillOperationInfo(attemptEndInfo, opInfo);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -175,7 +175,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     );
   });
 
-  it("should call onOperationAttemptEnd with retrying when condition not yet met", async () => {
+  it("should call onOperationAttemptEnd with failed when condition not yet met", async () => {
     const handler = createWaitForConditionHandler(
       mockContext,
       mockCheckpoint,
@@ -207,7 +207,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
 
     await handler("my-condition", checkFunc, config);
 
-    // First attempt: start + retrying end
+    // First attempt: start + failed end
     // Second attempt: start + succeeded end
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(2);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(2);
@@ -216,7 +216,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
       1,
       expect.objectContaining({
         isReplay: false,
-        outcome: AttemptEndInfoOutcome.RETRYING,
+        outcome: AttemptEndInfoOutcome.FAILED,
         nextAttemptDelaySeconds: 5,
       }),
     );

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -217,7 +217,6 @@ describe("WaitForCondition Handler - plugin hooks", () => {
       expect.objectContaining({
         isReplay: false,
         outcome: AttemptEndInfoOutcome.FAILED,
-        nextAttemptDelaySeconds: 5,
       }),
     );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -337,7 +337,6 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
             AttemptEndInfoOutcome.FAILED,
             {
               attempt: currentAttempt,
-              nextAttemptDelaySeconds,
             },
           );
           backfillOperationInfo(attemptEndInfo, opInfo);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -334,7 +334,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
           stepData = context.getStepData(stepId);
           const attemptEndInfo = toAttemptEndInfo(
             stepData,
-            AttemptEndInfoOutcome.RETRYING,
+            AttemptEndInfoOutcome.FAILED,
             {
               attempt: currentAttempt,
               nextAttemptDelaySeconds,

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -96,7 +96,6 @@ export interface AttemptInfo extends OperationInfo {
 export const AttemptEndInfoOutcome = {
   SUCCEEDED: "SUCCEEDED",
   FAILED: "FAILED",
-  RETRYING: "RETRYING",
 } as const;
 
 export type AttemptEndInfoOutcome =

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -109,7 +109,6 @@ export type AttemptEndInfoOutcome =
 export interface AttemptEndInfo extends AttemptInfo {
   outcome: AttemptEndInfoOutcome;
   error?: Error;
-  nextAttemptDelaySeconds?: number;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/operation/operation.ts
@@ -83,14 +83,12 @@ export function toAttemptEndInfo(
   options?: {
     attempt?: number;
     error?: Error;
-    nextAttemptDelaySeconds?: number;
   },
 ): AttemptEndInfo {
   return {
     ...toAttemptInfo(operation, options?.attempt),
     outcome,
     error: options?.error,
-    nextAttemptDelaySeconds: options?.nextAttemptDelaySeconds,
   };
 }
 


### PR DESCRIPTION
Replace AttemptEndInfoOutcome.RETRYING with FAILED for attempt-level outcomes. Also removes the nextAttemptDelaySeconds field.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
