### PR TITLE
feat(sdk): add SQS live view to the Workflow Insight VS Code extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,7 +597,6 @@
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1076.0.tgz",
       "integrity": "sha512-uxlJolGmtcyLGvmJq7CkCrPd88ExsSRT44Bc6oUR+gj/WcYVZbm0/mCrI5FAVB59hv7wxEt/c7c4Fek4THaudQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1004,7 +1003,6 @@
       "version": "3.972.32",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.32.tgz",
       "integrity": "sha512-xUm3LbZQpYpWirmN9ZdcUCYAGy2yBA7ENm/+MKiqp4rQlPo/zbDxqtkgcyFgHfpyVNGX96WJrV7HcrSEjn7ydA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.14",
@@ -16132,6 +16130,7 @@
         "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
         "@aws-sdk/client-dynamodb": "^3.658.0",
         "@aws-sdk/client-rds-data": "^3.658.0",
+        "@aws-sdk/client-sqs": "^3.658.0",
         "@aws-sdk/credential-providers": "^3.658.0",
         "@aws-sdk/util-dynamodb": "^3.658.0",
         "node-llama-cpp": "^3.18.1"

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -76,6 +76,24 @@ Click the **⚙** button and fill in your settings. The form shows only the fiel
 | Aurora Database    | `postgres`                      |
 | Aurora Table       | `workflow_insight`              |
 
+#### Amazon SQS (live view)
+
+SQS has no query engine, so this destination doesn't use the "Ask" pipeline at
+all — it's a **live view** instead. Click **Start Listening** and messages
+appear as they arrive on the queue.
+
+| Field                            | Value                                                                                                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Region                           | `us-east-1`                                                                                                                                   |
+| Destination Type                 | Amazon SQS (live view)                                                                                                                        |
+| SQS Queue URL                    | Your queue's URL                                                                                                                              |
+| Delete messages after displaying | Off by default (peek-only — other consumers still get every message). Turn on only if this Explorer should be the sole consumer of the queue. |
+
+Peek-only mode (the default) uses SQS long-polling without deleting messages,
+so the same message can be redelivered after its visibility timeout — the
+Explorer de-duplicates by message ID when displaying, but this also means it
+is not a substitute for a real consumer if you need exactly-once processing.
+
 ### 3. Configure Bedrock
 
 Set the **Bedrock Model ID** to an inference profile you have access to:
@@ -110,18 +128,20 @@ Type a question and click **Ask**. Examples:
 
 All settings are under the `workflowInsight.*` namespace.
 
-| Setting             | Description                                   | Required     |
-| ------------------- | --------------------------------------------- | ------------ |
-| `region`            | AWS region                                    | Yes          |
-| `destinationType`   | Where your data lives (see above)             | Yes          |
-| `logGroupName`      | CloudWatch log group name(s), comma-separated | For CW Logs  |
-| `dynamodbTableName` | DynamoDB table name                           | For DynamoDB |
-| `auroraResourceArn` | Aurora cluster ARN                            | For Aurora   |
-| `auroraSecretArn`   | Secrets Manager secret ARN                    | For Aurora   |
-| `auroraDatabase`    | Database name                                 | For Aurora   |
-| `auroraTable`       | Table name                                    | For Aurora   |
-| `awsProfile`        | Named AWS profile (empty = default chain)     | No           |
-| `bedrockModelId`    | Bedrock model/inference profile for NL→query  | Yes          |
+| Setting              | Description                                                   | Required     |
+| -------------------- | ------------------------------------------------------------- | ------------ |
+| `region`             | AWS region                                                    | Yes          |
+| `destinationType`    | Where your data lives (see above)                             | Yes          |
+| `logGroupName`       | CloudWatch log group name(s), comma-separated                 | For CW Logs  |
+| `dynamodbTableName`  | DynamoDB table name                                           | For DynamoDB |
+| `auroraResourceArn`  | Aurora cluster ARN                                            | For Aurora   |
+| `auroraSecretArn`    | Secrets Manager secret ARN                                    | For Aurora   |
+| `auroraDatabase`     | Database name                                                 | For Aurora   |
+| `auroraTable`        | Table name                                                    | For Aurora   |
+| `sqsQueueUrl`        | SQS queue URL to listen to                                    | For SQS      |
+| `sqsDeleteAfterRead` | Delete messages after displaying (default `false`; peek-only) | No           |
+| `awsProfile`         | Named AWS profile (empty = default chain)                     | No           |
+| `bedrockModelId`     | Bedrock model/inference profile for NL→query                  | Yes          |
 
 ## Authentication
 
@@ -143,12 +163,13 @@ No credentials are stored by the extension.
 
 Depending on your destination:
 
-| Destination     | Permissions needed                                               |
-| --------------- | ---------------------------------------------------------------- |
-| CloudWatch Logs | `logs:StartQuery`, `logs:GetQueryResults`                        |
-| DynamoDB        | `dynamodb:PartiQLSelect` (or `dynamodb:Scan` + `dynamodb:Query`) |
-| Aurora          | `rds-data:ExecuteStatement`, `secretsmanager:GetSecretValue`     |
-| Bedrock (all)   | `bedrock:InvokeModel` on your model/inference profile            |
+| Destination     | Permissions needed                                                                 |
+| --------------- | ---------------------------------------------------------------------------------- |
+| CloudWatch Logs | `logs:StartQuery`, `logs:GetQueryResults`                                          |
+| DynamoDB        | `dynamodb:PartiQLSelect` (or `dynamodb:Scan` + `dynamodb:Query`)                   |
+| Aurora          | `rds-data:ExecuteStatement`, `secretsmanager:GetSecretValue`                       |
+| SQS             | `sqs:ReceiveMessage` (plus `sqs:DeleteMessage` if `sqsDeleteAfterRead` is enabled) |
+| Bedrock (all)   | `bedrock:InvokeModel` on your model/inference profile                              |
 
 ## How Queries Are Generated
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -53,15 +53,27 @@
             "cloudwatch-logs-exporter",
             "lambda-log-exporter",
             "dynamodb",
-            "aurora"
+            "aurora",
+            "sqs"
           ],
           "enumDescriptions": [
             "Dedicated log group via CloudWatchLogsExporter — records are raw JSON, fields queryable directly",
             "Function's own log group via LambdaLogExporter — records nested in Lambda JSON envelope (message field)",
             "DynamoDB table via DynamoDBExporter — records queryable via PartiQL",
-            "Aurora PostgreSQL/MySQL via AuroraExporter — full SQL with GROUP BY, JOIN, aggregations"
+            "Aurora PostgreSQL/MySQL via AuroraExporter — full SQL with GROUP BY, JOIN, aggregations",
+            "Amazon SQS via SQSExporter — live view that listens to the queue as records arrive (no query engine)"
           ],
           "description": "Where and how records are stored. Determines query engine and format."
