### PR TITLE
refactor(sdk): drop sdkVersion and pluginVersion from Workflow Insight

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -33,8 +33,6 @@ const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord
 - operationsByName: object keyed by operation name → per-name summary (this destination carries this INSTEAD OF a raw operations array):
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
     Metric fields aggregate ALL occurrences of that name; type/subType/status reflect the most recent occurrence; result/error are present only when the name occurs exactly once.
-- pluginVersion: string
-- sdkVersion: string
 
 Fields are directly queryable (no parsing needed). Nested object fields use dot notation (error.name, error.message).
 For PER-OPERATION-NAME queries use operationsByName — it is directly dot-path queryable, e.g.
@@ -103,8 +101,6 @@ The "message" field contains a JSON-serialized WorkflowInsightRecord with these 
 - output: object (optional)
 - error: { name: string, message: string } (optional)
 - operationsByName: object keyed by operation name → per-name summary (type, subType, count, min/max/totalDurationMs, failedCount, maxAttempt, status, result, error). This destination carries this INSTEAD OF a raw operations array.
-- pluginVersion: string
-- sdkVersion: string
 
 IMPORTANT: The "message" field is a flat JSON string, NOT a nested object.
 To access sub-fields you MUST use: parse message "\\"fieldName\\":\\"*\\"" as alias
@@ -176,9 +172,7 @@ The partition key is "pk" (the executionArn). All record fields are stored as to
 - operationsByName: map keyed by operation name → per-name summary map (stored INSTEAD OF a raw operations list)
     { type, subType, count, minDurationMs, maxDurationMs, totalDurationMs, failedCount, maxAttempt, status, result, error }
     Metrics aggregate all occurrences; status is the most recent; result/error are present only when the name occurs exactly once.
-    Navigate it for per-operation-name filters, e.g. WHERE "operationsByName"."convert_data"."maxDurationMs" < 5000
-- pluginVersion: string
-- sdkVersion: string`;
+    Navigate it for per-operation-name filters, e.g. WHERE "operationsByName"."convert_data"."maxDurationMs" < 5000`;
 
 const DIALECT_DYNAMODB = `Target query language: PartiQL for DynamoDB (NOT standard SQL).
 Rules:

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -50,10 +50,6 @@ interface WorkflowInsightRecord {
 
   // Operations (steps, waits, invokes, callbacks)
   operations: OperationRecord[];
-
-  // Metadata
-  pluginVersion: string;
-  sdkVersion: string;
 }
 
 interface OperationRecord {
@@ -139,9 +135,7 @@ interface OperationRecord {
       "endTime": "2026-06-16T17:00:27.480Z",
       "durationMs": 80
     }
-  ],
-  "pluginVersion": "0.1.0-alpha.0",
-  "sdkVersion": "2.0.0-alpha.1"
+  ]
 }
 ```
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -355,14 +355,6 @@ interface WorkflowInsightRecord {
    * Each operation represents a step, wait, invoke, callback, or child context.
    */
   operations: OperationRecord[];
-
-  // --- Metadata ---
-
-  /** Plugin version that emitted this record. */
-  pluginVersion: string;
-
-  /** SDK version. */
-  sdkVersion: string;
 }
 
 interface OperationRecord {
@@ -468,9 +460,7 @@ interface OperationRecord {
       "startTime": null,
       "endTime": null
     }
-  ],
-  "pluginVersion": "0.1.0",
-  "sdkVersion": "2.0.0"
+  ]
 }
 ```
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -14,7 +14,6 @@
 - [x] Capture execution error from `InvocationEndInfo.executionError`
 - [x] Compute execution `startTime` and `endTime`/`durationMs`
 - [x] Handle non-Date operation timestamps (runtime sends epoch ms numbers, not Date objects)
-- [ ] Emit operations in execution order (currently `Object.values` insertion order; sort by `startTime`)
 
 ## Operation-Level Detail Capture
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
@@ -110,7 +110,7 @@ export class OTelExporter implements InsightExporter {
             {
               scope: {
                 name: "@aws/durable-execution-sdk-js-insight",
-                version: record.pluginVersion,
+                version: record.schemaVersion,
               },
               logRecords: [
                 {

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -337,9 +337,6 @@ async function flushAll(exporters: InsightExporter[]): Promise<void> {
 
 // --- Plugin Factory ---
 
-const PLUGIN_VERSION = "0.1.0-alpha.0";
-const SDK_VERSION = "2.0.0-alpha.1";
-
 /**
  * Creates a Workflow Insight plugin that listens to execution lifecycle events.
  * @experimental This function is experimental and may change in future releases.
@@ -430,8 +427,6 @@ export function workflowInsight(
         ? { name: args.error.name, message: args.error.message }
         : undefined,
       operations: args.operations,
-      pluginVersion: PLUGIN_VERSION,
-      sdkVersion: SDK_VERSION,
     };
   };
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -198,6 +198,11 @@ export interface OperationSummary {
 export interface WorkflowInsightRecord {
   /** Fixed identifier to distinguish insight records from other log data. */
   recordType: "WorkflowInsight";
+  /**
+   * Record schema version. New fields are additive and do not change this
+   * value; it is bumped only for a breaking change (a field is renamed,
+   * removed, or changes meaning/type) so consumers can detect and adapt.
+   */
   schemaVersion: "1.0";
   emittedAt: string;
   executionArn: string;
@@ -217,6 +222,4 @@ export interface WorkflowInsightRecord {
     message: string;
   };
   operations: OperationRecord[];
-  pluginVersion: string;
-  sdkVersion: string;
 }


### PR DESCRIPTION
Remove the sdkVersion and pluginVersion fields from the emitted WorkflowInsightRecord. Both were static metadata that added weight to every emitted record without carrying query value, and neither is needed by consumers. Dropping them reduces per-record payload size across all exporters.

schemaVersion ("1.0") is retained as the single version signal for the record shape. Its JSDoc is expanded to document the intended contract: new fields are additive and do not change the version, while a breaking change (a field renamed, removed, or changed in meaning/type) bumps schemaVersion so consumers can detect and adapt.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
