### PR TITLE
fix(sdk): exclude the SDK's internal EXECUTION pseudo-operation

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -138,6 +138,41 @@ describe("content filtering", () => {
     expect(rec.operations.every((o) => o.error === undefined)).toBe(true);
   });
 
+  it("excludes the SDK's internal EXECUTION pseudo-operation", async () => {
+    // The SDK core tracks the invocation itself as a same-named entry of
+    // type EXECUTION in its internal operations map (for its own
+    // ancestor-completion bookkeeping) — it has a `name` (the execution
+    // name), so it isn't caught by the unnamed-operation filter, and its
+    // status is never transitioned past STARTED. It must be excluded
+    // explicitly, since the execution's real status/timing is already
+    // captured at the top level of the record.
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({
+      exporters: [exporter],
+      emitMode: "on-complete",
+    });
+
+    await endAndDrain(
+      plugin,
+      endInfo({
+        status: "SUCCEEDED",
+        operations: {
+          exec: op({
+            id: "exec-1",
+            name: "exec-1",
+            type: "EXECUTION",
+            status: "STARTED",
+          }),
+          o1: op({ id: "o1", name: "validate", status: "SUCCEEDED" }),
+        },
+      }),
+    );
+
+    expect(exporter.records).toHaveLength(1);
+    const rec = exporter.records[0];
+    expect(rec.operations.map((o) => o.name)).toEqual(["validate"]);
+  });
+
   it("includes input/output as-is and omits results by default (no content config)", async () => {
     const exporter = new CapturingExporter();
     const plugin = workflowInsight({ exporters: [exporter] });

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -286,6 +286,17 @@ function buildOperationRecords(
 ): OperationRecord[] {
   const records: OperationRecord[] = [];
   for (const op of Object.values(operations)) {
+    // The SDK core tracks the invocation/execution itself as a pseudo-entry
+    // of type EXECUTION in its internal operations map (used for its own
+    // ancestor-completion bookkeeping). It's not an operation a customer
+    // created, its status is never transitioned past STARTED (that would
+    // require rewriting core SDK internals unrelated to this plugin), and
+    // the record already carries the execution's real status/startTime/
+    // endTime/durationMs at the top level — so surfacing it as an "operation"
+    // is redundant at best and misleadingly stuck-looking at worst. Exclude
+    // it here rather than leaving it for exporters/consumers to filter.
+    if (op.type === "EXECUTION") continue;
+
     // Unnamed operations are excluded by default (can't be targeted or keyed).
     if (!op.name) continue;
 


### PR DESCRIPTION
Every emitted record's operations/operationsByName included an extra entry
of type EXECUTION whose name/id were the execution's own executionName/
executionArn, always stuck at status STARTED — even on records whose
overall status was SUCCEEDED. Confirmed against real DynamoDB-exported
records: this entry appears on every execution, unconditionally.

Root cause: the SDK core tracks the invocation itself as a same-named
pseudo-operation in its internal operations map and passes the
full map — including this entry — into onInvocationStart/onInvocationEnd/
onOperationChange. It has a `name`, so the existing unnamed-operation
filter in buildOperationRecords doesn't catch it, and nothing updates its
status because it isn't a real customer operation going through the
normal step/wait/callback lifecycle.

Filter entries with type === "EXECUTION" out of buildOperationRecords —
the execution's real status/startTime/endTime/durationMs are already on
the record itself, so this pseudo-operation was redundant even before
considering the stuck-status bug.

Added a regression test asserting an EXECUTION-typed, named entry is
excluded while real named operations are kept.
