### PR TITLE
fix(sdk): pass expressionInterpreter to Vega expr in VS Code extension

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VegaChart.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VegaChart.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState } from "react";
 import embed, { type Result } from "vega-embed";
-import * as vegaInterpreter from "vega-interpreter";
+import { expressionInterpreter } from "vega-interpreter";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
@@ -41,7 +41,7 @@ export function VegaChart({ spec, data }: Props) {
       actions: false,
       renderer: "svg",
       ast: true,
-      expr: vegaInterpreter,
+      expr: expressionInterpreter,
     })
       .then((result) => {
         viewRef.current = result;


### PR DESCRIPTION
The VegaChart webview renders charts with Vega's CSP-safe path (`ast: true` plus an `expr` interpreter) to avoid the default Function/eval-based expression compilation. It passed the whole `vega-interpreter` module namespace (`import * as vegaInterpreter`) as `expr`, but Vega calls `this.expr.operator(...)` internally and the operator lives on the named `expressionInterpreter` export — so `expr.operator` was undefined and rendering failed with "this.expr.operator is not a function".

Import the named `expressionInterpreter` and pass it directly (this is also the shape vega-embed's `expr?: typeof expressionInterpreter` option expects). Keeps rendering fully eval-free / CSP-compliant; only the wiring changes.

Verified: webview-ui build succeeds and `tsc --noEmit` passes. (tsc would have caught this — the build script only runs esbuild, which strips types without checking, so it slipped through.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
