### PR TITLE
feat(sdk): enforce maxRecordSizeBytes with best-effort record truncation

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -53,7 +53,6 @@ interface WorkflowInsightRecord {
 
   // Truncation markers — present only when the size limiter dropped data
   truncated?: boolean; // true when data was dropped to fit maxRecordSizeBytes
-  droppedOperationResults?: number; // count of operation results dropped
   droppedOperations?: number; // count of whole operations dropped
   droppedInput?: boolean; // true if execution input was dropped (last resort)
   droppedOutput?: boolean; // true if execution output was dropped (last resort)
@@ -75,6 +74,7 @@ interface OperationRecord {
     name: string;
     message: string;
   };
+  truncated?: boolean; // true if the size limiter dropped this operation's result
 }
 ```
 
@@ -348,10 +348,11 @@ Drop order, until the record fits:
 Identity/timeline fields are **never** dropped, and `input`/`output` are dropped
 only after all operations are gone — so prefer `content.input` /
 `content.output` transforms to bound them earlier (those run before truncation).
-When anything is dropped, the emitted record carries `truncated: true` plus the
-relevant markers (`droppedOperationResults` / `droppedOperations` counts,
-`droppedInput` / `droppedOutput` flags), so a trimmed record is always
-distinguishable from a complete one ("cut, not missing").
+When anything is dropped, the emitted record carries `truncated: true`; each
+operation whose result was dropped is itself marked `truncated: true`, and
+`droppedOperations` (count), `droppedInput` / `droppedOutput` flags are set as
+applicable — so a trimmed record is always distinguishable from a complete one
+("cut, not missing").
 
 Per-exporter defaults (override via each exporter's `maxRecordSizeBytes`):
 

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -55,6 +55,8 @@ interface WorkflowInsightRecord {
   truncated?: boolean; // true when data was dropped to fit maxRecordSizeBytes
   droppedOperationResults?: number; // count of operation results dropped
   droppedOperations?: number; // count of whole operations dropped
+  droppedInput?: boolean; // true if execution input was dropped (last resort)
+  droppedOutput?: boolean; // true if execution output was dropped (last resort)
 }
 
 interface OperationRecord {
@@ -339,14 +341,17 @@ and trimmed to another.
 Drop order, until the record fits:
 
 1. operation `result` fields, **oldest operation first**;
-2. whole operations, **oldest first**.
+2. whole operations, **oldest first**;
+3. as a last resort (once every operation is gone), execution `input`, then
+   `output`.
 
-Execution `input`/`output` and identity/timeline fields are **never** dropped by
-the size limiter — bound those with `content.input` / `content.output`
-transforms (which run before truncation). When anything is dropped, the emitted
-record carries `truncated: true` plus `droppedOperationResults` /
-`droppedOperations` counts, so a trimmed record is always distinguishable from a
-complete one ("cut, not missing").
+Identity/timeline fields are **never** dropped, and `input`/`output` are dropped
+only after all operations are gone — so prefer `content.input` /
+`content.output` transforms to bound them earlier (those run before truncation).
+When anything is dropped, the emitted record carries `truncated: true` plus the
+relevant markers (`droppedOperationResults` / `droppedOperations` counts,
+`droppedInput` / `droppedOutput` flags), so a trimmed record is always
+distinguishable from a complete one ("cut, not missing").
 
 Per-exporter defaults (override via each exporter's `maxRecordSizeBytes`):
 
@@ -1385,8 +1390,8 @@ import {
 class MyExporter implements InsightExporter {
   // Optional: opt into size-based truncation. When set, the plugin sends this
   // exporter a copy trimmed to fit (drops operation results, then whole
-  // operations, oldest-first) and sets `truncated: true` on it. Omit to
-  // receive full records.
+  // operations oldest-first, then execution input/output as a last resort) and
+  // sets `truncated: true` on it. Omit to receive full records.
   readonly maxRecordSizeBytes = 256_000;
 
   async export(record: WorkflowInsightRecord): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -354,6 +354,16 @@ operation whose result was dropped is itself marked `truncated: true`, and
 applicable — so a trimmed record is always distinguishable from a complete one
 ("cut, not missing").
 
+The size check measures the **exact shape each exporter emits**, not just the
+canonical record. Exporters that reshape operations (the `operationsByName`
+expansion used by CloudWatch Logs / DynamoDB / Lambda log, or the `"both"`
+format) expose a `render` the limiter sizes against, so a record trimmed to its
+limit reflects what is actually serialized. This bounds the serialized record
+_body_; it does not model the destination wire envelope (DynamoDB type
+descriptors, CloudWatch Logs event framing, gzip, etc.) — which is why the
+first-party defaults below sit under each destination's hard limit to leave
+headroom.
+
 Per-exporter defaults (override via each exporter's `maxRecordSizeBytes`):
 
 | Exporter(s)                                   | Default |

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -50,6 +50,11 @@ interface WorkflowInsightRecord {
 
   // Operations (steps, waits, invokes, callbacks)
   operations: OperationRecord[];
+
+  // Truncation markers — present only when the size limiter dropped data
+  truncated?: boolean; // true when data was dropped to fit maxRecordSizeBytes
+  droppedOperationResults?: number; // count of operation results dropped
+  droppedOperations?: number; // count of whole operations dropped
 }
 
 interface OperationRecord {
@@ -322,6 +327,39 @@ Notes:
 - The array remains the source of truth; array-native exporters (S3/Athena,
   OpenSearch, Aurora, Redshift) emit only the array. See
   [`docs/operations-shape.md`](./docs/operations-shape.md).
+
+## Record size & truncation
+
+Destinations cap payload size (CloudWatch Logs events at 256 KB, DynamoDB items
+at 400 KB, etc.). Each exporter carries a `maxRecordSizeBytes`; when a record's
+serialized JSON exceeds it, the plugin truncates a **per-exporter copy**
+(best-effort) before sending — the same record can go out full to one exporter
+and trimmed to another.
+
+Drop order, until the record fits:
+
+1. operation `result` fields, **oldest operation first**;
+2. whole operations, **oldest first**.
+
+Execution `input`/`output` and identity/timeline fields are **never** dropped by
+the size limiter — bound those with `content.input` / `content.output`
+transforms (which run before truncation). When anything is dropped, the emitted
+record carries `truncated: true` plus `droppedOperationResults` /
+`droppedOperations` counts, so a trimmed record is always distinguishable from a
+complete one ("cut, not missing").
+
+Per-exporter defaults (override via each exporter's `maxRecordSizeBytes`):
+
+| Exporter(s)                                   | Default |
+| --------------------------------------------- | ------- |
+| Lambda log, CloudWatch Logs, SQS, EventBridge | 256 KB  |
+| DynamoDB                                      | 400 KB  |
+| Aurora, Redshift, Firehose, OTel              | 1 MB    |
+| S3                                            | 5 MB    |
+| OpenSearch                                    | 10 MB   |
+| HTTP, File, Timestream                        | none¹   |
+
+¹ No default — truncation is disabled unless you set `maxRecordSizeBytes`.
 
 ## Exporters
 
@@ -1345,6 +1383,12 @@ import {
 } from "@aws/durable-execution-sdk-js-insight";
 
 class MyExporter implements InsightExporter {
+  // Optional: opt into size-based truncation. When set, the plugin sends this
+  // exporter a copy trimmed to fit (drops operation results, then whole
+  // operations, oldest-first) and sets `truncated: true` on it. Omit to
+  // receive full records.
+  readonly maxRecordSizeBytes = 256_000;
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     // Send record wherever you want
   }

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -17,9 +17,21 @@ interface InsightExporter {
   flush?(): Promise<void>;
 
   /**
-   * Maximum record size in bytes before truncation.
-   * Each exporter can set its own limit based on destination constraints.
-   * Default: 256KB. Truncation removes operation results starting from oldest.
+   * Maximum serialized record size in bytes before truncation. Each exporter
+   * can set its own limit based on destination constraints.
+   *
+   * Truncation is best-effort and drops in this order until the record fits:
+   *   1. operation `result` fields, oldest operation first;
+   *   2. whole operations, oldest first.
+   * Execution `input`/`output` and identity/timeline fields are never dropped —
+   * shrink those with `content.input`/`content.output` transforms. When anything
+   * is dropped, `truncated: true` (+ `droppedOperationResults` /
+   * `droppedOperations` counts) is set on the emitted record.
+   *
+   * First-party defaults: CloudWatch Logs / Lambda log / SQS / EventBridge
+   * 256KB, DynamoDB 400KB, Aurora / Redshift / Firehose / OTel 1MB, S3 5MB,
+   * OpenSearch 10MB. HTTP, File, and Timestream have no default (`undefined`
+   * disables truncation).
    */
   maxRecordSizeBytes?: number;
 }
@@ -356,6 +368,15 @@ interface WorkflowInsightRecord {
    * Each operation represents a step, wait, invoke, callback, or child context.
    */
   operations: OperationRecord[];
+
+  // --- Truncation markers (present only when the size limiter dropped data) ---
+
+  /** True when data was dropped to fit the exporter's maxRecordSizeBytes. */
+  truncated?: boolean;
+  /** Number of operation `result` fields dropped. */
+  droppedOperationResults?: number;
+  /** Number of whole operations dropped. */
+  droppedOperations?: number;
 }
 
 interface OperationRecord {

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -26,9 +26,10 @@ interface InsightExporter {
    *   3. last resort — execution `input`, then `output`.
    * Identity/timeline fields are never dropped; prefer `content.input`/
    * `content.output` transforms to bound `input`/`output` before it comes to
-   * that. When anything is dropped, `truncated: true` (+ the relevant
-   * `droppedOperationResults` / `droppedOperations` counts and `droppedInput` /
-   * `droppedOutput` flags) is set on the emitted record.
+   * that. When anything is dropped, `truncated: true` is set on the record, each
+   * operation whose result was dropped is itself marked `truncated: true`, and
+   * the `droppedOperations` count / `droppedInput` / `droppedOutput` flags are
+   * set as applicable.
    *
    * First-party defaults: CloudWatch Logs / Lambda log / SQS / EventBridge
    * 256KB, DynamoDB 400KB, Aurora / Redshift / Firehose / OTel 1MB, S3 5MB,
@@ -375,8 +376,6 @@ interface WorkflowInsightRecord {
 
   /** True when data was dropped to fit the exporter's maxRecordSizeBytes. */
   truncated?: boolean;
-  /** Number of operation `result` fields dropped. */
-  droppedOperationResults?: number;
   /** Number of whole operations dropped. */
   droppedOperations?: number;
   /** True when execution input was dropped as a last resort. */
@@ -421,6 +420,9 @@ interface OperationRecord {
     name: string;
     message: string;
   };
+
+  /** True when the size limiter dropped this operation's result. */
+  truncated?: boolean;
 }
 ```
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -22,11 +22,13 @@ interface InsightExporter {
    *
    * Truncation is best-effort and drops in this order until the record fits:
    *   1. operation `result` fields, oldest operation first;
-   *   2. whole operations, oldest first.
-   * Execution `input`/`output` and identity/timeline fields are never dropped —
-   * shrink those with `content.input`/`content.output` transforms. When anything
-   * is dropped, `truncated: true` (+ `droppedOperationResults` /
-   * `droppedOperations` counts) is set on the emitted record.
+   *   2. whole operations, oldest first;
+   *   3. last resort — execution `input`, then `output`.
+   * Identity/timeline fields are never dropped; prefer `content.input`/
+   * `content.output` transforms to bound `input`/`output` before it comes to
+   * that. When anything is dropped, `truncated: true` (+ the relevant
+   * `droppedOperationResults` / `droppedOperations` counts and `droppedInput` /
+   * `droppedOutput` flags) is set on the emitted record.
    *
    * First-party defaults: CloudWatch Logs / Lambda log / SQS / EventBridge
    * 256KB, DynamoDB 400KB, Aurora / Redshift / Firehose / OTel 1MB, S3 5MB,
@@ -377,6 +379,10 @@ interface WorkflowInsightRecord {
   droppedOperationResults?: number;
   /** Number of whole operations dropped. */
   droppedOperations?: number;
+  /** True when execution input was dropped as a last resort. */
+  droppedInput?: boolean;
+  /** True when execution output was dropped as a last resort. */
+  droppedOutput?: boolean;
 }
 
 interface OperationRecord {

--- a/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/plugin-contracts.md
@@ -31,12 +31,26 @@ interface InsightExporter {
    * the `droppedOperations` count / `droppedInput` / `droppedOutput` flags are
    * set as applicable.
    *
+   * The size is measured against the shape the exporter emits (via its optional
+   * `render` — e.g. the `operationsByName` expansion), not the canonical record,
+   * so a trimmed record reflects what is actually serialized. This bounds the
+   * record body, not the destination wire envelope; defaults sit below the hard
+   * limits to leave headroom.
+   *
    * First-party defaults: CloudWatch Logs / Lambda log / SQS / EventBridge
    * 256KB, DynamoDB 400KB, Aurora / Redshift / Firehose / OTel 1MB, S3 5MB,
    * OpenSearch 10MB. HTTP, File, and Timestream have no default (`undefined`
    * disables truncation).
    */
   maxRecordSizeBytes?: number;
+
+  /**
+   * Optional: maps a record to the exact value this exporter serializes (e.g.
+   * the operationsByName expansion), so the size limiter measures the emitted
+   * shape. Defaults to the record unchanged; reuse it from `export` to avoid
+   * drift.
+   */
+  render?(record: WorkflowInsightRecord): unknown;
 }
 
 interface WorkflowInsightConfig {

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -82,10 +82,16 @@
 
 ## Record Size / Truncation
 
-> `InsightExporter.maxRecordSizeBytes` exists in the types but is never read.
-
-- [ ] Enforce `maxRecordSizeBytes` per exporter (contract default 256KB)
-- [ ] Truncate oversized records by dropping operation results starting from oldest
+- [x] Enforce `maxRecordSizeBytes` per exporter — applied per-exporter in
+      `ExportScheduler` via `truncateRecord`; each first-party exporter sets a
+      destination-appropriate default (CW/Lambda-log/SQS/EventBridge 256KB,
+      DynamoDB 400KB, Aurora/Redshift/Firehose/OTel 1MB, S3 5MB, OpenSearch 10MB;
+      HTTP/File/Timestream none). `undefined` disables truncation.
+- [x] Truncate oversized records by dropping operation results oldest-first, then
+      whole operations oldest-first; input/output/identity are never dropped.
+      Sets `truncated` + `droppedOperationResults`/`droppedOperations` markers
+      (additive fields — schemaVersion stays "1.0"). Never mutates the shared
+      record (each exporter gets its own trimmed copy).
 
 ## Exporters (first-party)
 
@@ -118,6 +124,10 @@
 - [ ] Unit tests for `ExportScheduler` (coalescing, no overlap, drain)
 - [x] Unit tests for content filtering (input/output transforms, operation overrides,
       includeErrors, result transform incl. non-JSON + throwing-transform safety)
+- [x] Unit tests for record truncation — drop order (results then whole
+      operations, oldest-first), `truncated`/dropped counts, no-op when it fits,
+      no input mutation, input/output never dropped, and per-exporter application
+      via the scheduler (different limits → different copies).
 - [x] Unit tests for sampling logic (including replay determinism) — covers
       rate 0 / 1 / omitted, fractional partitioning, invocationId-independence
       (replay stability), stable re-runs, and out-of-range/NaN clamping.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -89,10 +89,11 @@
       HTTP/File/Timestream none). `undefined` disables truncation.
 - [x] Truncate oversized records by dropping operation results oldest-first, then
       whole operations oldest-first, then — as a last resort — execution input
-      then output; identity/timeline fields are never dropped. Sets `truncated` +
-      `droppedOperationResults`/`droppedOperations` counts and
-      `droppedInput`/`droppedOutput` flags (additive fields — schemaVersion stays
-      "1.0"). Never mutates the shared record (each exporter gets its own trimmed copy).
+      then output; identity/timeline fields are never dropped. Sets record-level
+      `truncated`, a per-operation `truncated` flag on operations whose result was
+      dropped, the `droppedOperations` count, and `droppedInput`/`droppedOutput`
+      flags (additive fields — schemaVersion stays "1.0"). Never mutates the
+      shared record (each exporter gets its own trimmed copy).
 
 ## Exporters (first-party)
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -88,10 +88,11 @@
       DynamoDB 400KB, Aurora/Redshift/Firehose/OTel 1MB, S3 5MB, OpenSearch 10MB;
       HTTP/File/Timestream none). `undefined` disables truncation.
 - [x] Truncate oversized records by dropping operation results oldest-first, then
-      whole operations oldest-first; input/output/identity are never dropped.
-      Sets `truncated` + `droppedOperationResults`/`droppedOperations` markers
-      (additive fields — schemaVersion stays "1.0"). Never mutates the shared
-      record (each exporter gets its own trimmed copy).
+      whole operations oldest-first, then — as a last resort — execution input
+      then output; identity/timeline fields are never dropped. Sets `truncated` +
+      `droppedOperationResults`/`droppedOperations` counts and
+      `droppedInput`/`droppedOutput` flags (additive fields — schemaVersion stays
+      "1.0"). Never mutates the shared record (each exporter gets its own trimmed copy).
 
 ## Exporters (first-party)
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -518,6 +518,13 @@ operation is gone — (3) execution `input`, then `output`. Identity/timeline
 fields are never dropped; use `content.input`/`content.output` transforms to
 bound input/output before it comes to that (they run before truncation).
 
+The limiter measures the shape each exporter actually emits — exporters that
+reshape operations (the `operationsByName` expansion, or the `"both"` format)
+expose a `render` used both to size and to serialize, so the two can't drift.
+This bounds the serialized record body, not the destination wire envelope
+(DynamoDB type descriptors, CloudWatch Logs framing, gzip); defaults sit below
+the hard limits to absorb that overhead.
+
 | Destination                                      | Default Limit        |
 | ------------------------------------------------ | -------------------- |
 | CloudWatch Logs / Lambda log / SQS / EventBridge | 256 KB               |

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -94,9 +94,10 @@ The system is built on three pillars:
 │                                     ▼                                        │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
 │  │ 4. Truncation                                                        │    │
-│  │    - Check total record size against maxPayloadSize                  │    │
-│  │    - If over limit: truncate input → output → operation results      │    │
-│  │    - Set truncated=true if any field was cut                         │    │
+│  │    - Check total record size against maxRecordSizeBytes              │    │
+│  │    - If over: drop operation results (oldest first), then whole      │    │
+│  │      operations (oldest first); input/output are never dropped       │    │
+│  │    - Set truncated=true (+ dropped* counts) if anything was cut      │    │
 │  └──────────────────────────────────┬──────────────────────────────────┘    │
 │                                     │                                        │
 │                                     ▼                                        │
@@ -466,9 +467,9 @@ interface ExecutionRecord {
   endTime?: string; // ISO 8601
   durationMs?: number;
 
-  // Payload (configurable)
-  input?: unknown; // Truncated if exceeds maxPayloadSize
-  output?: unknown; // Truncated if exceeds maxPayloadSize
+  // Payload (configurable via content.input/output transforms; never size-truncated)
+  input?: unknown;
+  output?: unknown;
   error?: { message: string; type: string; stack?: string };
 
   // Operations (configurable)
@@ -484,7 +485,7 @@ interface ExecutionRecord {
       endTime?: string;
       durationMs?: number;
       attempts: number;
-      result?: unknown; // Operation output/return value (truncated if exceeds limit)
+      result?: unknown; // Operation output/return value (dropped oldest-first when over size limit)
       error?: { message: string; type: string };
     }
   >;
@@ -509,17 +510,24 @@ The `schemaVersion` field enables forward-compatible evolution. New fields are a
 
 ### Size Limits & Truncation
 
-Each destination plugin enforces size limits appropriate for its destination:
+Each exporter sets a `maxRecordSizeBytes` appropriate for its destination. When a
+record's serialized JSON exceeds it, the plugin truncates a per-exporter copy
+(best-effort) by dropping, in order: (1) operation `result` fields oldest-first,
+then (2) whole operations oldest-first. Execution `input`/`output` and
+identity/timeline fields are never dropped — use `content.input`/`content.output`
+transforms to bound those (they run before truncation).
 
-| Destination     | Default Limit | Truncation Behavior                    |
-| --------------- | ------------- | -------------------------------------- |
-| CloudWatch Logs | 256 KB        | Truncate input/output, then operations |
-| DynamoDB        | 400 KB        | Truncate input/output, then operations |
-| Aurora          | 1 MB          | Truncate input/output                  |
-| S3              | 5 MB          | Truncate input/output                  |
-| Kinesis         | 1 MB          | Truncate input/output, then operations |
+| Destination                                      | Default Limit        |
+| ------------------------------------------------ | -------------------- |
+| CloudWatch Logs / Lambda log / SQS / EventBridge | 256 KB               |
+| DynamoDB                                         | 400 KB               |
+| Aurora / Redshift / Firehose (Kinesis) / OTel    | 1 MB                 |
+| S3                                               | 5 MB                 |
+| OpenSearch                                       | 10 MB                |
+| HTTP / File / Timestream                         | none (no truncation) |
 
-When truncation occurs, `truncated: true` is set in the record so customers know data was cut.
+When truncation occurs, `truncated: true` is set (plus `droppedOperationResults`
+and `droppedOperations` counts) so customers know data was cut, not missing.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -96,8 +96,8 @@ The system is built on three pillars:
 │  │ 4. Truncation                                                        │    │
 │  │    - Check total record size against maxRecordSizeBytes              │    │
 │  │    - If over: drop operation results (oldest first), then whole      │    │
-│  │      operations (oldest first); input/output are never dropped       │    │
-│  │    - Set truncated=true (+ dropped* counts) if anything was cut      │    │
+│  │      operations (oldest first), then input, then output             │    │
+│  │    - Set truncated=true (+ dropped* markers) if anything was cut     │    │
 │  └──────────────────────────────────┬──────────────────────────────────┘    │
 │                                     │                                        │
 │                                     ▼                                        │
@@ -467,7 +467,7 @@ interface ExecutionRecord {
   endTime?: string; // ISO 8601
   durationMs?: number;
 
-  // Payload (configurable via content.input/output transforms; never size-truncated)
+  // Payload (bound via content.input/output transforms; size-dropped only as a last resort)
   input?: unknown;
   output?: unknown;
   error?: { message: string; type: string; stack?: string };
@@ -513,9 +513,10 @@ The `schemaVersion` field enables forward-compatible evolution. New fields are a
 Each exporter sets a `maxRecordSizeBytes` appropriate for its destination. When a
 record's serialized JSON exceeds it, the plugin truncates a per-exporter copy
 (best-effort) by dropping, in order: (1) operation `result` fields oldest-first,
-then (2) whole operations oldest-first. Execution `input`/`output` and
-identity/timeline fields are never dropped — use `content.input`/`content.output`
-transforms to bound those (they run before truncation).
+(2) whole operations oldest-first, then — only as a last resort, once every
+operation is gone — (3) execution `input`, then `output`. Identity/timeline
+fields are never dropped; use `content.input`/`content.output` transforms to
+bound input/output before it comes to that (they run before truncation).
 
 | Destination                                      | Default Limit        |
 | ------------------------------------------------ | -------------------- |
@@ -527,7 +528,8 @@ transforms to bound those (they run before truncation).
 | HTTP / File / Timestream                         | none (no truncation) |
 
 When truncation occurs, `truncated: true` is set (plus `droppedOperationResults`
-and `droppedOperations` counts) so customers know data was cut, not missing.
+and `droppedOperations` counts, and `droppedInput`/`droppedOutput` flags when
+those last-resort drops happen) so customers know data was cut, not missing.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/workflow-insight-design.md
@@ -527,9 +527,10 @@ bound input/output before it comes to that (they run before truncation).
 | OpenSearch                                       | 10 MB                |
 | HTTP / File / Timestream                         | none (no truncation) |
 
-When truncation occurs, `truncated: true` is set (plus `droppedOperationResults`
-and `droppedOperations` counts, and `droppedInput`/`droppedOutput` flags when
-those last-resort drops happen) so customers know data was cut, not missing.
+When truncation occurs, `truncated: true` is set on the record; each operation
+whose result was dropped is itself marked `truncated: true`, and the
+`droppedOperations` count / `droppedInput` / `droppedOutput` flags are set when
+those drops happen — so customers know data was cut, not missing.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.ts
@@ -36,6 +36,12 @@ export interface AuroraExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 1_000_000 (Aurora Data API practical row/statement limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -56,6 +62,7 @@ export class AuroraExporter implements InsightExporter {
   private readonly table: string;
   private readonly engine: "postgresql" | "mysql";
   private readonly client: RDSDataClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: AuroraExporterConfig) {
     this.resourceArn = config.resourceArn;
@@ -63,6 +70,7 @@ export class AuroraExporter implements InsightExporter {
     this.database = config.database;
     this.table = sanitizeIdentifier(config.table ?? "workflow_insight");
     this.engine = config.engine;
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 1_000_000;
     this.client = new RDSDataClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
@@ -61,6 +61,10 @@ export class CloudWatchLogsExporter implements InsightExporter {
     );
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return withOperationsByName(record);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     const streamName = this.buildStreamName();
     await this.ensureStream(streamName);
@@ -72,7 +76,7 @@ export class CloudWatchLogsExporter implements InsightExporter {
         logEvents: [
           {
             timestamp: Date.now(),
-            message: JSON.stringify(withOperationsByName(record)),
+            message: JSON.stringify(this.render(record)),
           },
         ],
       }),

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
@@ -23,6 +23,12 @@ export interface CloudWatchLogsExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 256_000 (CloudWatch Logs' 256 KB event limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -44,10 +50,12 @@ export class CloudWatchLogsExporter implements InsightExporter {
   private readonly logStreamPrefix: string;
   private readonly client: CloudWatchLogsClient;
   private readonly createdStreams = new Set<string>();
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: CloudWatchLogsExporterConfig) {
     this.logGroupName = config.logGroupName;
     this.logStreamPrefix = config.logStreamPrefix ?? "workflow-insight/";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
     this.client = new CloudWatchLogsClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.ts
@@ -61,9 +61,7 @@ export class CloudWatchLogsExporter implements InsightExporter {
     );
   }
 
-  render(record: WorkflowInsightRecord): unknown {
-    return withOperationsByName(record);
-  }
+  render = withOperationsByName;
 
   async export(record: WorkflowInsightRecord): Promise<void> {
     const streamName = this.buildStreamName();

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
@@ -61,6 +61,10 @@ export class DynamoDBExporter implements InsightExporter {
     );
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return withOperationsByName(record);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     const item: Record<string, unknown> = {
       ...withOperationsByName(record),

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
@@ -61,9 +61,7 @@ export class DynamoDBExporter implements InsightExporter {
     );
   }
 
-  render(record: WorkflowInsightRecord): unknown {
-    return withOperationsByName(record);
-  }
+  render = withOperationsByName;
 
   async export(record: WorkflowInsightRecord): Promise<void> {
     const item: Record<string, unknown> = {

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.ts
@@ -26,6 +26,12 @@ export interface DynamoDBExporterConfig {
 
   /** AWS region of the table. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 400_000 (DynamoDB's 400 KB item limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -43,11 +49,13 @@ export class DynamoDBExporter implements InsightExporter {
   private readonly partitionKey: string;
   private readonly sortKey: string | undefined;
   private readonly client: DynamoDBClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: DynamoDBExporterConfig) {
     this.tableName = config.tableName;
     this.partitionKey = config.partitionKey ?? "pk";
     this.sortKey = config.sortKey ?? "sk";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 400_000;
     this.client = new DynamoDBClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
@@ -73,6 +73,10 @@ export class EventBridgeExporter implements InsightExporter {
     );
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return applyOperationsFormat(record, this.operationsFormat);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     const result = await this.client.send(
       new PutEventsCommand({
@@ -81,9 +85,7 @@ export class EventBridgeExporter implements InsightExporter {
             EventBusName: this.eventBusName,
             Source: this.source,
             DetailType: record.status,
-            Detail: JSON.stringify(
-              applyOperationsFormat(record, this.operationsFormat),
-            ),
+            Detail: JSON.stringify(this.render(record)),
             Time: new Date(record.emittedAt),
           },
         ],

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.ts
@@ -35,6 +35,12 @@ export interface EventBridgeExporterConfig {
    * `"both"`. Choose based on what your rule targets consume.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 256_000 (EventBridge's 256 KB PutEvents entry limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -55,11 +61,13 @@ export class EventBridgeExporter implements InsightExporter {
   private readonly source: string;
   private readonly operationsFormat: OperationsFormat;
   private readonly client: EventBridgeClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: EventBridgeExporterConfig = {}) {
     this.eventBusName = config.eventBusName ?? "default";
     this.source = config.source ?? "aws.durable-execution.insight";
     this.operationsFormat = config.operationsFormat ?? "array";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
     this.client = new EventBridgeClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
@@ -32,6 +32,12 @@ export interface FileExporterConfig {
    * `"both"`.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation. No default — the filesystem
+   * has no practical per-record limit; set this only if you want smaller files.
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -53,11 +59,13 @@ export class FileExporter implements InsightExporter {
   private readonly mode: "ndjson" | "json";
   private readonly operationsFormat: OperationsFormat;
   private dirCreated = false;
+  readonly maxRecordSizeBytes?: number;
 
   constructor(config: FileExporterConfig) {
     this.directory = config.directory;
     this.mode = config.mode ?? "ndjson";
     this.operationsFormat = config.operationsFormat ?? "array";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes;
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.ts
@@ -68,10 +68,14 @@ export class FileExporter implements InsightExporter {
     this.maxRecordSizeBytes = config.maxRecordSizeBytes;
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return applyOperationsFormat(record, this.operationsFormat);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     await this.ensureDir();
 
-    const formatted = applyOperationsFormat(record, this.operationsFormat);
+    const formatted = this.render(record);
 
     if (this.mode === "ndjson") {
       const date = record.emittedAt.slice(0, 10); // YYYY-MM-DD

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
@@ -23,6 +23,12 @@ export interface FirehoseExporterConfig {
    * `"both"`. Choose based on the downstream destination's consumer.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 1_000_000 (Firehose's 1 MB per-record limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -41,10 +47,12 @@ export class FirehoseExporter implements InsightExporter {
   private readonly deliveryStreamName: string;
   private readonly operationsFormat: OperationsFormat;
   private readonly client: FirehoseClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: FirehoseExporterConfig) {
     this.deliveryStreamName = config.deliveryStreamName;
     this.operationsFormat = config.operationsFormat ?? "array";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 1_000_000;
     this.client = new FirehoseClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.ts
@@ -58,10 +58,12 @@ export class FirehoseExporter implements InsightExporter {
     );
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return applyOperationsFormat(record, this.operationsFormat);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
-    const data =
-      JSON.stringify(applyOperationsFormat(record, this.operationsFormat)) +
-      "\n";
+    const data = JSON.stringify(this.render(record)) + "\n";
 
     await this.client.send(
       new PutRecordCommand({

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
@@ -66,6 +66,10 @@ export class HttpExporter implements InsightExporter {
     this.operationsFormat = config.operationsFormat ?? "array";
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return applyOperationsFormat(record, this.operationsFormat);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -77,9 +81,7 @@ export class HttpExporter implements InsightExporter {
           "Content-Type": "application/json",
           ...this.headers,
         },
-        body: JSON.stringify(
-          applyOperationsFormat(record, this.operationsFormat),
-        ),
+        body: JSON.stringify(this.render(record)),
         signal: controller.signal,
       });
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.ts
@@ -31,6 +31,12 @@ export interface HttpExporterConfig {
    * map (`"by-name"`), or `"both"`. Choose based on what your endpoint consumes.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation. No default — a generic HTTP
+   * endpoint has no known limit; set this if your endpoint caps request size.
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -49,12 +55,14 @@ export class HttpExporter implements InsightExporter {
   private readonly headers: Record<string, string>;
   private readonly timeoutMs: number;
   private readonly operationsFormat: OperationsFormat;
+  readonly maxRecordSizeBytes?: number;
 
   constructor(config: HttpExporterConfig) {
     this.url = config.url;
     this.method = config.method ?? "POST";
     this.headers = config.headers ?? {};
     this.timeoutMs = config.timeoutMs ?? 10_000;
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes;
     this.operationsFormat = config.operationsFormat ?? "array";
   }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.ts
@@ -29,6 +29,12 @@ export interface OpenSearchExporterConfig {
 
   /** Password for basic auth. Required if auth is "basic". */
   password?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 10_000_000 (a generous guard; OpenSearch accepts large documents).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -49,6 +55,7 @@ export class OpenSearchExporter implements InsightExporter {
   private readonly auth: "sigv4" | "basic";
   private readonly username?: string;
   private readonly password?: string;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: OpenSearchExporterConfig) {
     this.endpoint = config.endpoint.replace(/\/$/, "");
@@ -57,6 +64,7 @@ export class OpenSearchExporter implements InsightExporter {
     this.auth = config.auth ?? "sigv4";
     this.username = config.username;
     this.password = config.password;
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 10_000_000;
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
@@ -34,6 +34,12 @@ export interface OTelExporterConfig {
    * attributes), so this has no effect on attribute cardinality.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 1_000_000 (a conservative OTLP/HTTP request guard).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -54,6 +60,7 @@ export class OTelExporter implements InsightExporter {
   private readonly endpoint: string;
   private readonly headers: Record<string, string>;
   private readonly operationsFormat: OperationsFormat;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: OTelExporterConfig) {
     if (config.protocol === "http/protobuf") {
@@ -64,6 +71,7 @@ export class OTelExporter implements InsightExporter {
     this.endpoint = config.endpoint;
     this.headers = config.headers ?? {};
     this.operationsFormat = config.operationsFormat ?? "array";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 1_000_000;
   }
 
   async export(record: WorkflowInsightRecord): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.ts
@@ -74,6 +74,12 @@ export class OTelExporter implements InsightExporter {
     this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 1_000_000;
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    // Measure the full OTLP request — the record is embedded in body.stringValue,
+    // so this captures both the record content and the OTLP envelope.
+    return this.buildPayload(record);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     const payload = this.buildPayload(record);
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
@@ -52,6 +52,12 @@ export interface RedshiftExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 1_000_000 (Redshift Data API practical statement/parameter limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -77,6 +83,7 @@ export class RedshiftExporter implements InsightExporter {
   private readonly dbUser?: string;
   private readonly secretArn?: string;
   private readonly client: RedshiftDataClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: RedshiftExporterConfig) {
     if (!config.workgroupName && !config.clusterIdentifier) {
@@ -92,6 +99,7 @@ export class RedshiftExporter implements InsightExporter {
     this.clusterIdentifier = config.clusterIdentifier;
     this.dbUser = config.dbUser;
     this.secretArn = config.secretArn;
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 1_000_000;
     this.client = new RedshiftDataClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.ts
@@ -23,6 +23,12 @@ export interface S3ExporterConfig {
 
   /** AWS region of the bucket. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 5_000_000 (S3 has no small per-object limit; a generous guard).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -39,11 +45,13 @@ export class S3Exporter implements InsightExporter {
   private readonly prefix: string;
   private readonly partitioning: "date" | "function-name" | "none";
   private readonly client: S3Client;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: S3ExporterConfig) {
     this.bucket = config.bucket;
     this.prefix = config.prefix ?? "workflow-insight/";
     this.partitioning = config.partitioning ?? "date";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 5_000_000;
     this.client = new S3Client(config.region ? { region: config.region } : {});
   }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
@@ -29,6 +29,12 @@ export interface SQSExporterConfig {
    * `"both"`. Choose based on what your consumer expects.
    */
   operationsFormat?: OperationsFormat;
+
+  /**
+   * Max serialized record size before truncation.
+   * Default: 256_000 (SQS's 256 KB message limit).
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -49,12 +55,14 @@ export class SQSExporter implements InsightExporter {
   private readonly isFifo: boolean;
   private readonly operationsFormat: OperationsFormat;
   private readonly client: SQSClient;
+  readonly maxRecordSizeBytes: number;
 
   constructor(config: SQSExporterConfig) {
     this.queueUrl = config.queueUrl;
     this.messageGroupId = config.messageGroupId;
     this.isFifo = config.queueUrl.endsWith(".fifo");
     this.operationsFormat = config.operationsFormat ?? "array";
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
     this.client = new SQSClient(config.region ? { region: config.region } : {});
   }
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.ts
@@ -66,13 +66,15 @@ export class SQSExporter implements InsightExporter {
     this.client = new SQSClient(config.region ? { region: config.region } : {});
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return applyOperationsFormat(record, this.operationsFormat);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     await this.client.send(
       new SendMessageCommand({
         QueueUrl: this.queueUrl,
-        MessageBody: JSON.stringify(
-          applyOperationsFormat(record, this.operationsFormat),
-        ),
+        MessageBody: JSON.stringify(this.render(record)),
         MessageGroupId: this.isFifo
           ? (this.messageGroupId ?? record.executionArn)
           : undefined,

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/timestream-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/timestream-exporter.ts
@@ -20,6 +20,13 @@ export interface TimestreamExporterConfig {
 
   /** AWS region. If omitted, uses the SDK default. */
   region?: string;
+
+  /**
+   * Max serialized record size before truncation. No default — Timestream is
+   * dimensional (the record is one VARCHAR measure), so truncation rarely
+   * applies; set this only if the `recordJson` measure risks exceeding limits.
+   */
+  maxRecordSizeBytes?: number;
 }
 
 /**
@@ -40,10 +47,12 @@ export class TimestreamExporter implements InsightExporter {
   private readonly databaseName: string;
   private readonly tableName: string;
   private readonly client: TimestreamWriteClient;
+  readonly maxRecordSizeBytes?: number;
 
   constructor(config: TimestreamExporterConfig) {
     this.databaseName = config.databaseName;
     this.tableName = config.tableName;
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes;
     this.client = new TimestreamWriteClient(
       config.region ? { region: config.region } : {},
     );

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -496,4 +496,52 @@ describe("per-exporter truncation", () => {
     // The two exporters got different objects — no shared mutation.
     expect(small.records[0]).not.toBe(unlimited.records[0]);
   });
+
+  it("sizes truncation against the exporter's rendered (emitted) shape", async () => {
+    // An exporter that emits a strictly larger shape than the canonical record.
+    class RenderExporter implements InsightExporter {
+      records: WorkflowInsightRecord[] = [];
+      constructor(readonly maxRecordSizeBytes: number) {}
+      render(record: WorkflowInsightRecord): unknown {
+        return { ...record, operationsExpanded: record.operations };
+      }
+      async export(record: WorkflowInsightRecord): Promise<void> {
+        this.records.push(record);
+      }
+    }
+
+    const sizeOf = (v: unknown): number =>
+      new TextEncoder().encode(JSON.stringify(v)).length;
+
+    const exporter = new RenderExporter(900);
+    const plugin = workflowInsight({
+      exporters: [exporter],
+      content: {
+        operations: {
+          overrides: [{ operationName: "big", result: (r) => r }],
+        },
+      },
+    });
+
+    await endAndDrain(
+      plugin,
+      endInfo({
+        status: "SUCCEEDED",
+        operations: {
+          o1: op({
+            id: "o1",
+            name: "big",
+            status: "SUCCEEDED",
+            result: JSON.stringify("X".repeat(1500)),
+          }),
+        },
+      }),
+    );
+
+    const got = exporter.records[0];
+    // The rendered shape (what is actually emitted) fits the limit — the plain
+    // record alone would have been measured smaller and mis-sized.
+    expect(got.truncated).toBe(true);
+    expect(sizeOf(exporter.render(got))).toBeLessThanOrEqual(900);
+  });
 });

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -443,3 +443,57 @@ describe("sampling", () => {
     }
   });
 });
+
+describe("per-exporter truncation", () => {
+  class LimitedExporter implements InsightExporter {
+    records: WorkflowInsightRecord[] = [];
+    constructor(readonly maxRecordSizeBytes?: number) {}
+    async export(record: WorkflowInsightRecord): Promise<void> {
+      this.records.push(record);
+    }
+  }
+
+  it("sends each exporter a copy truncated to its own limit", async () => {
+    const small = new LimitedExporter(700);
+    const unlimited = new LimitedExporter(undefined);
+
+    const plugin = workflowInsight({
+      exporters: [small, unlimited],
+      // Opt the big operation's result into the record so it dominates size.
+      content: {
+        operations: {
+          overrides: [{ operationName: "big", result: (r) => r }],
+        },
+      },
+    });
+
+    await endAndDrain(
+      plugin,
+      endInfo({
+        status: "SUCCEEDED",
+        operations: {
+          o1: op({
+            id: "o1",
+            name: "big",
+            status: "SUCCEEDED",
+            result: JSON.stringify("X".repeat(2000)),
+          }),
+        },
+      }),
+    );
+
+    const sizeOf = (r: WorkflowInsightRecord): number =>
+      new TextEncoder().encode(JSON.stringify(r)).length;
+
+    // Small-limit exporter received a truncated copy within its budget.
+    expect(small.records[0].truncated).toBe(true);
+    expect(sizeOf(small.records[0])).toBeLessThanOrEqual(700);
+
+    // Unlimited exporter received the full, untruncated record.
+    expect(unlimited.records[0].truncated).toBeUndefined();
+    expect(unlimited.records[0].operations[0].result).toBe("X".repeat(2000));
+
+    // The two exporters got different objects — no shared mutation.
+    expect(small.records[0]).not.toBe(unlimited.records[0]);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -327,8 +327,12 @@ export class LambdaLogExporter implements InsightExporter {
     this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
   }
 
+  render(record: WorkflowInsightRecord): unknown {
+    return withOperationsByName(record);
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
-    console.log(JSON.stringify(withOperationsByName(record)));
+    console.log(JSON.stringify(this.render(record)));
   }
 }
 
@@ -382,11 +386,16 @@ class ExportScheduler {
         this.pending = undefined;
         // allSettled so one failing/slow exporter never blocks or fails the others,
         // and an export error never propagates into the execution. Each exporter
-        // gets a copy truncated to its own maxRecordSizeBytes (no-op when unset).
+        // gets a copy truncated to its own maxRecordSizeBytes (no-op when unset),
+        // measured against the exact shape that exporter emits (its `render`).
         await Promise.allSettled(
           this.exporters.map((exporter) =>
             exporter.export(
-              truncateRecord(record, exporter.maxRecordSizeBytes),
+              truncateRecord(
+                record,
+                exporter.maxRecordSizeBytes,
+                exporter.render ? (r) => exporter.render!(r) : undefined,
+              ),
             ),
           ),
         );

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -327,9 +327,7 @@ export class LambdaLogExporter implements InsightExporter {
     this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
   }
 
-  render(record: WorkflowInsightRecord): unknown {
-    return withOperationsByName(record);
-  }
+  render = withOperationsByName;
 
   async export(record: WorkflowInsightRecord): Promise<void> {
     console.log(JSON.stringify(this.render(record)));

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -394,7 +394,7 @@ class ExportScheduler {
               truncateRecord(
                 record,
                 exporter.maxRecordSizeBytes,
-                exporter.render ? (r) => exporter.render!(r) : undefined,
+                exporter.render?.bind(exporter),
               ),
             ),
           ),

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -17,6 +17,7 @@ import type {
   InsightExporter,
 } from "./types";
 import { withOperationsByName } from "./operations-index";
+import { truncateRecord } from "./truncation";
 
 export type {
   InsightExporter,
@@ -34,6 +35,8 @@ export {
   withOperationsByName,
   applyOperationsFormat,
 } from "./operations-index";
+
+export { truncateRecord } from "./truncation";
 
 export { S3Exporter } from "./exporters/s3-exporter";
 export type { S3ExporterConfig } from "./exporters/s3-exporter";
@@ -317,6 +320,13 @@ function buildOperationRecords(
  * @experimental This class is experimental and may change in future releases.
  */
 export class LambdaLogExporter implements InsightExporter {
+  /** CloudWatch Logs caps a single log event at 256 KB. */
+  readonly maxRecordSizeBytes: number;
+
+  constructor(config: { maxRecordSizeBytes?: number } = {}) {
+    this.maxRecordSizeBytes = config.maxRecordSizeBytes ?? 256_000;
+  }
+
   async export(record: WorkflowInsightRecord): Promise<void> {
     console.log(JSON.stringify(withOperationsByName(record)));
   }
@@ -371,9 +381,14 @@ class ExportScheduler {
         const record = this.pending;
         this.pending = undefined;
         // allSettled so one failing/slow exporter never blocks or fails the others,
-        // and an export error never propagates into the execution.
+        // and an export error never propagates into the execution. Each exporter
+        // gets a copy truncated to its own maxRecordSizeBytes (no-op when unset).
         await Promise.allSettled(
-          this.exporters.map((exporter) => exporter.export(record)),
+          this.exporters.map((exporter) =>
+            exporter.export(
+              truncateRecord(record, exporter.maxRecordSizeBytes),
+            ),
+          ),
         );
       }
     } finally {

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
@@ -1,0 +1,148 @@
+import { truncateRecord } from "./truncation";
+import type { OperationRecord, WorkflowInsightRecord } from "./types";
+
+function op(
+  partial: Partial<OperationRecord> & { id: string },
+): OperationRecord {
+  return {
+    type: "STEP",
+    status: "SUCCEEDED",
+    ...partial,
+  } as OperationRecord;
+}
+
+function record(
+  partial: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-02T00:00:00.000Z",
+    executionArn:
+      "arn:aws:lambda:us-east-1:123:function:fn:1/durable-execution/e/i",
+    functionName: "fn",
+    functionQualifier: "1",
+    region: "us-east-1",
+    accountId: "123",
+    status: "SUCCEEDED",
+    startTime: "2026-07-02T00:00:00.000Z",
+    operations: [],
+    ...partial,
+  };
+}
+
+const bytes = (r: unknown): number =>
+  new TextEncoder().encode(JSON.stringify(r)).length;
+
+describe("truncateRecord", () => {
+  it("returns the original record unchanged when it fits", () => {
+    const r = record({ operations: [op({ id: "o1", name: "a" })] });
+    const out = truncateRecord(r, 10_000);
+    expect(out).toBe(r); // same reference — no copy
+    expect(out.truncated).toBeUndefined();
+  });
+
+  it("returns the original when no limit is set", () => {
+    const r = record({
+      operations: [op({ id: "o1", name: "a", result: "x".repeat(1000) })],
+    });
+    expect(truncateRecord(r, undefined)).toBe(r);
+    expect(truncateRecord(r, 0)).toBe(r);
+  });
+
+  it("drops operation results oldest-first until it fits, marking truncated", () => {
+    const ops = [
+      op({
+        id: "o1",
+        name: "old",
+        startTime: "2026-07-02T00:00:01.000Z",
+        result: "A".repeat(500),
+      }),
+      op({
+        id: "o2",
+        name: "new",
+        startTime: "2026-07-02T00:00:02.000Z",
+        result: "B".repeat(500),
+      }),
+    ];
+    const r = record({ operations: ops });
+    const full = bytes(r);
+    // Limit that forces dropping exactly one result (the oldest).
+    const limit = full - 400;
+
+    const out = truncateRecord(r, limit);
+
+    expect(out).not.toBe(r);
+    expect(out.truncated).toBe(true);
+    expect(out.droppedOperationResults).toBe(1);
+    expect(out.droppedOperations).toBeUndefined();
+    // Oldest (o1) lost its result; newest (o2) kept it. Both operations remain.
+    expect(out.operations).toHaveLength(2);
+    expect(out.operations.find((o) => o.id === "o1")?.result).toBeUndefined();
+    expect(out.operations.find((o) => o.id === "o2")?.result).toBe(
+      "B".repeat(500),
+    );
+    expect(bytes(out)).toBeLessThanOrEqual(limit);
+  });
+
+  it("drops whole operations oldest-first after results are exhausted", () => {
+    const ops = Array.from({ length: 5 }, (_, i) =>
+      op({
+        id: `o${i}`,
+        name: `step-${i}`,
+        startTime: `2026-07-02T00:00:0${i}.000Z`,
+      }),
+    );
+    const r = record({ operations: ops });
+    // Tight limit that no result-dropping can satisfy (there are no results),
+    // forcing whole-operation drops.
+    const limit = bytes(record({ operations: ops.slice(0, 2) })) + 20;
+
+    const out = truncateRecord(r, limit);
+
+    expect(out.truncated).toBe(true);
+    expect(out.droppedOperations).toBeGreaterThan(0);
+    // The survivors must be the newest ones (oldest dropped first).
+    const survivingIds = out.operations.map((o) => o.id);
+    expect(survivingIds).not.toContain("o0");
+    expect(bytes(out)).toBeLessThanOrEqual(limit);
+  });
+
+  it("does not mutate the input record (shared across exporters)", () => {
+    const ops = [op({ id: "o1", name: "a", result: "X".repeat(1000) })];
+    const r = record({ operations: ops });
+    const before = JSON.stringify(r);
+
+    truncateRecord(r, bytes(r) - 500);
+
+    expect(JSON.stringify(r)).toBe(before);
+    expect(r.operations[0].result).toBe("X".repeat(1000));
+    expect(r.truncated).toBeUndefined();
+  });
+
+  it("leaves input/output untouched and returns original if nothing can be dropped", () => {
+    // No operations to shed; a huge input keeps the record over the limit.
+    const r = record({ input: { blob: "Z".repeat(5000) }, operations: [] });
+    const out = truncateRecord(r, 100);
+    // Nothing was actually cut → original returned, no misleading marker.
+    expect(out).toBe(r);
+    expect(out.truncated).toBeUndefined();
+    expect(out.input).toEqual({ blob: "Z".repeat(5000) });
+  });
+
+  it("treats operations without a startTime as newest (dropped last)", () => {
+    const ops = [
+      op({ id: "timed", name: "timed", startTime: "2026-07-02T00:00:01.000Z" }),
+      op({ id: "untimed", name: "untimed" }), // no startTime
+    ];
+    const r = record({ operations: ops });
+    // Force dropping exactly one whole operation.
+    const limit = bytes(record({ operations: [ops[0]] })) + 5;
+
+    const out = truncateRecord(r, limit);
+
+    expect(out.droppedOperations).toBe(1);
+    // The timed (older) op is dropped; the untimed one survives.
+    expect(out.operations.map((o) => o.id)).toEqual(["untimed"]);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
@@ -247,4 +247,22 @@ describe("truncateRecord render-aware sizing", () => {
     expect(out).toBe(r);
     expect(out.truncated).toBeUndefined();
   });
+
+  it("does not throw when render is explicitly undefined (falls back to identity)", () => {
+    // Mirrors the scheduler's `exporter.render?.bind(exporter)`, which evaluates
+    // to `undefined` for exporters without a `render`. The default parameter
+    // applies to an explicit `undefined` argument, so this must behave exactly
+    // like omitting the argument, not throw.
+    const ops = [
+      op({ id: "o1", name: "a", result: "A".repeat(500) }),
+      op({ id: "o2", name: "b", result: "B".repeat(500) }),
+    ];
+    const r = record({ operations: ops });
+    const limit = bytes(r) - 400;
+
+    expect(() => truncateRecord(r, limit, undefined)).not.toThrow();
+    expect(truncateRecord(r, limit, undefined)).toEqual(
+      truncateRecord(r, limit),
+    );
+  });
 });

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
@@ -74,14 +74,16 @@ describe("truncateRecord", () => {
 
     expect(out).not.toBe(r);
     expect(out.truncated).toBe(true);
-    expect(out.droppedOperationResults).toBe(1);
     expect(out.droppedOperations).toBeUndefined();
-    // Oldest (o1) lost its result; newest (o2) kept it. Both operations remain.
+    // Oldest (o1) lost its result and is marked truncated; newest (o2) kept it.
+    // Both operations remain in the array.
     expect(out.operations).toHaveLength(2);
-    expect(out.operations.find((o) => o.id === "o1")?.result).toBeUndefined();
-    expect(out.operations.find((o) => o.id === "o2")?.result).toBe(
-      "B".repeat(500),
-    );
+    const o1 = out.operations.find((o) => o.id === "o1");
+    const o2 = out.operations.find((o) => o.id === "o2");
+    expect(o1?.result).toBeUndefined();
+    expect(o1?.truncated).toBe(true);
+    expect(o2?.result).toBe("B".repeat(500));
+    expect(o2?.truncated).toBeUndefined();
     expect(bytes(out)).toBeLessThanOrEqual(limit);
   });
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
@@ -210,3 +210,41 @@ describe("truncateRecord", () => {
     expect(out.operations.map((o) => o.id)).toEqual(["untimed"]);
   });
 });
+
+describe("truncateRecord render-aware sizing", () => {
+  // A render that emits a strictly larger shape than the canonical record,
+  // mirroring exporters that expand operations (e.g. operationsByName / "both").
+  const expand = (r: WorkflowInsightRecord): unknown => ({
+    ...r,
+    operationsExpanded: r.operations,
+  });
+
+  it("measures the rendered shape, not the canonical record", () => {
+    const r = record({
+      operations: [
+        op({ id: "o1", name: "a", result: "A".repeat(400) }),
+        op({ id: "o2", name: "b", result: "B".repeat(400) }),
+      ],
+    });
+    // Limit sits between the plain record and its (larger) rendered shape.
+    const limit = bytes(r) + 50;
+    expect(bytes(r)).toBeLessThanOrEqual(limit); // plain record already fits...
+    expect(bytes(expand(r))).toBeGreaterThan(limit); // ...but the emitted shape doesn't.
+
+    // Without a render, truncateRecord sees a fitting record → no-op.
+    expect(truncateRecord(r, limit)).toBe(r);
+
+    // With the render, it trims until the *emitted* shape fits.
+    const out = truncateRecord(r, limit, expand);
+    expect(out).not.toBe(r);
+    expect(out.truncated).toBe(true);
+    expect(bytes(expand(out))).toBeLessThanOrEqual(limit);
+  });
+
+  it("still returns the original when the rendered shape already fits", () => {
+    const r = record({ operations: [op({ id: "o1", name: "a" })] });
+    const out = truncateRecord(r, 10_000, expand);
+    expect(out).toBe(r);
+    expect(out.truncated).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.test.ts
@@ -121,13 +121,75 @@ describe("truncateRecord", () => {
   });
 
   it("leaves input/output untouched and returns original if nothing can be dropped", () => {
-    // No operations to shed; a huge input keeps the record over the limit.
-    const r = record({ input: { blob: "Z".repeat(5000) }, operations: [] });
-    const out = truncateRecord(r, 100);
-    // Nothing was actually cut → original returned, no misleading marker.
+    // No operations, tiny input/output — already fits, nothing to drop.
+    const r = record({ input: { a: 1 }, output: { b: 2 }, operations: [] });
+    const out = truncateRecord(r, 10_000);
     expect(out).toBe(r);
     expect(out.truncated).toBeUndefined();
-    expect(out.input).toEqual({ blob: "Z".repeat(5000) });
+  });
+
+  it("drops execution input then output as a last resort", () => {
+    // No operations to shed; a huge input keeps the record over the limit, so
+    // the limiter must fall through to dropping input (then output).
+    const r = record({
+      input: { blob: "Z".repeat(5000) },
+      output: { blob: "Y".repeat(50) },
+      operations: [],
+    });
+    // Big enough to hold the record minus the (huge) input, plus marker overhead.
+    const limit =
+      bytes(record({ output: { blob: "Y".repeat(50) }, operations: [] })) + 80;
+    const out = truncateRecord(r, limit);
+
+    expect(out).not.toBe(r);
+    expect(out.truncated).toBe(true);
+    expect(out.droppedInput).toBe(true);
+    expect(out.input).toBeUndefined();
+    // Input alone was enough to get under the limit → output is preserved
+    // (input is dropped before output).
+    expect(out.droppedOutput).toBeUndefined();
+    expect(out.output).toEqual({ blob: "Y".repeat(50) });
+    // Original is never mutated.
+    expect(r.input).toEqual({ blob: "Z".repeat(5000) });
+  });
+
+  it("drops output too when dropping input is not enough", () => {
+    const r = record({
+      input: { blob: "Z".repeat(5000) },
+      output: { blob: "Y".repeat(5000) },
+      operations: [],
+    });
+    const out = truncateRecord(r, 300);
+
+    expect(out.truncated).toBe(true);
+    expect(out.droppedInput).toBe(true);
+    expect(out.droppedOutput).toBe(true);
+    expect(out.input).toBeUndefined();
+    expect(out.output).toBeUndefined();
+  });
+
+  it("drops operations before touching input/output", () => {
+    // A big operation result plus a modest input: dropping the operation should
+    // suffice, leaving input intact.
+    const r = record({
+      input: { keep: "me" },
+      operations: [
+        op({
+          id: "o1",
+          name: "big",
+          startTime: "2026-07-02T00:00:01.000Z",
+          result: "R".repeat(3000),
+        }),
+      ],
+    });
+    const limit = bytes(record({ input: { keep: "me" }, operations: [] })) + 80;
+
+    const out = truncateRecord(r, limit);
+
+    expect(out.truncated).toBe(true);
+    expect(out.input).toEqual({ keep: "me" });
+    expect(out.droppedInput).toBeUndefined();
+    expect(out.droppedOutput).toBeUndefined();
   });
 
   it("treats operations without a startTime as newest (dropped last)", () => {

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
@@ -1,0 +1,104 @@
+import type { OperationRecord, WorkflowInsightRecord } from "./types";
+
+const encoder = new TextEncoder();
+
+/** UTF-8 byte length of a value's JSON, or `undefined` if it can't be serialized. */
+function jsonByteSize(value: unknown): number | undefined {
+  try {
+    return encoder.encode(JSON.stringify(value)).length;
+  } catch {
+    // Non-serializable payloads (e.g. bigint) can't be measured; the exporter's
+    // own JSON.stringify would fail the same way, so we can't truncate here.
+    return undefined;
+  }
+}
+
+/**
+ * Orders operation indices oldest-first for dropping. Sorts by `startTime`
+ * ascending; operations without a parseable `startTime` (e.g. not-yet-started)
+ * are treated as newest so they are dropped last. Stable within equal keys.
+ */
+function oldestFirstOrder(operations: OperationRecord[]): number[] {
+  return operations
+    .map((op, idx) => {
+      const t = op.startTime ? Date.parse(op.startTime) : Number.NaN;
+      return { idx, t: Number.isNaN(t) ? Number.POSITIVE_INFINITY : t };
+    })
+    .sort((a, b) => a.t - b.t || a.idx - b.idx)
+    .map((x) => x.idx);
+}
+
+/**
+ * Returns a copy of `record` shrunk to fit `maxBytes` (best-effort), or the
+ * original record when it already fits or `maxBytes` is not set.
+ *
+ * Drop order (see `docs/plugin-contracts.md`):
+ *   1. operation `result` fields, oldest operation first;
+ *   2. whole operations, oldest first.
+ *
+ * Execution `input`/`output` and identity/timeline fields are never dropped —
+ * use `content.input`/`content.output` transforms to bound those. When anything
+ * is dropped, the returned record has `truncated: true` and the
+ * `droppedOperationResults` / `droppedOperations` counts.
+ *
+ * The input record is never mutated (the same instance is shared across
+ * exporters, which may have different limits).
+ */
+export function truncateRecord(
+  record: WorkflowInsightRecord,
+  maxBytes: number | undefined,
+): WorkflowInsightRecord {
+  if (maxBytes === undefined || maxBytes <= 0) return record;
+
+  const initialSize = jsonByteSize(record);
+  if (initialSize === undefined || initialSize <= maxBytes) return record;
+
+  // Clone operations (and each op we may edit) so we never touch the shared input.
+  const ops: OperationRecord[] = record.operations.map((op) => ({ ...op }));
+  const kept = new Array<boolean>(ops.length).fill(true);
+  const order = oldestFirstOrder(ops);
+
+  let droppedOperationResults = 0;
+  let droppedOperations = 0;
+
+  const candidate = (): WorkflowInsightRecord => {
+    const out: WorkflowInsightRecord = {
+      ...record,
+      operations: ops.filter((_, i) => kept[i]),
+      truncated: true,
+    };
+    if (droppedOperationResults > 0)
+      out.droppedOperationResults = droppedOperationResults;
+    if (droppedOperations > 0) out.droppedOperations = droppedOperations;
+    return out;
+  };
+
+  const fits = (): boolean => {
+    const size = jsonByteSize(candidate());
+    return size !== undefined && size <= maxBytes;
+  };
+
+  // Phase 1: drop operation results, oldest first.
+  for (const idx of order) {
+    if (fits()) break;
+    if (kept[idx] && ops[idx].result !== undefined) {
+      ops[idx] = { ...ops[idx], result: undefined };
+      droppedOperationResults++;
+    }
+  }
+
+  // Phase 2: drop whole operations, oldest first.
+  for (const idx of order) {
+    if (fits()) break;
+    if (kept[idx]) {
+      kept[idx] = false;
+      droppedOperations++;
+    }
+  }
+
+  // If nothing was actually dropped (e.g. an oversized input/output with no
+  // operation data to shed), return the original untouched — it wasn't cut.
+  if (droppedOperationResults === 0 && droppedOperations === 0) return record;
+
+  return candidate();
+}

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
@@ -47,14 +47,23 @@ function oldestFirstOrder(operations: OperationRecord[]): number[] {
  *
  * The input record is never mutated (the same instance is shared across
  * exporters, which may have different limits).
+ *
+ * `render` maps the record to the exact value the exporter will serialize (e.g.
+ * the `operationsByName` expansion), so the size check measures what is actually
+ * emitted rather than the canonical record. It defaults to the identity. Note
+ * this bounds the serialized record *body*, not any destination wire envelope
+ * (DynamoDB type descriptors, CloudWatch Logs event framing, gzip, etc.);
+ * exporters with non-trivial envelope overhead should keep `maxRecordSizeBytes`
+ * below their hard limit to leave headroom.
  */
 export function truncateRecord(
   record: WorkflowInsightRecord,
   maxBytes: number | undefined,
+  render: (r: WorkflowInsightRecord) => unknown = (r) => r,
 ): WorkflowInsightRecord {
   if (maxBytes === undefined || maxBytes <= 0) return record;
 
-  const initialSize = jsonByteSize(record);
+  const initialSize = jsonByteSize(render(record));
   if (initialSize === undefined || initialSize <= maxBytes) return record;
 
   // Clone operations (and each op we may edit) so we never touch the shared input.
@@ -86,7 +95,7 @@ export function truncateRecord(
   };
 
   const fits = (): boolean => {
-    const size = jsonByteSize(candidate());
+    const size = jsonByteSize(render(candidate()));
     return size !== undefined && size <= maxBytes;
   };
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
@@ -34,12 +34,15 @@ function oldestFirstOrder(operations: OperationRecord[]): number[] {
  *
  * Drop order (see `docs/plugin-contracts.md`):
  *   1. operation `result` fields, oldest operation first;
- *   2. whole operations, oldest first.
+ *   2. whole operations, oldest first;
+ *   3. last resort — execution `input`, then `output`.
  *
- * Execution `input`/`output` and identity/timeline fields are never dropped —
- * use `content.input`/`content.output` transforms to bound those. When anything
- * is dropped, the returned record has `truncated: true` and the
- * `droppedOperationResults` / `droppedOperations` counts.
+ * Identity/timeline fields (arn, status, timestamps, etc.) are never dropped.
+ * `input`/`output` are dropped only after every operation is gone, so prefer
+ * `content.input`/`content.output` transforms to bound them earlier. When
+ * anything is dropped, the returned record has `truncated: true` and the
+ * relevant markers (`droppedOperationResults` / `droppedOperations` counts,
+ * `droppedInput` / `droppedOutput` flags).
  *
  * The input record is never mutated (the same instance is shared across
  * exporters, which may have different limits).
@@ -60,6 +63,8 @@ export function truncateRecord(
 
   let droppedOperationResults = 0;
   let droppedOperations = 0;
+  let droppedInput = false;
+  let droppedOutput = false;
 
   const candidate = (): WorkflowInsightRecord => {
     const out: WorkflowInsightRecord = {
@@ -70,6 +75,14 @@ export function truncateRecord(
     if (droppedOperationResults > 0)
       out.droppedOperationResults = droppedOperationResults;
     if (droppedOperations > 0) out.droppedOperations = droppedOperations;
+    if (droppedInput) {
+      out.input = undefined;
+      out.droppedInput = true;
+    }
+    if (droppedOutput) {
+      out.output = undefined;
+      out.droppedOutput = true;
+    }
     return out;
   };
 
@@ -96,9 +109,20 @@ export function truncateRecord(
     }
   }
 
-  // If nothing was actually dropped (e.g. an oversized input/output with no
-  // operation data to shed), return the original untouched — it wasn't cut.
-  if (droppedOperationResults === 0 && droppedOperations === 0) return record;
+  // Phase 3 (last resort): drop execution input, then output. Only reached once
+  // every operation is gone and the record is still over the limit.
+  if (!fits() && record.input !== undefined) droppedInput = true;
+  if (!fits() && record.output !== undefined) droppedOutput = true;
+
+  // If nothing was actually dropped, return the original untouched — not cut.
+  if (
+    droppedOperationResults === 0 &&
+    droppedOperations === 0 &&
+    !droppedInput &&
+    !droppedOutput
+  ) {
+    return record;
+  }
 
   return candidate();
 }

--- a/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/truncation.ts
@@ -40,9 +40,10 @@ function oldestFirstOrder(operations: OperationRecord[]): number[] {
  * Identity/timeline fields (arn, status, timestamps, etc.) are never dropped.
  * `input`/`output` are dropped only after every operation is gone, so prefer
  * `content.input`/`content.output` transforms to bound them earlier. When
- * anything is dropped, the returned record has `truncated: true` and the
- * relevant markers (`droppedOperationResults` / `droppedOperations` counts,
- * `droppedInput` / `droppedOutput` flags).
+ * anything is dropped, the returned record has `truncated: true`; each operation
+ * whose result was dropped is itself marked `truncated: true`, and
+ * `droppedOperations` / `droppedInput` / `droppedOutput` markers are set as
+ * applicable.
  *
  * The input record is never mutated (the same instance is shared across
  * exporters, which may have different limits).
@@ -61,7 +62,7 @@ export function truncateRecord(
   const kept = new Array<boolean>(ops.length).fill(true);
   const order = oldestFirstOrder(ops);
 
-  let droppedOperationResults = 0;
+  let anyResultDropped = false;
   let droppedOperations = 0;
   let droppedInput = false;
   let droppedOutput = false;
@@ -72,8 +73,6 @@ export function truncateRecord(
       operations: ops.filter((_, i) => kept[i]),
       truncated: true,
     };
-    if (droppedOperationResults > 0)
-      out.droppedOperationResults = droppedOperationResults;
     if (droppedOperations > 0) out.droppedOperations = droppedOperations;
     if (droppedInput) {
       out.input = undefined;
@@ -91,12 +90,13 @@ export function truncateRecord(
     return size !== undefined && size <= maxBytes;
   };
 
-  // Phase 1: drop operation results, oldest first.
+  // Phase 1: drop operation results, oldest first. The operation is kept and
+  // marked `truncated` so consumers can tell its result was cut, not absent.
   for (const idx of order) {
     if (fits()) break;
     if (kept[idx] && ops[idx].result !== undefined) {
-      ops[idx] = { ...ops[idx], result: undefined };
-      droppedOperationResults++;
+      ops[idx] = { ...ops[idx], result: undefined, truncated: true };
+      anyResultDropped = true;
     }
   }
 
@@ -116,7 +116,7 @@ export function truncateRecord(
 
   // If nothing was actually dropped, return the original untouched — not cut.
   if (
-    droppedOperationResults === 0 &&
+    !anyResultDropped &&
     droppedOperations === 0 &&
     !droppedInput &&
     !droppedOutput

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -75,6 +75,19 @@ export interface ContentConfig {
 export interface InsightExporter {
   export(record: WorkflowInsightRecord): Promise<void>;
   flush?(): Promise<void>;
+  /**
+   * Maximum serialized record size, in bytes, this exporter will emit. When a
+   * record's JSON exceeds this, the plugin truncates a per-exporter copy before
+   * calling {@link InsightExporter.export | export} (best-effort): it drops
+   * operation `result` fields oldest-first, then whole operations oldest-first,
+   * and sets `truncated: true` (plus `droppedOperationResults` /
+   * `droppedOperations` counts) on the emitted record. Execution `input` /
+   * `output` and identity/timeline fields are never dropped by the size limiter
+   * — shrink those with `content.input` / `content.output` transforms instead.
+   *
+   * First-party exporters default this to their destination's practical limit;
+   * `undefined` disables truncation.
+   */
   maxRecordSizeBytes?: number;
 }
 
@@ -230,4 +243,14 @@ export interface WorkflowInsightRecord {
     message: string;
   };
   operations: OperationRecord[];
+  /**
+   * `true` when the size limiter dropped data to fit the exporter's
+   * `maxRecordSizeBytes`. Omitted when nothing was dropped, so a truncated
+   * record is always distinguishable from a complete one ("cut, not missing").
+   */
+  truncated?: boolean;
+  /** Number of operation `result` fields dropped by the size limiter. */
+  droppedOperationResults?: number;
+  /** Number of whole operations dropped by the size limiter. */
+  droppedOperations?: number;
 }

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -80,10 +80,12 @@ export interface InsightExporter {
    * record's JSON exceeds this, the plugin truncates a per-exporter copy before
    * calling {@link InsightExporter.export | export} (best-effort): it drops
    * operation `result` fields oldest-first, then whole operations oldest-first,
-   * and sets `truncated: true` (plus `droppedOperationResults` /
-   * `droppedOperations` counts) on the emitted record. Execution `input` /
-   * `output` and identity/timeline fields are never dropped by the size limiter
-   * — shrink those with `content.input` / `content.output` transforms instead.
+   * then — only as a last resort — execution `input` and `output`. It sets
+   * `truncated: true` plus the relevant markers (`droppedOperationResults` /
+   * `droppedOperations` counts, `droppedInput` / `droppedOutput` flags) on the
+   * emitted record. Prefer `content.input` / `content.output` transforms to
+   * bound `input`/`output` before it comes to that; identity/timeline fields
+   * are never dropped.
    *
    * First-party exporters default this to their destination's practical limit;
    * `undefined` disables truncation.
@@ -253,4 +255,12 @@ export interface WorkflowInsightRecord {
   droppedOperationResults?: number;
   /** Number of whole operations dropped by the size limiter. */
   droppedOperations?: number;
+  /**
+   * `true` when the size limiter dropped execution `input` as a last resort
+   * (only after every operation was already dropped). Distinguishes a
+   * size-dropped input from one omitted by a `content.input` transform.
+   */
+  droppedInput?: boolean;
+  /** `true` when the size limiter dropped execution `output` as a last resort. */
+  droppedOutput?: boolean;
 }

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -91,6 +91,19 @@ export interface InsightExporter {
    * `undefined` disables truncation.
    */
   maxRecordSizeBytes?: number;
+  /**
+   * Maps a record to the exact value this exporter serializes/sends — e.g. the
+   * `operationsByName` expansion, or a chosen {@link OperationsFormat}. The size
+   * limiter measures this shape (not the canonical record) so a record trimmed
+   * to `maxRecordSizeBytes` reflects what is actually emitted. Defaults to the
+   * record unchanged.
+   *
+   * To avoid drift, an exporter that reshapes the record should call the same
+   * `render` from its {@link InsightExporter.export | export} so sizing and
+   * emission share one code path. This bounds the serialized record body only,
+   * not the destination wire envelope.
+   */
+  render?(record: WorkflowInsightRecord): unknown;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -81,11 +81,11 @@ export interface InsightExporter {
    * calling {@link InsightExporter.export | export} (best-effort): it drops
    * operation `result` fields oldest-first, then whole operations oldest-first,
    * then — only as a last resort — execution `input` and `output`. It sets
-   * `truncated: true` plus the relevant markers (`droppedOperationResults` /
-   * `droppedOperations` counts, `droppedInput` / `droppedOutput` flags) on the
-   * emitted record. Prefer `content.input` / `content.output` transforms to
-   * bound `input`/`output` before it comes to that; identity/timeline fields
-   * are never dropped.
+   * `truncated: true` on the emitted record, marks each operation whose result
+   * was dropped with its own `truncated: true`, and adds the `droppedOperations`
+   * count and `droppedInput` / `droppedOutput` flags. Prefer `content.input` /
+   * `content.output` transforms to bound `input`/`output` before it comes to
+   * that; identity/timeline fields are never dropped.
    *
    * First-party exporters default this to their destination's practical limit;
    * `undefined` disables truncation.
@@ -165,6 +165,12 @@ export interface OperationRecord {
    * `content.operations.overrides` entry supplies a `result` transform.
    */
   result?: OperationResult;
+  /**
+   * `true` when the size limiter dropped this operation's `result` to fit the
+   * exporter's `maxRecordSizeBytes`. The operation's other fields are retained;
+   * only the (opted-in) `result` value was removed.
+   */
+  truncated?: boolean;
 }
 
 /**
@@ -251,8 +257,6 @@ export interface WorkflowInsightRecord {
    * record is always distinguishable from a complete one ("cut, not missing").
    */
   truncated?: boolean;
-  /** Number of operation `result` fields dropped by the size limiter. */
-  droppedOperationResults?: number;
   /** Number of whole operations dropped by the size limiter. */
   droppedOperations?: number;
   /**


### PR DESCRIPTION
Implements the previously-unused `InsightExporter.maxRecordSizeBytes` for the
   Workflow Insight plugin. Until now the field existed on the interface but was
   never read, so oversized records were emitted as-is and could be rejected by
   size-capped destinations (CloudWatch Logs 256 KB, DynamoDB 400 KB, etc.).

   When a record's serialized JSON exceeds an exporter's limit, the plugin now
   truncates a **per-exporter copy** before export — so the same execution can be
   emitted in full to one destination and trimmed to another. The shared record is
   never mutated.

### Drop order (best-effort, least-destructive first)

   Applied until the record fits the limit:

   1. operation `result` fields, **oldest operation first** (the operation is kept
      and marked `truncated: true`);
   2. whole operations, **oldest first**;
   3. last resort — execution `input`, then `output`.

   Identity/timeline fields are never dropped. Because `content.input` /
   `content.output` transforms run *before* truncation, they remain the preferred
   way to bound large payloads.

### Markers ("cut, not missing")

   Additive, optional fields — `schemaVersion` stays `"1.0"`:

   - record `truncated: boolean` — anything was cut
   - `OperationRecord.truncated: boolean` — that operation's result was dropped
   - `droppedOperations: number` — whole operations removed
   - `droppedInput` / `droppedOutput: boolean` — last-resort payload drops

### Per-exporter defaults (all overridable)
```
   | Exporter(s)                                    | Default   |
   | ---------------------------------------------- | --------- |
   | Lambda log, CloudWatch Logs, SQS, EventBridge  | 256 KB    |
   | DynamoDB                                       | 400 KB    |
   | Aurora, Redshift, Firehose, OTel               | 1 MB      |
   | S3                                             | 5 MB      |
   | OpenSearch                                     | 10 MB     |
   | HTTP, File, Timestream                         | none¹     |
```
   ¹ No default — truncation disabled unless `maxRecordSizeBytes` is set.

   ### Docs

   `README.md` (new "Record size & truncation" section + record fields + custom
   exporter example), `plugin-contracts.md`, `workflow-insight-design.md`, and
   `remaining-tasks.md` updated and reconciled.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
