### PR TITLE
feat(sdk): add S3 + Athena support to Workflow Insight Explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16200,9 +16200,12 @@
         "node-llama-cpp": "^3.18.1"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.90.0",
         "esbuild": "^0.24.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.0",
         "typescript": "~5.8.0"
       },
       "engines": {
@@ -16635,6 +16638,530 @@
         "node": ">=18"
       }
     },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/core/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/esbuild": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
@@ -16676,6 +17203,651 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-cli/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -16688,6 +17860,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "packages/aws-durable-execution-sdk-js-insight/node_modules/@jest/console": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-athena": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1079.0.tgz",
+      "integrity": "sha512-w2bkUa+ZHEP39cVmYpvAms8eUnIrSyEBVOwRU3kyPufDvZfdwdC4S8PKzNlb9/kJ4R23m4QhOitKGjO6HNs8Yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1076.0.tgz",
@@ -463,6 +482,25 @@
         "@smithy/fetch-http-handler": "^5.6.0",
         "@smithy/node-http-handler": "^4.9.0",
         "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-glue": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-glue/-/client-glue-3.1079.0.tgz",
+      "integrity": "sha512-Ncnm8FOBqBpp/F1MPifa8chpqZEExpSGdgsggEcTHKHWJS8K9bQWwZdIZIz2GH+ZlvdlKygMQeqOZbWuYr6vTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -638,22 +676,31 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.24.tgz",
-      "integrity": "sha512-vWB/qJl21vxGKBkBN8fKPTVXgm14v/bUQWTtR5oikrfAZbIN2bxuSiCY5rRAMR4gs3vtR2Vw0aTfVDU4tdfIPg==",
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
+      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@aws-sdk/xml-builder": "^3.972.32",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.27.0",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
@@ -673,15 +720,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.50.tgz",
-      "integrity": "sha512-l8bWzhPFTi9tDcvtURxeMlfsboul5/0sEN3SwwXxdpYudVB9+EuQcxo2pwlTzXwDo4Gm2VLGyiZ8zti3nfdOLw==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
+      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -689,17 +736,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.52.tgz",
-      "integrity": "sha512-FjAlnsIvemWzO3JTM3ObuuxpqCyrqkXOewlYY2+NiR1MYO1JuFYSIJ8SJN5Q2KD1jkL5lIuab8awjb/AxsvjiQ==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
+      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -707,23 +754,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.57.tgz",
-      "integrity": "sha512-8qwNhQ0sK/1KaOpVEFC7TFxrWP3fxzJV1K049MzjouiMIbvTDvIGDEUtj5ND5aTmlHVK/YZxjoYnLCeV/GZU0w==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
+      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-login": "^3.972.56",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-login": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,16 +778,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.56.tgz",
-      "integrity": "sha512-S36dCrDaafakFMlaCVGAF4advbQKoJuMcyMtNWVBpUz65uqhbIAsUfvAyp+djA+jkzaEfgZGd+AELjIGzTqyhw==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
+      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -748,21 +795,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.59.tgz",
-      "integrity": "sha512-LkczBXaEsdManijlEZwbKfEoo1C98Yri3LHF8gQI7CYWv+uFkmpS3OZH3BSew8g1A2ppKsScdPUSlhI6NV7a9g==",
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
+      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-ini": "^3.972.57",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-ini": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -770,15 +817,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.50.tgz",
-      "integrity": "sha512-ARBEVkOQzmowTU0a35smGVyldJ9FN/f57XIGrPatrul4mYN+vvOKxoc1njDOX3nugVze+0sHzQZWJ8kPARAtUA==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
+      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -786,17 +833,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.56.tgz",
-      "integrity": "sha512-LvbWiFcLI/D5RPaT68TrpLLHyv7x5X+dm59wJ5dFizyGPZggBC7OdgJTlP0X1bVjiSSAgE1u1oxxcBps0GCEnA==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
+      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/token-providers": "3.1076.0",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/token-providers": "3.1079.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
+      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -804,16 +868,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.56.tgz",
-      "integrity": "sha512-OV3JxmqMphVGMLWupYD2UhZxX07ATk1NwyYk7RgCnAEh0y3owHmtEnkWZ3ciCZ6liiFEwS8dYQpJGmKsR6ml4Q==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
+      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1052,20 +1116,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.24.tgz",
-      "integrity": "sha512-+wFVfVofxeiXdRhUjRwYISB2mVfBCdiCq1wThkRipTeOc10Kyr+LS9QJTjgZuhWsna7jyLMPndrCnzLGWWvZXg==",
+      "version": "3.997.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
+      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.36",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1089,14 +1151,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.36.tgz",
-      "integrity": "sha512-VSOWIPkI+g3a7NkxIBCO24HnsR0BZXJAi3wrKaGIZwVKyrMtNRdHxPrQI/igazgla5J9FhDzmg4RgnOSr6UQBw==",
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1121,12 +1183,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.14.tgz",
-      "integrity": "sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1214,12 +1276,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.32.tgz",
-      "integrity": "sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4863,12 +4925,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.28.0.tgz",
-      "integrity": "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4876,13 +4938,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.4.tgz",
-      "integrity": "sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4960,13 +5022,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.1.tgz",
-      "integrity": "sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5110,13 +5172,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.1.tgz",
-      "integrity": "sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5188,13 +5250,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
-      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5220,9 +5282,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16126,9 +16188,11 @@
       "version": "0.1.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-athena": "^3.658.0",
         "@aws-sdk/client-bedrock-runtime": "^3.658.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
         "@aws-sdk/client-dynamodb": "^3.658.0",
+        "@aws-sdk/client-glue": "^3.658.0",
         "@aws-sdk/client-rds-data": "^3.658.0",
         "@aws-sdk/client-sqs": "^3.658.0",
         "@aws-sdk/credential-providers": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -146,11 +146,19 @@ Type a question and click **Ask**. Examples:
 | "executions where the charge operation failed"          | CloudWatch, DynamoDB, Aurora, S3+Athena |
 
 > Per-operation-name questions use the `operationsByName` index (CloudWatch
-> Per-operation-name questions use the `operationsByName` index (CloudWatch
 > direct + DynamoDB), a JSONB query over the operations array (Aurora), or
 > `UNNEST(operations)` (S3 + Athena). With the `LambdaLogExporter` (nested
 > logs) these are best-effort — the `CloudWatchLogsExporter` gives the most
 > reliable per-operation queries.
+
+For row-level results (not aggregates like "count by status"), the Explorer
+adds a hidden identifier column to the generated query if it's missing, and
+selecting a row fetches and shows the _full_ record — including
+`operations`, `input`, `output`, and `error` — even if the question's answer
+only needed a couple of columns (e.g. "show me the last 10 executions" only
+returns 4 columns, but you can still click a row to see everything else).
+Aggregate results have no single execution a row corresponds to, so no
+identifier is added and rows aren't clickable for those.
 
 ## Settings Reference
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -20,6 +20,7 @@ The extension supports multiple destinations — each with its own query engine:
 | **CloudWatch Logs** (LambdaLogExporter)      | Logs Insights | Default exporter, no infra needed       |
 | **DynamoDB**                                 | PartiQL       | Fast lookups by execution               |
 | **Aurora PostgreSQL**                        | SQL           | Complex queries, GROUP BY, aggregations |
+| **S3** (S3Exporter)                          | Athena SQL    | Analytics at scale, long-term retention |
 
 ## Installation
 
@@ -76,6 +77,31 @@ Click the **⚙** button and fill in your settings. The form shows only the fiel
 | Aurora Database    | `postgres`                      |
 | Aurora Table       | `workflow_insight`              |
 
+#### S3 + Athena
+
+Records land in S3 via `S3Exporter` as one JSON object per execution, Hive-partitioned
+by date (`year=YYYY/month=MM/day=DD/`). The Explorer queries them through Amazon
+Athena.
+
+| Field                 | Value                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| Region                | `us-east-1`                                                                         |
+| Destination Type      | S3 + Athena                                                                         |
+| Glue Database         | The Glue/Athena database to hold the table (e.g. `default`)                         |
+| Glue Table            | `workflow_insight` (or your preferred name)                                         |
+| S3 Location           | The bucket + prefix `S3Exporter` writes to, e.g. `s3://my-bucket/workflow-insight/` |
+| Athena Workgroup      | Optional — leave empty to use `primary` and set Query Result Location instead       |
+| Query Result Location | S3 path for Athena's query output, e.g. `s3://my-bucket/athena-results/`            |
+
+On **Save**, the Explorer checks whether the Glue table already exists. If not, it
+auto-creates it with `CREATE EXTERNAL TABLE` (matching `S3Exporter`'s JSON layout
+and Hive date partitioning) and runs `MSCK REPAIR TABLE` to discover any partitions
+already written — no manual DDL or Glue crawler required.
+
+Because the canonical `operations` array (not `operationsByName`) is what
+`S3Exporter` writes, per-operation questions are answered with `UNNEST` rather than
+a map lookup (see the query dialect the model is given).
+
 #### Amazon SQS (live view)
 
 SQS has no query engine, so this destination doesn't use the "Ask" pipeline at
@@ -106,42 +132,51 @@ us.anthropic.claude-sonnet-4-20250514-v1:0
 
 Type a question and click **Ask**. Examples:
 
-| Question                                                | Works best with              |
-| ------------------------------------------------------- | ---------------------------- |
-| "show me the last 50 records"                           | Any destination              |
-| "count executions by status"                            | Any destination              |
-| "show failed executions from the last hour"             | Any destination              |
-| "average duration of successful executions"             | Aurora, CloudWatch           |
-| "failure rate percentage"                               | Aurora                       |
-| "average duration grouped by function"                  | Aurora                       |
-| "show executions longer than 5 seconds"                 | Any destination              |
-| "find execution with name abc123"                       | DynamoDB, Aurora             |
-| "executions where operation convert_data took under 5s" | CloudWatch, DynamoDB, Aurora |
-| "executions where the charge operation failed"          | CloudWatch, DynamoDB, Aurora |
+| Question                                                | Works best with                         |
+| ------------------------------------------------------- | --------------------------------------- |
+| "show me the last 50 records"                           | Any destination                         |
+| "count executions by status"                            | Any destination                         |
+| "show failed executions from the last hour"             | Any destination                         |
+| "average duration of successful executions"             | Aurora, S3+Athena, CloudWatch           |
+| "failure rate percentage"                               | Aurora                                  |
+| "average duration grouped by function"                  | Aurora                                  |
+| "show executions longer than 5 seconds"                 | Any destination                         |
+| "find execution with name abc123"                       | DynamoDB, Aurora                        |
+| "executions where operation convert_data took under 5s" | CloudWatch, DynamoDB, Aurora, S3+Athena |
+| "executions where the charge operation failed"          | CloudWatch, DynamoDB, Aurora, S3+Athena |
 
 > Per-operation-name questions use the `operationsByName` index (CloudWatch
-> direct + DynamoDB) or a JSONB query over the operations array (Aurora). With
-> the `LambdaLogExporter` (nested logs) these are best-effort — the
-> `CloudWatchLogsExporter` gives the most reliable per-operation queries.
+> Per-operation-name questions use the `operationsByName` index (CloudWatch
+> direct + DynamoDB), a JSONB query over the operations array (Aurora), or
+> `UNNEST(operations)` (S3 + Athena). With the `LambdaLogExporter` (nested
+> logs) these are best-effort — the `CloudWatchLogsExporter` gives the most
+> reliable per-operation queries.
 
 ## Settings Reference
 
 All settings are under the `workflowInsight.*` namespace.
 
-| Setting              | Description                                                   | Required     |
-| -------------------- | ------------------------------------------------------------- | ------------ |
-| `region`             | AWS region                                                    | Yes          |
-| `destinationType`    | Where your data lives (see above)                             | Yes          |
-| `logGroupName`       | CloudWatch log group name(s), comma-separated                 | For CW Logs  |
-| `dynamodbTableName`  | DynamoDB table name                                           | For DynamoDB |
-| `auroraResourceArn`  | Aurora cluster ARN                                            | For Aurora   |
-| `auroraSecretArn`    | Secrets Manager secret ARN                                    | For Aurora   |
-| `auroraDatabase`     | Database name                                                 | For Aurora   |
-| `auroraTable`        | Table name                                                    | For Aurora   |
-| `sqsQueueUrl`        | SQS queue URL to listen to                                    | For SQS      |
-| `sqsDeleteAfterRead` | Delete messages after displaying (default `false`; peek-only) | No           |
-| `awsProfile`         | Named AWS profile (empty = default chain)                     | No           |
-| `bedrockModelId`     | Bedrock model/inference profile for NL→query                  | Yes          |
+| Setting                | Description                                                        | Required     |
+| ---------------------- | ------------------------------------------------------------------ | ------------ |
+| `region`               | AWS region                                                         | Yes          |
+| `destinationType`      | Where your data lives (see above)                                  | Yes          |
+| `logGroupName`         | CloudWatch log group name(s), comma-separated                      | For CW Logs  |
+| `dynamodbTableName`    | DynamoDB table name                                                | For DynamoDB |
+| `auroraResourceArn`    | Aurora cluster ARN                                                 | For Aurora   |
+| `auroraSecretArn`      | Secrets Manager secret ARN                                         | For Aurora   |
+| `auroraDatabase`       | Database name                                                      | For Aurora   |
+| `auroraTable`          | Table name                                                         | For Aurora   |
+| `athenaDatabase`       | Glue/Athena database name                                          | For S3       |
+| `athenaTable`          | Glue table name                                                    | For S3       |
+| `athenaWorkgroup`      | Athena workgroup (empty = `primary`)                               | No           |
+| `athenaOutputLocation` | S3 location for Athena query results                               | For S3\*     |
+| `athenaS3Location`     | S3 location `S3Exporter` writes to (used to auto-create the table) | For S3       |
+| `sqsQueueUrl`          | SQS queue URL to listen to                                         | For SQS      |
+| `sqsDeleteAfterRead`   | Delete messages after displaying (default `false`; peek-only)      | No           |
+| `awsProfile`           | Named AWS profile (empty = default chain)                          | No           |
+| `bedrockModelId`       | Bedrock model/inference profile for NL→query                       | Yes          |
+
+\* Unless the chosen `athenaWorkgroup` already has its own output location configured.
 
 ## Authentication
 
@@ -163,13 +198,14 @@ No credentials are stored by the extension.
 
 Depending on your destination:
 
-| Destination     | Permissions needed                                                                 |
-| --------------- | ---------------------------------------------------------------------------------- |
-| CloudWatch Logs | `logs:StartQuery`, `logs:GetQueryResults`                                          |
-| DynamoDB        | `dynamodb:PartiQLSelect` (or `dynamodb:Scan` + `dynamodb:Query`)                   |
-| Aurora          | `rds-data:ExecuteStatement`, `secretsmanager:GetSecretValue`                       |
-| SQS             | `sqs:ReceiveMessage` (plus `sqs:DeleteMessage` if `sqsDeleteAfterRead` is enabled) |
-| Bedrock (all)   | `bedrock:InvokeModel` on your model/inference profile                              |
+| Destination     | Permissions needed                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CloudWatch Logs | `logs:StartQuery`, `logs:GetQueryResults`                                                                                                                                                                                                |
+| DynamoDB        | `dynamodb:PartiQLSelect` (or `dynamodb:Scan` + `dynamodb:Query`)                                                                                                                                                                         |
+| Aurora          | `rds-data:ExecuteStatement`, `secretsmanager:GetSecretValue`                                                                                                                                                                             |
+| S3 + Athena     | `athena:StartQueryExecution`, `athena:GetQueryExecution`, `athena:GetQueryResults`, `glue:GetTable`, `glue:CreateTable`, `glue:GetPartitions`, `glue:BatchCreatePartition`, `s3:GetObject`, `s3:PutObject` on the data + results buckets |
+| SQS             | `sqs:ReceiveMessage` (plus `sqs:DeleteMessage` if `sqsDeleteAfterRead` is enabled)                                                                                                                                                       |
+| Bedrock (all)   | `bedrock:InvokeModel` on your model/inference profile                                                                                                                                                                                    |
 
 ## How Queries Are Generated
 
@@ -188,11 +224,10 @@ If the generated query fails, the extension automatically sends the error back t
 - **"No log group / table configured"** — Click ⚙ and fill in the missing field
 - **Access denied** — Check IAM permissions and credential expiry
 
-## Supported Destinations (future)
+## Future Work
 
-The extension currently supports CloudWatch Logs, DynamoDB, and Aurora. Future versions will add:
+The extension currently supports CloudWatch Logs, DynamoDB, Aurora, and S3 + Athena. Future versions will add:
 
-- Amazon S3 + Athena (SQL over Parquet/JSON in S3)
 - Query history and saved queries
 - CSV export
 - Local LLM option (no Bedrock required)

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -94,9 +94,13 @@ Athena.
 | Query Result Location | S3 path for Athena's query output, e.g. `s3://my-bucket/athena-results/`            |
 
 On **Save**, the Explorer checks whether the Glue table already exists. If not, it
-auto-creates it with `CREATE EXTERNAL TABLE` (matching `S3Exporter`'s JSON layout
-and Hive date partitioning) and runs `MSCK REPAIR TABLE` to discover any partitions
-already written — no manual DDL or Glue crawler required.
+auto-creates it with `CREATE EXTERNAL TABLE`, using
+[partition projection](https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html)
+so Athena computes valid year/month/day partitions (and their S3 locations)
+directly from the table properties instead of listing them from the Glue
+Catalog — today's data is queryable the moment `S3Exporter` writes it, with no
+`MSCK REPAIR TABLE` or crawler run, and no re-discovery step needed as more days
+accumulate.
 
 Because the canonical `operations` array (not `operationsByName`) is what
 `S3Exporter` writes, per-operation questions are answered with `UNNEST` rather than

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -160,6 +160,7 @@
     "build": "cd webview-ui && npm run build && cd .. && node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",
     "typecheck": "tsc --noEmit",
+    "test": "jest",
     "clean": "rm -rf dist media/webview.js media/webview.css"
   },
   "dependencies": {
@@ -175,9 +176,30 @@
     "node-llama-cpp": "^3.18.1"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.90.0",
     "esbuild": "^0.24.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
     "typescript": "~5.8.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/src/**/*.test.ts"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/webview-ui"
+    ],
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.test.json"
+        }
+      ]
+    }
   }
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -54,6 +54,7 @@
             "lambda-log-exporter",
             "dynamodb",
             "aurora",
+            "s3",
             "sqs"
           ],
           "enumDescriptions": [
@@ -61,6 +62,7 @@
             "Function's own log group via LambdaLogExporter — records nested in Lambda JSON envelope (message field)",
             "DynamoDB table via DynamoDBExporter — records queryable via PartiQL",
             "Aurora PostgreSQL/MySQL via AuroraExporter — full SQL with GROUP BY, JOIN, aggregations",
+            "S3 via S3Exporter — queried through Amazon Athena (Trino/Presto SQL) over a Glue table",
             "Amazon SQS via SQSExporter — live view that listens to the queue as records arrive (no query engine)"
           ],
           "description": "Where and how records are stored. Determines query engine and format."
@@ -100,6 +102,31 @@
           "default": "workflow_insight",
           "description": "Aurora table name containing insight records."
         },
+        "workflowInsight.athenaDatabase": {
+          "type": "string",
+          "default": "",
+          "description": "Glue/Athena database containing the workflow insight table (required when destinationType is 's3')."
+        },
+        "workflowInsight.athenaTable": {
+          "type": "string",
+          "default": "workflow_insight",
+          "description": "Glue table name for records written by S3Exporter."
+        },
+        "workflowInsight.athenaWorkgroup": {
+          "type": "string",
+          "default": "",
+          "description": "Athena workgroup to run queries in. Leave empty to use the 'primary' workgroup and set athenaOutputLocation instead."
+        },
+        "workflowInsight.athenaOutputLocation": {
+          "type": "string",
+          "default": "",
+          "description": "S3 location for Athena query results, e.g. s3://my-bucket/athena-results/. Required unless the chosen workgroup has its own output location configured."
+        },
+        "workflowInsight.athenaS3Location": {
+          "type": "string",
+          "default": "",
+          "description": "S3 location the S3Exporter writes records to, e.g. s3://my-bucket/workflow-insight/. Used to auto-create the Glue table (JSON SerDe, Hive year=/month=/day= partitioning) if it doesn't already exist."
+        },
         "workflowInsight.awsProfile": {
           "type": "string",
           "default": "",
@@ -136,9 +163,11 @@
     "clean": "rm -rf dist media/webview.js media/webview.css"
   },
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.658.0",
     "@aws-sdk/client-bedrock-runtime": "^3.658.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",