+        },
+        "workflowInsight.sqsQueueUrl": {
+          "type": "string",
+          "default": "",
+          "description": "SQS queue URL to listen to (required when destinationType is 'sqs')."
+        },
+        "workflowInsight.sqsDeleteAfterRead": {
+          "type": "boolean",
+          "default": false,
+          "description": "Delete messages from the queue after displaying them in the live view. Off by default so the Explorer only observes — other consumers still receive every message. Enable only if this Explorer should be the sole consumer of the queue."
         },
         "workflowInsight.dynamodbTableName": {
           "type": "string",
@@ -128,6 +140,7 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",
     "@aws-sdk/client-rds-data": "^3.658.0",
+    "@aws-sdk/client-sqs": "^3.658.0",
     "@aws-sdk/credential-providers": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",
     "node-llama-cpp": "^3.18.1"

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -9,12 +9,15 @@ export interface InsightConfig {
     | "cloudwatch-logs-exporter"
     | "lambda-log-exporter"
     | "dynamodb"
-    | "aurora";
+    | "aurora"
+    | "sqs";
   dynamodbTableName: string;
   auroraResourceArn: string;
   auroraSecretArn: string;
   auroraDatabase: string;
   auroraTable: string;
+  sqsQueueUrl: string;
+  sqsDeleteAfterRead: boolean;
   llmProvider: "bedrock" | "copilot" | "local";
   awsProfile?: string;
   bedrockModelId: string;
@@ -41,7 +44,9 @@ export function readConfig(): InsightConfig {
         ? ("dynamodb" as const)
         : raw === "aurora"
           ? ("aurora" as const)
-          : ("cloudwatch-logs-exporter" as const);
+          : raw === "sqs"
+            ? ("sqs" as const)
+            : ("cloudwatch-logs-exporter" as const);
   const dynamodbTableName = (c.get<string>("dynamodbTableName") || "").trim();
   const auroraResourceArn = (c.get<string>("auroraResourceArn") || "").trim();
   const auroraSecretArn = (c.get<string>("auroraSecretArn") || "").trim();
@@ -49,6 +54,8 @@ export function readConfig(): InsightConfig {
     (c.get<string>("auroraDatabase") || "").trim() || "postgres";
   const auroraTable =
     (c.get<string>("auroraTable") || "").trim() || "workflow_insight";
+  const sqsQueueUrl = (c.get<string>("sqsQueueUrl") || "").trim();
+  const sqsDeleteAfterRead = c.get<boolean>("sqsDeleteAfterRead") ?? false;
   const llmProvider =
     (c.get<string>("llmProvider") || "").trim() === "copilot"
       ? ("copilot" as const)
@@ -69,6 +76,8 @@ export function readConfig(): InsightConfig {
     auroraSecretArn,
     auroraDatabase,
     auroraTable,
+    sqsQueueUrl,
+    sqsDeleteAfterRead,
     llmProvider,
     awsProfile,
     bedrockModelId,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { generateQuery, isModelDownloaded, ensureModel } from "./llm";
 import { runLogsInsightsQuery } from "./logsInsights";
 import { runDynamoDBQuery } from "./dynamodb";
 import { runAuroraQuery } from "./aurora";
+import { listenToQueue, type SqsMessageRow } from "./sqs";
 import { ensureLimit } from "./schema";
 import { assertReadOnly } from "./queryValidator";
 
@@ -12,7 +13,9 @@ type InboundMessage =
   | { type: "generate"; question: string }
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel" }
-  | { type: "exportChart"; format: "svg" | "png"; content: string };
+  | { type: "exportChart"; format: "svg" | "png"; content: string }
+  | { type: "startListening" }
+  | { type: "stopListening" };
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -27,6 +30,7 @@ export function deactivate(): void {}
 class ExplorerPanel {
   private static current: ExplorerPanel | undefined;
   private readonly disposables: vscode.Disposable[] = [];
+  private listenController: AbortController | undefined;
 
   static show(extensionUri: vscode.Uri): void {
     const column = vscode.window.activeTextEditor?.viewColumn;
@@ -73,6 +77,10 @@ class ExplorerPanel {
           return await this.onDownloadModel();
         case "exportChart":
           return await this.onExportChart(msg.format, msg.content);
+        case "startListening":
+          return this.onStartListening();
+        case "stopListening":
+          return this.onStopListening();
       }
     } catch (err) {
       this.post({
@@ -95,6 +103,8 @@ class ExplorerPanel {
         auroraSecretArn: cfg.auroraSecretArn,
         auroraDatabase: cfg.auroraDatabase,
         auroraTable: cfg.auroraTable,
+        sqsQueueUrl: cfg.sqsQueueUrl,
+        sqsDeleteAfterRead: cfg.sqsDeleteAfterRead,
         llmProvider: cfg.llmProvider,
         awsProfile: cfg.awsProfile ?? "",
         bedrockModelId: cfg.bedrockModelId,
@@ -108,11 +118,12 @@ class ExplorerPanel {
   ): Promise<void> {
     const config = vscode.workspace.getConfiguration("workflowInsight");
     for (const [key, value] of Object.entries(settings)) {
-      await config.update(
-        key,
-        value || undefined,
-        vscode.ConfigurationTarget.Global,
-      );
+      // sqsDeleteAfterRead is boolean-typed in the settings schema; the
+      // webview always sends strings, so coerce it before writing. `false` is
+      // a meaningful value here, so it must not be treated as "unset".
+      const coerced: string | boolean | undefined =
+        key === "sqsDeleteAfterRead" ? value === "true" : value || undefined;
+      await config.update(key, coerced, vscode.ConfigurationTarget.Global);
     }
     this.sendConfig();
     this.post({ type: "settingsSaved" });
@@ -150,6 +161,46 @@ class ExplorerPanel {
       await vscode.workspace.fs.writeFile(uri, Buffer.from(base64, "base64"));
     }
     vscode.window.showInformationMessage(`Chart saved to ${uri.fsPath}`);
+  }
+
+  private onStartListening(): void {
+    if (this.listenController) return; // already listening
+    const cfg = readConfig();
+    if (!cfg.sqsQueueUrl) {
+      this.post({
+        type: "error",
+        message: "No SQS queue configured. Set workflowInsight.sqsQueueUrl.",
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    this.listenController = controller;
+    this.post({ type: "sqsStatus", listening: true });
+
+    void listenToQueue({
+      region: cfg.region,
+      credentials: resolveCredentials(cfg.awsProfile),
+      queueUrl: cfg.sqsQueueUrl,
+      deleteAfterRead: cfg.sqsDeleteAfterRead,
+      signal: controller.signal,
+      onMessages: (messages: SqsMessageRow[]) =>
+        this.post({ type: "sqsMessages", messages }),
+      onError: (error) => this.post({ type: "error", message: error.message }),
+    }).finally(() => {
+      // Only clear/notify if this call owns the current controller — a newer
+      // start/stop may have already replaced it.
+      if (this.listenController === controller) {
+        this.listenController = undefined;
+        this.post({ type: "sqsStatus", listening: false });
+      }
+    });
+  }
+
+  private onStopListening(): void {
+    this.listenController?.abort();
+    this.listenController = undefined;
+    this.post({ type: "sqsStatus", listening: false });
   }
 
   private async onGenerate(question: string): Promise<void> {
@@ -317,6 +368,8 @@ class ExplorerPanel {
 
   private dispose(): void {
     ExplorerPanel.current = undefined;
+    this.listenController?.abort();
+    this.listenController = undefined;
     this.panel.dispose();
     while (this.disposables.length) this.disposables.pop()?.dispose();
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/sqs.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/sqs.ts
@@ -1,0 +1,110 @@
+import {
+  SQSClient,
+  ReceiveMessageCommand,
+  DeleteMessageBatchCommand,
+} from "@aws-sdk/client-sqs";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+
+export interface SqsMessageRow {
+  messageId: string;
+  receivedAt: string;
+  body: string;
+  attributes: Record<string, string>;
+}
+
+const LONG_POLL_WAIT_SECONDS = 20;
+const MAX_MESSAGES_PER_POLL = 10;
+
+/**
+ * Long-polls an SQS queue indefinitely, invoking `onMessages` with each batch
+ * as it arrives, until `signal` is aborted.
+ *
+ * Peek-only by default (`deleteAfterRead: false`): messages are left on the
+ * queue so other consumers still receive every message — the Explorer is just
+ * observing. Because messages aren't deleted, the SAME message will be
+ * re-delivered on a later poll once its visibility timeout elapses; callers
+ * should de-duplicate by `messageId` when rendering.
+ *
+ * When `deleteAfterRead` is true, the Explorer becomes a real consumer:
+ * messages are deleted immediately after being handed to `onMessages`, so no
+ * other consumer will see them and no re-delivery will occur.
+ */
+export async function listenToQueue(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  queueUrl: string;
+  deleteAfterRead: boolean;
+  signal: AbortSignal;
+  onMessages: (messages: SqsMessageRow[]) => void;
+  onError: (error: Error) => void;
+}): Promise<void> {
+  const client = new SQSClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  try {
+    while (!opts.signal.aborted) {
+      let result;
+      try {
+        result = await client.send(
+          new ReceiveMessageCommand({
+            QueueUrl: opts.queueUrl,
+            MaxNumberOfMessages: MAX_MESSAGES_PER_POLL,
+            WaitTimeSeconds: LONG_POLL_WAIT_SECONDS,
+            MessageAttributeNames: ["All"],
+            AttributeNames: ["All"],
+          }),
+          { abortSignal: opts.signal },
+        );
+      } catch (err) {
+        if (opts.signal.aborted) return; // aborted mid-request; stop quietly
+        opts.onError(err instanceof Error ? err : new Error(String(err)));
+        continue;
+      }
+
+      const messages = result.Messages ?? [];
+      if (messages.length > 0) {
+        const receivedAt = new Date().toISOString();
+        opts.onMessages(
+          messages.map((m) => ({
+            messageId: m.MessageId ?? "",
+            receivedAt,
+            body: m.Body ?? "",
+            attributes: Object.fromEntries(
+              Object.entries(m.MessageAttributes ?? {}).map(([k, v]) => [
+                k,
+                v.StringValue ?? "",
+              ]),
+            ),
+          })),
+        );
+
+        if (opts.deleteAfterRead) {
+          const entries = messages
+            .filter((m) => m.MessageId && m.ReceiptHandle)
+            .map((m) => ({
+              Id: m.MessageId!,
+              ReceiptHandle: m.ReceiptHandle!,
+            }));
+          if (entries.length > 0) {
+            try {
+              await client.send(
+                new DeleteMessageBatchCommand({
+                  QueueUrl: opts.queueUrl,
+                  Entries: entries,
+                }),
+              );
+            } catch (err) {
+              // Non-fatal: message was already shown to the user; failing to
+              // delete just means it may be re-delivered later. Keep listening.
+              opts.onError(err instanceof Error ? err : new Error(String(err)));
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    client.destroy();
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package-lock.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "insight-vscode-webview-ui",
       "version": "0.0.0",
       "dependencies": {
+        "@cloudscape-design/code-view": "^3.0.151",
         "@cloudscape-design/components": "^3.0.0",
         "@cloudscape-design/global-styles": "^1.0.0",
         "react": "^18.3.0",
@@ -31,6 +32,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudscape-design/code-view": {
+      "version": "3.0.151",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/code-view/-/code-view-3.0.151.tgz",
+      "integrity": "sha512-ksYn790nPO2PKMXsl2RADrKw2zYKSdhMWaQfo669sJUQSRApKc5NfPdnnnd0xl1k2JDu1a2a3uXCatM947+akw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
+        "ace-code": "^1.32.3",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@cloudscape-design/components": "^3",
+        "react": ">=18.2.0"
       }
     },
     "node_modules/@cloudscape-design/collection-hooks": {
@@ -731,6 +747,15 @@
       "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.44.0.tgz",
       "integrity": "sha512-PFNMSYqFdEUkul2Ntud0HvA09AgY+F1ag0UYdpMH60wNI/qOA8cB8tlTgoALMEwIdUPJK2CjrIQ7OnbiSS/ugQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ace-code": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/ace-code/-/ace-code-1.44.0.tgz",
+      "integrity": "sha512-6hmMdpJ7DTB4xGSPfZcINgwL2v5/0u6Oh5GXbcH7KZqjWkVADxSbA1IMoWmk/WvgHAsbaYmZoWh7DS2zCfVbeQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package.json
@@ -7,6 +7,7 @@
     "watch": "node build.mjs --watch"
   },
   "dependencies": {
+    "@cloudscape-design/code-view": "^3.0.151",
     "@cloudscape-design/components": "^3.0.0",
     "@cloudscape-design/global-styles": "^1.0.0",
     "react": "^18.3.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -8,7 +8,8 @@ import { QueryPanel } from "./QueryPanel";
 import { ResultsTable } from "./ResultsTable";
 import { VisualizePage } from "./VisualizePage";
 import { SettingsModal } from "./SettingsModal";
-import type { InboundMessage, Settings } from "./types";
+import { SqsLiveView } from "./SqsLiveView";
+import type { InboundMessage, Settings, SqsMessageRow } from "./types";
 import { DEFAULT_SETTINGS } from "./types";
 
 applyMode(Mode.Dark);
@@ -26,6 +27,8 @@ export function App() {
   const [downloadPercent, setDownloadPercent] = useState(0);
   const [page, setPage] = useState<Page>("data");
   const [explanation, setExplanation] = useState("");
+  const [sqsMessages, setSqsMessages] = useState<SqsMessageRow[]>([]);
+  const [sqsListening, setSqsListening] = useState(false);
 
   const handleMessage = useCallback((event: MessageEvent<InboundMessage>) => {
     const msg = event.data;
@@ -56,6 +59,18 @@ export function App() {
       case "settingsSaved":
         setSettingsOpen(false);
         break;
+      case "sqsStatus":
+        setSqsListening(msg.listening);
+        break;
+      case "sqsMessages":
+        setSqsMessages((prev) => {
+          // De-dupe by messageId: in peek-only mode (sqsDeleteAfterRead=false)
+          // the same message can be re-delivered after its visibility timeout.
+          const seen = new Set(prev.map((m) => m.messageId));
+          const next = msg.messages.filter((m) => !seen.has(m.messageId));
+          return next.length > 0 ? [...prev, ...next] : prev;
+        });
+        break;
     }
   }, []);
 
@@ -74,7 +89,13 @@ export function App() {
   };
 
   const handleSave = (s: Settings) => {
-    postMessage({ type: "saveSettings", settings: s });
+    // The wire contract for saveSettings is all-string (matches every VS Code
+    // setting key it writes through 1:1); sqsDeleteAfterRead is the only
+    // boolean field in Settings, so serialize it here at the boundary.
+    const wire: Record<string, string> = Object.fromEntries(
+      Object.entries(s).map(([key, value]) => [key, String(value)]),
+    );
+    postMessage({ type: "saveSettings", settings: wire });
   };
 
   return (
@@ -86,7 +107,7 @@ export function App() {
             <Button iconName="settings" variant="icon" onClick={() => setSettingsOpen(true)} />
           }
           description={
-            settings.logGroupName || settings.dynamodbTableName || settings.auroraTable
+            settings.logGroupName || settings.dynamodbTableName || settings.auroraTable || settings.sqsQueueUrl
               ? `${settings.region} · ${settings.destinationType}`
               : "Click ⚙ to configure"
           }
@@ -94,37 +115,49 @@ export function App() {
           Workflow Insight Explorer
         </Header>
 
-        {page === "data" && (
+        {settings.destinationType === "sqs" ? (
+          <SqsLiveView
+            listening={sqsListening}
+            messages={sqsMessages}
+            error={error}
+            queueConfigured={!!settings.sqsQueueUrl}
+            onClear={() => setSqsMessages([])}
+          />
+        ) : (
           <>
-            <QueryPanel
-              onAsk={handleAsk}
-              loading={loading}
-              status={status}
-              error={error}
-            />
-
-            {results && (
-              <SpaceBetween size="m">
-                <ResultsTable
-                  columns={results.columns}
-                  rows={results.rows}
-                  explanation={explanation}
+            {page === "data" && (
+              <>
+                <QueryPanel
+                  onAsk={handleAsk}
+                  loading={loading}
+                  status={status}
+                  error={error}
                 />
-                <Button variant="primary" onClick={() => setPage("visualize")}>
-                  Visualize →
-                </Button>
-              </SpaceBetween>
+
+                {results && (
+                  <SpaceBetween size="m">
+                    <ResultsTable
+                      columns={results.columns}
+                      rows={results.rows}
+                      explanation={explanation}
+                    />
+                    <Button variant="primary" onClick={() => setPage("visualize")}>
+                      Visualize →
+                    </Button>
+                  </SpaceBetween>
+                )}
+              </>
+            )}
+
+            {page === "visualize" && results && (
+              <VisualizePage
+                columns={results.columns}
+                rows={results.rows}
+                suggestedCharts={results.suggestedCharts}
+                onBack={() => setPage("data")}
+              />
             )}
           </>
-        )}
-
-        {page === "visualize" && results && (
-          <VisualizePage
-            columns={results.columns}
-            rows={results.rows}
-            suggestedCharts={results.suggestedCharts}
-            onBack={() => setPage("data")}
-          />
         )}
 
         <SettingsModal

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -8,7 +8,7 @@ import { QueryPanel } from "./QueryPanel";
 import { ResultsTable } from "./ResultsTable";
 import { VisualizePage } from "./VisualizePage";
 import { SettingsModal } from "./SettingsModal";
-import { SqsLiveView } from "./SqsLiveView";
+import { SqsLiveView, toTable as sqsToTable, MAX_DISPLAYED_MESSAGES } from "./SqsLiveView";
 import type { InboundMessage, Settings, SqsMessageRow } from "./types";
 import { DEFAULT_SETTINGS } from "./types";
 
@@ -116,13 +116,32 @@ export function App() {
         </Header>
 
         {settings.destinationType === "sqs" ? (
-          <SqsLiveView
-            listening={sqsListening}
-            messages={sqsMessages}
-            error={error}
-            queueConfigured={!!settings.sqsQueueUrl}
-            onClear={() => setSqsMessages([])}
-          />
+          <>
+            {page === "data" && (
+              <SqsLiveView
+                listening={sqsListening}
+                messages={sqsMessages}
+                error={error}
+                queueConfigured={!!settings.sqsQueueUrl}
+                onClear={() => setSqsMessages([])}
+                onVisualize={() => setPage("visualize")}
+              />
+            )}
+
+            {page === "visualize" &&
+              (() => {
+                const { columns, rows } = sqsToTable(
+                  sqsMessages.slice(-MAX_DISPLAYED_MESSAGES),
+                );
+                return (
+                  <VisualizePage
+                    columns={columns}
+                    rows={rows}
+                    onBack={() => setPage("data")}
+                  />
+                );
+              })()}
+          </>
         ) : (
           <>
             {page === "data" && (

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -68,7 +68,14 @@ export function App() {
           // the same message can be re-delivered after its visibility timeout.
           const seen = new Set(prev.map((m) => m.messageId));
           const next = msg.messages.filter((m) => !seen.has(m.messageId));
-          return next.length > 0 ? [...prev, ...next] : prev;
+          if (next.length === 0) return prev;
+          // Cap at MAX_DISPLAYED_MESSAGES so a long-running listener session
+          // doesn't grow this state (and the seen-set rebuild above) without
+          // bound — only the most recent messages are ever shown anyway.
+          const combined = [...prev, ...next];
+          return combined.length > MAX_DISPLAYED_MESSAGES
+            ? combined.slice(-MAX_DISPLAYED_MESSAGES)
+            : combined;
         });
         break;
     }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/RecordDetail.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/RecordDetail.tsx
@@ -56,6 +56,8 @@ function JsonView({ value }: { value: unknown }) {
 function OperationsTable({ operations }: { operations: OperationRecord[] }) {
   const [selected, setSelected] = useState<OperationRecord | null>(null);
 
+  // Operation `id` is unique per the SDK's OperationRecord contract, so it's a
+  // safe trackBy key (unlike name, which can repeat across loop iterations).
   const columnDefs = [
     { id: "name", header: "Name", cell: (o: OperationRecord) => o.name ?? o.id },
     { id: "type", header: "Type", cell: (o: OperationRecord) => o.subType ?? o.type },
@@ -74,14 +76,20 @@ function OperationsTable({ operations }: { operations: OperationRecord[] }) {
 
   const hasDetail = (o: OperationRecord) => o.result !== undefined || o.error !== undefined;
 
+  const selectOperation = (o: OperationRecord | null) => setSelected(o && hasDetail(o) ? o : null);
+
   return (
     <>
       <Table
         columnDefinitions={columnDefs}
         items={operations}
+        trackBy="id"
+        selectionType="single"
+        selectedItems={selected ? [selected] : []}
+        onSelectionChange={({ detail }) => selectOperation(detail.selectedItems[0] ?? null)}
         variant="embedded"
         wrapLines
-        onRowClick={({ detail }) => (hasDetail(detail.item) ? setSelected(detail.item) : undefined)}
+        onRowClick={({ detail }) => selectOperation(detail.item)}
         empty={
           <Box textAlign="center" color="text-body-secondary">
             No operations.
@@ -134,11 +142,17 @@ function OperationsTable({ operations }: { operations: OperationRecord[] }) {
 export function RecordDetail({ visible, onDismiss, fields, columns }: Props) {
   const operations = tryParseJson(fields.operations ?? fields.operationsByName ?? "");
   const operationsList: OperationRecord[] | undefined = Array.isArray(operations)
+    // Raw operations array (Aurora, and the "array"/"both" operationsFormat):
+    // `id` is already unique per the SDK contract.
     ? operations
     : operations && typeof operations === "object"
+      // operationsByName map (DynamoDB, CloudWatch direct): OperationSummary
+      // has no `id` field, but the map key (name) is unique by construction —
+      // use it as a synthetic id so the table can select rows reliably.
       ? Object.entries(operations as Record<string, unknown>).map(([name, v]) => ({
+          id: name,
           name,
-          ...(v as Omit<OperationRecord, "name">),
+          ...(v as Omit<OperationRecord, "id" | "name">),
         }))
       : undefined;
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/RecordDetail.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/RecordDetail.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import Modal from "@cloudscape-design/components/modal";
+import Box from "@cloudscape-design/components/box";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Tabs from "@cloudscape-design/components/tabs";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Table from "@cloudscape-design/components/table";
+import CodeView from "@cloudscape-design/code-view/code-view";
+import jsonHighlight from "@cloudscape-design/code-view/highlight/json";
+
+interface OperationRecord {
+  id: string;
+  name?: string;
+  type: string;
+  subType?: string;
+  parentId?: string;
+  status: string;
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+  attempt?: number;
+  error?: { name: string; message: string };
+  result?: unknown;
+  truncated?: boolean;
+}
+
+interface Props {
+  visible: boolean;
+  onDismiss: () => void;
+  /** Every field of the record, as raw strings (matches ResultsTable's row shape). */
+  fields: Record<string, string>;
+  columns: string[];
+}
+
+const JSON_FIELDS = new Set(["input", "output", "error"]);
+
+function tryParseJson(value: string): unknown {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function JsonView({ value }: { value: unknown }) {
+  return (
+    <CodeView
+      content={JSON.stringify(value, null, 2)}
+      highlight={jsonHighlight}
+      wrapLines
+    />
+  );
+}
+
+function OperationsTable({ operations }: { operations: OperationRecord[] }) {
+  const [selected, setSelected] = useState<OperationRecord | null>(null);
+
+  const columnDefs = [
+    { id: "name", header: "Name", cell: (o: OperationRecord) => o.name ?? o.id },
+    { id: "type", header: "Type", cell: (o: OperationRecord) => o.subType ?? o.type },
+    { id: "status", header: "Status", cell: (o: OperationRecord) => o.status },
+    {
+      id: "durationMs",
+      header: "Duration (ms)",
+      cell: (o: OperationRecord) => (o.durationMs != null ? String(o.durationMs) : ""),
+    },
+    {
+      id: "attempt",
+      header: "Attempt",
+      cell: (o: OperationRecord) => (o.attempt != null ? String(o.attempt) : ""),
+    },
+  ];
+
+  const hasDetail = (o: OperationRecord) => o.result !== undefined || o.error !== undefined;
+
+  return (
+    <>
+      <Table
+        columnDefinitions={columnDefs}
+        items={operations}
+        variant="embedded"
+        wrapLines
+        onRowClick={({ detail }) => (hasDetail(detail.item) ? setSelected(detail.item) : undefined)}
+        empty={
+          <Box textAlign="center" color="text-body-secondary">
+            No operations.
+          </Box>
+        }
+      />
+
+      <Modal
+        visible={selected != null}
+        onDismiss={() => setSelected(null)}
+        header={selected ? `Operation: ${selected.name ?? selected.id}` : "Operation"}
+        size="large"
+      >
+        {selected && (
+          <SpaceBetween size="m">
+            <KeyValuePairs
+              columns={2}
+              items={[
+                { label: "Type", value: selected.type },
+                { label: "Status", value: selected.status },
+                { label: "Start Time", value: selected.startTime ?? "—" },
+                { label: "End Time", value: selected.endTime ?? "—" },
+              ]}
+            />
+            {selected.error && (
+              <Box>
+                <Box variant="awsui-key-label">Error</Box>
+                <JsonView value={selected.error} />
+              </Box>
+            )}
+            {selected.result !== undefined && (
+              <Box>
+                <Box variant="awsui-key-label">Result</Box>
+                <JsonView value={selected.result} />
+              </Box>
+            )}
+          </SpaceBetween>
+        )}
+      </Modal>
+    </>
+  );
+}
+
+/**
+ * Full detail view for a single WorkflowInsightRecord. Unlike a flat
+ * KeyValuePairs dump, this renders `operations` as its own table (row click
+ * shows that operation's result/error), and `input`/`output`/`error` as
+ * syntax-highlighted JSON instead of an inline stringified blob.
+ */
+export function RecordDetail({ visible, onDismiss, fields, columns }: Props) {
+  const operations = tryParseJson(fields.operations ?? fields.operationsByName ?? "");
+  const operationsList: OperationRecord[] | undefined = Array.isArray(operations)
+    ? operations
+    : operations && typeof operations === "object"
+      ? Object.entries(operations as Record<string, unknown>).map(([name, v]) => ({
+          name,
+          ...(v as Omit<OperationRecord, "name">),
+        }))
+      : undefined;
+
+  const otherColumns = columns.filter(
+    (c) => c !== "operations" && c !== "operationsByName" && !JSON_FIELDS.has(c),
+  );
+
+  return (
+    <Modal visible={visible} onDismiss={onDismiss} header="Record Details" size="max">
+      <Tabs
+        tabs={[
+          {
+            id: "fields",
+            label: "Fields",
+            content: (
+              <KeyValuePairs
+                columns={1}
+                items={otherColumns.map((col) => ({
+                  label: col,
+                  value: fields[col] || <Box color="text-body-secondary">—</Box>,
+                }))}
+              />
+            ),
+          },
+          ...(operationsList
+            ? [
+                {
+                  id: "operations",
+                  label: `Operations (${operationsList.length})`,
+                  content: <OperationsTable operations={operationsList} />,
+                },
+              ]
+            : []),
+          ...(fields.input
+            ? [
+                {
+                  id: "input",
+                  label: "Input",
+                  content: <JsonView value={tryParseJson(fields.input) ?? fields.input} />,
+                },
+              ]
+            : []),
+          ...(fields.output
+            ? [
+                {
+                  id: "output",
+                  label: "Output",
+                  content: <JsonView value={tryParseJson(fields.output) ?? fields.output} />,
+                },
+              ]
+            : []),
+          ...(fields.error
+            ? [
+                {
+                  id: "error",
+                  label: "Error",
+                  content: <JsonView value={tryParseJson(fields.error) ?? fields.error} />,
+                },
+              ]
+            : []),
+        ]}
+      />
+    </Modal>
+  );
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -23,6 +23,7 @@ const PAGE_SIZE = 25;
 export function ResultsTable({ columns, rows, explanation, primaryColumns }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
   const [detailItem, setDetailItem] = useState<Record<string, string> | null>(null);
+  const [selectedItems, setSelectedItems] = useState<Record<string, string>[]>([]);
 
   if (columns.length === 0) {
     return (
@@ -45,16 +46,27 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
     sortingField: col,
   }));
 
-  const items: Record<string, string>[] = rows.map((row) => {
-    const obj: Record<string, string> = {};
-    columns.forEach((col, i) => {
-      obj[col] = row[i] ?? "";
+  // __rowIndex (added below, then columns are applied) gives every row a
+  // stable identity for selection, independent of column contents, which may
+  // repeat or be empty. If a record ever has a real "__rowIndex" column, its
+  // value below wins (it's applied last) — vanishingly unlikely given the
+  // WorkflowInsightRecord shape, but the double-underscore keeps it clear
+  // this key is synthetic if a reader spots it in the data.
+  const items: Record<string, string>[] = rows.map((row, i) => {
+    const obj: Record<string, string> = { __rowIndex: String(i) };
+    columns.forEach((col, j) => {
+      obj[col] = row[j] ?? "";
     });
     return obj;
   });
 
   const totalPages = Math.ceil(items.length / PAGE_SIZE);
   const pagedItems = items.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const selectItem = (item: Record<string, string> | null) => {
+    setSelectedItems(item ? [item] : []);
+    setDetailItem(item);
+  };
 
   return (
     <>
@@ -64,7 +76,7 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
             counter={`(${items.length})`}
             description={
               hasDetail
-                ? [explanation, "Click a row to see all fields."].filter(Boolean).join(" — ")
+                ? [explanation, "Select a row to see all fields."].filter(Boolean).join(" — ")
                 : explanation
             }
           >
@@ -73,10 +85,18 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
         }
         columnDefinitions={columnDefs}
         items={pagedItems}
+        trackBy="__rowIndex"
+        selectionType={hasDetail ? "single" : undefined}
+        selectedItems={selectedItems}
+        onSelectionChange={
+          hasDetail
+            ? ({ detail }) => selectItem(detail.selectedItems[0] ?? null)
+            : undefined
+        }
         sortingDisabled
         variant="container"
         wrapLines
-        onRowClick={hasDetail ? ({ detail }) => setDetailItem(detail.item) : undefined}
+        onRowClick={hasDetail ? ({ detail }) => selectItem(detail.item) : undefined}
         pagination={
           totalPages > 1 ? (
             <Pagination
@@ -95,7 +115,7 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
 
       <RecordDetail
         visible={detailItem != null}
-        onDismiss={() => setDetailItem(null)}
+        onDismiss={() => selectItem(null)}
         fields={detailItem ?? {}}
         columns={columns}
       />

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -2,18 +2,28 @@ import Table from "@cloudscape-design/components/table";
 import Box from "@cloudscape-design/components/box";
 import Header from "@cloudscape-design/components/header";
 import Pagination from "@cloudscape-design/components/pagination";
+import Modal from "@cloudscape-design/components/modal";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import { useState } from "react";
 
 interface Props {
   columns: string[];
   rows: string[][];
   explanation?: string;
+  /**
+   * When set, only these columns are shown in the table (in this order,
+   * skipping any not present in `columns`); the rest of each record's fields
+   * are still available by clicking the row, in a detail view. Omit to show
+   * every column in the table with no detail view (previous behavior).
+   */
+  primaryColumns?: string[];
 }
 
 const PAGE_SIZE = 25;
 
-export function ResultsTable({ columns, rows, explanation }: Props) {
+export function ResultsTable({ columns, rows, explanation, primaryColumns }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
+  const [detailItem, setDetailItem] = useState<Record<string, string> | null>(null);
 
   if (columns.length === 0) {
     return (
@@ -23,7 +33,13 @@ export function ResultsTable({ columns, rows, explanation }: Props) {
     );
   }
 
-  const columnDefs = columns.map((col) => ({
+  const displayColumns = primaryColumns
+    ? primaryColumns.filter((c) => columns.includes(c))
+    : columns;
+  // Only offer a detail view when there's actually something extra to show.
+  const hasDetail = primaryColumns != null && displayColumns.length < columns.length;
+
+  const columnDefs = displayColumns.map((col) => ({
     id: col,
     header: col,
     cell: (item: Record<string, string>) => item[col] || "",
@@ -42,34 +58,58 @@ export function ResultsTable({ columns, rows, explanation }: Props) {
   const pagedItems = items.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   return (
-    <Table
-      header={
-        <Header
-          counter={`(${items.length})`}
-          description={explanation}
-        >
-          Results
-        </Header>
-      }
-      columnDefinitions={columnDefs}
-      items={pagedItems}
-      sortingDisabled
-      variant="container"
-      wrapLines
-      pagination={
-        totalPages > 1 ? (
-          <Pagination
-            currentPageIndex={currentPage}
-            pagesCount={totalPages}
-            onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+    <>
+      <Table
+        header={
+          <Header
+            counter={`(${items.length})`}
+            description={
+              hasDetail
+                ? [explanation, "Click a row to see all fields."].filter(Boolean).join(" — ")
+                : explanation
+            }
+          >
+            Results
+          </Header>
+        }
+        columnDefinitions={columnDefs}
+        items={pagedItems}
+        sortingDisabled
+        variant="container"
+        wrapLines
+        onRowClick={hasDetail ? ({ detail }) => setDetailItem(detail.item) : undefined}
+        pagination={
+          totalPages > 1 ? (
+            <Pagination
+              currentPageIndex={currentPage}
+              pagesCount={totalPages}
+              onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+            />
+          ) : undefined
+        }
+        empty={
+          <Box textAlign="center" color="text-body-secondary">
+            No results.
+          </Box>
+        }
+      />
+
+      <Modal
+        visible={detailItem != null}
+        onDismiss={() => setDetailItem(null)}
+        header="Record Details"
+        size="large"
+      >
+        {detailItem && (
+          <KeyValuePairs
+            columns={1}
+            items={columns.map((col) => ({
+              label: col,
+              value: detailItem[col] || <Box color="text-body-secondary">—</Box>,
+            }))}
           />
-        ) : undefined
-      }
-      empty={
-        <Box textAlign="center" color="text-body-secondary">
-          No results.
-        </Box>
-      }
-    />
+        )}
+      </Modal>
+    </>
   );
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -2,9 +2,8 @@ import Table from "@cloudscape-design/components/table";
 import Box from "@cloudscape-design/components/box";
 import Header from "@cloudscape-design/components/header";
 import Pagination from "@cloudscape-design/components/pagination";
-import Modal from "@cloudscape-design/components/modal";
-import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import { useState } from "react";
+import { RecordDetail } from "./RecordDetail";
 
 interface Props {
   columns: string[];
@@ -94,22 +93,12 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
         }
       />
 
-      <Modal
+      <RecordDetail
         visible={detailItem != null}
         onDismiss={() => setDetailItem(null)}
-        header="Record Details"
-        size="large"
-      >
-        {detailItem && (
-          <KeyValuePairs
-            columns={1}
-            items={columns.map((col) => ({
-              label: col,
-              value: detailItem[col] || <Box color="text-body-secondary">—</Box>,
-            }))}
-          />
-        )}
-      </Modal>
+        fields={detailItem ?? {}}
+        columns={columns}
+      />
     </>
   );
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -5,6 +5,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Button from "@cloudscape-design/components/button";
 import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
+import Checkbox from "@cloudscape-design/components/checkbox";
 import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Tabs from "@cloudscape-design/components/tabs";
@@ -25,6 +26,7 @@ const DEST_OPTIONS: SelectProps.Option[] = [
   { value: "lambda-log-exporter", label: "CloudWatch Logs (Lambda function log group)" },
   { value: "dynamodb", label: "DynamoDB" },
   { value: "aurora", label: "Aurora PostgreSQL" },
+  { value: "sqs", label: "Amazon SQS (live view)" },
 ];
 
 export function SettingsModal({ visible, settings, modelDownloaded, downloadPercent, onDismiss, onSave }: Props) {
@@ -35,7 +37,7 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
     setForm(settings);
   }, [settings, visible]);
 
-  const update = (field: keyof Settings, value: string) =>
+  const update = (field: keyof Settings, value: string | boolean) =>
     setForm((f) => ({ ...f, [field]: value }));
 
   const canSave = form.llmProvider !== "local" || modelDownloaded;
@@ -49,6 +51,7 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
   const showLogGroup = dest === "cloudwatch-logs-exporter" || dest === "lambda-log-exporter";
   const showDdb = dest === "dynamodb";
   const showAurora = dest === "aurora";
+  const showSqs = dest === "sqs";
 
   return (
     <Modal
@@ -106,6 +109,29 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                     <FormField label="Table">
                       <Input value={form.auroraTable} onChange={({ detail }) => update("auroraTable", detail.value)} placeholder="workflow_insight" />
                     </FormField>
+                  </SpaceBetween>
+                )}
+
+                {showSqs && (
+                  <SpaceBetween size="s">
+                    <FormField label="SQS Queue URL">
+                      <Input
+                        value={form.sqsQueueUrl}
+                        onChange={({ detail }) => update("sqsQueueUrl", detail.value)}
+                        placeholder="https://sqs.us-east-1.amazonaws.com/123456789012/workflow-insight"
+                      />
+                    </FormField>
+                    <Checkbox
+                      checked={form.sqsDeleteAfterRead}
+                      onChange={({ detail }) => update("sqsDeleteAfterRead", detail.checked)}
+                    >
+                      Delete messages after displaying them
+                    </Checkbox>
+                    <Box color="text-body-secondary" fontSize="body-s">
+                      Off by default — the Explorer only observes the queue, so other
+                      consumers still receive every message. Enable only if this
+                      Explorer should be the sole consumer.
+                    </Box>
                   </SpaceBetween>
                 )}
               </SpaceBetween>

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
@@ -32,6 +32,19 @@ const COLUMN_PRIORITY = [
   "emittedAt",
 ];
 
+// The subset of fields shown directly in the table; everything else (input,
+// output, error, operationsByName, etc.) is still available — click a row to
+// see the full record.
+const PRIMARY_COLUMNS = [
+  "receivedAt",
+  "status",
+  "functionName",
+  "executionName",
+  "durationMs",
+  "startTime",
+  "endTime",
+];
+
 /**
  * Live view for the "sqs" destination type. Unlike the other destinations,
  * SQS has no query engine — this just starts/stops a long-poll listener in
@@ -84,7 +97,7 @@ export function SqsLiveView({ listening, messages, error, queueConfigured, onCle
             Stopped — {messages.length} message{messages.length === 1 ? "" : "s"} received
           </StatusIndicator>
         )}
-        <ResultsTable columns={columns} rows={rows} />
+        <ResultsTable columns={columns} rows={rows} primaryColumns={PRIMARY_COLUMNS} />
         {rows.length > 0 && (
           <Button variant="primary" onClick={onVisualize}>
             Visualize →

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
@@ -1,0 +1,87 @@
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Button from "@cloudscape-design/components/button";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Alert from "@cloudscape-design/components/alert";
+import { ResultsTable } from "./ResultsTable";
+import { postMessage } from "./vscode";
+import type { SqsMessageRow } from "./types";
+
+interface Props {
+  listening: boolean;
+  messages: SqsMessageRow[];
+  error: string;
+  queueConfigured: boolean;
+  onClear: () => void;
+}
+
+const MAX_DISPLAYED_MESSAGES = 500;
+
+/**
+ * Live view for the "sqs" destination type. Unlike the other destinations,
+ * SQS has no query engine — this just starts/stops a long-poll listener in
+ * the extension host and appends messages as they arrive, de-duplicated by
+ * messageId (the same message can be re-delivered by SQS if it isn't deleted
+ * after being read — see workflowInsight.sqsDeleteAfterRead).
+ */
+export function SqsLiveView({ listening, messages, error, queueConfigured, onClear }: Props) {
+  const handleToggle = () => {
+    postMessage({ type: listening ? "stopListening" : "startListening" });
+  };
+
+  const { columns, rows } = toTable(messages.slice(-MAX_DISPLAYED_MESSAGES));
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description="Live messages received from the configured SQS queue."
+          actions={
+            <SpaceBetween direction="horizontal" size="s">
+              <Button onClick={onClear} disabled={messages.length === 0}>
+                Clear
+              </Button>
+              <Button variant="primary" onClick={handleToggle} disabled={!queueConfigured}>
+                {listening ? "Stop Listening" : "Start Listening"}
+              </Button>
+            </SpaceBetween>
+          }
+        >
+          SQS Live View
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {!queueConfigured && (
+          <Alert type="warning">
+            No SQS queue configured. Click ⚙ and set the Queue URL under Data Source.
+          </Alert>
+        )}
+        {error && <Alert type="error">{error}</Alert>}
+        {listening && (
+          <StatusIndicator type="in-progress">
+            Listening — {messages.length} message{messages.length === 1 ? "" : "s"} received
+          </StatusIndicator>
+        )}
+        {!listening && messages.length > 0 && (
+          <StatusIndicator type="stopped">
+            Stopped — {messages.length} message{messages.length === 1 ? "" : "s"} received
+          </StatusIndicator>
+        )}
+        <ResultsTable columns={columns} rows={rows} />
+      </SpaceBetween>
+    </Container>
+  );
+}
+
+function toTable(messages: SqsMessageRow[]): { columns: string[]; rows: string[][] } {
+  if (messages.length === 0) return { columns: [], rows: [] };
+
+  // Most recently received first.
+  const ordered = [...messages].reverse();
+  const columns = ["receivedAt", "messageId", "body"];
+  const rows = ordered.map((m) => [m.receivedAt, m.messageId, m.body]);
+  return { columns, rows };
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SqsLiveView.tsx
@@ -14,9 +14,23 @@ interface Props {
   error: string;
   queueConfigured: boolean;
   onClear: () => void;
+  onVisualize: () => void;
 }
 
-const MAX_DISPLAYED_MESSAGES = 500;
+export const MAX_DISPLAYED_MESSAGES = 500;
+
+// Same priority order used by the DynamoDB destination, so records look
+// consistent across destinations regardless of where they were queried from.
+const COLUMN_PRIORITY = [
+  "pk",
+  "status",
+  "functionName",
+  "executionName",
+  "durationMs",
+  "startTime",
+  "endTime",
+  "emittedAt",
+];
 
 /**
  * Live view for the "sqs" destination type. Unlike the other destinations,
@@ -25,7 +39,7 @@ const MAX_DISPLAYED_MESSAGES = 500;
  * messageId (the same message can be re-delivered by SQS if it isn't deleted
  * after being read — see workflowInsight.sqsDeleteAfterRead).
  */
-export function SqsLiveView({ listening, messages, error, queueConfigured, onClear }: Props) {
+export function SqsLiveView({ listening, messages, error, queueConfigured, onClear, onVisualize }: Props) {
   const handleToggle = () => {
     postMessage({ type: listening ? "stopListening" : "startListening" });
   };
@@ -71,17 +85,71 @@ export function SqsLiveView({ listening, messages, error, queueConfigured, onCle
           </StatusIndicator>
         )}
         <ResultsTable columns={columns} rows={rows} />
+        {rows.length > 0 && (
+          <Button variant="primary" onClick={onVisualize}>
+            Visualize →
+          </Button>
+        )}
       </SpaceBetween>
     </Container>
   );
 }
 
-function toTable(messages: SqsMessageRow[]): { columns: string[]; rows: string[][] } {
+/**
+ * Flatten SQS messages into the same columns/rows shape the other
+ * destinations use. Each message body is a WorkflowInsightRecord JSON string
+ * (as produced by SQSExporter) — parse it and surface its fields as columns,
+ * the same way runDynamoDBQuery does for DynamoDB records, so results look
+ * consistent regardless of destination. Falls back to raw columns
+ * (messageId/receivedAt/body) for any message whose body isn't valid JSON.
+ */
+export function toTable(messages: SqsMessageRow[]): { columns: string[]; rows: string[][] } {
   if (messages.length === 0) return { columns: [], rows: [] };
 
   // Most recently received first.
   const ordered = [...messages].reverse();
-  const columns = ["receivedAt", "messageId", "body"];
-  const rows = ordered.map((m) => [m.receivedAt, m.messageId, m.body]);
+
+  const parsed: Array<{ receivedAt: string; fields: Record<string, unknown> | undefined }> =
+    ordered.map((m) => {
+      try {
+        const body = JSON.parse(m.body);
+        return {
+          receivedAt: m.receivedAt,
+          fields: typeof body === "object" && body !== null ? body : undefined,
+        };
+      } catch {
+        return { receivedAt: m.receivedAt, fields: undefined };
+      }
+    });
+
+  if (parsed.every((p) => !p.fields)) {
+    // Nothing parsed as a record — fall back to raw display.
+    const columns = ["receivedAt", "messageId", "body"];
+    const rows = ordered.map((m) => [m.receivedAt, m.messageId, m.body]);
+    return { columns, rows };
+  }
+
+  const columnSet = new Set<string>(["receivedAt"]);
+  for (const p of parsed) {
+    if (p.fields) for (const key of Object.keys(p.fields)) columnSet.add(key);
+  }
+  const columns = [
+    "receivedAt",
+    ...COLUMN_PRIORITY.filter((c) => columnSet.has(c)),
+    ...[...columnSet]
+      .filter((c) => c !== "receivedAt" && !COLUMN_PRIORITY.includes(c))
+      .sort(),
+  ];
+
+  const rows = parsed.map((p) =>
+    columns.map((col) => {
+      if (col === "receivedAt") return p.receivedAt;
+      const val = p.fields?.[col];
+      if (val == null) return "";
+      if (typeof val === "object") return JSON.stringify(val);
+      return String(val);
+    }),
+  );
+
   return { columns, rows };
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -2,8 +2,18 @@
 export type OutboundMessage =
   | { type: "ready" }
   | { type: "generate"; question: string }
-  | { type: "saveSettings"; settings: Settings }
-  | { type: "downloadModel" };
+  | { type: "saveSettings"; settings: Record<string, string> }
+  | { type: "downloadModel" }
+  | { type: "startListening" }
+  | { type: "stopListening" };
+
+/** A single SQS message, normalized for display. */
+export interface SqsMessageRow {
+  messageId: string;
+  receivedAt: string;
+  body: string;
+  attributes: Record<string, string>;
+}
 
 /** Messages from extension host → webview */
 export type InboundMessage =
@@ -20,7 +30,9 @@ export type InboundMessage =
     }
   | { type: "error"; message: string }
   | { type: "settingsSaved" }
-  | { type: "downloadProgress"; percent: number; done: boolean };
+  | { type: "downloadProgress"; percent: number; done: boolean }
+  | { type: "sqsStatus"; listening: boolean }
+  | { type: "sqsMessages"; messages: SqsMessageRow[] };
 
 export interface Settings {
   region: string;
@@ -31,6 +43,8 @@ export interface Settings {
   auroraSecretArn: string;
   auroraDatabase: string;
   auroraTable: string;
+  sqsQueueUrl: string;
+  sqsDeleteAfterRead: boolean;
   llmProvider: string;
   awsProfile: string;
   bedrockModelId: string;
@@ -45,6 +59,8 @@ export const DEFAULT_SETTINGS: Settings = {
   auroraSecretArn: "",
   auroraDatabase: "postgres",
   auroraTable: "workflow_insight",
+  sqsQueueUrl: "",
+  sqsDeleteAfterRead: false,
   llmProvider: "bedrock",
   awsProfile: "",
   bedrockModelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",


### PR DESCRIPTION
SQS has no query engine, so it doesn't fit the extension's existing "ask a
   question → LLM generates a query → run it → render a table" pipeline used by
   CloudWatch Logs, DynamoDB, and Aurora. This adds `sqs` as a distinct
   destination type with its own live view instead: start a listener, watch
   messages arrive in real time, click a row for full detail.

### What's new

   **Settings**
   - `workflowInsight.destinationType` gains `"sqs"`.
   - New `workflowInsight.sqsQueueUrl` and `workflowInsight.sqsDeleteAfterRead`
     (boolean, default `false`).

   **Live listener (extension host)**
   - `src/sqs.ts`: long-polls the queue (`ReceiveMessageCommand`,
     `WaitTimeSeconds=20`) in a loop until aborted.
   - **Peek-only by default** — other consumers still receive every message.
     Enabling `sqsDeleteAfterRead` makes the Explorer a real consumer
     (`DeleteMessageBatchCommand` after each batch).
   - New `startListening`/`stopListening` messages; an `AbortController` tracks
     the active listener and is aborted on both `stopListening` and panel
     dispose, so closing the Explorer can't leak a running poll loop.

   **Webview**
   - `SqsLiveView.tsx`: Start/Stop control, running message count, JSON message
     bodies parsed into the same columns/rows shape the other destinations use
     (so results look consistent regardless of source) — falls back to raw
     display if a body isn't valid JSON.
   - Table shows only the primary fields (status, functionName, executionName,
     durationMs, startTime, endTime); the rest of each record is one click away.
   - `ResultsTable` gets a single-select radio column (previously rows were
     clickable with no visual indicator) and a `RecordDetail` modal:
     - `operations`/`operationsByName` render as their own selectable table
       instead of a raw JSON blob; selecting an operation shows its
       `result`/`error` as syntax-highlighted JSON.
     - `input`/`output`/`error` each get their own tab via Cloudscape's
       `CodeView` (`@cloudscape-design/code-view`) with JSON highlighting,
       instead of an inline stringified string.
   - Visualize (chart) flow now also works for the SQS view, reusing the
     existing `VisualizePage`.

   ### Testing

   - `tsc --noEmit` clean for both the extension and webview-ui packages.
   - Full extension build (esbuild + webview bundle) succeeds.
   - Manually verified end-to-end against a real deployed SQS queue: started
     listening, confirmed live message counts, parsed record columns, operation
     detail (result/error), input/output JSON views, and the Visualize chart.
   - No existing test suite for this package.