### PR TITLE
chore: minor version bumps for SDK, patch bumps for testing SDK and otel plugin

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -50,7 +50,7 @@
     "typescript-eslint": "^8.34.1"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=2.0.1",
+    "@aws/durable-execution-sdk-js": ">=2.1.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.219.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/durable-execution-sdk-js-otel",
   "description": "OpenTelemetry instrumentation plugin for AWS Durable Execution SDK",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
     "typescript-eslint": "^8.34.1"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": "*",
+    "@aws/durable-execution-sdk-js": ">=2.0.1",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.219.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -64,7 +64,7 @@
     "commander": "^14.0.2"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.0.1"
+    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.1.0"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/durable-execution-sdk-js-testing",
   "description": "AWS Durable Execution Testing SDK for TypeScript",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -64,7 +64,7 @@
     "commander": "^14.0.2"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": "*"
+    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.0.1"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'm doing a patch version bump for the below packages. I plan to release all three afterwards.

- @aws/durable-execution-sdk-js: 2.0.0 -> 2.1.0
  - changes to @experimental plugin interface
- @aws/durable-execution-sdk-js-testing: 1.1.2 -> 1.1.3
  - peerDependencies on core SDK: >=1.0.1 <=2.1.0
  - no changes since 1.1.2 other than the peerDependencies version pinning update
- @aws/durable-execution-sdk-js-otel: 0.1.0 -> 0.1.1
  - peerDependencies on core SDK: >=2.1.0
  - made a bug fix to the deterministicIdGenerator (backwards compatible)

I believe other commits to the repository were related to the insights plugin.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
