### PR TITLE
feat(sdk): implement deterministic sampling for Workflow Insight

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -206,7 +206,7 @@ A number between 0 and 1 (default `1.0` = every execution). When below 1.0, only
 samplingRate: 0.1, // Only 10% of executions emit records
 ```
 
-The decision is **per-execution and all-or-nothing**: a sampled-in execution emits all of its records, a sampled-out execution emits none — you never get fragmented partial data. It is **deterministic across replays**: the decision is derived from a hash of the execution's stable identity (its `executionName`), not the full ARN (which carries a per-invocation suffix), so a resumed execution always reaches the same decision. Values outside `[0, 1]` or non-numeric values are clamped/defaulted to `1.0` with a warning.
+The decision is **per-execution and all-or-nothing**: a sampled-in execution emits all of its records, a sampled-out execution emits none — you never get fragmented partial data. It is **deterministic across replays**: the decision is derived from a hash of the execution ARN, which is stable across replays, so a resumed execution always reaches the same decision. Values outside `[0, 1]` or non-numeric values are clamped/defaulted to `1.0` with a warning.
 
 ### `exporters`
 

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -200,13 +200,13 @@ const insight = workflowInsight({
 
 ### `samplingRate`
 
-> **Not yet implemented.** Reserved for a future release. Setting this currently has no effect.
-
-A number between 0 and 1. The decision is per-execution (all-or-nothing):
+A number between 0 and 1 (default `1.0` = every execution). When below 1.0, only a fraction of executions emit records; the rest are skipped entirely — no records and no exporter calls.
 
 ```typescript
 samplingRate: 0.1, // Only 10% of executions emit records
 ```
+
+The decision is **per-execution and all-or-nothing**: a sampled-in execution emits all of its records, a sampled-out execution emits none — you never get fragmented partial data. It is **deterministic across replays**: the decision is derived from a hash of the execution's stable identity (its `executionName`), not the full ARN (which carries a per-invocation suffix), so a resumed execution always reaches the same decision. Values outside `[0, 1]` or non-numeric values are clamped/defaulted to `1.0` with a warning.
 
 ### `exporters`
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -34,7 +34,8 @@ interface WorkflowInsightConfig {
 
   /**
    * Sampling rate: 0.0 to 1.0.
-   * Decision is made once per execution (all-or-nothing).
+   * Decision is made once per execution (all-or-nothing) and is deterministic
+   * across replays (hashed from the execution's stable executionName).
    * Default: 1.0 (emit all executions)
    */
   samplingRate?: number;

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -35,7 +35,7 @@ interface WorkflowInsightConfig {
   /**
    * Sampling rate: 0.0 to 1.0.
    * Decision is made once per execution (all-or-nothing) and is deterministic
-   * across replays (hashed from the execution's stable executionName).
+   * across replays (hashed from the stable execution ARN).
    * Default: 1.0 (emit all executions)
    */
   samplingRate?: number;

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -59,10 +59,14 @@
 
 ## Sampling
 
-- [ ] Implement sampling decision (skip all work if not sampled)
-- [ ] Make the sampling decision **deterministic across replays** — a per-execution
-      decision based only on `isFirstInvocation` won't reproduce on replays;
-      derive it deterministically (e.g., hash of `executionArn`/`executionName`)
+- [x] Implement sampling decision (skip all work if not sampled) — all-or-nothing
+      per execution; sampled-out executions schedule no records and make no
+      exporter calls (guarded in every hook + drain/flush skipped in `wrapInvocation`).
+- [x] Make the sampling decision **deterministic across replays** — keyed on the
+      execution's stable `executionName` (not the full ARN, which carries a
+      per-invocation suffix), hashed with FNV-1a via `Math.imul` for a
+      cross-engine-stable 32-bit result. Out-of-range/non-numeric rates are
+      clamped/defaulted with a warning.
 
 ## Emit Timing & Lifecycle
 
@@ -115,7 +119,9 @@
 - [ ] Unit tests for `ExportScheduler` (coalescing, no overlap, drain)
 - [x] Unit tests for content filtering (input/output transforms, operation overrides,
       includeErrors, result transform incl. non-JSON + throwing-transform safety)
-- [ ] Unit tests for sampling logic (including replay determinism)
+- [x] Unit tests for sampling logic (including replay determinism) — covers
+      rate 0 / 1 / omitted, fractional partitioning, invocationId-independence
+      (replay stability), stable re-runs, and out-of-range/NaN clamping.
 - [ ] Unit tests for each exporter (mock SDK clients, verify correct API calls)
 - [ ] Integration test with the testing SDK (end-to-end plugin lifecycle)
 - [x] Verified end-to-end on deployed Lambda (account 730758745077, `insight-demo-scheduled`)

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -63,10 +63,9 @@
       per execution; sampled-out executions schedule no records and make no
       exporter calls (guarded in every hook + drain/flush skipped in `wrapInvocation`).
 - [x] Make the sampling decision **deterministic across replays** — keyed on the
-      execution's stable `executionName` (not the full ARN, which carries a
-      per-invocation suffix), hashed with FNV-1a via `Math.imul` for a
-      cross-engine-stable 32-bit result. Out-of-range/non-numeric rates are
-      clamped/defaulted with a warning.
+      execution ARN, which is stable across replays, hashed with FNV-1a via
+      `Math.imul` for a cross-engine-stable 32-bit result. Out-of-range/non-numeric
+      rates are clamped/defaulted with a warning.
 
 ## Emit Timing & Lifecycle
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -305,9 +305,9 @@ enum OperationDetail {
 
 ### Sampling
 
-Sampling is decided deterministically at execution start using a hash of the execution's stable identity — its `executionName`. If sampled in, all data for that execution is emitted (every hook fires). If sampled out, no hooks fire. This ensures complete records for sampled executions rather than fragmented partial data.
+Sampling is decided deterministically at execution start using a hash of the execution ARN, which is stable across all invocations and replays of the same execution. If sampled in, all data for that execution is emitted (every hook fires). If sampled out, no hooks fire. This ensures complete records for sampled executions rather than fragmented partial data.
 
-The key is the `executionName`, **not** the full execution ARN: the ARN carries a per-invocation suffix (`.../<executionName>/<invocationId>`) that changes on replay, so hashing the whole ARN would let a resumed execution flip its decision mid-flight. `Math.imul` is used for the FNV-1a multiply so the 32-bit result is identical across JS engines (a plain `*` loses precision past 2^53).
+`Math.imul` is used for the FNV-1a multiply so the 32-bit result is identical across JS engines (a plain `*` loses precision past 2^53).
 
 ```typescript
 function shouldSampleExecution(
@@ -316,11 +316,9 @@ function shouldSampleExecution(
 ): boolean {
   if (samplingRate >= 1.0) return true;
   if (samplingRate <= 0.0) return false;
-  const { executionName } = parseExecutionArn(executionArn);
-  const key = executionName || executionArn; // fall back to ARN if no name
   let hash = 0x811c9dc5;
-  for (let i = 0; i < key.length; i++) {
-    hash ^= key.charCodeAt(i);
+  for (let i = 0; i < executionArn.length; i++) {
+    hash ^= executionArn.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193);
   }
   return (hash >>> 0) / 0xffffffff < samplingRate;

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -305,7 +305,9 @@ enum OperationDetail {
 
 ### Sampling
 
-Sampling is decided deterministically at execution start using a hash of the execution ARN. If sampled in, all data for that execution is emitted (every hook fires). If sampled out, no hooks fire. This ensures complete records for sampled executions rather than fragmented partial data.
+Sampling is decided deterministically at execution start using a hash of the execution's stable identity — its `executionName`. If sampled in, all data for that execution is emitted (every hook fires). If sampled out, no hooks fire. This ensures complete records for sampled executions rather than fragmented partial data.
+
+The key is the `executionName`, **not** the full execution ARN: the ARN carries a per-invocation suffix (`.../<executionName>/<invocationId>`) that changes on replay, so hashing the whole ARN would let a resumed execution flip its decision mid-flight. `Math.imul` is used for the FNV-1a multiply so the 32-bit result is identical across JS engines (a plain `*` loses precision past 2^53).
 
 ```typescript
 function shouldSampleExecution(
@@ -314,12 +316,14 @@ function shouldSampleExecution(
 ): boolean {
   if (samplingRate >= 1.0) return true;
   if (samplingRate <= 0.0) return false;
+  const { executionName } = parseExecutionArn(executionArn);
+  const key = executionName || executionArn; // fall back to ARN if no name
   let hash = 0x811c9dc5;
-  for (let i = 0; i < executionArn.length; i++) {
-    hash ^= executionArn.charCodeAt(i);
-    hash = (hash * 0x01000193) >>> 0;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
   }
-  return hash / 0xffffffff < samplingRate;
+  return (hash >>> 0) / 0xffffffff < samplingRate;
 }
 ```
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -295,3 +295,151 @@ describe("emit modes", () => {
     expect(exporter.records[0].status).toBe("FAILED");
   });
 });
+
+describe("sampling", () => {
+  // Build an execution ARN whose executionName is `name` and whose trailing
+  // per-invocation segment is `inv`. Sampling must depend on `name` only.
+  function arnFor(name: string, inv = "inv-1"): string {
+    return `arn:aws:lambda:us-east-1:123456789012:function:fn:1/durable-execution/${name}/${inv}`;
+  }
+
+  function baseInfo(arn: string): InvocationInfo {
+    return {
+      executionArn: arn,
+      requestId: "req-1",
+      isFirstInvocation: true,
+      executionInput: undefined,
+      operations: {},
+    } as InvocationInfo;
+  }
+
+  // Drive one full execution (terminal SUCCEEDED end + drain) through the
+  // plugin using a single ARN, so wrapInvocation drains the record scheduled by
+  // onInvocationEnd for that same execution.
+  async function runExecution(
+    plugin: DurableInstrumentationPlugin,
+    arn: string,
+    status: InvocationEndInfo["status"] = "SUCCEEDED",
+  ): Promise<void> {
+    await plugin.onInvocationEnd?.({
+      ...baseInfo(arn),
+      status,
+      executionResult: undefined,
+      operations: {},
+    } as InvocationEndInfo);
+    await plugin.wrapInvocation?.(
+      baseInfo(arn),
+      async () => ({}) as unknown as DurableExecutionInvocationOutput,
+    );
+  }
+
+  const NAMES = Array.from({ length: 200 }, (_, i) => `exec-${i}`);
+
+  it("emits for every execution when samplingRate is 1.0 or omitted", async () => {
+    for (const rate of [undefined, 1.0]) {
+      const exporter = new CapturingExporter();
+      const plugin = workflowInsight({
+        exporters: [exporter],
+        samplingRate: rate,
+      });
+      for (const name of NAMES) await runExecution(plugin, arnFor(name));
+      expect(exporter.records).toHaveLength(NAMES.length);
+    }
+  });
+
+  it("emits for no execution when samplingRate is 0", async () => {
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({ exporters: [exporter], samplingRate: 0 });
+    for (const name of NAMES) await runExecution(plugin, arnFor(name));
+    expect(exporter.records).toHaveLength(0);
+  });
+
+  it("partitions the population at a fractional rate (not all-or-nothing)", async () => {
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({
+      exporters: [exporter],
+      samplingRate: 0.5,
+    });
+    for (const name of NAMES) await runExecution(plugin, arnFor(name));
+    // Deterministic hash → stable count; assert a healthy split rather than an
+    // exact number so the bound doesn't couple to the hash implementation.
+    expect(exporter.records.length).toBeGreaterThan(NAMES.length * 0.25);
+    expect(exporter.records.length).toBeLessThan(NAMES.length * 0.75);
+  });
+
+  it("makes the same decision across replays, independent of invocationId", async () => {
+    const rate = 0.5;
+    const runWithInvocation = async (inv: string): Promise<Set<string>> => {
+      const exporter = new CapturingExporter();
+      const plugin = workflowInsight({
+        exporters: [exporter],
+        samplingRate: rate,
+      });
+      for (const name of NAMES) await runExecution(plugin, arnFor(name, inv));
+      return new Set(exporter.records.map((r) => r.executionName as string));
+    };
+
+    // Same executionNames, different per-invocation ARN suffix (as on replay).
+    const sampledWithA = await runWithInvocation("inv-a");
+    const sampledWithB = await runWithInvocation("inv-b");
+
+    // The sampled-in set must be identical — the invocationId must not affect it.
+    expect([...sampledWithA].sort()).toEqual([...sampledWithB].sort());
+    expect(sampledWithA.size).toBeGreaterThan(0);
+    expect(sampledWithA.size).toBeLessThan(NAMES.length);
+  });
+
+  it("re-runs of the same execution agree (stable per-execution decision)", async () => {
+    // Whatever the decision for a given name, running it twice yields either
+    // two records or zero — never a mix.
+    const sampledIn: string[] = [];
+    for (const name of NAMES) {
+      const exporter = new CapturingExporter();
+      const plugin = workflowInsight({
+        exporters: [exporter],
+        samplingRate: 0.5,
+      });
+      await runExecution(plugin, arnFor(name, "inv-1"));
+      await runExecution(plugin, arnFor(name, "inv-2"));
+      expect([0, 2]).toContain(exporter.records.length);
+      if (exporter.records.length === 2) sampledIn.push(name);
+    }
+    expect(sampledIn.length).toBeGreaterThan(0);
+  });
+
+  it("clamps out-of-range and non-numeric rates with a warning", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // > 1 clamps to 1 (all emit)
+      const high = new CapturingExporter();
+      const pHigh = workflowInsight({
+        exporters: [high],
+        samplingRate: 5 as number,
+      });
+      for (const name of NAMES) await runExecution(pHigh, arnFor(name));
+      expect(high.records).toHaveLength(NAMES.length);
+
+      // < 0 clamps to 0 (none emit)
+      const low = new CapturingExporter();
+      const pLow = workflowInsight({
+        exporters: [low],
+        samplingRate: -1 as number,
+      });
+      for (const name of NAMES) await runExecution(pLow, arnFor(name));
+      expect(low.records).toHaveLength(0);
+
+      // NaN defaults to 1.0 (all emit)
+      const nan = new CapturingExporter();
+      const pNan = workflowInsight({
+        exporters: [nan],
+        samplingRate: Number.NaN,
+      });
+      for (const name of NAMES) await runExecution(pNan, arnFor(name));
+      expect(nan.records).toHaveLength(NAMES.length);
+
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -297,10 +297,9 @@ describe("emit modes", () => {
 });
 
 describe("sampling", () => {
-  // Build an execution ARN whose executionName is `name` and whose trailing
-  // per-invocation segment is `inv`. Sampling must depend on `name` only.
-  function arnFor(name: string, inv = "inv-1"): string {
-    return `arn:aws:lambda:us-east-1:123456789012:function:fn:1/durable-execution/${name}/${inv}`;
+  // Build a distinct, replay-stable execution ARN for `name`.
+  function arnFor(name: string): string {
+    return `arn:aws:lambda:us-east-1:123456789012:function:fn:1/durable-execution/${name}/inv-1`;
   }
 
   function baseInfo(arn: string): InvocationInfo {
@@ -367,31 +366,31 @@ describe("sampling", () => {
     expect(exporter.records.length).toBeLessThan(NAMES.length * 0.75);
   });
 
-  it("makes the same decision across replays, independent of invocationId", async () => {
+  it("is reproducible: identical ARNs yield identical decisions", async () => {
     const rate = 0.5;
-    const runWithInvocation = async (inv: string): Promise<Set<string>> => {
+    const decideAll = async (): Promise<Set<string>> => {
       const exporter = new CapturingExporter();
       const plugin = workflowInsight({
         exporters: [exporter],
         samplingRate: rate,
       });
-      for (const name of NAMES) await runExecution(plugin, arnFor(name, inv));
-      return new Set(exporter.records.map((r) => r.executionName as string));
+      for (const name of NAMES) await runExecution(plugin, arnFor(name));
+      return new Set(exporter.records.map((r) => r.executionArn));
     };
 
-    // Same executionNames, different per-invocation ARN suffix (as on replay).
-    const sampledWithA = await runWithInvocation("inv-a");
-    const sampledWithB = await runWithInvocation("inv-b");
+    // The execution ARN is stable across replays, so the same set of ARNs must
+    // always produce the same sampled-in set.
+    const first = await decideAll();
+    const second = await decideAll();
 
-    // The sampled-in set must be identical — the invocationId must not affect it.
-    expect([...sampledWithA].sort()).toEqual([...sampledWithB].sort());
-    expect(sampledWithA.size).toBeGreaterThan(0);
-    expect(sampledWithA.size).toBeLessThan(NAMES.length);
+    expect([...first].sort()).toEqual([...second].sort());
+    expect(first.size).toBeGreaterThan(0);
+    expect(first.size).toBeLessThan(NAMES.length);
   });
 
   it("re-runs of the same execution agree (stable per-execution decision)", async () => {
-    // Whatever the decision for a given name, running it twice yields either
-    // two records or zero — never a mix.
+    // Whatever the decision for a given ARN, running it twice yields either two
+    // records or zero — never a mix.
     const sampledIn: string[] = [];
     for (const name of NAMES) {
       const exporter = new CapturingExporter();
@@ -399,8 +398,9 @@ describe("sampling", () => {
         exporters: [exporter],
         samplingRate: 0.5,
       });
-      await runExecution(plugin, arnFor(name, "inv-1"));
-      await runExecution(plugin, arnFor(name, "inv-2"));
+      const arn = arnFor(name);
+      await runExecution(plugin, arn);
+      await runExecution(plugin, arn);
       expect([0, 2]).toContain(exporter.records.length);
       if (exporter.records.length === 2) sampledIn.push(name);
     }

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -119,21 +119,15 @@ function fnv1a32(input: string): number {
 /**
  * Deterministic, all-or-nothing per-execution sampling decision.
  *
- * The decision must be identical for every invocation and replay of the same
- * execution, otherwise a resumed execution could flip its decision mid-flight
- * and emit fragmented records. We therefore key the hash on the execution's
- * stable identity — its `executionName` — and NOT the full ARN: the ARN carries
- * a per-invocation suffix (`.../<executionName>/<invocationId>`) that changes on
- * replay. Falls back to the raw ARN only when no `executionName` is present.
- *
- * Maps the hash into [0, 1) and samples in when it falls below `rate`.
+ * The execution ARN is stable across all invocations and replays of the same
+ * execution, so hashing it directly yields a decision that never changes
+ * mid-flight — a resumed execution always reaches the same conclusion. Maps the
+ * hash into [0, 1) and samples in when it falls below `rate`.
  */
 function shouldSampleExecution(executionArn: string, rate: number): boolean {
   if (rate >= 1) return true;
   if (rate <= 0) return false;
-  const { executionName } = parseExecutionArn(executionArn);
-  const key = executionName || executionArn;
-  return fnv1a32(key) / 0xffffffff < rate;
+  return fnv1a32(executionArn) / 0xffffffff < rate;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -100,6 +100,66 @@ function parseExecutionArn(executionArn: string): ParsedArn {
   };
 }
 
+// --- Sampling ---
+
+/**
+ * FNV-1a 32-bit hash. `Math.imul` performs a correct 32-bit integer multiply —
+ * a plain `*` loses precision once the intermediate exceeds 2^53 — so the
+ * result is identical across JS engines and therefore stable across replays.
+ */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Deterministic, all-or-nothing per-execution sampling decision.
+ *
+ * The decision must be identical for every invocation and replay of the same
+ * execution, otherwise a resumed execution could flip its decision mid-flight
+ * and emit fragmented records. We therefore key the hash on the execution's
+ * stable identity — its `executionName` — and NOT the full ARN: the ARN carries
+ * a per-invocation suffix (`.../<executionName>/<invocationId>`) that changes on
+ * replay. Falls back to the raw ARN only when no `executionName` is present.
+ *
+ * Maps the hash into [0, 1) and samples in when it falls below `rate`.
+ */
+function shouldSampleExecution(executionArn: string, rate: number): boolean {
+  if (rate >= 1) return true;
+  if (rate <= 0) return false;
+  const { executionName } = parseExecutionArn(executionArn);
+  const key = executionName || executionArn;
+  return fnv1a32(key) / 0xffffffff < rate;
+}
+
+/**
+ * Normalizes a user-supplied `samplingRate` into a rate in [0, 1]. `undefined`
+ * means "sample everything" (1.0). Out-of-range or non-numeric values are
+ * clamped/defaulted with a warning rather than throwing, so a misconfiguration
+ * never breaks instrumentation.
+ */
+function resolveSamplingRate(rate: number | undefined): number {
+  if (rate === undefined) return 1;
+  if (typeof rate !== "number" || Number.isNaN(rate)) {
+    console.warn(
+      "[workflow-insight] samplingRate is not a number; defaulting to 1.0 (all executions).",
+    );
+    return 1;
+  }
+  if (rate < 0 || rate > 1) {
+    const clamped = Math.max(0, Math.min(1, rate));
+    console.warn(
+      `[workflow-insight] samplingRate ${rate} is out of range [0, 1]; clamping to ${clamped}.`,
+    );
+    return clamped;
+  }
+  return rate;
+}
+
 // --- Status Mapping ---
 
 const STATUS_MAP: Record<string, WorkflowInsightRecord["status"]> = {
@@ -344,12 +404,7 @@ async function flushAll(exporters: InsightExporter[]): Promise<void> {
 export function workflowInsight(
   config: WorkflowInsightConfig,
 ): DurableInstrumentationPlugin {
-  // Warn about unimplemented config options
-  if (config.samplingRate !== undefined) {
-    console.warn(
-      "[workflow-insight] samplingRate is not yet implemented and has no effect.",
-    );
-  }
+  const samplingRate = resolveSamplingRate(config.samplingRate);
 
   const content = config.content;
   const includeErrors = content?.operations?.includeErrors ?? true;
@@ -375,6 +430,12 @@ export function workflowInsight(
     startTime: Date;
     parsedArn: ParsedArn;
     cachedInput: unknown;
+    /**
+     * Deterministic sampling decision for this execution. Computed once from the
+     * execution's stable identity so every invocation/replay agrees, then reused
+     * by all hooks to skip work entirely when the execution is sampled out.
+     */
+    sampledIn: boolean;
   }
   const execState = new Map<string, ExecutionState>();
 
@@ -385,6 +446,7 @@ export function workflowInsight(
         startTime: new Date(),
         parsedArn: parseExecutionArn(executionArn),
         cachedInput: undefined,
+        sampledIn: shouldSampleExecution(executionArn, samplingRate),
       };
       execState.set(executionArn, state);
     }
@@ -433,6 +495,7 @@ export function workflowInsight(
   return {
     async onInvocationStart(info: InvocationInfo): Promise<void> {
       const state = getState(info.executionArn);
+      if (!state.sampledIn) return;
       if (info.isFirstInvocation) {
         state.startTime = new Date();
       }
@@ -458,18 +521,24 @@ export function workflowInsight(
     // record (scheduled by onInvocationEnd, which runs inside fn) is delivered.
     // The drain runs in `finally` so it also covers the throwing/retry paths.
     async wrapInvocation(
-      _info: InvocationInfo,
+      info: InvocationInfo,
       fn: () => Promise<DurableExecutionInvocationOutput>,
     ): Promise<DurableExecutionInvocationOutput> {
+      const state = getState(info.executionArn);
       try {
         return await fn();
       } finally {
-        await scheduler.drain();
-        await flushAll(exporters);
+        // Sampled-out executions never schedule a record, so there is nothing
+        // to drain or flush — skip the work entirely.
+        if (state.sampledIn) {
+          await scheduler.drain();
+          await flushAll(exporters);
+        }
       }
     },
 
     async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
+      const state = getState(info.executionArn);
       const status = mapStatus(info.status);
       const isTerminal = status === "SUCCEEDED" || status === "FAILED";
       const isFailure = status === "FAILED";
@@ -485,7 +554,9 @@ export function workflowInsight(
             ? isFailure
             : isTerminal;
 
-      if (shouldEmit) {
+      // Sampled-out executions emit nothing, but must still fall through to the
+      // terminal state cleanup below so their state entry doesn't leak.
+      if (state.sampledIn && shouldEmit) {
         scheduler.schedule(
           buildRecord({
             executionArn: info.executionArn,
@@ -516,6 +587,7 @@ export function workflowInsight(
         return;
       }
       const state = getState(info.executionArn);
+      if (!state.sampledIn) return;
       scheduler.schedule(
         buildRecord({
           executionArn: info.executionArn,

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -86,11 +86,17 @@ export interface WorkflowInsightConfig {
   exporters?: InsightExporter[];
 
   /**
-   * Sampling rate: 0.0–1.0. When set, only a fraction of executions emit records.
-   * The decision is per-execution (all-or-nothing).
+   * Sampling rate: 0.0–1.0 (default: 1.0 = every execution). When below 1.0,
+   * only a fraction of executions emit records; the rest are skipped entirely
+   * (no records, no exporter calls).
    *
-   * @experimental **Not yet implemented.** This field is reserved for a future release.
-   * Setting it currently has no effect.
+   * The decision is per-execution and all-or-nothing: a sampled-in execution
+   * emits all of its records, a sampled-out execution emits none. It is
+   * deterministic across replays — derived from the execution's stable identity
+   * (its `executionName`) — so a resumed execution never flips its decision and
+   * produces fragmented records.
+   *
+   * Out-of-range or non-numeric values are clamped/defaulted with a warning.
    */
   samplingRate?: number;
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -97,6 +97,8 @@ export interface WorkflowInsightConfig {
    * decision and produces fragmented records.
    *
    * Out-of-range or non-numeric values are clamped/defaulted with a warning.
+   *
+   * @experimental This field is experimental and may change in future releases.
    */
   samplingRate?: number;
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -92,9 +92,9 @@ export interface WorkflowInsightConfig {
    *
    * The decision is per-execution and all-or-nothing: a sampled-in execution
    * emits all of its records, a sampled-out execution emits none. It is
-   * deterministic across replays — derived from the execution's stable identity
-   * (its `executionName`) — so a resumed execution never flips its decision and
-   * produces fragmented records.
+   * deterministic across replays — derived from a hash of the execution ARN,
+   * which is stable across replays — so a resumed execution never flips its
+   * decision and produces fragmented records.
    *
    * Out-of-range or non-numeric values are clamped/defaulted with a warning.
    */


### PR DESCRIPTION
 Implements the previously-stubbed `samplingRate` config for the Workflow
   Insight plugin. Until now the field existed in the types but had no effect
   (the plugin only logged a "not yet implemented" warning). It now controls
   what fraction of executions emit records.

### Behavior
   - `samplingRate` is a number in `[0, 1]`, default `1.0` (every execution).
   - When below `1.0`, only a fraction of executions emit records; sampled-out
     executions schedule **no** records and make **no** exporter calls.
   - The decision is **per-execution and all-or-nothing**: a sampled-in execution
     emits all of its records, a sampled-out execution emits none — records are
     never fragmented.
   - The decision is **deterministic across replays**: it is derived from a hash
     of the execution ARN, which is stable across all invocations/replays of the
     same execution, so a resumed execution never flips its decision mid-flight.
   - Out-of-range or non-numeric values are clamped/defaulted to `1.0` with a
     warning rather than throwing, so a misconfiguration never breaks
     instrumentation.

### Implementation

   - `fnv1a32` — FNV-1a 32-bit hash using `Math.imul` for a correct, cross-engine
     stable 32-bit multiply (a plain `*` loses precision past 2^53).
   - `shouldSampleExecution(executionArn, rate)` — maps the hash into `[0, 1)` and
     samples in when it falls below `rate`.
   - `resolveSamplingRate` — normalizes/clamps the configured rate.
   - The decision is computed once per execution into `ExecutionState.sampledIn`
     and reused; every lifecycle hook is guarded. `wrapInvocation` still runs the
     execution but skips drain/flush when sampled out, and terminal state cleanup
     still runs for sampled-out executions so state entries don't leak.

### Tests

   Adds a `sampling` suite (fully deterministic, no flakiness): rate `0` / `1` /
   omitted, fractional partitioning, reproducibility (identical ARNs → identical
   decisions), stable re-runs, and out-of-range/NaN clamping. Full insight suite:
   29 tests passing.

### Docs

   Updates the `samplingRate` JSDoc, README config section, `plugin-contracts.md`,
   `workflow-insight-design.md`, and marks the sampling tasks/tests done in
   `remaining-tasks.md`.

 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