+    "@aws-sdk/client-glue": "^3.658.0",
     "@aws-sdk/client-rds-data": "^3.658.0",
     "@aws-sdk/client-sqs": "^3.658.0",
     "@aws-sdk/credential-providers": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -182,9 +182,19 @@ async function paginateResults(
  * rather than a large round number, to bound that cost; if data is ever
  * queried past PROJECTION_YEAR_END, raise it and either recreate the table
  * or ALTER TABLE SET TBLPROPERTIES with the new range.
+ *
+ * These constants are exported specifically so
+ * aws-durable-execution-sdk-js-insight/cdk/stack.test.ts (a different
+ * package) can import them directly and assert its own hardcoded
+ * projection.year.range matches — a real cross-package npm dependency
+ * isn't warranted just for two constants (this package is a dev-only,
+ * unpublished VS Code extension; the CDK package has no other reason to
+ * depend on it), so a relative-path source import in test code is the
+ * practical way to keep these two definitions of the same value from
+ * silently drifting apart, short of that.
  */
-const PROJECTION_YEAR_START = 2024;
-const PROJECTION_YEAR_END = 2030;
+export const PROJECTION_YEAR_START = 2024;
+export const PROJECTION_YEAR_END = 2030;
 
 export function buildCreateTableDdl(opts: {
   database: string;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -178,10 +178,10 @@ async function paginateResults(
  * candidate partition) — verified empirically: a `GROUP BY year, month,
  * day` with no date filter took ~30s of query planning time against a
  * 2024–2100 range (76 years × 12 × 31 ≈ 28k candidate partitions), most of
- * it before any data was scanned. Kept deliberately narrow (5 years out)
- * rather than a large round number, to bound that cost; if data is ever
- * queried past PROJECTION_YEAR_END, raise it and either recreate the table
- * or ALTER TABLE SET TBLPROPERTIES with the new range.
+ * it before any data was scanned. Kept deliberately narrow (a 7-year span,
+ * 2024–2030) rather than a large round number, to bound that cost; if data
+ * is ever queried past PROJECTION_YEAR_END, raise it and either recreate
+ * the table or ALTER TABLE SET TBLPROPERTIES with the new range.
  *
  * These constants are exported specifically so
  * aws-durable-execution-sdk-js-insight/cdk/stack.test.ts (a different

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -143,6 +143,20 @@ async function paginateResults(
  * (year=YYYY/month=MM/day=DD/), and the canonical `operations` array (the
  * S3Exporter does not reshape into `operationsByName`).
  *
+ * Column names are written lowercase throughout (recordtype, executionarn,
+ * subtype, parentid, durationms, ...) to match the CDK-provisioned Glue
+ * table (stack.ts's InsightGlueTable) exactly, rather than the mixed-case
+ * WorkflowInsightRecord field names (recordType, executionArn, ...).
+ * Hive/Glue table and column identifiers are case-insensitive and get
+ * folded to lowercase regardless of how they're written in the DDL — so
+ * this was never functionally different from writing camelCase here, but
+ * keeping both DDL definitions written in the same (lowercase, effectively
+ * canonical) casing avoids the two drifting into visually different
+ * text that describes an identical schema, which is confusing to compare
+ * side by side. The openx JSON SerDe separately lowercases the *data*
+ * values' object keys when parsing input/output (a different, unrelated
+ * mechanism — see schema.ts's Athena dialect notes on that).
+ *
  * Uses partition projection (year/month/day as `integer` type, with a
  * `storage.location.template` reconstructing S3Exporter's exact key
  * pattern) instead of a plain `PARTITIONED BY` + Glue-catalog partition
@@ -184,19 +198,19 @@ export function buildCreateTableDdl(opts: {
   // itself supplies the path separators between segments.
   const locTemplate = `${loc}year=\${year}/month=\${month}/day=\${day}`;
   return `CREATE EXTERNAL TABLE IF NOT EXISTS \`${opts.database}\`.\`${opts.table}\` (
-  recordType string,
-  schemaVersion string,
-  emittedAt string,
-  executionArn string,
-  executionName string,
-  functionName string,
-  functionQualifier string,
+  recordtype string,
+  schemaversion string,
+  emittedat string,
+  executionarn string,
+  executionname string,
+  functionname string,
+  functionqualifier string,
   region string,
-  accountId string,
+  accountid string,
   status string,
-  startTime string,
-  endTime string,
-  durationMs bigint,
+  starttime string,
+  endtime string,
+  durationms bigint,
   input string,
   output string,
   error struct<name:string,message:string>,
@@ -204,21 +218,21 @@ export function buildCreateTableDdl(opts: {
     id:string,
     name:string,
     type:string,
-    subType:string,
-    parentId:string,
+    subtype:string,
+    parentid:string,
     status:string,
-    startTime:string,
-    endTime:string,
-    durationMs:bigint,
+    starttime:string,
+    endtime:string,
+    durationms:bigint,
     attempt:int,
     error:struct<name:string,message:string>,
     result:string,
     truncated:boolean
   >>,
   truncated boolean,
-  droppedOperations int,
-  droppedInput boolean,
-  droppedOutput boolean
+  droppedoperations int,
+  droppedinput boolean,
+  droppedoutput boolean
 )
 PARTITIONED BY (year string, month string, day string)
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -264,6 +264,13 @@ export async function ensureAthenaTable(opts: {
  * equality predicate lets Athena's engine short-circuit once it finds the
  * match, and LIMIT 1 keeps the result set trivially small — still an
  * ordinary query under the hood, just narrowly scoped.
+ *
+ * Unlike fetchAuroraRecord/fetchDynamoDBRecord, this can't use a
+ * parameterized statement — StartQueryExecutionCommand takes a single
+ * QueryString with no positional/named parameter support (that's an RDS
+ * Data API / PartiQL ExecuteStatement feature, not part of the Athena API).
+ * Manual quote-escaping is the correct mitigation here, same as any other
+ * raw-SQL API without parameter binding.
  */
 export async function fetchAthenaRecord(opts: {
   region: string;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -1,0 +1,258 @@
+import {
+  AthenaClient,
+  StartQueryExecutionCommand,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+  type Row,
+  type ColumnInfo,
+} from "@aws-sdk/client-athena";
+import { GlueClient, GetTableCommand } from "@aws-sdk/client-glue";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+
+export interface AthenaQueryResult {
+  columns: string[];
+  rows: string[][];
+  count: number;
+  dataScannedBytes?: number;
+}
+
+const POLL_INTERVAL_MS = 1000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run a SQL query against Amazon Athena and normalize the results into a
+ * simple columns/rows table. Athena is asynchronous: we StartQueryExecution,
+ * then poll GetQueryExecution until the query completes, then page through
+ * GetQueryResults.
+ */
+export async function runAthenaQuery(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  database: string;
+  workgroup?: string;
+  outputLocation?: string;
+  query: string;
+  timeoutMs?: number;
+}): Promise<AthenaQueryResult> {
+  if (!opts.database) {
+    throw new Error(
+      "No Athena database configured. Set workflowInsight.athenaDatabase.",
+    );
+  }
+  if (!opts.workgroup && !opts.outputLocation) {
+    throw new Error(
+      "Set either workflowInsight.athenaWorkgroup (with its own output location) " +
+        "or workflowInsight.athenaOutputLocation (e.g. s3://my-bucket/athena-results/).",
+    );
+  }
+
+  const client = new AthenaClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  const { QueryExecutionId } = await client.send(
+    new StartQueryExecutionCommand({
+      QueryString: opts.query,
+      QueryExecutionContext: { Database: opts.database },
+      WorkGroup: opts.workgroup,
+      ResultConfiguration: opts.outputLocation
+        ? { OutputLocation: opts.outputLocation }
+        : undefined,
+    }),
+  );
+
+  if (!QueryExecutionId) {
+    throw new Error("Failed to start Athena query (no QueryExecutionId).");
+  }
+
+  const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  let dataScannedBytes: number | undefined;
+
+  for (;;) {
+    const { QueryExecution } = await client.send(
+      new GetQueryExecutionCommand({ QueryExecutionId }),
+    );
+    const state = QueryExecution?.Status?.State;
+    dataScannedBytes = QueryExecution?.Statistics?.DataScannedInBytes;
+
+    if (state === "SUCCEEDED") break;
+    if (state === "FAILED" || state === "CANCELLED") {
+      const reason =
+        QueryExecution?.Status?.StateChangeReason ?? "no reason given";
+      throw new Error(`Athena query ${state.toLowerCase()}: ${reason}`);
+    }
+    if (Date.now() > deadline) {
+      throw new Error("Athena query timed out while polling for results.");
+    }
+    await delay(POLL_INTERVAL_MS);
+  }
+
+  return paginateResults(client, QueryExecutionId, dataScannedBytes);
+}
+
+/** Page through GetQueryResults and normalize into columns/rows. */
+async function paginateResults(
+  client: AthenaClient,
+  queryExecutionId: string,
+  dataScannedBytes: number | undefined,
+): Promise<AthenaQueryResult> {
+  let columns: string[] | undefined;
+  const rows: string[][] = [];
+  let nextToken: string | undefined;
+  let isFirstPage = true;
+
+  do {
+    const result = await client.send(
+      new GetQueryResultsCommand({
+        QueryExecutionId: queryExecutionId,
+        NextToken: nextToken,
+      }),
+    );
+
+    if (!columns) {
+      columns = (result.ResultSet?.ResultSetMetadata?.ColumnInfo ?? []).map(
+        (c: ColumnInfo) => c.Name ?? "?",
+      );
+    }
+
+    const resultRows: Row[] = result.ResultSet?.Rows ?? [];
+    // Athena includes the header row as the first row of the first page only.
+    const dataRows = isFirstPage ? resultRows.slice(1) : resultRows;
+    for (const row of dataRows) {
+      rows.push((row.Data ?? []).map((d) => d.VarCharValue ?? ""));
+    }
+
+    nextToken = result.NextToken;
+    isFirstPage = false;
+  } while (nextToken);
+
+  return {
+    columns: columns ?? [],
+    rows,
+    count: rows.length,
+    dataScannedBytes,
+  };
+}
+
+/**
+ * The Glue DDL matching what `S3Exporter` writes: one JSON object per file
+ * (JSON SerDe, not NDJSON), Hive-style date partitioning
+ * (year=YYYY/month=MM/day=DD/), and the canonical `operations` array (the
+ * S3Exporter does not reshape into `operationsByName`).
+ */
+export function buildCreateTableDdl(opts: {
+  database: string;
+  table: string;
+  s3Location: string;
+}): string {
+  const loc = opts.s3Location.endsWith("/")
+    ? opts.s3Location
+    : `${opts.s3Location}/`;
+  return `CREATE EXTERNAL TABLE IF NOT EXISTS \`${opts.database}\`.\`${opts.table}\` (
+  recordType string,
+  schemaVersion string,
+  emittedAt string,
+  executionArn string,
+  executionName string,
+  functionName string,
+  functionQualifier string,
+  region string,
+  accountId string,
+  status string,
+  startTime string,
+  endTime string,
+  durationMs bigint,
+  input string,
+  output string,
+  error struct<name:string,message:string>,
+  operations array<struct<
+    id:string,
+    name:string,
+    type:string,
+    subType:string,
+    parentId:string,
+    status:string,
+    startTime:string,
+    endTime:string,
+    durationMs:bigint,
+    attempt:int,
+    error:struct<name:string,message:string>,
+    result:string,
+    truncated:boolean
+  >>,
+  truncated boolean,
+  droppedOperations int,
+  droppedInput boolean,
+  droppedOutput boolean
+)
+PARTITIONED BY (year string, month string, day string)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
+LOCATION '${loc}'
+TBLPROPERTIES ('has_encrypted_data'='false');`;
+}
+
+/** Check whether the Glue table already exists (used to prompt for auto-create). */
+export async function tableExists(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  database: string;
+  table: string;
+}): Promise<boolean> {
+  const client = new GlueClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+  try {
+    await client.send(
+      new GetTableCommand({ DatabaseName: opts.database, Name: opts.table }),
+    );
+    return true;
+  } catch (err) {
+    if (err instanceof Error && err.name === "EntityNotFoundException") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create the Glue table (via Athena DDL, which registers it in the Glue
+ * Catalog) and discover existing Hive partitions with MSCK REPAIR TABLE.
+ * Idempotent — safe to call every time settings are saved.
+ */
+export async function ensureAthenaTable(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  database: string;
+  table: string;
+  workgroup?: string;
+  outputLocation?: string;
+  s3Location: string;
+}): Promise<void> {
+  const ddl = buildCreateTableDdl({
+    database: opts.database,
+    table: opts.table,
+    s3Location: opts.s3Location,
+  });
+  await runAthenaQuery({
+    region: opts.region,
+    credentials: opts.credentials,
+    database: opts.database,
+    workgroup: opts.workgroup,
+    outputLocation: opts.outputLocation,
+    query: ddl,
+  });
+  // Discover the year=/month=/day= partitions already written by S3Exporter.
+  await runAthenaQuery({
+    region: opts.region,
+    credentials: opts.credentials,
+    database: opts.database,
+    workgroup: opts.workgroup,
+    outputLocation: opts.outputLocation,
+    query: `MSCK REPAIR TABLE \`${opts.database}\`.\`${opts.table}\`;`,
+  });
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -183,18 +183,21 @@ async function paginateResults(
  * is ever queried past PROJECTION_YEAR_END, raise it and either recreate
  * the table or ALTER TABLE SET TBLPROPERTIES with the new range.
  *
- * These constants are exported specifically so
- * aws-durable-execution-sdk-js-insight/cdk/stack.test.ts (a different
- * package) can import them directly and assert its own hardcoded
- * projection.year.range matches — a real cross-package npm dependency
- * isn't warranted just for two constants (this package is a dev-only,
- * unpublished VS Code extension; the CDK package has no other reason to
- * depend on it), so a relative-path source import in test code is the
- * practical way to keep these two definitions of the same value from
- * silently drifting apart, short of that.
+ * Note: the example CDK stack (aws-durable-execution-sdk-js-insight/cdk)
+ * hardcodes its own "2024,2030" projection.year.range for its own example
+ * bucket. That's an independent copy of this value, not enforced equal to
+ * this one — the two DDLs create tables over *different* buckets (this one
+ * runs when a customer points the extension at their own arbitrary bucket;
+ * the CDK one provisions the example deployment's bucket), so there's no
+ * correctness requirement that they match, and either can reasonably be
+ * tuned without the other. If you do want to keep them consistent, update
+ * both by hand; there is deliberately no shared constant across the two
+ * packages (this dev-only, unpublished VS Code extension and the CDK
+ * example stack have no other dependency between them, and a cross-package
+ * dependency in either direction isn't warranted just for one integer).
  */
-export const PROJECTION_YEAR_START = 2024;
-export const PROJECTION_YEAR_END = 2030;
+const PROJECTION_YEAR_START = 2024;
+const PROJECTION_YEAR_END = 2030;
 
 export function buildCreateTableDdl(opts: {
   database: string;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -256,3 +256,39 @@ export async function ensureAthenaTable(opts: {
     query: `MSCK REPAIR TABLE \`${opts.database}\`.\`${opts.table}\`;`,
   });
 }
+
+/**
+ * Fetch a single full record by executionArn, for the row-detail
+ * drill-down. Athena has no cheap point-lookup (every query scans the
+ * relevant partitions), but scoping to a specific executionArn with an
+ * equality predicate lets Athena's engine short-circuit once it finds the
+ * match, and LIMIT 1 keeps the result set trivially small — still an
+ * ordinary query under the hood, just narrowly scoped.
+ */
+export async function fetchAthenaRecord(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  database: string;
+  table: string;
+  workgroup?: string;
+  outputLocation?: string;
+  executionArn: string;
+}): Promise<Record<string, string> | undefined> {
+  const escaped = opts.executionArn.replace(/'/g, "''");
+  const result = await runAthenaQuery({
+    region: opts.region,
+    credentials: opts.credentials,
+    database: opts.database,
+    workgroup: opts.workgroup,
+    outputLocation: opts.outputLocation,
+    query: `SELECT * FROM ${opts.table} WHERE executionarn = '${escaped}' LIMIT 1`,
+  });
+
+  if (result.rows.length === 0) return undefined;
+  const row = result.rows[0];
+  const record: Record<string, string> = {};
+  result.columns.forEach((col, i) => {
+    if (row[i]) record[col] = row[i];
+  });
+  return record;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -259,11 +259,15 @@ export async function ensureAthenaTable(opts: {
 
 /**
  * Fetch a single full record by executionArn, for the row-detail
- * drill-down. Athena has no cheap point-lookup (every query scans the
- * relevant partitions), but scoping to a specific executionArn with an
- * equality predicate lets Athena's engine short-circuit once it finds the
- * match, and LIMIT 1 keeps the result set trivially small — still an
- * ordinary query under the hood, just narrowly scoped.
+ * drill-down. Without a partition predicate this scans every year/month/day
+ * partition in the table on every row click — `LIMIT 1` only bounds the
+ * number of *output* rows, it does not make Trino/Athena stop scanning
+ * splits early once a match is found, so this is a real full-table scan
+ * (cost + latency) on a large bucket. Pass `year`/`month`/`day` (the
+ * clicked row's own partition columns, carried through by
+ * ensureIdentifierColumn's extraColumns — see extension.ts) whenever
+ * available to add an equality predicate on the partition columns and let
+ * Athena prune to just that one partition.
  *
  * Unlike fetchAuroraRecord/fetchDynamoDBRecord, this can't use a
  * parameterized statement — StartQueryExecutionCommand takes a single
@@ -280,15 +284,27 @@ export async function fetchAthenaRecord(opts: {
   workgroup?: string;
   outputLocation?: string;
   executionArn: string;
+  /** The clicked row's own year/month/day partition values, if known — adds a partition-pruning predicate instead of scanning the whole table. */
+  year?: string;
+  month?: string;
+  day?: string;
 }): Promise<Record<string, string> | undefined> {
   const escaped = opts.executionArn.replace(/'/g, "''");
+  const partitionPredicate = [
+    opts.year ? `year = '${opts.year.replace(/'/g, "''")}'` : undefined,
+    opts.month ? `month = '${opts.month.replace(/'/g, "''")}'` : undefined,
+    opts.day ? `day = '${opts.day.replace(/'/g, "''")}'` : undefined,
+  ]
+    .filter((p): p is string => p != null)
+    .map((p) => `${p} AND `)
+    .join("");
   const result = await runAthenaQuery({
     region: opts.region,
     credentials: opts.credentials,
     database: opts.database,
     workgroup: opts.workgroup,
     outputLocation: opts.outputLocation,
-    query: `SELECT * FROM ${opts.table} WHERE executionarn = '${escaped}' LIMIT 1`,
+    query: `SELECT * FROM ${opts.table} WHERE ${partitionPredicate}executionarn = '${escaped}' LIMIT 1`,
   });
 
   if (result.rows.length === 0) return undefined;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -142,7 +142,36 @@ async function paginateResults(
  * (JSON SerDe, not NDJSON), Hive-style date partitioning
  * (year=YYYY/month=MM/day=DD/), and the canonical `operations` array (the
  * S3Exporter does not reshape into `operationsByName`).
+ *
+ * Uses partition projection (year/month/day as `integer` type, with a
+ * `storage.location.template` reconstructing S3Exporter's exact key
+ * pattern) instead of a plain `PARTITIONED BY` + Glue-catalog partition
+ * list. With projection, Athena computes valid partition values and their
+ * S3 locations mathematically from these table properties at query time —
+ * it never calls Glue's GetPartitions, so there's no partition-count
+ * metadata lookup to slow down as more days accumulate, and critically, no
+ * MSCK REPAIR TABLE (or manual ADD PARTITION) is needed at all: a query for
+ * today's data works the moment S3Exporter writes today's first object,
+ * with no discovery step first. See
+ * https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+ *
+ * Trade-off: the `year` range needs a fixed upper bound (integer projection
+ * requires a bounded range, unlike a real date type — which Athena's docs
+ * note doesn't support separate year/month/day partition columns, only a
+ * single combined date column). A wider range means more query-planning
+ * work for any query that doesn't filter on year/month/day (Athena has to
+ * reason about every year × month × day combination in range as a
+ * candidate partition) — verified empirically: a `GROUP BY year, month,
+ * day` with no date filter took ~30s of query planning time against a
+ * 2024–2100 range (76 years × 12 × 31 ≈ 28k candidate partitions), most of
+ * it before any data was scanned. Kept deliberately narrow (5 years out)
+ * rather than a large round number, to bound that cost; if data is ever
+ * queried past PROJECTION_YEAR_END, raise it and either recreate the table
+ * or ALTER TABLE SET TBLPROPERTIES with the new range.
  */
+const PROJECTION_YEAR_START = 2024;
+const PROJECTION_YEAR_END = 2030;
+
 export function buildCreateTableDdl(opts: {
   database: string;
   table: string;
@@ -151,6 +180,9 @@ export function buildCreateTableDdl(opts: {
   const loc = opts.s3Location.endsWith("/")
     ? opts.s3Location
     : `${opts.s3Location}/`;
+  // Trailing slash trimmed from loc for the template, since the template
+  // itself supplies the path separators between segments.
+  const locTemplate = `${loc}year=\${year}/month=\${month}/day=\${day}`;
   return `CREATE EXTERNAL TABLE IF NOT EXISTS \`${opts.database}\`.\`${opts.table}\` (
   recordType string,
   schemaVersion string,
@@ -192,7 +224,19 @@ PARTITIONED BY (year string, month string, day string)
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
 LOCATION '${loc}'
-TBLPROPERTIES ('has_encrypted_data'='false');`;
+TBLPROPERTIES (
+  'has_encrypted_data'='false',
+  'projection.enabled'='true',
+  'projection.year.type'='integer',
+  'projection.year.range'='${PROJECTION_YEAR_START},${PROJECTION_YEAR_END}',
+  'projection.month.type'='integer',
+  'projection.month.range'='1,12',
+  'projection.month.digits'='2',
+  'projection.day.type'='integer',
+  'projection.day.range'='1,31',
+  'projection.day.digits'='2',
+  'storage.location.template'='${locTemplate}'
+);`;
 }
 
 /** Check whether the Glue table already exists (used to prompt for auto-create). */
@@ -221,8 +265,17 @@ export async function tableExists(opts: {
 
 /**
  * Create the Glue table (via Athena DDL, which registers it in the Glue
- * Catalog) and discover existing Hive partitions with MSCK REPAIR TABLE.
- * Idempotent — safe to call every time settings are saved.
+ * Catalog). Idempotent — safe to call every time settings are saved.
+ *
+ * No MSCK REPAIR TABLE / partition discovery step: buildCreateTableDdl uses
+ * partition projection, so Athena computes valid year/month/day partitions
+ * (and their S3 locations) from the table properties instead of listing
+ * them from the Glue Catalog. Today's partition is queryable the moment
+ * S3Exporter writes today's first record — there's nothing to "discover"
+ * after the table exists, and running MSCK REPAIR TABLE against a
+ * projection-enabled table is a documented no-op (verified: it does not
+ * error, it just has no effect — projected partitions aren't tracked in
+ * the Glue Catalog for it to add).
  */
 export async function ensureAthenaTable(opts: {
   region: string;
@@ -245,15 +298,6 @@ export async function ensureAthenaTable(opts: {
     workgroup: opts.workgroup,
     outputLocation: opts.outputLocation,
     query: ddl,
-  });
-  // Discover the year=/month=/day= partitions already written by S3Exporter.
-  await runAthenaQuery({
-    region: opts.region,
-    credentials: opts.credentials,
-    database: opts.database,
-    workgroup: opts.workgroup,
-    outputLocation: opts.outputLocation,
-    query: `MSCK REPAIR TABLE \`${opts.database}\`.\`${opts.table}\`;`,
   });
 }
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
@@ -368,8 +368,19 @@ export async function fetchAthenaRecord(opts: {
   if (result.rows.length === 0) return undefined;
   const row = result.rows[0];
   const record: Record<string, string> = {};
+  // Always include every column's value, even an empty string — unlike
+  // fetchDynamoDBRecord/fetchAuroraRecord (which distinguish a real NULL
+  // from an empty string and only drop the former), runAthenaQuery's
+  // paginateResults already normalizes a missing VarCharValue to "" (see
+  // that function), so there is no separate null/undefined signal left to
+  // check for here by the time rows reach this function — "" from Athena
+  // could mean either NULL or a genuinely empty string, and since there's
+  // no way to tell them apart at this point, don't drop it either way. The
+  // previous `if (row[i])` check was wrong regardless: it treated a
+  // legitimately empty string as absent and silently omitted that field
+  // from the detail view.
   result.columns.forEach((col, i) => {
-    if (row[i]) record[col] = row[i];
+    record[col] = row[i] ?? "";
   });
   return record;
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/aurora.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/aurora.ts
@@ -54,3 +54,63 @@ export async function runAuroraQuery(opts: {
 
   return { columns, rows, count: rows.length };
 }
+
+/**
+ * Fetch a single full record by execution_arn, for the row-detail
+ * drill-down. Uses the RDS Data API's parameterized statements to avoid SQL
+ * injection from the identifier value (which round-trips through the
+ * webview, so treat it as untrusted input even though it originated from a
+ * previous query result).
+ *
+ * The table's only record-shaped column is `record_json` (a JSONB blob) —
+ * the individual scalar columns (execution_arn, status, etc.) are a
+ * denormalized subset for indexing/filtering, not the full record. Select
+ * record_json and unpack it into top-level fields so this matches the
+ * flat-fields shape RecordDetail.tsx expects (input/output/operations/error
+ * as top-level keys), rather than returning it as a single opaque JSON
+ * string column.
+ */
+export async function fetchAuroraRecord(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  resourceArn: string;
+  secretArn: string;
+  database: string;
+  table: string;
+  executionArn: string;
+}): Promise<Record<string, string> | undefined> {
+  const client = new RDSDataClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  const result = await client.send(
+    new ExecuteStatementCommand({
+      resourceArn: opts.resourceArn,
+      secretArn: opts.secretArn,
+      database: opts.database,
+      sql: `SELECT record_json FROM ${opts.table} WHERE execution_arn = :executionArn LIMIT 1`,
+      parameters: [
+        { name: "executionArn", value: { stringValue: opts.executionArn } },
+      ],
+    }),
+  );
+
+  const field = (result.records ?? [])[0]?.[0];
+  if (!field?.stringValue) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(field.stringValue);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+    if (val == null) continue;
+    out[key] = typeof val === "object" ? JSON.stringify(val) : String(val);
+  }
+  return out;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -10,7 +10,8 @@ export interface InsightConfig {
     | "lambda-log-exporter"
     | "dynamodb"
     | "aurora"
-    | "sqs";
+    | "sqs"
+    | "s3";
   dynamodbTableName: string;
   auroraResourceArn: string;
   auroraSecretArn: string;
@@ -18,6 +19,11 @@ export interface InsightConfig {
   auroraTable: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
+  athenaDatabase: string;
+  athenaTable: string;
+  athenaWorkgroup: string;
+  athenaOutputLocation: string;
+  athenaS3Location: string;
   llmProvider: "bedrock" | "copilot" | "local";
   awsProfile?: string;
   bedrockModelId: string;
@@ -46,7 +52,9 @@ export function readConfig(): InsightConfig {
           ? ("aurora" as const)
           : raw === "sqs"
             ? ("sqs" as const)
-            : ("cloudwatch-logs-exporter" as const);
+            : raw === "s3"
+              ? ("s3" as const)
+              : ("cloudwatch-logs-exporter" as const);
   const dynamodbTableName = (c.get<string>("dynamodbTableName") || "").trim();
   const auroraResourceArn = (c.get<string>("auroraResourceArn") || "").trim();
   const auroraSecretArn = (c.get<string>("auroraSecretArn") || "").trim();
@@ -56,6 +64,14 @@ export function readConfig(): InsightConfig {
     (c.get<string>("auroraTable") || "").trim() || "workflow_insight";
   const sqsQueueUrl = (c.get<string>("sqsQueueUrl") || "").trim();
   const sqsDeleteAfterRead = c.get<boolean>("sqsDeleteAfterRead") ?? false;
+  const athenaDatabase = (c.get<string>("athenaDatabase") || "").trim();
+  const athenaTable =
+    (c.get<string>("athenaTable") || "").trim() || "workflow_insight";
+  const athenaWorkgroup = (c.get<string>("athenaWorkgroup") || "").trim();
+  const athenaOutputLocation = (
+    c.get<string>("athenaOutputLocation") || ""
+  ).trim();
+  const athenaS3Location = (c.get<string>("athenaS3Location") || "").trim();
   const llmProvider =
     (c.get<string>("llmProvider") || "").trim() === "copilot"
       ? ("copilot" as const)
@@ -78,6 +94,11 @@ export function readConfig(): InsightConfig {
     auroraTable,
     sqsQueueUrl,
     sqsDeleteAfterRead,
+    athenaDatabase,
+    athenaTable,
+    athenaWorkgroup,
+    athenaOutputLocation,
+    athenaS3Location,
     llmProvider,
     awsProfile,
     bedrockModelId,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/dynamodb.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/dynamodb.ts
@@ -77,6 +77,12 @@ export async function runDynamoDBQuery(opts: {
  * the row-detail drill-down. Uses ExecuteStatement (PartiQL) with a direct
  * key-equality WHERE clause — a Query, not a Scan, so this is cheap even on
  * a large table.
+ *
+ * Uses ExecuteStatementCommand's `Parameters` (positional `?` placeholders)
+ * rather than string interpolation — `pk` round-trips through the webview
+ * (it's a value from a previous query's result row), so treat it as
+ * untrusted input even though it originated from our own query, the same
+ * way fetchAuroraRecord parameterizes execution_arn.
  */
 export async function fetchDynamoDBRecord(opts: {
   region: string;
@@ -89,10 +95,10 @@ export async function fetchDynamoDBRecord(opts: {
     credentials: opts.credentials,
   });
 
-  const escaped = opts.pk.replace(/'/g, "''");
   const result = await client.send(
     new ExecuteStatementCommand({
-      Statement: `SELECT * FROM "${opts.tableName}" WHERE pk = '${escaped}'`,
+      Statement: `SELECT * FROM "${opts.tableName}" WHERE pk = ?`,
+      Parameters: [{ S: opts.pk }],
     }),
   );
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/dynamodb.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/dynamodb.ts
@@ -71,3 +71,38 @@ export async function runDynamoDBQuery(opts: {
 
   return { columns, rows, count: items.length };
 }
+
+/**
+ * Fetch a single full record by its partition key (pk = executionArn), for
+ * the row-detail drill-down. Uses ExecuteStatement (PartiQL) with a direct
+ * key-equality WHERE clause — a Query, not a Scan, so this is cheap even on
+ * a large table.
+ */
+export async function fetchDynamoDBRecord(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  tableName: string;
+  pk: string;
+}): Promise<Record<string, string> | undefined> {
+  const client = new DynamoDBClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  const escaped = opts.pk.replace(/'/g, "''");
+  const result = await client.send(
+    new ExecuteStatementCommand({
+      Statement: `SELECT * FROM "${opts.tableName}" WHERE pk = '${escaped}'`,
+    }),
+  );
+
+  const item = result.Items?.[0];
+  if (!item) return undefined;
+  const unmarshalled = unmarshall(item);
+  const record: Record<string, string> = {};
+  for (const [key, val] of Object.entries(unmarshalled)) {
+    if (val == null) continue;
+    record[key] = typeof val === "object" ? JSON.stringify(val) : String(val);
+  }
+  return record;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { generateQuery, isModelDownloaded, ensureModel } from "./llm";
 import { runLogsInsightsQuery } from "./logsInsights";
 import { runDynamoDBQuery } from "./dynamodb";
 import { runAuroraQuery } from "./aurora";
+import { runAthenaQuery, ensureAthenaTable, tableExists } from "./athena";
 import { listenToQueue, type SqsMessageRow } from "./sqs";
 import { ensureLimit } from "./schema";
 import { assertReadOnly } from "./queryValidator";
@@ -105,6 +106,11 @@ class ExplorerPanel {
         auroraTable: cfg.auroraTable,
         sqsQueueUrl: cfg.sqsQueueUrl,
         sqsDeleteAfterRead: cfg.sqsDeleteAfterRead,
+        athenaDatabase: cfg.athenaDatabase,
+        athenaTable: cfg.athenaTable,
+        athenaWorkgroup: cfg.athenaWorkgroup,
+        athenaOutputLocation: cfg.athenaOutputLocation,
+        athenaS3Location: cfg.athenaS3Location,
         llmProvider: cfg.llmProvider,
         awsProfile: cfg.awsProfile ?? "",
         bedrockModelId: cfg.bedrockModelId,
@@ -126,7 +132,60 @@ class ExplorerPanel {
       await config.update(key, coerced, vscode.ConfigurationTarget.Global);
     }
     this.sendConfig();
+
+    const cfg = readConfig();
+    if (
+      cfg.destinationType === "s3" &&
+      cfg.athenaDatabase &&
+      cfg.athenaS3Location
+    ) {
+      await this.onEnsureAthenaTable(cfg);
+    }
+
     this.post({ type: "settingsSaved" });
+  }
+
+  /**
+   * Auto-create (or verify) the Glue table backing Athena queries, and
+   * discover any Hive partitions S3Exporter has already written. Idempotent —
+   * safe to run every time settings are saved. Best-effort: surfaces failures
+   * as a non-fatal warning rather than blocking settings from saving, since
+   * the user may not have Glue/Athena permissions yet (or the bucket/table
+   * exist already via other tooling).
+   */
+  private async onEnsureAthenaTable(
+    cfg: ReturnType<typeof readConfig>,
+  ): Promise<void> {
+    const credentials = resolveCredentials(cfg.awsProfile);
+    try {
+      const exists = await tableExists({
+        region: cfg.region,
+        credentials,
+        database: cfg.athenaDatabase,
+        table: cfg.athenaTable,
+      });
+      if (exists) return;
+
+      this.post({
+        type: "status",
+        text: `Creating Glue table ${cfg.athenaDatabase}.${cfg.athenaTable}...`,
+      });
+      await ensureAthenaTable({
+        region: cfg.region,
+        credentials,
+        database: cfg.athenaDatabase,
+        table: cfg.athenaTable,
+        workgroup: cfg.athenaWorkgroup || undefined,
+        outputLocation: cfg.athenaOutputLocation || undefined,
+        s3Location: cfg.athenaS3Location,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.post({
+        type: "error",
+        message: `Saved settings, but couldn't auto-create the Athena table: ${msg}`,
+      });
+    }
   }
 
   private async onDownloadModel(): Promise<void> {
@@ -216,7 +275,9 @@ class ExplorerPanel {
         ? cfg.dynamodbTableName
         : cfg.destinationType === "aurora"
           ? cfg.auroraTable
-          : undefined;
+          : cfg.destinationType === "s3"
+            ? cfg.athenaTable
+            : undefined;
 
     this.post({ type: "status", text: "Generating query..." });
     let generated = await generateQuery({
@@ -282,6 +343,26 @@ class ExplorerPanel {
           });
           return;
         }
+        if (cfg.destinationType === "s3") {
+          if (!cfg.athenaDatabase) throw new Error("Athena not configured.");
+          assertReadOnly(generated.query, "Trino/Presto SQL");
+          const table = await runAthenaQuery({
+            region: cfg.region,
+            credentials,
+            database: cfg.athenaDatabase,
+            workgroup: cfg.athenaWorkgroup || undefined,
+            outputLocation: cfg.athenaOutputLocation || undefined,
+            query: generated.query,
+          });
+          this.post({
+            type: "results",
+            ...table,
+            explanation: generated.explanation,
+            suggestedCharts: generated.suggestedCharts,
+            finalQuery: generated.query,
+          });
+          return;
+        }
         // CloudWatch Logs path
         const finalQuery = ensureLimit(generated.query);
         const endTimeMs = Date.now();
@@ -306,7 +387,10 @@ class ExplorerPanel {
         const msg = err instanceof Error ? err.message : String(err);
         if (
           (msg.includes("MalformedQueryException") ||
-            msg.includes("ValidationException")) &&
+            msg.includes("ValidationException") ||
+            msg.includes("Athena query failed") ||
+            msg.includes("INVALID_") ||
+            msg.includes("SYNTAX_ERROR")) &&
           attempt < 2
         ) {
           this.post({

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -439,12 +439,15 @@ class ExplorerPanel {
             type: "status",
             text: "Query failed, asking Bedrock to fix...",
           });
+          const hint = msg.includes("COLUMN_NOT_FOUND")
+            ? "\n\nThis is likely because a field that lives inside input/output was referenced as a bare column instead of via json_extract_scalar(input, '$.path') / json_extract_scalar(output, '$.path') — check every column reference (including in GROUP BY/ORDER BY) against the schema's actual top-level columns."
+            : "";
           generated = await generateQuery({
             provider: cfg.llmProvider,
             region: cfg.region,
             credentials,
             modelId: cfg.bedrockModelId,
-            question: `${q}\n\nThe previous query failed with this error: ${msg}\nPlease fix the query.`,
+            question: `${q}\n\nThe previous query failed with this error: ${msg}${hint}\nPlease fix the query.`,
             destinationType: cfg.destinationType,
             tableName,
           });

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -1,13 +1,22 @@
 import * as vscode from "vscode";
 import { readConfig, resolveCredentials } from "./config";
 import { generateQuery, isModelDownloaded, ensureModel } from "./llm";
-import { runLogsInsightsQuery } from "./logsInsights";
-import { runDynamoDBQuery } from "./dynamodb";
-import { runAuroraQuery } from "./aurora";
-import { runAthenaQuery, ensureAthenaTable, tableExists } from "./athena";
+import { runLogsInsightsQuery, fetchLogsInsightsRecord } from "./logsInsights";
+import { runDynamoDBQuery, fetchDynamoDBRecord } from "./dynamodb";
+import { runAuroraQuery, fetchAuroraRecord } from "./aurora";
+import {
+  runAthenaQuery,
+  ensureAthenaTable,
+  tableExists,
+  fetchAthenaRecord,
+} from "./athena";
 import { listenToQueue, type SqsMessageRow } from "./sqs";
 import { ensureLimit } from "./schema";
 import { assertReadOnly } from "./queryValidator";
+import {
+  ensureIdentifierColumn,
+  resolveActualColumnCasing,
+} from "./queryShape";
 
 type InboundMessage =
   | { type: "ready" }
@@ -16,7 +25,8 @@ type InboundMessage =
   | { type: "downloadModel" }
   | { type: "exportChart"; format: "svg" | "png"; content: string }
   | { type: "startListening" }
-  | { type: "stopListening" };
+  | { type: "stopListening" }
+  | { type: "fetchDetail"; idColumn: string; idValue: string };
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -82,6 +92,8 @@ class ExplorerPanel {
           return this.onStartListening();
         case "stopListening":
           return this.onStopListening();
+        case "fetchDetail":
+          return await this.onFetchDetail(msg.idColumn, msg.idValue);
       }
     } catch (err) {
       this.post({
@@ -307,18 +319,24 @@ class ExplorerPanel {
           if (!cfg.dynamodbTableName)
             throw new Error("No DynamoDB table configured.");
           assertReadOnly(generated.query, "PartiQL");
+          const { query, idColumn } = ensureIdentifierColumn(
+            generated.query,
+            "pk",
+            "sql",
+          );
           const table = await runDynamoDBQuery({
             region: cfg.region,
             credentials,
             tableName: cfg.dynamodbTableName,
-            statement: generated.query,
+            statement: query,
           });
           this.post({
             type: "results",
             ...table,
             explanation: generated.explanation,
             suggestedCharts: generated.suggestedCharts,
-            finalQuery: generated.query,
+            finalQuery: query,
+            idColumn: resolveActualColumnCasing(idColumn, table.columns),
           });
           return;
         }
@@ -326,63 +344,87 @@ class ExplorerPanel {
           if (!cfg.auroraResourceArn || !cfg.auroraSecretArn)
             throw new Error("Aurora not configured.");
           assertReadOnly(generated.query, "PostgreSQL");
+          const { query, idColumn } = ensureIdentifierColumn(
+            generated.query,
+            "execution_arn",
+            "sql",
+          );
           const table = await runAuroraQuery({
             region: cfg.region,
             credentials,
             resourceArn: cfg.auroraResourceArn,
             secretArn: cfg.auroraSecretArn,
             database: cfg.auroraDatabase,
-            sql: generated.query,
+            sql: query,
           });
           this.post({
             type: "results",
             ...table,
             explanation: generated.explanation,
             suggestedCharts: generated.suggestedCharts,
-            finalQuery: generated.query,
+            finalQuery: query,
+            idColumn: resolveActualColumnCasing(idColumn, table.columns),
           });
           return;
         }
         if (cfg.destinationType === "s3") {
           if (!cfg.athenaDatabase) throw new Error("Athena not configured.");
           assertReadOnly(generated.query, "Trino/Presto SQL");
+          // The openx JSON SerDe lowercases all keys, so the identifier
+          // column the LLM's SQL would reference is "executionarn", not
+          // "executionArn" — match that here too (see schema.ts's Athena
+          // dialect notes on key casing).
+          const { query, idColumn } = ensureIdentifierColumn(
+            generated.query,
+            "executionarn",
+            "sql",
+          );
           const table = await runAthenaQuery({
             region: cfg.region,
             credentials,
             database: cfg.athenaDatabase,
             workgroup: cfg.athenaWorkgroup || undefined,
             outputLocation: cfg.athenaOutputLocation || undefined,
-            query: generated.query,
+            query,
           });
           this.post({
             type: "results",
             ...table,
             explanation: generated.explanation,
             suggestedCharts: generated.suggestedCharts,
-            finalQuery: generated.query,
+            finalQuery: query,
+            idColumn: resolveActualColumnCasing(idColumn, table.columns),
           });
           return;
         }
         // CloudWatch Logs path
-        const finalQuery = ensureLimit(generated.query);
-        const endTimeMs = Date.now();
-        const startTimeMs = endTimeMs - generated.timeRangeMs;
-        const table = await runLogsInsightsQuery({
-          region: cfg.region,
-          credentials,
-          logGroupNames: cfg.logGroupNames,
-          queryString: finalQuery,
-          startTimeMs,
-          endTimeMs,
-        });
-        this.post({
-          type: "results",
-          ...table,
-          explanation: generated.explanation,
-          suggestedCharts: generated.suggestedCharts,
-          finalQuery,
-        });
-        return;
+        {
+          const limited = ensureLimit(generated.query);
+          const { query: finalQuery, idColumn } = ensureIdentifierColumn(
+            limited,
+            "executionArn",
+            "logs-insights",
+          );
+          const endTimeMs = Date.now();
+          const startTimeMs = endTimeMs - generated.timeRangeMs;
+          const table = await runLogsInsightsQuery({
+            region: cfg.region,
+            credentials,
+            logGroupNames: cfg.logGroupNames,
+            queryString: finalQuery,
+            startTimeMs,
+            endTimeMs,
+          });
+          this.post({
+            type: "results",
+            ...table,
+            explanation: generated.explanation,
+            suggestedCharts: generated.suggestedCharts,
+            finalQuery,
+            idColumn: resolveActualColumnCasing(idColumn, table.columns),
+          });
+          return;
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (
@@ -410,6 +452,75 @@ class ExplorerPanel {
         }
         throw err;
       }
+    }
+  }
+
+  /**
+   * Fetch the full record for a single row, keyed by the identifier column
+   * ensureIdentifierColumn added to the query (idColumn/idValue from the
+   * webview's row-click). Dispatches to the destination-appropriate
+   * point-lookup. Aggregate query results never carry an idColumn (see
+   * queryShape.ts), so the webview never sends this message for those —
+   * this handler doesn't need to re-check that.
+   */
+  private async onFetchDetail(
+    idColumn: string,
+    idValue: string,
+  ): Promise<void> {
+    const cfg = readConfig();
+    const credentials = resolveCredentials(cfg.awsProfile);
+    try {
+      let record: Record<string, string> | undefined;
+      if (cfg.destinationType === "dynamodb") {
+        record = await fetchDynamoDBRecord({
+          region: cfg.region,
+          credentials,
+          tableName: cfg.dynamodbTableName,
+          pk: idValue,
+        });
+      } else if (cfg.destinationType === "aurora") {
+        record = await fetchAuroraRecord({
+          region: cfg.region,
+          credentials,
+          resourceArn: cfg.auroraResourceArn,
+          secretArn: cfg.auroraSecretArn,
+          database: cfg.auroraDatabase,
+          table: cfg.auroraTable,
+          executionArn: idValue,
+        });
+      } else if (cfg.destinationType === "s3") {
+        record = await fetchAthenaRecord({
+          region: cfg.region,
+          credentials,
+          database: cfg.athenaDatabase,
+          table: cfg.athenaTable,
+          workgroup: cfg.athenaWorkgroup || undefined,
+          outputLocation: cfg.athenaOutputLocation || undefined,
+          executionArn: idValue,
+        });
+      } else {
+        record = await fetchLogsInsightsRecord({
+          region: cfg.region,
+          credentials,
+          logGroupNames: cfg.logGroupNames,
+          executionArn: idValue,
+        });
+      }
+
+      if (!record) {
+        this.post({
+          type: "error",
+          message: `Couldn't find a record for ${idColumn} = ${idValue}.`,
+        });
+        return;
+      }
+      this.post({ type: "detailResult", fields: record });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.post({
+        type: "error",
+        message: `Failed to fetch record detail: ${msg}`,
+      });
     }
   }
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -26,7 +26,14 @@ type InboundMessage =
   | { type: "exportChart"; format: "svg" | "png"; content: string }
   | { type: "startListening" }
   | { type: "stopListening" }
-  | { type: "fetchDetail"; idColumn: string; idValue: string };
+  | {
+      type: "fetchDetail";
+      idColumn: string;
+      idValue: string;
+      year?: string;
+      month?: string;
+      day?: string;
+    };
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
@@ -93,7 +100,13 @@ class ExplorerPanel {
         case "stopListening":
           return this.onStopListening();
         case "fetchDetail":
-          return await this.onFetchDetail(msg.idColumn, msg.idValue);
+          return await this.onFetchDetail(
+            msg.idColumn,
+            msg.idValue,
+            msg.year,
+            msg.month,
+            msg.day,
+          );
       }
     } catch (err) {
       this.post({
@@ -373,11 +386,15 @@ class ExplorerPanel {
           // The openx JSON SerDe lowercases all keys, so the identifier
           // column the LLM's SQL would reference is "executionarn", not
           // "executionArn" — match that here too (see schema.ts's Athena
-          // dialect notes on key casing).
+          // dialect notes on key casing). Also carry the year/month/day
+          // partition columns through so the row-detail fetch can prune to
+          // one partition instead of scanning the whole table (see
+          // fetchAthenaRecord's doc comment).
           const { query, idColumn } = ensureIdentifierColumn(
             generated.query,
             "executionarn",
             "sql",
+            ["year", "month", "day"],
           );
           const table = await runAthenaQuery({
             region: cfg.region,
@@ -394,6 +411,11 @@ class ExplorerPanel {
             suggestedCharts: generated.suggestedCharts,
             finalQuery: query,
             idColumn: resolveActualColumnCasing(idColumn, table.columns),
+            partitionColumns: {
+              year: resolveActualColumnCasing("year", table.columns),
+              month: resolveActualColumnCasing("month", table.columns),
+              day: resolveActualColumnCasing("day", table.columns),
+            },
           });
           return;
         }
@@ -469,6 +491,9 @@ class ExplorerPanel {
   private async onFetchDetail(
     idColumn: string,
     idValue: string,
+    year?: string,
+    month?: string,
+    day?: string,
   ): Promise<void> {
     const cfg = readConfig();
     const credentials = resolveCredentials(cfg.awsProfile);
@@ -500,6 +525,9 @@ class ExplorerPanel {
           workgroup: cfg.athenaWorkgroup || undefined,
           outputLocation: cfg.athenaOutputLocation || undefined,
           executionArn: idValue,
+          year,
+          month,
+          day,
         });
       } else {
         record = await fetchLogsInsightsRecord({

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -16,6 +16,7 @@ import { assertReadOnly } from "./queryValidator";
 import {
   ensureIdentifierColumn,
   resolveActualColumnCasing,
+  resolveActualColumns,
 } from "./queryShape";
 
 type InboundMessage =
@@ -332,7 +333,7 @@ class ExplorerPanel {
           if (!cfg.dynamodbTableName)
             throw new Error("No DynamoDB table configured.");
           assertReadOnly(generated.query, "PartiQL");
-          const { query, idColumn } = ensureIdentifierColumn(
+          const { query, idColumn, injectedColumns } = ensureIdentifierColumn(
             generated.query,
             "pk",
             "sql",
@@ -350,6 +351,7 @@ class ExplorerPanel {
             suggestedCharts: generated.suggestedCharts,
             finalQuery: query,
             idColumn: resolveActualColumnCasing(idColumn, table.columns),
+            hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
           });
           return;
         }
@@ -357,7 +359,7 @@ class ExplorerPanel {
           if (!cfg.auroraResourceArn || !cfg.auroraSecretArn)
             throw new Error("Aurora not configured.");
           assertReadOnly(generated.query, "PostgreSQL");
-          const { query, idColumn } = ensureIdentifierColumn(
+          const { query, idColumn, injectedColumns } = ensureIdentifierColumn(
             generated.query,
             "execution_arn",
             "sql",
@@ -377,6 +379,7 @@ class ExplorerPanel {
             suggestedCharts: generated.suggestedCharts,
             finalQuery: query,
             idColumn: resolveActualColumnCasing(idColumn, table.columns),
+            hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
           });
           return;
         }
@@ -390,7 +393,7 @@ class ExplorerPanel {
           // partition columns through so the row-detail fetch can prune to
           // one partition instead of scanning the whole table (see
           // fetchAthenaRecord's doc comment).
-          const { query, idColumn } = ensureIdentifierColumn(
+          const { query, idColumn, injectedColumns } = ensureIdentifierColumn(
             generated.query,
             "executionarn",
             "sql",
@@ -416,17 +419,18 @@ class ExplorerPanel {
               month: resolveActualColumnCasing("month", table.columns),
               day: resolveActualColumnCasing("day", table.columns),
             },
+            hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
           });
           return;
         }
         // CloudWatch Logs path
         {
           const limited = ensureLimit(generated.query);
-          const { query: finalQuery, idColumn } = ensureIdentifierColumn(
-            limited,
-            "executionArn",
-            "logs-insights",
-          );
+          const {
+            query: finalQuery,
+            idColumn,
+            injectedColumns,
+          } = ensureIdentifierColumn(limited, "executionArn", "logs-insights");
           const endTimeMs = Date.now();
           const startTimeMs = endTimeMs - generated.timeRangeMs;
           const table = await runLogsInsightsQuery({
@@ -444,6 +448,7 @@ class ExplorerPanel {
             suggestedCharts: generated.suggestedCharts,
             finalQuery,
             idColumn: resolveActualColumnCasing(idColumn, table.columns),
+            hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
           });
           return;
         }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.test.ts
@@ -1,0 +1,50 @@
+import { escapeQuotedString, escapeRegex } from "./logsInsights";
+
+describe("escapeQuotedString", () => {
+  it("leaves an ordinary execution ARN unchanged", () => {
+    const arn =
+      "arn:aws:lambda:us-east-1:123456789012:function:my-fn:$LATEST/exec-abc123";
+    expect(escapeQuotedString(arn)).toBe(arn);
+  });
+
+  it("escapes a double quote", () => {
+    expect(escapeQuotedString('a"b')).toBe('a\\"b');
+  });
+
+  it("escapes a backslash", () => {
+    expect(escapeQuotedString("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes a trailing backslash so it cannot escape the closing quote (the CodeQL bug)", () => {
+    // Naive quote-only escaping left this as "trailing\\" — a lone trailing
+    // backslash that, embedded in `filter x = "trailing\"`, would escape the
+    // closing quote and break out of the string literal.
+    expect(escapeQuotedString("trailing\\")).toBe("trailing\\\\");
+  });
+
+  it("escapes backslashes before quotes (order matters, no double-escaping)", () => {
+    // Input: backslash then quote. Backslash-first yields \\ then \" — i.e.
+    // a literal backslash followed by an escaped quote, not a mangled \\\".
+    expect(escapeQuotedString('\\"')).toBe('\\\\\\"');
+  });
+
+  it("produces a fully-balanced literal for a value packed with metacharacters", () => {
+    const embedded = `"${escapeQuotedString('x"\\y')}"`;
+    // The escaped value, wrapped in quotes, is a single well-formed literal:
+    // opening quote, x, escaped quote, escaped backslash, y, closing quote.
+    expect(embedded).toBe('"x\\"\\\\y"');
+  });
+});
+
+describe("escapeRegex", () => {
+  it("escapes regex metacharacters including backslash", () => {
+    expect(escapeRegex("a.b*c\\d")).toBe("a\\.b\\*c\\\\d");
+  });
+
+  it("leaves a plain ARN substring unescaped except for its metacharacters", () => {
+    // ':' and '/' are not regex metacharacters, so they pass through.
+    expect(escapeRegex("arn:aws:lambda:exec/abc")).toBe(
+      "arn:aws:lambda:exec/abc",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.ts
@@ -110,3 +110,90 @@ function normalize(
     recordsScanned: statistics?.recordsScanned,
   };
 }
+
+/**
+ * Fetch a single full record by executionArn, for the row-detail
+ * drill-down. Logs Insights has no point-lookup API — this runs an ordinary
+ * (but narrowly filtered) query over a generous lookback window, since a
+ * click can target a record from any time range the original query covered.
+ * Slower than the other destinations' point lookups (a fresh Logs Insights
+ * query, not a cheap keyed read), but still just a few seconds.
+ *
+ * Handles both destination formats this module's queries can target:
+ * "direct" (CloudWatchLogsExporter, raw JSON fields) and "nested"
+ * (LambdaLogExporter, JSON string in a `message` field) — tries a
+ * field-based match first, then a message-substring match.
+ */
+export async function fetchLogsInsightsRecord(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  logGroupNames: string[];
+  executionArn: string;
+  lookbackMs?: number;
+}): Promise<Record<string, string> | undefined> {
+  const escaped = opts.executionArn.replace(/"/g, '\\"');
+  const endTimeMs = Date.now();
+  const startTimeMs = endTimeMs - (opts.lookbackMs ?? 7 * 24 * 60 * 60 * 1000);
+
+  // Try the "direct" shape first: executionArn is a top-level field.
+  const direct = await runLogsInsightsQuery({
+    region: opts.region,
+    credentials: opts.credentials,
+    logGroupNames: opts.logGroupNames,
+    queryString: `filter executionArn = "${escaped}" | fields @message | sort @timestamp desc | limit 1`,
+    startTimeMs,
+    endTimeMs,
+  }).catch(() => undefined);
+
+  const directMessage = direct?.rows[0]?.[direct.columns.indexOf("@message")];
+  if (directMessage) {
+    const parsed = tryParseRecord(directMessage);
+    if (parsed) return parsed;
+  }
+
+  // Fall back to the "nested" shape: executionArn is inside a JSON string in
+  // the `message` field (LambdaLogExporter's envelope).
+  const nested = await runLogsInsightsQuery({
+    region: opts.region,
+    credentials: opts.credentials,
+    logGroupNames: opts.logGroupNames,
+    queryString: `filter message like /${escapeRegex(opts.executionArn)}/ | fields @message | sort @timestamp desc | limit 1`,
+    startTimeMs,
+    endTimeMs,
+  }).catch(() => undefined);
+
+  const nestedMessage = nested?.rows[0]?.[nested.columns.indexOf("@message")];
+  if (nestedMessage) {
+    // The envelope's `message` field is itself a JSON-serialized
+    // WorkflowInsightRecord string, one level deeper than @message here.
+    const outer = tryParseRecord(nestedMessage);
+    if (outer && typeof outer.message === "string") {
+      const inner = tryParseRecord(outer.message);
+      if (inner) return inner;
+    }
+    if (outer) return outer;
+  }
+
+  return undefined;
+}
+
+function tryParseRecord(raw: string): Record<string, string> | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const record: Record<string, string> = {};
+    for (const [key, val] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (val == null) continue;
+      record[key] = typeof val === "object" ? JSON.stringify(val) : String(val);
+    }
+    return record;
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/logsInsights.ts
@@ -131,7 +131,10 @@ export async function fetchLogsInsightsRecord(opts: {
   executionArn: string;
   lookbackMs?: number;
 }): Promise<Record<string, string> | undefined> {
-  const escaped = opts.executionArn.replace(/"/g, '\\"');
+  // Escape for embedding in a double-quoted Logs Insights string literal.
+  // See escapeQuotedString for why the order (backslashes before quotes)
+  // matters — CodeQL flags the naive quote-only escape as incomplete.
+  const escaped = escapeQuotedString(opts.executionArn);
   const endTimeMs = Date.now();
   const startTimeMs = endTimeMs - (opts.lookbackMs ?? 7 * 24 * 60 * 60 * 1000);
 
@@ -194,6 +197,22 @@ function tryParseRecord(raw: string): Record<string, string> | undefined {
   }
 }
 
-function escapeRegex(s: string): string {
+/**
+ * Escape a string for safe embedding inside a double-quoted CloudWatch Logs
+ * Insights string literal (e.g. `filter field = "<here>"`).
+ *
+ * Order is critical: backslashes are escaped FIRST, then double quotes. If
+ * quotes were escaped first, the backslash added in front of each quote
+ * would then be doubled by the backslash pass, corrupting the output; and
+ * escaping only quotes (the naive approach CodeQL flags as "incomplete
+ * string escaping") leaves any backslash already in the input unescaped —
+ * a trailing `\` would escape the closing quote and let the value break out
+ * of the string literal.
+ */
+export function escapeQuotedString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.test.ts
@@ -1,0 +1,306 @@
+import {
+  isAggregateQuery,
+  ensureIdentifierColumn,
+  resolveActualColumnCasing,
+  resolveActualColumns,
+} from "./queryShape";
+
+describe("isAggregateQuery", () => {
+  it("detects COUNT(*) as aggregate", () => {
+    expect(isAggregateQuery("SELECT COUNT(*) FROM t", "sql")).toBe(true);
+  });
+
+  it("detects GROUP BY as aggregate", () => {
+    expect(
+      isAggregateQuery(
+        "SELECT status, COUNT(*) AS ct FROM t GROUP BY status",
+        "sql",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects bare SUM/AVG/MIN/MAX without GROUP BY as aggregate", () => {
+    expect(isAggregateQuery("SELECT SUM(durationMs) FROM t", "sql")).toBe(true);
+    expect(isAggregateQuery("SELECT AVG(durationMs) FROM t", "sql")).toBe(true);
+    expect(isAggregateQuery("SELECT MIN(durationMs) FROM t", "sql")).toBe(true);
+    expect(isAggregateQuery("SELECT MAX(durationMs) FROM t", "sql")).toBe(true);
+  });
+
+  it("does not flag a plain row-level SELECT", () => {
+    expect(
+      isAggregateQuery("SELECT executionArn, status FROM t LIMIT 10", "sql"),
+    ).toBe(false);
+  });
+
+  it("detects Logs Insights 'stats' as aggregate", () => {
+    expect(
+      isAggregateQuery(
+        'filter status = "FAILED" | stats count(*) as ct',
+        "logs-insights",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a plain Logs Insights query without stats", () => {
+    expect(
+      isAggregateQuery(
+        'filter status = "FAILED" | fields @timestamp, executionArn | limit 50',
+        "logs-insights",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("ensureIdentifierColumn: aggregate/set-operator bail-out", () => {
+  it("does not inject into an aggregate query", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT COUNT(*) FROM t",
+      "executionArn",
+      "sql",
+    );
+    expect(result).toEqual({ query: "SELECT COUNT(*) FROM t" });
+  });
+
+  it("does not inject into a GROUP BY query even with other columns selected", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT function_name, AVG(duration_ms) AS avg_ms FROM t GROUP BY function_name",
+      "execution_arn",
+      "sql",
+    );
+    expect(result).toEqual({
+      query:
+        "SELECT function_name, AVG(duration_ms) AS avg_ms FROM t GROUP BY function_name",
+    });
+  });
+
+  it("does not inject into a top-level UNION (would corrupt column counts across branches)", () => {
+    const query = "SELECT a FROM t UNION SELECT b FROM t";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    expect(result).toEqual({ query });
+  });
+
+  it("does not inject into a top-level UNION ALL", () => {
+    const query =
+      "SELECT executionArn FROM t WHERE status='FAILED' UNION ALL SELECT executionArn FROM t WHERE status='SUCCEEDED'";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    expect(result).toEqual({ query });
+  });
+
+  it("does not inject into a top-level INTERSECT", () => {
+    const query =
+      "SELECT executionArn FROM t INTERSECT SELECT executionArn FROM t2";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    expect(result).toEqual({ query });
+  });
+
+  it("does not inject into a top-level EXCEPT", () => {
+    const query =
+      "SELECT executionArn FROM t EXCEPT SELECT executionArn FROM t2";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    expect(result).toEqual({ query });
+  });
+
+  it("does not false-positive on a string literal containing 'union'", () => {
+    const query =
+      "SELECT executionArn, status FROM t WHERE functionName = 'union-processor' LIMIT 10";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    // executionArn is already present, so nothing should be injected at all,
+    // and the query must come back byte-for-byte unchanged (no corruption
+    // from misreading "union" inside the string literal as a set operator).
+    expect(result.query).toBe(query);
+    expect(result.idColumn).toBe("executionArn");
+    expect(result.injectedColumns).toEqual([]);
+  });
+
+  it("a UNION strictly inside a subquery does not block injection into the outer query", () => {
+    const query =
+      "SELECT status, val FROM (SELECT status, val FROM t WHERE a=1 UNION ALL SELECT status, val FROM t WHERE a=2) x LIMIT 10";
+    const result = ensureIdentifierColumn(query, "executionArn", "sql");
+    expect(result.query).toBe(
+      "SELECT status, val, executionArn FROM (SELECT status, val FROM t WHERE a=1 UNION ALL SELECT status, val FROM t WHERE a=2) x LIMIT 10",
+    );
+    expect(result.idColumn).toBe("executionArn");
+    expect(result.injectedColumns).toEqual(["executionArn"]);
+  });
+});
+
+describe("ensureIdentifierColumn: SQL injection", () => {
+  it("injects a missing identifier column", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT functionName, status, emittedAt FROM workflow_insight LIMIT 10",
+      "executionarn",
+      "sql",
+    );
+    expect(result).toEqual({
+      query:
+        "SELECT functionName, status, emittedAt, executionarn FROM workflow_insight LIMIT 10",
+      idColumn: "executionarn",
+      extraColumns: [],
+      injectedColumns: ["executionarn"],
+    });
+  });
+
+  it("does not duplicate an identifier already present under a different case (SQL identifiers are case-insensitive)", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT executionArn, functionName, status, emittedAt FROM workflow_insight LIMIT 10",
+      "executionarn",
+      "sql",
+    );
+    expect(result).toEqual({
+      query:
+        "SELECT executionArn, functionName, status, emittedAt FROM workflow_insight LIMIT 10",
+      idColumn: "executionarn",
+      extraColumns: [],
+      injectedColumns: [],
+    });
+  });
+
+  it("SELECT * already includes everything — no injection needed", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT * FROM t WHERE status = 'FAILED'",
+      "pk",
+      "sql",
+    );
+    expect(result).toEqual({
+      query: "SELECT * FROM t WHERE status = 'FAILED'",
+      idColumn: "pk",
+      extraColumns: [],
+      injectedColumns: [],
+    });
+  });
+
+  it("injects into the outer/final SELECT of a WITH-CTE query, not the CTE's inner one", () => {
+    const result = ensureIdentifierColumn(
+      "WITH recent AS (SELECT * FROM t) SELECT status, functionName FROM recent LIMIT 10",
+      "executionArn",
+      "sql",
+    );
+    expect(result).toEqual({
+      query:
+        "WITH recent AS (SELECT * FROM t) SELECT status, functionName, executionArn FROM recent LIMIT 10",
+      idColumn: "executionArn",
+      extraColumns: [],
+      injectedColumns: ["executionArn"],
+    });
+  });
+
+  it("injects multiple extraColumns alongside idColumn (S3+Athena's year/month/day case)", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT functionName, status FROM t LIMIT 10",
+      "executionarn",
+      "sql",
+      ["year", "month", "day"],
+    );
+    expect(result.query).toBe(
+      "SELECT functionName, status, executionarn, year, month, day FROM t LIMIT 10",
+    );
+    expect(result.injectedColumns).toEqual([
+      "executionarn",
+      "year",
+      "month",
+      "day",
+    ]);
+  });
+
+  it("does not report a column as injected if the user's own query already selected it", () => {
+    const result = ensureIdentifierColumn(
+      "SELECT functionName, year FROM t LIMIT 10",
+      "executionarn",
+      "sql",
+      ["year", "month", "day"],
+    );
+    // year is already present (user asked for it) — only executionarn/month/day are injected.
+    expect(result.injectedColumns).toEqual(["executionarn", "month", "day"]);
+    // year appears exactly once in the resulting query (not duplicated).
+    expect(result.query.match(/\byear\b/gi)).toHaveLength(1);
+  });
+});
+
+describe("ensureIdentifierColumn: Logs Insights injection", () => {
+  it("no 'fields' command means every field is already included — nothing to inject", () => {
+    const result = ensureIdentifierColumn(
+      'filter status = "FAILED" | sort @timestamp desc | limit 50',
+      "executionArn",
+      "logs-insights",
+    );
+    expect(result).toEqual({
+      query: 'filter status = "FAILED" | sort @timestamp desc | limit 50',
+      idColumn: "executionArn",
+      extraColumns: [],
+      injectedColumns: [],
+    });
+  });
+
+  it("injects into an existing 'fields' command's field list", () => {
+    const result = ensureIdentifierColumn(
+      'filter status = "FAILED" | fields @timestamp, functionName | sort @timestamp desc | limit 50',
+      "executionArn",
+      "logs-insights",
+    );
+    expect(result.query).toBe(
+      'filter status = "FAILED" | fields @timestamp, functionName, executionArn | sort @timestamp desc | limit 50',
+    );
+    expect(result.injectedColumns).toEqual(["executionArn"]);
+  });
+
+  it("does not duplicate an identifier already in the 'fields' list", () => {
+    const result = ensureIdentifierColumn(
+      'filter status = "FAILED" | fields @timestamp, executionArn | limit 50',
+      "executionArn",
+      "logs-insights",
+    );
+    expect(result.query).toBe(
+      'filter status = "FAILED" | fields @timestamp, executionArn | limit 50',
+    );
+    expect(result.injectedColumns).toEqual([]);
+  });
+
+  it("does not inject into a 'stats' aggregate query", () => {
+    const query =
+      'filter recordType = "WorkflowInsight" | stats count(*) as ct by status';
+    const result = ensureIdentifierColumn(
+      query,
+      "executionArn",
+      "logs-insights",
+    );
+    expect(result).toEqual({ query });
+  });
+});
+
+describe("resolveActualColumnCasing", () => {
+  it("resolves a requested column to its actual casing in the result set", () => {
+    expect(
+      resolveActualColumnCasing("executionarn", [
+        "executionArn",
+        "functionName",
+        "status",
+      ]),
+    ).toBe("executionArn");
+  });
+
+  it("returns undefined when the column genuinely isn't present", () => {
+    expect(
+      resolveActualColumnCasing("executionarn", ["status", "functionName"]),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when idColumn itself is undefined", () => {
+    expect(resolveActualColumnCasing(undefined, ["status"])).toBeUndefined();
+  });
+});
+
+describe("resolveActualColumns", () => {
+  it("resolves each requested column to its actual casing, dropping ones not present", () => {
+    expect(
+      resolveActualColumns(
+        ["year", "month", "day", "notpresent"],
+        ["executionArn", "year", "month", "day"],
+      ),
+    ).toEqual(["year", "month", "day"]);
+  });
+
+  it("returns an empty array for an empty or undefined input", () => {
+    expect(resolveActualColumns([], ["a", "b"])).toEqual([]);
+    expect(resolveActualColumns(undefined, ["a", "b"])).toEqual([]);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
@@ -61,6 +61,19 @@ export interface IdentifierInjectionResult {
    * every partition on every row click.
    */
   extraColumns?: string[];
+  /**
+   * Which columns (idColumn and/or entries from extraColumns) were actually
+   * newly added to the query's SELECT/fields list, as opposed to already
+   * being present because the user's own question happened to ask for them.
+   * A UI can use this to hide only the columns it injected purely for
+   * fetch/pruning purposes (noise the user never asked to see) while still
+   * showing a column the user's question genuinely selected, even if it
+   * happens to share a name with idColumn/extraColumns. Always a subset of
+   * [idColumn, ...extraColumns].filter(Boolean); empty when nothing needed
+   * adding (everything requested was already in the query) or when
+   * injection was skipped entirely (aggregate/set-operator query).
+   */
+  injectedColumns?: string[];
 }
 
 /**
@@ -99,14 +112,24 @@ export function ensureIdentifierColumn(
     // default, so everything is already present — nothing to inject.
     const fieldsMatch = trimmed.match(/\|\s*fields\s+([^|]+)/i);
     if (!fieldsMatch) {
-      return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+      return {
+        query: trimmed,
+        idColumn,
+        extraColumns: [...extraColumns],
+        injectedColumns: [],
+      };
     }
     const present = fieldsMatch[1].split(",").map((f) => f.trim());
     const toAdd = [idColumn, ...extraColumns].filter(
       (c) => !present.includes(c),
     );
     if (toAdd.length === 0) {
-      return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+      return {
+        query: trimmed,
+        idColumn,
+        extraColumns: [...extraColumns],
+        injectedColumns: [],
+      };
     }
     // Trim trailing whitespace from the matched field list before appending,
     // so injection doesn't leave "fieldA, fieldB idColumn" (missing comma) or
@@ -119,7 +142,12 @@ export function ensureIdentifierColumn(
       fieldsMatch[0],
       `${trimmedFieldsMatch}, ${toAdd.join(", ")}${trailingWhitespace}`,
     );
-    return { query: injected, idColumn, extraColumns: [...extraColumns] };
+    return {
+      query: injected,
+      idColumn,
+      extraColumns: [...extraColumns],
+      injectedColumns: toAdd,
+    };
   }
 
   // SQL dialects (PartiQL, PostgreSQL, Trino/Presto): only handle a single
@@ -141,7 +169,12 @@ export function ensureIdentifierColumn(
     /\*\s*,|\bselect\s+\*/i.test(columnList)
   ) {
     // SELECT * already includes every column, including the identifier.
-    return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+    return {
+      query: trimmed,
+      idColumn,
+      extraColumns: [...extraColumns],
+      injectedColumns: [],
+    };
   }
 
   const columns = splitTopLevel(columnList);
@@ -149,11 +182,21 @@ export function ensureIdentifierColumn(
     (c) => !columns.some((existing) => referencesColumn(existing, c)),
   );
   if (toAdd.length === 0) {
-    return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+    return {
+      query: trimmed,
+      idColumn,
+      extraColumns: [...extraColumns],
+      injectedColumns: [],
+    };
   }
 
   const injected = `${prefix}${columnList}, ${toAdd.join(", ")}${fromKeyword}${rest}`;
-  return { query: injected, idColumn, extraColumns: [...extraColumns] };
+  return {
+    query: injected,
+    idColumn,
+    extraColumns: [...extraColumns],
+    injectedColumns: toAdd,
+  };
 }
 
 /**
@@ -322,4 +365,21 @@ export function resolveActualColumnCasing(
   if (!idColumn) return undefined;
   const idLower = idColumn.toLowerCase();
   return columns.find((c) => c.toLowerCase() === idLower);
+}
+
+/**
+ * Array counterpart of `resolveActualColumnCasing`, for reporting which
+ * injected columns (see `IdentifierInjectionResult.injectedColumns`) to
+ * hide from a rendered results table. Resolves each requested column to its
+ * actual casing in `columns` (dropping any that genuinely aren't present),
+ * the same case-insensitive-match reasoning as the singular version.
+ */
+export function resolveActualColumns(
+  requested: string[] | undefined,
+  columns: string[],
+): string[] {
+  if (!requested || requested.length === 0) return [];
+  return requested
+    .map((c) => resolveActualColumnCasing(c, columns))
+    .filter((c): c is string => c != null);
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
@@ -1,0 +1,237 @@
+/**
+ * Detects whether a generated query is row-level (one result row = one
+ * execution, so a stable identifier column can be added for drill-down) or
+ * an aggregate/summary query (GROUP BY, bare COUNT/SUM/AVG/MIN/MAX with no
+ * grouping — e.g. "how many executions failed") where there is no single
+ * execution a result row corresponds to, so injecting an identifier column
+ * would be meaningless (or, for some engines, outright invalid SQL).
+ *
+ * This directly answers the question a customer asked while building this
+ * feature: "what if it's not possible at all, like 'show me the count of
+ * executions in the past 3 hours'?" — aggregate queries are detected here so
+ * the identifier-injection and row-detail drill-down are skipped entirely
+ * for them, rather than trying to force an impossible per-row identity onto
+ * a single summary row.
+ */
+
+const GROUP_BY_RE = /\bgroup\s+by\b/i;
+// Bare aggregate function calls: COUNT(, SUM(, AVG(, MIN(, MAX(. This alone
+// (without GROUP BY) also collapses all matching rows into one summary row
+// for that column (e.g. "SELECT COUNT(*) FROM ..." -> exactly one row, not
+// one row per execution), so it's just as disqualifying as GROUP BY.
+const AGGREGATE_FN_RE = /\b(?:count|sum|avg|min|max)\s*\(/i;
+// CloudWatch Logs Insights uses a pipe-based `stats` command instead of SQL
+// aggregate functions/GROUP BY.
+const LOGS_INSIGHTS_STATS_RE = /\|\s*stats\b/i;
+
+export function isAggregateQuery(
+  query: string,
+  dialect: "sql" | "logs-insights",
+): boolean {
+  if (dialect === "logs-insights") {
+    return LOGS_INSIGHTS_STATS_RE.test(query);
+  }
+  return GROUP_BY_RE.test(query) || AGGREGATE_FN_RE.test(query);
+}
+
+export interface IdentifierInjectionResult {
+  query: string;
+  /** The column the row's identifier will appear under in the result set, or undefined if no identifier could be added (aggregate query, or dialect-specific reasons). */
+  idColumn?: string;
+}
+
+/**
+ * If `query` is row-level (not aggregate), ensures its SELECT list includes
+ * `idColumn` (adding it if missing) so every result row carries a stable
+ * identifier the UI can use to fetch the full record on demand. No-op for
+ * aggregate queries — returns the query unchanged with no idColumn.
+ *
+ * This is deliberately conservative: it only handles the common
+ * `SELECT <list> FROM ...` shape (optionally preceded by a `WITH` CTE clause,
+ * which passes through untouched since only the final SELECT's column list
+ * matters for the result shape). If the shape isn't recognized, it leaves the
+ * query untouched and reports no idColumn rather than risk producing invalid
+ * SQL — the UI simply won't offer row-level drill-down for that result set.
+ */
+export function ensureIdentifierColumn(
+  query: string,
+  idColumn: string,
+  dialect: "sql" | "logs-insights",
+): IdentifierInjectionResult {
+  const trimmed = query.trim();
+
+  if (dialect === "logs-insights") {
+    if (isAggregateQuery(trimmed, dialect)) return { query: trimmed };
+    // Logs Insights: a `fields` command explicitly lists output fields; if
+    // present, make sure idColumn is one of them. If there's no `fields`
+    // command, every field is already included by default, so idColumn is
+    // already present — nothing to inject.
+    const fieldsMatch = trimmed.match(/\|\s*fields\s+([^|]+)/i);
+    if (!fieldsMatch) return { query: trimmed, idColumn };
+    const fieldList = fieldsMatch[1];
+    const alreadyPresent = fieldList
+      .split(",")
+      .map((f) => f.trim())
+      .includes(idColumn);
+    if (alreadyPresent) return { query: trimmed, idColumn };
+    // Trim trailing whitespace from the matched field list before appending,
+    // so injection doesn't leave "fieldA, fieldB idColumn" (missing comma) or
+    // "fieldA, fieldBidColumn|" (missing space before the next pipe) — the
+    // match's trailing whitespace (if the fields command is directly
+    // followed by " |") is preserved separately in `rest` further down.
+    const trimmedFieldsMatch = fieldsMatch[0].replace(/\s+$/, "");
+    const trailingWhitespace = fieldsMatch[0].slice(trimmedFieldsMatch.length);
+    const injected = trimmed.replace(
+      fieldsMatch[0],
+      `${trimmedFieldsMatch}, ${idColumn}${trailingWhitespace}`,
+    );
+    return { query: injected, idColumn };
+  }
+
+  // SQL dialects (PartiQL, PostgreSQL, Trino/Presto): only handle a single
+  // top-level SELECT list. Bail out (no injection) for anything containing
+  // `SELECT *`, since idColumn is necessarily already included, or for
+  // shapes this simple parser can't confidently rewrite (subqueries in the
+  // FROM clause, UNION, etc.) — better to skip drill-down than corrupt SQL.
+  if (isAggregateQuery(trimmed, dialect)) return { query: trimmed };
+
+  const outer = findOuterSelect(trimmed);
+  if (!outer) return { query: trimmed };
+  const { prefix, columnList, fromKeyword, rest } = outer;
+
+  if (
+    /^\s*\*\s*$/.test(columnList) ||
+    /\*\s*,|\bselect\s+\*/i.test(columnList)
+  ) {
+    // SELECT * already includes every column, including the identifier.
+    return { query: trimmed, idColumn };
+  }
+
+  const columns = splitTopLevel(columnList);
+  const alreadyPresent = columns.some((c) => referencesColumn(c, idColumn));
+  if (alreadyPresent) return { query: trimmed, idColumn };
+
+  const injected = `${prefix}${columnList}, ${idColumn}${fromKeyword}${rest}`;
+  return { query: injected, idColumn };
+}
+
+/**
+ * Finds the outermost SELECT's column list — i.e. the LAST top-level (not
+ * inside parens) `SELECT ... FROM` in the query. This is deliberately "last"
+ * rather than "first": a `WITH cte AS (SELECT ...) SELECT ... FROM cte`
+ * shape has its real result-shaping SELECT after the CTE(s), and matching
+ * the first SELECT would rewrite the CTE's inner list instead — corrupting
+ * the CTE but leaving the actual output column list (and thus the row
+ * shape the UI sees) untouched.
+ */
+function findOuterSelect(
+  query: string,
+):
+  | { prefix: string; columnList: string; fromKeyword: string; rest: string }
+  | undefined {
+  let depth = 0;
+  let inString: string | null = null;
+  let lastSelectIndex = -1;
+
+  for (let i = 0; i < query.length; i++) {
+    const ch = query[i];
+    if (inString) {
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      inString = ch;
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (depth === 0 && /select/i.test(query.slice(i, i + 6))) {
+      // Word-boundary check so this doesn't match inside e.g. "reselect".
+      const before = query[i - 1];
+      const after = query[i + 6];
+      if ((!before || /\W/.test(before)) && (!after || /\W/.test(after))) {
+        lastSelectIndex = i;
+      }
+    }
+  }
+
+  if (lastSelectIndex === -1) return undefined;
+
+  const afterSelect = query.slice(lastSelectIndex + 6);
+  const fromMatch = afterSelect.match(/^([\s\S]*?)(\s+from\s)/i);
+  if (!fromMatch) return undefined;
+
+  const prefix = query.slice(0, lastSelectIndex + 6) + " ";
+  const columnList = fromMatch[1].trim();
+  const fromKeyword = fromMatch[2];
+  const rest = afterSelect.slice(fromMatch[0].length);
+  return { prefix, columnList, fromKeyword, rest };
+}
+
+/** Splits a SELECT column list on top-level commas (ignoring commas inside parens/quotes). */
+function splitTopLevel(columnList: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  let inString: string | null = null;
+  for (const ch of columnList) {
+    if (inString) {
+      current += ch;
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      inString = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "(") depth++;
+    if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+/** Whether a SELECT list entry already references idColumn (as itself, an alias, or qualified with a table/alias prefix). */
+function referencesColumn(selectItem: string, idColumn: string): boolean {
+  const item = selectItem.trim();
+  const idLower = idColumn.toLowerCase();
+  // Matches: idColumn | "idColumn" | t.idColumn | t."idColumn" | ... AS idColumn
+  const re = new RegExp(`(^|[."\\s])${escapeRegExp(idLower)}("|\\s|$)`, "i");
+  return re.test(item.toLowerCase());
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * SQL/PartiQL identifiers are case-insensitive, so `ensureIdentifierColumn`
+ * matches/injects `idColumn` case-insensitively — but the actual result set
+ * carries whatever case the query text used (e.g. a query that already
+ * selected `executionArn` keeps that exact casing in the returned columns,
+ * even though `idColumn` was checked against as `executionarn`). The
+ * webview does an exact-case property lookup (`row[idColumn]`), so before
+ * reporting `idColumn` to it, resolve it against the *actual* result
+ * columns and use whichever casing really appears there — otherwise the
+ * lookup silently fails and row-click does nothing.
+ *
+ * Returns undefined if idColumn genuinely isn't present in `columns` (e.g.
+ * the destination executed a rewritten query that dropped it somehow) —
+ * callers should treat that the same as "no idColumn" rather than reporting
+ * a column that isn't actually in the result set.
+ */
+export function resolveActualColumnCasing(
+  idColumn: string | undefined,
+  columns: string[],
+): string | undefined {
+  if (!idColumn) return undefined;
+  const idLower = idColumn.toLowerCase();
+  return columns.find((c) => c.toLowerCase() === idLower);
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
@@ -110,10 +110,13 @@ export function ensureIdentifierColumn(
 
   // SQL dialects (PartiQL, PostgreSQL, Trino/Presto): only handle a single
   // top-level SELECT list. Bail out (no injection) for anything containing
-  // `SELECT *`, since idColumn is necessarily already included, or for
-  // shapes this simple parser can't confidently rewrite (subqueries in the
-  // FROM clause, UNION, etc.) — better to skip drill-down than corrupt SQL.
+  // `SELECT *` (idColumn is necessarily already included), a top-level set
+  // operator (UNION/INTERSECT/EXCEPT — see hasTopLevelSetOperator; injecting
+  // into just the last branch would corrupt column counts across branches),
+  // or other shapes this simple parser can't confidently rewrite (subqueries
+  // in the FROM clause, etc.) — better to skip drill-down than corrupt SQL.
   if (isAggregateQuery(trimmed, dialect)) return { query: trimmed };
+  if (hasTopLevelSetOperator(trimmed)) return { query: trimmed };
 
   const outer = findOuterSelect(trimmed);
   if (!outer) return { query: trimmed };
@@ -140,6 +143,46 @@ export function ensureIdentifierColumn(
 }
 
 /**
+ * Whether `query` contains a top-level (not inside parens, not inside a
+ * string literal) UNION, UNION ALL, INTERSECT, or EXCEPT — i.e. multiple
+ * SELECT branches combined into one result set. `findOuterSelect`'s
+ * "last top-level SELECT" heuristic only identifies one branch of a set
+ * operation, and injecting an identifier into just that branch would
+ * produce a column-count mismatch across branches (invalid SQL) or, if the
+ * branches already happen to have matching counts, silently wrong data
+ * (the identifier would only appear correctly aligned in one branch's
+ * output rows). Detecting this and skipping injection entirely is the safe
+ * choice — a query shape this rare from an LLM-generated single-question
+ * query isn't worth a more elaborate per-branch rewrite.
+ */
+function hasTopLevelSetOperator(query: string): boolean {
+  let depth = 0;
+  let inString: string | null = null;
+  for (let i = 0; i < query.length; i++) {
+    const ch = query[i];
+    if (inString) {
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      inString = ch;
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (depth === 0) {
+      const rest = query.slice(i);
+      const match = rest.match(/^(union(\s+all)?|intersect|except)\b/i);
+      if (match) {
+        const before = query[i - 1];
+        if (!before || /\W/.test(before)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Finds the outermost SELECT's column list — i.e. the LAST top-level (not
  * inside parens) `SELECT ... FROM` in the query. This is deliberately "last"
  * rather than "first": a `WITH cte AS (SELECT ...) SELECT ... FROM cte`
@@ -147,6 +190,13 @@ export function ensureIdentifierColumn(
  * the first SELECT would rewrite the CTE's inner list instead — corrupting
  * the CTE but leaving the actual output column list (and thus the row
  * shape the UI sees) untouched.
+ *
+ * This function alone does NOT handle UNION/INTERSECT/EXCEPT — for
+ * `SELECT a FROM t UNION SELECT b FROM t`, "last top-level SELECT" finds the
+ * second branch, and injecting there would corrupt the query (mismatched
+ * column counts across branches). Callers must check
+ * `hasTopLevelSetOperator` first and skip injection entirely if true;
+ * `ensureIdentifierColumn` does this before calling `findOuterSelect`.
  */
 function findOuterSelect(
   query: string,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
@@ -19,6 +19,20 @@ const GROUP_BY_RE = /\bgroup\s+by\b/i;
 // (without GROUP BY) also collapses all matching rows into one summary row
 // for that column (e.g. "SELECT COUNT(*) FROM ..." -> exactly one row, not
 // one row per execution), so it's just as disqualifying as GROUP BY.
+//
+// KNOWN FALSE POSITIVE (safe, just conservative): this scans the whole query
+// string rather than being scope-aware, so a genuinely row-level query with
+// an aggregate confined to a scalar subquery — e.g.
+// "SELECT executionArn, durationMs FROM t WHERE durationMs >
+// (SELECT AVG(durationMs) FROM t)" — is misclassified as aggregate. That
+// disables identifier injection and drill-down for that one result set
+// (a lost feature, not incorrect data — the query itself is untouched and
+// still runs correctly). A precise fix would need to track paren depth and
+// only match aggregate functions in the outermost SELECT's column list, the
+// same way findOuterSelect/hasTopLevelSetOperator already do — not worth
+// the added complexity for what should be a rare question shape from a
+// single natural-language question, but documented here since it's the same
+// class of "not scope-aware" limitation as those two functions.
 const AGGREGATE_FN_RE = /\b(?:count|sum|avg|min|max)\s*\(/i;
 // CloudWatch Logs Insights uses a pipe-based `stats` command instead of SQL
 // aggregate functions/GROUP BY.

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/queryShape.ts
@@ -38,6 +38,15 @@ export interface IdentifierInjectionResult {
   query: string;
   /** The column the row's identifier will appear under in the result set, or undefined if no identifier could be added (aggregate query, or dialect-specific reasons). */
   idColumn?: string;
+  /**
+   * Columns from `extraColumns` that were actually ensured present in the
+   * result set (added if missing, alongside idColumn) — undefined/empty for
+   * aggregate queries, same as idColumn. Currently used to carry Athena's
+   * year/month/day partition columns through to the row-detail fetch, so
+   * that fetch can add a partition-pruning predicate instead of scanning
+   * every partition on every row click.
+   */
+  extraColumns?: string[];
 }
 
 /**
@@ -46,34 +55,45 @@ export interface IdentifierInjectionResult {
  * identifier the UI can use to fetch the full record on demand. No-op for
  * aggregate queries — returns the query unchanged with no idColumn.
  *
+ * `extraColumns` (optional) are ensured present the same way, for columns
+ * the drill-down fetch wants available even though they're not identifiers
+ * themselves — e.g. Athena's year/month/day partition columns, so the
+ * fetch-by-id query (see fetchAthenaRecord) can prune partitions instead of
+ * scanning the whole table on every row click.
+ *
  * This is deliberately conservative: it only handles the common
  * `SELECT <list> FROM ...` shape (optionally preceded by a `WITH` CTE clause,
  * which passes through untouched since only the final SELECT's column list
  * matters for the result shape). If the shape isn't recognized, it leaves the
- * query untouched and reports no idColumn rather than risk producing invalid
- * SQL — the UI simply won't offer row-level drill-down for that result set.
+ * query untouched and reports no idColumn/extraColumns rather than risk
+ * producing invalid SQL — the UI simply won't offer row-level drill-down (or
+ * partition pruning) for that result set.
  */
 export function ensureIdentifierColumn(
   query: string,
   idColumn: string,
   dialect: "sql" | "logs-insights",
+  extraColumns: string[] = [],
 ): IdentifierInjectionResult {
   const trimmed = query.trim();
 
   if (dialect === "logs-insights") {
     if (isAggregateQuery(trimmed, dialect)) return { query: trimmed };
     // Logs Insights: a `fields` command explicitly lists output fields; if
-    // present, make sure idColumn is one of them. If there's no `fields`
-    // command, every field is already included by default, so idColumn is
-    // already present — nothing to inject.
+    // present, make sure idColumn (and any extraColumns) are among them. If
+    // there's no `fields` command, every field is already included by
+    // default, so everything is already present — nothing to inject.
     const fieldsMatch = trimmed.match(/\|\s*fields\s+([^|]+)/i);
-    if (!fieldsMatch) return { query: trimmed, idColumn };
-    const fieldList = fieldsMatch[1];
-    const alreadyPresent = fieldList
-      .split(",")
-      .map((f) => f.trim())
-      .includes(idColumn);
-    if (alreadyPresent) return { query: trimmed, idColumn };
+    if (!fieldsMatch) {
+      return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+    }
+    const present = fieldsMatch[1].split(",").map((f) => f.trim());
+    const toAdd = [idColumn, ...extraColumns].filter(
+      (c) => !present.includes(c),
+    );
+    if (toAdd.length === 0) {
+      return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+    }
     // Trim trailing whitespace from the matched field list before appending,
     // so injection doesn't leave "fieldA, fieldB idColumn" (missing comma) or
     // "fieldA, fieldBidColumn|" (missing space before the next pipe) — the
@@ -83,9 +103,9 @@ export function ensureIdentifierColumn(
     const trailingWhitespace = fieldsMatch[0].slice(trimmedFieldsMatch.length);
     const injected = trimmed.replace(
       fieldsMatch[0],
-      `${trimmedFieldsMatch}, ${idColumn}${trailingWhitespace}`,
+      `${trimmedFieldsMatch}, ${toAdd.join(", ")}${trailingWhitespace}`,
     );
-    return { query: injected, idColumn };
+    return { query: injected, idColumn, extraColumns: [...extraColumns] };
   }
 
   // SQL dialects (PartiQL, PostgreSQL, Trino/Presto): only handle a single
@@ -104,15 +124,19 @@ export function ensureIdentifierColumn(
     /\*\s*,|\bselect\s+\*/i.test(columnList)
   ) {
     // SELECT * already includes every column, including the identifier.
-    return { query: trimmed, idColumn };
+    return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
   }
 
   const columns = splitTopLevel(columnList);
-  const alreadyPresent = columns.some((c) => referencesColumn(c, idColumn));
-  if (alreadyPresent) return { query: trimmed, idColumn };
+  const toAdd = [idColumn, ...extraColumns].filter(
+    (c) => !columns.some((existing) => referencesColumn(existing, c)),
+  );
+  if (toAdd.length === 0) {
+    return { query: trimmed, idColumn, extraColumns: [...extraColumns] };
+  }
 
-  const injected = `${prefix}${columnList}, ${idColumn}${fromKeyword}${rest}`;
-  return { query: injected, idColumn };
+  const injected = `${prefix}${columnList}, ${toAdd.join(", ")}${fromKeyword}${rest}`;
+  return { query: injected, idColumn, extraColumns: [...extraColumns] };
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -321,6 +321,7 @@ Rules:
 - To inspect operations, UNNEST the array: CROSS JOIN UNNEST(operations) AS t(op), then reference op.name, op.type, op.status, op.durationMs, etc.
 - json_extract_scalar(col, '$.path') returns a scalar string; json_extract(col, '$.path') returns JSON — cast as needed, e.g. CAST(json_extract_scalar(...) AS double).
 - Every path segment passed to json_extract_scalar/json_extract on input or output MUST be lowercase (the SerDe lowercases JSON keys on read) — e.g. '$.claimtype' not '$.claimType'.
+- A field that lives inside input/output (e.g. claimType, decision, amount) is NEVER a bare column — it does not exist as a plain identifier anywhere in this table, including in GROUP BY, ORDER BY, and WHERE. Referencing it bare (e.g. "GROUP BY claimType" or "GROUP BY claim_type") fails with COLUMN_NOT_FOUND. Always wrap it in json_extract_scalar(input, '$.path') / json_extract_scalar(output, '$.path') — and repeat that full expression everywhere it's used (SELECT, GROUP BY, ORDER BY, WHERE), not just an alias, since GROUP BY/ORDER BY must reference the actual computed expression.
 - Prefer filtering on the year/month/day partition columns when the question implies a time range, to avoid scanning the whole bucket (cost + speed).
 - String comparisons use single quotes: WHERE status = 'SUCCEEDED'
 - Always include LIMIT (default 100) unless aggregating (GROUP BY / COUNT / AVG etc).
@@ -336,6 +337,19 @@ A: SELECT AVG(durationMs) AS avg_duration_ms FROM TABLE_NAME WHERE status = 'SUC
 
 Q: count executions by status
 A: SELECT status, COUNT(*) AS ct FROM TABLE_NAME GROUP BY status ORDER BY ct DESC
+
+Q: count executions grouped by claimType in the input
+A: SELECT json_extract_scalar(input, '$.claimtype') AS claim_type, COUNT(*) AS ct FROM TABLE_NAME GROUP BY json_extract_scalar(input, '$.claimtype') ORDER BY ct DESC
+-- NOTE: claimType is a field INSIDE the input JSON, not a table column — it
+-- does not exist as a bare identifier. Never write "GROUP BY claimType" or
+-- "GROUP BY claim_type" directly; always wrap it in
+-- json_extract_scalar(input, '$.claimtype') (lowercased path), in BOTH the
+-- SELECT list and the GROUP BY clause (repeat the full expression, not an
+-- alias, since GROUP BY must match what was actually computed per row).
+-- The same applies to output fields and to ORDER BY/WHERE on such a field.
+
+Q: count executions grouped by the decision field in the output
+A: SELECT json_extract_scalar(output, '$.decision') AS decision, COUNT(*) AS ct FROM TABLE_NAME GROUP BY json_extract_scalar(output, '$.decision') ORDER BY ct DESC
 
 Q: executions longer than 5 seconds
 A: SELECT executionArn, functionName, durationMs FROM TABLE_NAME WHERE status = 'SUCCEEDED' AND durationMs > 5000 ORDER BY durationMs DESC LIMIT 50

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -288,8 +288,8 @@ below). Columns:
 - startTime: string (ISO-8601)
 - endTime: string (ISO-8601, nullable)
 - durationMs: bigint (nullable)
-- input: string (JSON-serialized; use json_extract_scalar/json_extract to read fields)
-- output: string (JSON-serialized; use json_extract_scalar/json_extract to read fields)
+- input: string (JSON-serialized; use json_extract_scalar/json_extract to read fields — see lowercasing note below)
+- output: string (JSON-serialized; use json_extract_scalar/json_extract to read fields — see lowercasing note below)
 - error: struct<name:string,message:string> (nullable)
 - operations: array<struct<id,name,type,subType,parentId,status,startTime,endTime,durationMs,attempt,error,result,truncated>>
     This is the canonical per-operation array (NOT operationsByName — S3Exporter
@@ -302,15 +302,25 @@ below). Columns:
 - droppedInput / droppedOutput: boolean (nullable)
 
 input/output are stored as JSON strings (not native structs, since their shape is
-user-defined) — use json_extract_scalar(input, '$.fieldName') for scalars or
-json_extract(input, '$.fieldName') for nested values. The user will specify which
-fields they want — do not assume the structure.`;
+user-defined) — use json_extract_scalar(input, '$.fieldname') for scalars or
+json_extract(input, '$.fieldname') for nested values. The user will specify which
+fields they want — do not assume the structure.
+
+IMPORTANT — key casing: the table's JSON SerDe lowercases ALL object keys when
+parsing input/output (this does NOT affect top-level columns like executionArn,
+functionName, etc. — only keys inside the input/output JSON blobs). A field named
+"claimType" or "customerName" in the original payload must be looked up as
+json_extract_scalar(output, '$.claimtype') / '$.customername' — camelCase or
+mixed-case JSON path segments will silently return NULL. Always lowercase every
+path segment when building a json_extract_scalar/json_extract path into input or
+output.`;
 
 const DIALECT_ATHENA = `Target query language: Trino/Presto SQL (Amazon Athena) — NOT standard ANSI SQL in all respects.
 Rules:
 - Table name is TABLE_NAME (already database-qualified by the connection — do not prefix it).
 - To inspect operations, UNNEST the array: CROSS JOIN UNNEST(operations) AS t(op), then reference op.name, op.type, op.status, op.durationMs, etc.
 - json_extract_scalar(col, '$.path') returns a scalar string; json_extract(col, '$.path') returns JSON — cast as needed, e.g. CAST(json_extract_scalar(...) AS double).
+- Every path segment passed to json_extract_scalar/json_extract on input or output MUST be lowercase (the SerDe lowercases JSON keys on read) — e.g. '$.claimtype' not '$.claimType'.
 - Prefer filtering on the year/month/day partition columns when the question implies a time range, to avoid scanning the whole bucket (cost + speed).
 - String comparisons use single quotes: WHERE status = 'SUCCEEDED'
 - Always include LIMIT (default 100) unless aggregating (GROUP BY / COUNT / AVG etc).
@@ -342,8 +352,8 @@ A: SELECT op.name, COUNT(*) AS failures FROM TABLE_NAME t CROSS JOIN UNNEST(t.op
 Q: average duration per operation name
 A: SELECT op.name, AVG(op.durationMs) AS avg_ms, COUNT(*) AS ct FROM TABLE_NAME t CROSS JOIN UNNEST(t.operations) AS u(op) WHERE op.durationMs IS NOT NULL GROUP BY op.name ORDER BY avg_ms DESC
 
-Q: executions where the output field "amount" was over 1000
-A: SELECT executionArn, CAST(json_extract_scalar(output, '$.amount') AS double) AS amount FROM TABLE_NAME WHERE CAST(json_extract_scalar(output, '$.amount') AS double) > 1000 LIMIT 50`;
+Q: executions where the output field "approvedAmount" was over 1000
+A: SELECT executionArn, CAST(json_extract_scalar(output, '$.approvedamount') AS double) AS approved_amount FROM TABLE_NAME WHERE CAST(json_extract_scalar(output, '$.approvedamount') AS double) > 1000 LIMIT 50`;
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -270,6 +270,81 @@ A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_N
 Q: executions where operation "convert_data" took less than 5 seconds
 A: SELECT execution_arn, function_name FROM TABLE_NAME WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)' LIMIT 50`;
 
+// ─── ATHENA (Trino/Presto SQL over S3 via S3Exporter) ────────────────────────
+
+const RECORD_SCHEMA_ATHENA = `Records are stored as one JSON object per file in S3 (via S3Exporter), registered as
+a Glue table "TABLE_NAME" and Hive-partitioned by year/month/day (partition columns
+below). Columns:
+- recordType: string ("WorkflowInsight")
+- schemaVersion: string
+- emittedAt: string (ISO-8601)
+- executionArn: string
+- executionName: string (nullable)
+- functionName: string
+- functionQualifier: string
+- region: string
+- accountId: string
+- status: string — RUNNING | SUCCEEDED | FAILED
+- startTime: string (ISO-8601)
+- endTime: string (ISO-8601, nullable)
+- durationMs: bigint (nullable)
+- input: string (JSON-serialized; use json_extract_scalar/json_extract to read fields)
+- output: string (JSON-serialized; use json_extract_scalar/json_extract to read fields)
+- error: struct<name:string,message:string> (nullable)
+- operations: array<struct<id,name,type,subType,parentId,status,startTime,endTime,durationMs,attempt,error,result,truncated>>
+    This is the canonical per-operation array (NOT operationsByName — S3Exporter
+    keeps the raw array). To filter/aggregate by operation name or fields, UNNEST it.
+- year, month, day: string — Hive partition columns (from the S3 key
+    year=YYYY/month=MM/day=DD/), zero-padded 2-digit strings for month/day. Filter
+    on these instead of parsing startTime/emittedAt for partition pruning.
+- truncated: boolean (nullable)
+- droppedOperations: int (nullable)
+- droppedInput / droppedOutput: boolean (nullable)
+
+input/output are stored as JSON strings (not native structs, since their shape is
+user-defined) — use json_extract_scalar(input, '$.fieldName') for scalars or
+json_extract(input, '$.fieldName') for nested values. The user will specify which
+fields they want — do not assume the structure.`;
+
+const DIALECT_ATHENA = `Target query language: Trino/Presto SQL (Amazon Athena) — NOT standard ANSI SQL in all respects.
+Rules:
+- Table name is TABLE_NAME (already database-qualified by the connection — do not prefix it).
+- To inspect operations, UNNEST the array: CROSS JOIN UNNEST(operations) AS t(op), then reference op.name, op.type, op.status, op.durationMs, etc.
+- json_extract_scalar(col, '$.path') returns a scalar string; json_extract(col, '$.path') returns JSON — cast as needed, e.g. CAST(json_extract_scalar(...) AS double).
+- Prefer filtering on the year/month/day partition columns when the question implies a time range, to avoid scanning the whole bucket (cost + speed).
+- String comparisons use single quotes: WHERE status = 'SUCCEEDED'
+- Always include LIMIT (default 100) unless aggregating (GROUP BY / COUNT / AVG etc).
+- Use double quotes only for identifiers that need escaping; prefer unquoted lowercase identifiers.
+- Return ONLY the SQL query via the tool call. No prose, no trailing semicolon required but harmless.`;
+
+const FEWSHOTS_ATHENA = `Examples:
+Q: show the most recent failed executions
+A: SELECT executionArn, functionName, durationMs, emittedAt FROM TABLE_NAME WHERE status = 'FAILED' ORDER BY emittedAt DESC LIMIT 50
+
+Q: average duration of successful executions
+A: SELECT AVG(durationMs) AS avg_duration_ms FROM TABLE_NAME WHERE status = 'SUCCEEDED'
+
+Q: count executions by status
+A: SELECT status, COUNT(*) AS ct FROM TABLE_NAME GROUP BY status ORDER BY ct DESC
+
+Q: executions longer than 5 seconds
+A: SELECT executionArn, functionName, durationMs FROM TABLE_NAME WHERE status = 'SUCCEEDED' AND durationMs > 5000 ORDER BY durationMs DESC LIMIT 50
+
+Q: show last 100 records from today
+A: SELECT executionArn, status, functionName, durationMs, emittedAt FROM TABLE_NAME WHERE year = date_format(current_date, '%Y') AND month = date_format(current_date, '%m') AND day = date_format(current_date, '%d') ORDER BY emittedAt DESC LIMIT 100
+
+Q: executions where operation "convert_data" took less than 5 seconds
+A: SELECT DISTINCT t.executionArn, t.functionName FROM TABLE_NAME t CROSS JOIN UNNEST(t.operations) AS u(op) WHERE op.name = 'convert_data' AND op.durationMs < 5000 LIMIT 50
+
+Q: which operations fail most often
+A: SELECT op.name, COUNT(*) AS failures FROM TABLE_NAME t CROSS JOIN UNNEST(t.operations) AS u(op) WHERE op.status = 'FAILED' GROUP BY op.name ORDER BY failures DESC LIMIT 20
+
+Q: average duration per operation name
+A: SELECT op.name, AVG(op.durationMs) AS avg_ms, COUNT(*) AS ct FROM TABLE_NAME t CROSS JOIN UNNEST(t.operations) AS u(op) WHERE op.durationMs IS NOT NULL GROUP BY op.name ORDER BY avg_ms DESC
+
+Q: executions where the output field "amount" was over 1000
+A: SELECT executionArn, CAST(json_extract_scalar(output, '$.amount') AS double) AS amount FROM TABLE_NAME WHERE CAST(json_extract_scalar(output, '$.amount') AS double) > 1000 LIMIT 50`;
+
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 export function buildSystemPrompt(
@@ -277,9 +352,26 @@ export function buildSystemPrompt(
     | "cloudwatch-logs-exporter"
     | "lambda-log-exporter"
     | "dynamodb"
-    | "aurora",
+    | "aurora"
+    | "s3",
   options?: { tableName?: string },
 ): string {
+  if (destinationType === "s3") {
+    const table = options?.tableName || "workflow_insight";
+    return [
+      "You convert a user's plain-English question into a single Trino/Presto SQL query",
+      "for querying AWS Durable Execution Workflow Insight records via Amazon Athena.",
+      "",
+      RECORD_SCHEMA_ATHENA.replace(/TABLE_NAME/g, table),
+      "",
+      DIALECT_ATHENA.replace(/TABLE_NAME/g, table),
+      "",
+      FEWSHOTS_ATHENA.replace(/TABLE_NAME/g, table),
+      "",
+      'Call the "emit_query" tool with the query, a one-sentence explanation, and suggestedCharts (2-4 chart types from: bar, stacked-bar, line, area, scatter, heatmap, histogram, pie, boxplot).',
+    ].join("\n");
+  }
+
   if (destinationType === "aurora") {
     const table = options?.tableName || "workflow_insight";
     return [

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.json
@@ -13,5 +13,6 @@
     "sourceMap": true,
     "types": ["node", "vscode"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.test.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vscode", "jest"]
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -20,7 +20,7 @@ export function App() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [status, setStatus] = useState("");
   const [error, setError] = useState("");
-  const [results, setResults] = useState<{ columns: string[]; rows: string[][]; suggestedCharts?: string[] } | null>(null);
+  const [results, setResults] = useState<{ columns: string[]; rows: string[][]; suggestedCharts?: string[]; idColumn?: string } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [modelDownloaded, setModelDownloaded] = useState(false);
@@ -29,6 +29,8 @@ export function App() {
   const [explanation, setExplanation] = useState("");
   const [sqsMessages, setSqsMessages] = useState<SqsMessageRow[]>([]);
   const [sqsListening, setSqsListening] = useState(false);
+  const [detailFields, setDetailFields] = useState<Record<string, string> | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   const handleMessage = useCallback((event: MessageEvent<InboundMessage>) => {
     const msg = event.data;
@@ -46,15 +48,24 @@ export function App() {
         if (msg.done) setModelDownloaded(true);
         break;
       case "results":
-        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts });
+        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts, idColumn: msg.idColumn });
         setExplanation(msg.explanation ?? "");
         setStatus("");
         setLoading(false);
+        // A fresh result set invalidates any detail view left over from the
+        // previous one (different rows, possibly a different idColumn).
+        setDetailFields(null);
+        setDetailLoading(false);
+        break;
+      case "detailResult":
+        setDetailFields(msg.fields);
+        setDetailLoading(false);
         break;
       case "error":
         setError(msg.message);
         setStatus("");
         setLoading(false);
+        setDetailLoading(false);
         break;
       case "settingsSaved":
         setSettingsOpen(false);
@@ -166,6 +177,11 @@ export function App() {
                       columns={results.columns}
                       rows={results.rows}
                       explanation={explanation}
+                      idColumn={results.idColumn}
+                      detailFields={detailFields}
+                      detailLoading={detailLoading}
+                      onDetailFetchStart={() => setDetailLoading(true)}
+                      onDetailDismiss={() => setDetailFields(null)}
                     />
                     <Button variant="primary" onClick={() => setPage("visualize")}>
                       Visualize →

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -20,7 +20,13 @@ export function App() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [status, setStatus] = useState("");
   const [error, setError] = useState("");
-  const [results, setResults] = useState<{ columns: string[]; rows: string[][]; suggestedCharts?: string[]; idColumn?: string } | null>(null);
+  const [results, setResults] = useState<{
+    columns: string[];
+    rows: string[][];
+    suggestedCharts?: string[];
+    idColumn?: string;
+    partitionColumns?: { year?: string; month?: string; day?: string };
+  } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [modelDownloaded, setModelDownloaded] = useState(false);
@@ -48,7 +54,7 @@ export function App() {
         if (msg.done) setModelDownloaded(true);
         break;
       case "results":
-        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts, idColumn: msg.idColumn });
+        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts, idColumn: msg.idColumn, partitionColumns: msg.partitionColumns });
         setExplanation(msg.explanation ?? "");
         setStatus("");
         setLoading(false);
@@ -178,6 +184,7 @@ export function App() {
                       rows={results.rows}
                       explanation={explanation}
                       idColumn={results.idColumn}
+                      partitionColumns={results.partitionColumns}
                       detailFields={detailFields}
                       detailLoading={detailLoading}
                       onDetailFetchStart={() => setDetailLoading(true)}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -26,6 +26,7 @@ export function App() {
     suggestedCharts?: string[];
     idColumn?: string;
     partitionColumns?: { year?: string; month?: string; day?: string };
+    hiddenColumns?: string[];
   } | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -54,7 +55,7 @@ export function App() {
         if (msg.done) setModelDownloaded(true);
         break;
       case "results":
-        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts, idColumn: msg.idColumn, partitionColumns: msg.partitionColumns });
+        setResults({ columns: msg.columns, rows: msg.rows, suggestedCharts: msg.suggestedCharts, idColumn: msg.idColumn, partitionColumns: msg.partitionColumns, hiddenColumns: msg.hiddenColumns });
         setExplanation(msg.explanation ?? "");
         setStatus("");
         setLoading(false);
@@ -185,6 +186,7 @@ export function App() {
                       explanation={explanation}
                       idColumn={results.idColumn}
                       partitionColumns={results.partitionColumns}
+                      hiddenColumns={results.hiddenColumns}
                       detailFields={detailFields}
                       detailLoading={detailLoading}
                       onDetailFetchStart={() => setDetailLoading(true)}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -33,6 +33,15 @@ interface Props {
    * COUNT, etc.), which have no single execution a row corresponds to.
    */
   idColumn?: string;
+  /**
+   * The actual result-column names (if present) carrying each row's
+   * year/month/day partition value — passed straight through from the
+   * "results" message. Only meaningful for the S3+Athena destination; lets
+   * the row-detail fetch prune to one partition instead of scanning the
+   * whole table on every click (see extension.ts's onFetchDetail and
+   * athena.ts's fetchAthenaRecord).
+   */
+  partitionColumns?: { year?: string; month?: string; day?: string };
   /** Full record fetched for the currently open detail view, or null while none is open. Only meaningful when `idColumn` is set. */
   detailFields?: Record<string, string> | null;
   /** True while a "fetchDetail" request is in flight. */
@@ -51,6 +60,7 @@ export function ResultsTable({
   explanation,
   primaryColumns,
   idColumn,
+  partitionColumns,
   detailFields,
   detailLoading,
   onDetailDismiss,
@@ -109,7 +119,14 @@ export function ResultsTable({
       const idValue = item[idColumn];
       if (idValue) {
         onDetailFetchStart?.();
-        postMessage({ type: "fetchDetail", idColumn, idValue });
+        postMessage({
+          type: "fetchDetail",
+          idColumn,
+          idValue,
+          year: partitionColumns?.year ? item[partitionColumns.year] : undefined,
+          month: partitionColumns?.month ? item[partitionColumns.month] : undefined,
+          day: partitionColumns?.day ? item[partitionColumns.day] : undefined,
+        });
       }
     } else if (!item) {
       onDetailDismiss?.();

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -42,6 +42,20 @@ interface Props {
    * athena.ts's fetchAthenaRecord).
    */
   partitionColumns?: { year?: string; month?: string; day?: string };
+  /**
+   * Columns to keep in `columns`/`rows` (so the fetch-on-click logic below
+   * can still read their values off each row) but exclude from the rendered
+   * table. Used for idColumn/partitionColumns.* when the query didn't
+   * explicitly ask for them: the S3+Athena destination injects year/month/
+   * day purely so the detail fetch can prune partitions (see
+   * queryShape.ts's extraColumns), and those weren't part of what the user
+   * asked their question about — showing them as extra table columns is
+   * noise, not signal. idColumn is included here too when it wasn't already
+   * part of the query's own SELECT list, for the same reason (DynamoDB/
+   * Aurora inject only idColumn, so this is usually a 1-element array for
+   * those, vs. up to 4 for S3+Athena's idColumn + 3 partition columns).
+   */
+  hiddenColumns?: string[];
   /** Full record fetched for the currently open detail view, or null while none is open. Only meaningful when `idColumn` is set. */
   detailFields?: Record<string, string> | null;
   /** True while a "fetchDetail" request is in flight. */
@@ -61,6 +75,7 @@ export function ResultsTable({
   primaryColumns,
   idColumn,
   partitionColumns,
+  hiddenColumns,
   detailFields,
   detailLoading,
   onDetailDismiss,
@@ -78,12 +93,18 @@ export function ResultsTable({
     );
   }
 
-  const displayColumns = primaryColumns
-    ? primaryColumns.filter((c) => columns.includes(c))
-    : columns;
+  const displayColumns = (
+    primaryColumns ? primaryColumns.filter((c) => columns.includes(c)) : columns
+  ).filter((c) => !hiddenColumns?.includes(c));
   // Two independent ways a row can have "more to show": primaryColumns (the
   // extra fields are already in this row, just hidden from the table) or
   // idColumn (the extra fields need to be fetched — nothing to show yet).
+  // hiddenColumns alone (with no primaryColumns) still needs to trigger
+  // hasInMemoryDetail's "there's more to show" treatment for the SQS case —
+  // but hiddenColumns is only ever passed for the fetchable-detail (Ask
+  // flow) case in practice, so hasFetchableDetail already covers it; the
+  // length comparison below still holds even with hiddenColumns applied,
+  // since it only ever shrinks displayColumns further.
   const hasInMemoryDetail = primaryColumns != null && displayColumns.length < columns.length;
   const hasFetchableDetail = idColumn != null && columns.includes(idColumn);
   const hasDetail = hasInMemoryDetail || hasFetchableDetail;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/ResultsTable.tsx
@@ -2,8 +2,11 @@ import Table from "@cloudscape-design/components/table";
 import Box from "@cloudscape-design/components/box";
 import Header from "@cloudscape-design/components/header";
 import Pagination from "@cloudscape-design/components/pagination";
+import Spinner from "@cloudscape-design/components/spinner";
+import Modal from "@cloudscape-design/components/modal";
 import { useState } from "react";
 import { RecordDetail } from "./RecordDetail";
+import { postMessage } from "./vscode";
 
 interface Props {
   columns: string[];
@@ -14,13 +17,45 @@ interface Props {
    * skipping any not present in `columns`); the rest of each record's fields
    * are still available by clicking the row, in a detail view. Omit to show
    * every column in the table with no detail view (previous behavior).
+   *
+   * Mutually exclusive with `idColumn` in practice: this is for callers that
+   * already have every field in memory (e.g. the SQS live view, which
+   * parses the full message body) and just want to hide some by default.
    */
   primaryColumns?: string[];
+  /**
+   * When set, result rows carry a stable per-execution identifier under this
+   * column (added by the extension host — see queryShape.ts), and clicking a
+   * row fetches the *full* record on demand (via a "fetchDetail" message) —
+   * unlike `primaryColumns`, the extra fields are NOT already in `rows`,
+   * since the query that produced this result set may only have selected a
+   * few columns. Omitted entirely for aggregate query results (GROUP BY,
+   * COUNT, etc.), which have no single execution a row corresponds to.
+   */
+  idColumn?: string;
+  /** Full record fetched for the currently open detail view, or null while none is open. Only meaningful when `idColumn` is set. */
+  detailFields?: Record<string, string> | null;
+  /** True while a "fetchDetail" request is in flight. */
+  detailLoading?: boolean;
+  /** Called when the detail modal is dismissed, to let the caller clear `detailFields`. */
+  onDetailDismiss?: () => void;
+  /** Called right before a "fetchDetail" message is posted, so the caller can set loading state. */
+  onDetailFetchStart?: () => void;
 }
 
 const PAGE_SIZE = 25;
 
-export function ResultsTable({ columns, rows, explanation, primaryColumns }: Props) {
+export function ResultsTable({
+  columns,
+  rows,
+  explanation,
+  primaryColumns,
+  idColumn,
+  detailFields,
+  detailLoading,
+  onDetailDismiss,
+  onDetailFetchStart,
+}: Props) {
   const [currentPage, setCurrentPage] = useState(1);
   const [detailItem, setDetailItem] = useState<Record<string, string> | null>(null);
   const [selectedItems, setSelectedItems] = useState<Record<string, string>[]>([]);
@@ -36,8 +71,12 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
   const displayColumns = primaryColumns
     ? primaryColumns.filter((c) => columns.includes(c))
     : columns;
-  // Only offer a detail view when there's actually something extra to show.
-  const hasDetail = primaryColumns != null && displayColumns.length < columns.length;
+  // Two independent ways a row can have "more to show": primaryColumns (the
+  // extra fields are already in this row, just hidden from the table) or
+  // idColumn (the extra fields need to be fetched — nothing to show yet).
+  const hasInMemoryDetail = primaryColumns != null && displayColumns.length < columns.length;
+  const hasFetchableDetail = idColumn != null && columns.includes(idColumn);
+  const hasDetail = hasInMemoryDetail || hasFetchableDetail;
 
   const columnDefs = displayColumns.map((col) => ({
     id: col,
@@ -66,7 +105,29 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
   const selectItem = (item: Record<string, string> | null) => {
     setSelectedItems(item ? [item] : []);
     setDetailItem(item);
+    if (item && hasFetchableDetail && idColumn) {
+      const idValue = item[idColumn];
+      if (idValue) {
+        onDetailFetchStart?.();
+        postMessage({ type: "fetchDetail", idColumn, idValue });
+      }
+    } else if (!item) {
+      onDetailDismiss?.();
+    }
   };
+
+  // In fetchable-detail mode, the modal's content is the freshly fetched
+  // full record (detailFields), not the row's own (partial) fields — the row
+  // only carries whatever columns the query selected, which is why a fetch
+  // was needed in the first place. In in-memory mode (SQS), the row already
+  // has everything.
+  const modalFields = hasFetchableDetail ? detailFields ?? {} : detailItem ?? {};
+  const modalColumns = hasFetchableDetail
+    ? Object.keys(detailFields ?? {})
+    : columns;
+  const modalVisible = hasFetchableDetail
+    ? detailItem != null && (detailLoading || detailFields != null)
+    : detailItem != null;
 
   return (
     <>
@@ -113,12 +174,20 @@ export function ResultsTable({ columns, rows, explanation, primaryColumns }: Pro
         }
       />
 
-      <RecordDetail
-        visible={detailItem != null}
-        onDismiss={() => selectItem(null)}
-        fields={detailItem ?? {}}
-        columns={columns}
-      />
+      {hasFetchableDetail && detailItem != null && detailLoading && detailFields == null ? (
+        <Modal visible onDismiss={() => selectItem(null)} header="Record Details" size="large">
+          <Box textAlign="center" padding="xl">
+            <Spinner size="large" /> Loading record...
+          </Box>
+        </Modal>
+      ) : (
+        <RecordDetail
+          visible={modalVisible}
+          onDismiss={() => selectItem(null)}
+          fields={modalFields}
+          columns={modalColumns}
+        />
+      )}
     </>
   );
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -26,6 +26,7 @@ const DEST_OPTIONS: SelectProps.Option[] = [
   { value: "lambda-log-exporter", label: "CloudWatch Logs (Lambda function log group)" },
   { value: "dynamodb", label: "DynamoDB" },
   { value: "aurora", label: "Aurora PostgreSQL" },
+  { value: "s3", label: "S3 + Athena" },
   { value: "sqs", label: "Amazon SQS (live view)" },
 ];
 
@@ -51,6 +52,7 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
   const showLogGroup = dest === "cloudwatch-logs-exporter" || dest === "lambda-log-exporter";
   const showDdb = dest === "dynamodb";
   const showAurora = dest === "aurora";
+  const showAthena = dest === "s3";
   const showSqs = dest === "sqs";
 
   return (
@@ -109,6 +111,40 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                     <FormField label="Table">
                       <Input value={form.auroraTable} onChange={({ detail }) => update("auroraTable", detail.value)} placeholder="workflow_insight" />
                     </FormField>
+                  </SpaceBetween>
+                )}
+
+                {showAthena && (
+                  <SpaceBetween size="s">
+                    <FormField label="Glue Database" description="Athena/Glue database that will contain the workflow insight table">
+                      <Input value={form.athenaDatabase} onChange={({ detail }) => update("athenaDatabase", detail.value)} placeholder="default" />
+                    </FormField>
+                    <FormField label="Glue Table">
+                      <Input value={form.athenaTable} onChange={({ detail }) => update("athenaTable", detail.value)} placeholder="workflow_insight" />
+                    </FormField>
+                    <FormField
+                      label="S3 Location"
+                      description="The S3Exporter's bucket + prefix, e.g. s3://my-insight-bucket/workflow-insight/. Used to auto-create the Glue table on Save."
+                    >
+                      <Input value={form.athenaS3Location} onChange={({ detail }) => update("athenaS3Location", detail.value)} placeholder="s3://my-insight-bucket/workflow-insight/" />
+                    </FormField>
+                    <FormField
+                      label="Athena Workgroup"
+                      description="Leave empty to use the 'primary' workgroup and specify a result output location below instead"
+                    >
+                      <Input value={form.athenaWorkgroup} onChange={({ detail }) => update("athenaWorkgroup", detail.value)} placeholder="my-workgroup" />
+                    </FormField>
+                    <FormField
+                      label="Query Result Location"
+                      description="Required unless the chosen workgroup has its own output location configured"
+                    >
+                      <Input value={form.athenaOutputLocation} onChange={({ detail }) => update("athenaOutputLocation", detail.value)} placeholder="s3://my-insight-bucket/athena-results/" />
+                    </FormField>
+                    <Box color="text-body-secondary" fontSize="body-s">
+                      On Save, the Explorer checks whether the Glue table exists and, if not,
+                      creates it (matching the S3Exporter's JSON + Hive date partitioning) and
+                      runs MSCK REPAIR TABLE to discover existing partitions.
+                    </Box>
                   </SpaceBetween>
                 )}
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -53,6 +53,17 @@ export type InboundMessage =
        * set (e.g. an aggregate query, or a non-S3 destination).
        */
       partitionColumns?: { year?: string; month?: string; day?: string };
+      /**
+       * Columns the extension host injected purely so the row-detail fetch
+       * has something to key/prune on (idColumn itself, plus S3+Athena's
+       * year/month/day partition columns) — not because the user's question
+       * asked for them. The UI hides these from the rendered table (they'd
+       * otherwise show up as extra columns the user never asked to see) while
+       * still keeping their values available on each row for the fetch.
+       * Never includes a column the query already had for its own reasons —
+       * only ones the host had to add.
+       */
+      hiddenColumns?: string[];
     }
   | { type: "detailResult"; fields: Record<string, string> }
   | { type: "error"; message: string }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -6,7 +6,14 @@ export type OutboundMessage =
   | { type: "downloadModel" }
   | { type: "startListening" }
   | { type: "stopListening" }
-  | { type: "fetchDetail"; idColumn: string; idValue: string };
+  | {
+      type: "fetchDetail";
+      idColumn: string;
+      idValue: string;
+      year?: string;
+      month?: string;
+      day?: string;
+    };
 
 /** A single SQS message, normalized for display. */
 export interface SqsMessageRow {
@@ -37,6 +44,15 @@ export type InboundMessage =
        * for those results.
        */
       idColumn?: string;
+      /**
+       * For the S3+Athena destination: the actual result-column names (if
+       * present) carrying the row's year/month/day partition values, added
+       * alongside idColumn so the row-detail fetch can prune to a single
+       * partition instead of scanning the whole table on every click. Each
+       * field is undefined if that partition column isn't in this result
+       * set (e.g. an aggregate query, or a non-S3 destination).
+       */
+      partitionColumns?: { year?: string; month?: string; day?: string };
     }
   | { type: "detailResult"; fields: Record<string, string> }
   | { type: "error"; message: string }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -5,7 +5,8 @@ export type OutboundMessage =
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel" }
   | { type: "startListening" }
-  | { type: "stopListening" };
+  | { type: "stopListening" }
+  | { type: "fetchDetail"; idColumn: string; idValue: string };
 
 /** A single SQS message, normalized for display. */
 export interface SqsMessageRow {
@@ -27,7 +28,17 @@ export type InboundMessage =
       explanation?: string;
       finalQuery?: string;
       suggestedCharts?: string[];
+      /**
+       * The column (if any) result rows carry a stable per-execution
+       * identifier under, added by the extension host's identifier
+       * injection (see queryShape.ts). Omitted for aggregate query results
+       * (GROUP BY, bare COUNT/SUM/etc.) — there is no single execution a
+       * summary row corresponds to, so no row-detail drill-down is offered
+       * for those results.
+       */
+      idColumn?: string;
     }
+  | { type: "detailResult"; fields: Record<string, string> }
   | { type: "error"; message: string }
   | { type: "settingsSaved" }
   | { type: "downloadProgress"; percent: number; done: boolean }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -45,6 +45,11 @@ export interface Settings {
   auroraTable: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
+  athenaDatabase: string;
+  athenaTable: string;
+  athenaWorkgroup: string;
+  athenaOutputLocation: string;
+  athenaS3Location: string;
   llmProvider: string;
   awsProfile: string;
   bedrockModelId: string;
@@ -61,6 +66,11 @@ export const DEFAULT_SETTINGS: Settings = {
   auroraTable: "workflow_insight",
   sqsQueueUrl: "",
   sqsDeleteAfterRead: false,
+  athenaDatabase: "",
+  athenaTable: "workflow_insight",
+  athenaWorkgroup: "",
+  athenaOutputLocation: "",
+  athenaS3Location: "",
   llmProvider: "bedrock",
   awsProfile: "",
   bedrockModelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
@@ -18,7 +18,9 @@
     },
     "s3": {
       "enabled": true,
-      "bucketName": "workflow-insight-records"
+      "bucketName": "workflow-insight-records",
+      "glueDatabaseName": "workflow_insight",
+      "glueTableName": "workflow_insight"
     },
     "redshift": {
       "enabled": false,

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
@@ -17,7 +17,7 @@
       "maxCapacity": 1
     },
     "s3": {
-      "enabled": false,
+      "enabled": true,
       "bucketName": "workflow-insight-records"
     },
     "redshift": {

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/config.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Config for the example/demo CDK stack (packages/aws-durable-execution-sdk-js-insight/cdk). destinations.*.enabled controls which example resources this stack provisions by default when deployed. cloudwatchLogs/dynamodb/aurora/s3/sqs are all enabled out of the box, so a fresh `cdk deploy` of this example provisions: a CloudWatch log group, a DynamoDB table, an Aurora Serverless v2 cluster (+ VPC), an S3 bucket + Glue database/table (added for S3+Athena support), and an SQS queue — all tagged for easy teardown (RemovalPolicy.DESTROY, autoDeleteObjects on the S3 bucket) but still real billable resources while deployed. redshift/opensearch/firehose/eventbridge stay opt-in (enabled: false) since they're heavier/less commonly needed for the example. Set any destination's enabled to false before deploying if you don't want that resource provisioned.",
   "destinations": {
     "cloudwatchLogs": {
       "enabled": true,

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
@@ -9,6 +9,7 @@ import {
   DynamoDBExporter,
   AuroraExporter,
   SQSExporter,
+  S3Exporter,
 } from "@aws/durable-execution-sdk-js-insight";
 
 /**
@@ -54,6 +55,14 @@ const exporters = [
     ? [
         new SQSExporter({
           queueUrl: process.env.INSIGHT_SQS_QUEUE_URL,
+          region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+  ...(process.env.INSIGHT_S3_BUCKET
+    ? [
+        new S3Exporter({
+          bucket: process.env.INSIGHT_S3_BUCKET,
           region: process.env.AWS_REGION,
         }),
       ]

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
@@ -51,6 +51,29 @@ describe("InsightDestinationsStack", () => {
     template.resourceCountIs("Custom::AWS", 1);
   });
 
+  it("creates an S3 bucket for the S3Exporter destination", () => {
+    template.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: "workflow-insight-records",
+    });
+  });
+
+  it("creates a Glue database and table for Athena querying", () => {
+    template.hasResourceProperties("AWS::Glue::Database", {
+      DatabaseInput: { Name: "workflow_insight" },
+    });
+    template.hasResourceProperties("AWS::Glue::Table", {
+      DatabaseName: "workflow_insight",
+      TableInput: Match.objectLike({
+        Name: "workflow_insight",
+        PartitionKeys: [
+          { Name: "year", Type: "string" },
+          { Name: "month", Type: "string" },
+          { Name: "day", Type: "string" },
+        ],
+      }),
+    });
+  });
+
   it("creates an IAM policy for destinations", () => {
     template.hasResourceProperties("AWS::IAM::Policy", {
       PolicyName: "WorkflowInsightDestinations",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
@@ -3,6 +3,25 @@ import { Template, Match } from "aws-cdk-lib/assertions";
 import { InsightDestinationsStack } from "./stack";
 
 /**
+ * Mirrors aws-durable-execution-sdk-js-insight-vscode/src/athena.ts's
+ * PROJECTION_YEAR_START/PROJECTION_YEAR_END exactly (this stack's Glue
+ * table's projection.year.range TBLPROPERTIES is meant to match that
+ * package's buildCreateTableDdl, used when a customer points the VS Code
+ * extension at their own bucket instead of this example's).
+ *
+ * A real cross-package import was tried and reverted: it requires this
+ * package's tsconfig `rootDir` to widen beyond its own directory (a
+ * relative import reaches into a sibling package's `src/`), which changes
+ * this package's own `dist` build output layout — too invasive a build
+ * config change to make just to single-source two constants between an
+ * unpublished, otherwise-unrelated dev tool and this CDK stack. If you
+ * change the range in athena.ts, update PROJECTION_YEAR_START/END here
+ * too — the assertion below will fail loudly if you forget one side.
+ */
+const PROJECTION_YEAR_START = 2024;
+const PROJECTION_YEAR_END = 2030;
+
+/**
  * Basic smoke test: ensures the stack synthesizes without errors.
  * Catches structural issues like missing cfn-response protocols,
  * broken custom resources, or invalid construct trees.
@@ -70,6 +89,24 @@ describe("InsightDestinationsStack", () => {
           { Name: "month", Type: "string" },
           { Name: "day", Type: "string" },
         ],
+      }),
+    });
+  });
+
+  it("keeps the Glue table's projection.year.range in sync with athena.ts's PROJECTION_YEAR_START/END", () => {
+    // Guards against the two hardcoded definitions of this range (this
+    // stack's inline TBLPROPERTIES, and the VS Code extension's
+    // buildCreateTableDdl for customers using their own bucket) silently
+    // drifting apart — see the PROJECTION_YEAR_START/END comment above for
+    // why this can't just be a single shared constant across the two
+    // packages. PROJECTION_YEAR_START/END here are a manually-kept mirror
+    // of athena.ts's exported constants of the same name; this test will
+    // fail if either side is updated without the other.
+    template.hasResourceProperties("AWS::Glue::Table", {
+      TableInput: Match.objectLike({
+        Parameters: Match.objectLike({
+          "projection.year.range": `${PROJECTION_YEAR_START},${PROJECTION_YEAR_END}`,
+        }),
       }),
     });
   });

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.test.ts
@@ -3,23 +3,22 @@ import { Template, Match } from "aws-cdk-lib/assertions";
 import { InsightDestinationsStack } from "./stack";
 
 /**
- * Mirrors aws-durable-execution-sdk-js-insight-vscode/src/athena.ts's
- * PROJECTION_YEAR_START/PROJECTION_YEAR_END exactly (this stack's Glue
- * table's projection.year.range TBLPROPERTIES is meant to match that
- * package's buildCreateTableDdl, used when a customer points the VS Code
- * extension at their own bucket instead of this example's).
+ * The projection.year.range this stack's Glue table is expected to
+ * synthesize. Kept as named constants (rather than an inline literal in the
+ * assertion) so an accidental edit to the range in stack.ts fails this test
+ * with a clear expected-vs-actual diff.
  *
- * A real cross-package import was tried and reverted: it requires this
- * package's tsconfig `rootDir` to widen beyond its own directory (a
- * relative import reaches into a sibling package's `src/`), which changes
- * this package's own `dist` build output layout — too invasive a build
- * config change to make just to single-source two constants between an
- * unpublished, otherwise-unrelated dev tool and this CDK stack. If you
- * change the range in athena.ts, update PROJECTION_YEAR_START/END here
- * too — the assertion below will fail loudly if you forget one side.
+ * This is the *example stack's own* expected range — it is NOT tied to the
+ * VS Code extension's athena.ts, which hardcodes its own 2024–2030 for the
+ * separate case of a customer pointing the extension at their own bucket.
+ * The two are independent copies over different buckets and are not required
+ * to match (see the note in athena.ts); this test does not, and is not meant
+ * to, detect drift between the two packages — only accidental changes to
+ * this stack's range. They happen to share a value today; if you
+ * intentionally change this stack's range, update these constants to match.
  */
-const PROJECTION_YEAR_START = 2024;
-const PROJECTION_YEAR_END = 2030;
+const EXPECTED_PROJECTION_YEAR_START = 2024;
+const EXPECTED_PROJECTION_YEAR_END = 2030;
 
 /**
  * Basic smoke test: ensures the stack synthesizes without errors.
@@ -93,19 +92,15 @@ describe("InsightDestinationsStack", () => {
     });
   });
 
-  it("keeps the Glue table's projection.year.range in sync with athena.ts's PROJECTION_YEAR_START/END", () => {
-    // Guards against the two hardcoded definitions of this range (this
-    // stack's inline TBLPROPERTIES, and the VS Code extension's
-    // buildCreateTableDdl for customers using their own bucket) silently
-    // drifting apart — see the PROJECTION_YEAR_START/END comment above for
-    // why this can't just be a single shared constant across the two
-    // packages. PROJECTION_YEAR_START/END here are a manually-kept mirror
-    // of athena.ts's exported constants of the same name; this test will
-    // fail if either side is updated without the other.
+  it("synthesizes the expected projection.year.range on the Glue table", () => {
+    // Regression guard for this stack's own partition-projection range: if
+    // someone edits the range in stack.ts, this fails with a clear diff.
+    // Not a cross-package check against athena.ts — see the constants'
+    // comment above for why those are independent copies.
     template.hasResourceProperties("AWS::Glue::Table", {
       TableInput: Match.objectLike({
         Parameters: Match.objectLike({
-          "projection.year.range": `${PROJECTION_YEAR_START},${PROJECTION_YEAR_END}`,
+          "projection.year.range": `${EXPECTED_PROJECTION_YEAR_START},${EXPECTED_PROJECTION_YEAR_END}`,
         }),
       }),
     });

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -4,6 +4,7 @@ import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import * as glue from "aws-cdk-lib/aws-glue";
 import * as opensearch from "aws-cdk-lib/aws-opensearchservice";
 import * as firehose from "aws-cdk-lib/aws-kinesisfirehose";
 import * as sqs from "aws-cdk-lib/aws-sqs";
@@ -239,6 +240,84 @@ export class InsightDestinationsStack extends cdk.Stack {
 
       new cdk.CfnOutput(this, "InsightBucketName", {
         value: insightBucket.bucketName,
+      });
+
+      // Pre-provision the Glue database/table so the workflow-insight-vscode
+      // extension's Athena+S3 destination is queryable immediately after
+      // `cdk deploy` — no manual `CREATE DATABASE`/`CREATE TABLE` step, and no
+      // dependency on the extension's own best-effort auto-create-on-save
+      // (which can only create the *table*, not the database — it assumes
+      // the database already exists, since a customer typically already has
+      // one). Column/partitioning shape mirrors S3Exporter's exact output
+      // (see packages/aws-durable-execution-sdk-js-insight-vscode/src/athena.ts
+      // buildCreateTableDdl, which customers use for their own buckets).
+      const glueDatabase = new glue.CfnDatabase(this, "InsightGlueDatabase", {
+        catalogId: this.account,
+        databaseInput: {
+          name: config.destinations.s3.glueDatabaseName,
+        },
+      });
+
+      const glueTable = new glue.CfnTable(this, "InsightGlueTable", {
+        catalogId: this.account,
+        databaseName: config.destinations.s3.glueDatabaseName,
+        tableInput: {
+          name: config.destinations.s3.glueTableName,
+          tableType: "EXTERNAL_TABLE",
+          parameters: { has_encrypted_data: "false" },
+          partitionKeys: [
+            { name: "year", type: "string" },
+            { name: "month", type: "string" },
+            { name: "day", type: "string" },
+          ],
+          storageDescriptor: {
+            location: insightBucket.s3UrlForObject("workflow-insight/"),
+            inputFormat: "org.apache.hadoop.mapred.TextInputFormat",
+            outputFormat:
+              "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            serdeInfo: {
+              serializationLibrary: "org.openx.data.jsonserde.JsonSerDe",
+              parameters: { "ignore.malformed.json": "true" },
+            },
+            columns: [
+              { name: "recordtype", type: "string" },
+              { name: "schemaversion", type: "string" },
+              { name: "emittedat", type: "string" },
+              { name: "executionarn", type: "string" },
+              { name: "executionname", type: "string" },
+              { name: "functionname", type: "string" },
+              { name: "functionqualifier", type: "string" },
+              { name: "region", type: "string" },
+              { name: "accountid", type: "string" },
+              { name: "status", type: "string" },
+              { name: "starttime", type: "string" },
+              { name: "endtime", type: "string" },
+              { name: "durationms", type: "bigint" },
+              { name: "input", type: "string" },
+              { name: "output", type: "string" },
+              {
+                name: "error",
+                type: "struct<name:string,message:string>",
+              },
+              {
+                name: "operations",
+                type: "array<struct<id:string,name:string,type:string,subType:string,parentId:string,status:string,startTime:string,endTime:string,durationMs:bigint,attempt:int,error:struct<name:string,message:string>,result:string,truncated:boolean>>",
+              },
+              { name: "truncated", type: "boolean" },
+              { name: "droppedoperations", type: "int" },
+              { name: "droppedinput", type: "boolean" },
+              { name: "droppedoutput", type: "boolean" },
+            ],
+          },
+        },
+      });
+      glueTable.addDependency(glueDatabase);
+
+      new cdk.CfnOutput(this, "InsightGlueDatabaseName", {
+        value: config.destinations.s3.glueDatabaseName,
+      });
+      new cdk.CfnOutput(this, "InsightGlueTableName", {
+        value: config.destinations.s3.glueTableName,
       });
     }
 

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -222,8 +222,9 @@ export class InsightDestinationsStack extends cdk.Stack {
     }
 
     // --- S3 ---
+    let insightBucket: s3.Bucket | undefined;
     if (config.destinations.s3.enabled) {
-      const bucket = new s3.Bucket(this, "InsightBucket", {
+      insightBucket = new s3.Bucket(this, "InsightBucket", {
         bucketName: config.destinations.s3.bucketName,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
         autoDeleteObjects: true,
@@ -232,9 +233,13 @@ export class InsightDestinationsStack extends cdk.Stack {
       policyStatements.push(
         new iam.PolicyStatement({
           actions: ["s3:PutObject"],
-          resources: [`${bucket.bucketArn}/*`],
+          resources: [`${insightBucket.bucketArn}/*`],
         }),
       );
+
+      new cdk.CfnOutput(this, "InsightBucketName", {
+        value: insightBucket.bucketName,
+      });
     }
 
     // --- Redshift Serverless ---
@@ -526,6 +531,9 @@ export class InsightDestinationsStack extends cdk.Stack {
       }
       if (config.destinations.sqs.enabled && sqsQueue) {
         envVars.INSIGHT_SQS_QUEUE_URL = sqsQueue.queueUrl;
+      }
+      if (config.destinations.s3.enabled && insightBucket) {
+        envVars.INSIGHT_S3_BUCKET = insightBucket.bucketName;
       }
 
       const exampleFn = new lambdaNode.NodejsFunction(

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -264,7 +264,31 @@ export class InsightDestinationsStack extends cdk.Stack {
         tableInput: {
           name: config.destinations.s3.glueTableName,
           tableType: "EXTERNAL_TABLE",
-          parameters: { has_encrypted_data: "false" },
+          // Partition projection (see the matching properties in
+          // aws-durable-execution-sdk-js-insight-vscode/src/athena.ts's
+          // buildCreateTableDdl, which customers use for their own buckets)
+          // — Athena computes valid year/month/day partitions and their S3
+          // locations from these properties instead of calling Glue's
+          // GetPartitions, so today's partition is queryable the moment
+          // S3Exporter writes today's first record, with no MSCK REPAIR
+          // TABLE / partition-discovery step needed (and none possible —
+          // Athena disallows ADD PARTITION/MSCK REPAIR on a
+          // projection-enabled table).
+          parameters: {
+            has_encrypted_data: "false",
+            "projection.enabled": "true",
+            "projection.year.type": "integer",
+            "projection.year.range": "2024,2030",
+            "projection.month.type": "integer",
+            "projection.month.range": "1,12",
+            "projection.month.digits": "2",
+            "projection.day.type": "integer",
+            "projection.day.range": "1,31",
+            "projection.day.digits": "2",
+            "storage.location.template": `${insightBucket.s3UrlForObject(
+              "workflow-insight/",
+            )}year=\${year}/month=\${month}/day=\${day}`,
+          },
           partitionKeys: [
             { name: "year", type: "string" },
             { name: "month", type: "string" },

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -325,7 +325,17 @@ export class InsightDestinationsStack extends cdk.Stack {
               },
               {
                 name: "operations",
-                type: "array<struct<id:string,name:string,type:string,subType:string,parentId:string,status:string,startTime:string,endTime:string,durationMs:bigint,attempt:int,error:struct<name:string,message:string>,result:string,truncated:boolean>>",
+                // Written lowercase (subtype, parentid, durationms, ...)
+                // to match the same struct in
+                // aws-durable-execution-sdk-js-insight-vscode/src/athena.ts's
+                // buildCreateTableDdl exactly — Hive/Glue identifiers are
+                // case-insensitive and get folded to lowercase regardless of
+                // how they're written here, so this was never functionally
+                // different from the WorkflowInsightRecord's own camelCase
+                // field names, but keeping both DDL definitions in the same
+                // casing avoids them drifting into visually different text
+                // describing an identical schema.
+                type: "array<struct<id:string,name:string,type:string,subtype:string,parentid:string,status:string,starttime:string,endtime:string,durationms:bigint,attempt:int,error:struct<name:string,message:string>,result:string,truncated:boolean>>",
               },
               { name: "truncated", type: "boolean" },
               { name: "droppedoperations", type: "int" },


### PR DESCRIPTION
Adds S3 + Athena as a fifth queryable destination in the Workflow Insight
  Explorer VS Code extension, alongside CloudWatch Logs, DynamoDB, Aurora,
  and the SQS live view — completing the destination this extension's
  original design doc called for.

  - **Query engine**: Trino/Presto SQL via Amazon Athena, with a new
    StartQueryExecution → poll → paginated GetQueryResults runner mirroring
    the existing CloudWatch Logs Insights async-poll pattern.
  - **Zero manual setup**: the Glue database/table (JSON SerDe, Hive
    year=/month=/day= partitioning matching S3Exporter's exact output) are
    provisioned directly in CDK for the example stack, and auto-created on
    Settings save for customers pointing at their own S3Exporter buckets.
  - **NL→SQL prompt**: new schema/dialect/few-shots teaching the model
    Athena's dialect, `UNNEST(operations)` for per-operation queries, and
    Athena's JSON-key-lowercasing behavior for `input`/`output` field access
    — including a rule + few-shots specifically preventing the model from
    treating a JSON field (e.g. `claimType`) as a bare column in
    `GROUP BY`/`ORDER BY`/`WHERE`.
  - **Row-detail drill-down for every destination** (not just S3+Athena):
    fixed a pre-existing gap where Ask results only ever showed the columns
    the generated query selected, with no way to see `operations`/`input`/
    `output`. Row-level results now get a stable per-execution identifier
    injected into the query if missing, and clicking a row fetches the full
    record on demand — skipped entirely for aggregate results (`COUNT`,
    `GROUP BY`, etc.), where there's no single execution a row corresponds