### PR TITLE
feat(sdk): LLM-driven chart configuration on the Visualize page

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -105,6 +105,12 @@ describe("parseChartSpec", () => {
     ).toThrow(/malformed encoding/i);
   });
 
+  it("rejects a dynamic expr/signal in the encoding", () => {
+    const raw =
+      '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"y":{"value":{"expr":"width"}}}}';
+    expect(() => parseChartSpec(raw, COLS)).toThrow(/dynamic expression/i);
+  });
+
   it("rejects disallowed top-level keys (data/transform/etc.)", () => {
     const withData =
       '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"}},"data":{"url":"http://evil/x.json"}}';

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -87,6 +87,24 @@ describe("parseChartSpec", () => {
     );
   });
 
+  it("rejects an unsupported mark (image with a url)", () => {
+    const raw =
+      '{"mark":{"type":"image","url":"http://evil/x.png"},"encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(raw, COLS)).toThrow(/unsupported mark/i);
+  });
+
+  it("accepts an object mark with a known type", () => {
+    const raw =
+      '{"mark":{"type":"bar","tooltip":true},"encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(raw, COLS)).not.toThrow();
+  });
+
+  it("reports a malformed (non-object) encoding clearly", () => {
+    expect(() =>
+      parseChartSpec('{"mark":"bar","encoding":"oops"}', COLS),
+    ).toThrow(/malformed encoding/i);
+  });
+
   it("rejects disallowed top-level keys (data/transform/etc.)", () => {
     const withData =
       '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"}},"data":{"url":"http://evil/x.json"}}';

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -77,6 +77,20 @@ describe("parseChartSpec", () => {
     );
   });
 
+  it("validates nested field references (sort.field)", () => {
+    const raw =
+      '{"mark":"bar","encoding":{"x":{"field":"product_category","sort":{"field":"nope","op":"sum"}},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(raw, COLS)).toThrow(
+      /unknown column\(s\): nope/,
+    );
+  });
+
+  it("accepts a valid nested sort field", () => {
+    const raw =
+      '{"mark":"bar","encoding":{"x":{"field":"product_category","sort":{"field":"record_count","op":"sum"}},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(raw, COLS)).not.toThrow();
+  });
+
   it("parses a spec even with trailing prose after the object", () => {
     const raw = `${bar("hour_bucket")}\nThat should work!`;
     expect(parseChartSpec(raw, COLS).mark).toBe("bar");

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -61,12 +61,39 @@ describe("parseChartSpec", () => {
     );
   });
 
-  it("allows channels with no field (aggregate count, datum)", () => {
+  it("allows a bare aggregate channel as long as some channel has a field", () => {
     const raw =
       '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"y":{"aggregate":"count","type":"quantitative"}}}';
     expect(() => parseChartSpec(raw, COLS)).not.toThrow();
-    const withDatum = '{"mark":"rule","encoding":{"y":{"datum":100}}}';
-    expect(() => parseChartSpec(withDatum, COLS)).not.toThrow();
+  });
+
+  it("rejects an encoding that references no column", () => {
+    expect(() => parseChartSpec('{"mark":"bar","encoding":{}}', COLS)).toThrow(
+      /did not reference any column/i,
+    );
+    const datumOnly = '{"mark":"rule","encoding":{"y":{"datum":100}}}';
+    expect(() => parseChartSpec(datumOnly, COLS)).toThrow(
+      /did not reference any column/i,
+    );
+  });
+
+  it("rejects disallowed top-level keys (data/transform/etc.)", () => {
+    const withData =
+      '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"}},"data":{"url":"http://evil/x.json"}}';
+    expect(() => parseChartSpec(withData, COLS)).toThrow(
+      /disallowed top-level keys: data/,
+    );
+    const withTransform =
+      '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"}},"transform":[{"lookup":"x"}]}';
+    expect(() => parseChartSpec(withTransform, COLS)).toThrow(
+      /disallowed top-level keys: transform/,
+    );
+  });
+
+  it("allows an optional top-level title", () => {
+    const raw =
+      '{"mark":"bar","title":"Counts","encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(parseChartSpec(raw, COLS).title).toBe("Counts");
   });
 
   it("validates fields inside array channels (tooltip)", () => {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -1,0 +1,84 @@
+import { parseChartSpec, extractJsonObject } from "./chartSpec";
+
+const COLS = ["product_category", "hour_bucket", "record_count"];
+
+describe("extractJsonObject", () => {
+  it("returns null when there is no object", () => {
+    expect(extractJsonObject("no json here")).toBeNull();
+  });
+
+  it("extracts a balanced object and ignores trailing prose with a brace", () => {
+    const raw = '{"mark":"bar","encoding":{}} hope this helps :}';
+    expect(extractJsonObject(raw)).toBe('{"mark":"bar","encoding":{}}');
+  });
+
+  it("ignores braces inside string literals", () => {
+    const raw = '{"title":"a } b","x":1}';
+    expect(extractJsonObject(raw)).toBe(raw);
+  });
+
+  it("strips leading prose / code fences before the object", () => {
+    const raw =
+      'Here is your spec:\n```json\n{"mark":"bar","encoding":{}}\n```';
+    expect(extractJsonObject(raw)).toBe('{"mark":"bar","encoding":{}}');
+  });
+});
+
+describe("parseChartSpec", () => {
+  const bar = (field: string) =>
+    `{"mark":"bar","encoding":{"x":{"field":"${field}","type":"nominal"},"y":{"field":"record_count","type":"quantitative"}}}`;
+
+  it("parses a valid spec whose fields are all real columns", () => {
+    const spec = parseChartSpec(bar("product_category"), COLS);
+    expect(spec.mark).toBe("bar");
+    expect(spec.encoding).toBeDefined();
+  });
+
+  it("throws when there is no JSON object", () => {
+    expect(() => parseChartSpec("sorry, I cannot", COLS)).toThrow(
+      /did not return/i,
+    );
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseChartSpec('{"mark":"bar", encoding:}', COLS)).toThrow(
+      /invalid/i,
+    );
+  });
+
+  it("throws when mark or encoding is missing", () => {
+    expect(() => parseChartSpec('{"mark":"bar"}', COLS)).toThrow(
+      /missing mark\/encoding/i,
+    );
+    expect(() => parseChartSpec('{"encoding":{}}', COLS)).toThrow(
+      /missing mark\/encoding/i,
+    );
+  });
+
+  it("rejects an unknown / misspelled field and names it", () => {
+    expect(() => parseChartSpec(bar("product_cat"), COLS)).toThrow(
+      /unknown column\(s\): product_cat/,
+    );
+  });
+
+  it("allows channels with no field (aggregate count, datum)", () => {
+    const raw =
+      '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"y":{"aggregate":"count","type":"quantitative"}}}';
+    expect(() => parseChartSpec(raw, COLS)).not.toThrow();
+    const withDatum = '{"mark":"rule","encoding":{"y":{"datum":100}}}';
+    expect(() => parseChartSpec(withDatum, COLS)).not.toThrow();
+  });
+
+  it("validates fields inside array channels (tooltip)", () => {
+    const raw =
+      '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"tooltip":[{"field":"record_count"},{"field":"nope"}]}}';
+    expect(() => parseChartSpec(raw, COLS)).toThrow(
+      /unknown column\(s\): nope/,
+    );
+  });
+
+  it("parses a spec even with trailing prose after the object", () => {
+    const raw = `${bar("hour_bucket")}\nThat should work!`;
+    expect(parseChartSpec(raw, COLS).mark).toBe("bar");
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -111,6 +111,15 @@ describe("parseChartSpec", () => {
     expect(() => parseChartSpec(raw, COLS)).toThrow(/dynamic expression/i);
   });
 
+  it("rejects a dynamic expr in an object mark or title too", () => {
+    const inMark =
+      '{"mark":{"type":"bar","x":{"expr":"now()"}},"encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(inMark, COLS)).toThrow(/dynamic expression/i);
+    const inTitle =
+      '{"mark":"bar","title":{"text":{"expr":"foo"}},"encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(inTitle, COLS)).toThrow(/dynamic expression/i);
+  });
+
   it("rejects disallowed top-level keys (data/transform/etc.)", () => {
     const withData =
       '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"}},"data":{"url":"http://evil/x.json"}}';

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -130,6 +130,12 @@ describe("parseChartSpec", () => {
     expect(parseChartSpec(raw, COLS).title).toBe("Counts");
   });
 
+  it("rejects a malformed (array) title", () => {
+    const raw =
+      '{"mark":"bar","title":[1,2],"encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(() => parseChartSpec(raw, COLS)).toThrow(/malformed title/i);
+  });
+
   it("validates fields inside array channels (tooltip)", () => {
     const raw =
       '{"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"tooltip":[{"field":"record_count"},{"field":"nope"}]}}';

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.test.ts
@@ -22,6 +22,10 @@ describe("extractJsonObject", () => {
       'Here is your spec:\n```json\n{"mark":"bar","encoding":{}}\n```';
     expect(extractJsonObject(raw)).toBe('{"mark":"bar","encoding":{}}');
   });
+
+  it("skips a balanced-but-unparseable candidate and returns the next valid one", () => {
+    expect(extractJsonObject('use {value} then {"a":1}')).toBe('{"a":1}');
+  });
 });
 
 describe("parseChartSpec", () => {
@@ -40,10 +44,16 @@ describe("parseChartSpec", () => {
     );
   });
 
-  it("throws on invalid JSON", () => {
+  it("throws when no parseable JSON object is present", () => {
     expect(() => parseChartSpec('{"mark":"bar", encoding:}', COLS)).toThrow(
-      /invalid/i,
+      /did not return a valid/i,
     );
+  });
+
+  it("finds the valid spec even when earlier prose contains a brace", () => {
+    const raw =
+      'Use the {value} here: {"mark":"bar","encoding":{"x":{"field":"hour_bucket"},"y":{"field":"record_count"}}}';
+    expect(parseChartSpec(raw, COLS).mark).toBe("bar");
   });
 
   it("throws when mark or encoding is missing", () => {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -72,19 +72,15 @@ export function parseChartSpec(
   const valid = new Set(validColumns);
   const bad = new Set<string>();
   const encoding = (spec as { encoding?: unknown }).encoding;
-  if (encoding && typeof encoding === "object") {
-    for (const channel of Object.values(encoding as Record<string, unknown>)) {
-      // A channel is usually one definition object, but some (tooltip, detail)
-      // can be an array of them. Channels without a `field` (an aggregate
-      // "count", a datum/value) are legitimate and simply have nothing to check.
-      for (const def of Array.isArray(channel) ? channel : [channel]) {
-        const field = (def as { field?: unknown } | null)?.field;
-        if (typeof field === "string" && !valid.has(field)) {
-          bad.add(field);
-        }
-      }
-    }
-  }
+  // Collect every `field` reference anywhere under encoding — not just each
+  // channel's top-level field, but nested ones too (e.g. sort: {field: ...},
+  // which the prompt explicitly encourages, or condition: {field: ...}). A
+  // hallucinated field in any of them would otherwise pass and render a broken
+  // chart. Channels/definitions without a `field` (aggregate "count", datum,
+  // value) simply contribute nothing.
+  collectFieldRefs(encoding, (field) => {
+    if (!valid.has(field)) bad.add(field);
+  });
   if (bad.size > 0) {
     throw new Error(
       `The model's chart referenced unknown column(s): ${[...bad].join(", ")}. ` +
@@ -92,4 +88,29 @@ export function parseChartSpec(
     );
   }
   return spec as Record<string, unknown>;
+}
+
+/**
+ * Walk an encoding subtree and invoke `onField` for every string-valued `field`
+ * property found at any depth (channel definitions, arrays like tooltip, and
+ * nested defs such as sort/condition). A `field` whose value isn't a string
+ * (e.g. a repeat reference) is left for Vega-Lite to handle.
+ */
+function collectFieldRefs(
+  node: unknown,
+  onField: (field: string) => void,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectFieldRefs(item, onField);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "field" && typeof value === "string") {
+        onField(value);
+      } else {
+        collectFieldRefs(value, onField);
+      }
+    }
+  }
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -1,0 +1,95 @@
+/**
+ * Parsing and validation for the Vega-Lite spec the model returns for the
+ * Visualize page. Kept free of any `vscode`/SDK imports so it can be unit
+ * tested directly (see chartSpec.test.ts) — llm.ts owns the model call and
+ * delegates the parsing here.
+ */
+
+/**
+ * Extract the first brace-balanced JSON object from `raw`. Unlike a greedy
+ * `/\{[\s\S]*\}/`, this stops at the matching close brace, so trailing prose
+ * that happens to contain a brace (e.g. "…hope this helps :}") doesn't make the
+ * capture over-read. Brace counting ignores braces inside string literals.
+ * Returns null if there is no balanced object.
+ */
+export function extractJsonObject(raw: string): string | null {
+  const start = raw.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null; // never balanced
+}
+
+/**
+ * Parse the model's response into a Vega-Lite spec fragment and validate it.
+ * Throws (with a human-readable message) if there is no JSON object, it doesn't
+ * parse, it's missing mark/encoding, or any encoding channel references a
+ * `field` that isn't one of `validColumns` — a hallucinated or misspelled
+ * field is otherwise valid JSON and would render a blank/broken chart with no
+ * error, the exact failure this feature exists to prevent.
+ */
+export function parseChartSpec(
+  raw: string,
+  validColumns: string[],
+): Record<string, unknown> {
+  const json = extractJsonObject(raw);
+  if (!json) {
+    throw new Error("The model did not return a chart specification.");
+  }
+  let spec: unknown;
+  try {
+    spec = JSON.parse(json);
+  } catch {
+    throw new Error("The model returned an invalid chart specification.");
+  }
+  if (
+    spec == null ||
+    typeof spec !== "object" ||
+    !("mark" in spec) ||
+    !("encoding" in spec)
+  ) {
+    throw new Error(
+      "The model's chart specification was missing mark/encoding.",
+    );
+  }
+
+  const valid = new Set(validColumns);
+  const bad = new Set<string>();
+  const encoding = (spec as { encoding?: unknown }).encoding;
+  if (encoding && typeof encoding === "object") {
+    for (const channel of Object.values(encoding as Record<string, unknown>)) {
+      // A channel is usually one definition object, but some (tooltip, detail)
+      // can be an array of them. Channels without a `field` (an aggregate
+      // "count", a datum/value) are legitimate and simply have nothing to check.
+      for (const def of Array.isArray(channel) ? channel : [channel]) {
+        const field = (def as { field?: unknown } | null)?.field;
+        if (typeof field === "string" && !valid.has(field)) {
+          bad.add(field);
+        }
+      }
+    }
+  }
+  if (bad.size > 0) {
+    throw new Error(
+      `The model's chart referenced unknown column(s): ${[...bad].join(", ")}. ` +
+        `Available columns: ${validColumns.join(", ")}.`,
+    );
+  }
+  return spec as Record<string, unknown>;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -6,15 +6,36 @@
  */
 
 /**
- * Extract the first brace-balanced JSON object from `raw`. Unlike a greedy
- * `/\{[\s\S]*\}/`, this stops at the matching close brace, so trailing prose
- * that happens to contain a brace (e.g. "…hope this helps :}") doesn't make the
- * capture over-read. Brace counting ignores braces inside string literals.
- * Returns null if there is no balanced object.
+ * Extract the first brace-balanced JSON object from `raw` that actually parses.
+ * Unlike a greedy `/\{[\s\S]*\}/`, each candidate stops at its matching close
+ * brace (ignoring braces inside string literals), so trailing prose with a
+ * brace (e.g. "…hope this helps :}") doesn't make the capture over-read. If a
+ * candidate isn't valid JSON — e.g. leading prose like "use {value}: {...}"
+ * whose first balanced object is `{value}` — it advances to the next `{` and
+ * retries, so a valid spec that follows junk is still found. Returns null if no
+ * balanced, parseable object exists.
  */
 export function extractJsonObject(raw: string): string | null {
-  const start = raw.indexOf("{");
-  if (start === -1) return null;
+  for (
+    let start = raw.indexOf("{");
+    start !== -1;
+    start = raw.indexOf("{", start + 1)
+  ) {
+    const candidate = balancedObjectAt(raw, start);
+    if (candidate !== null) {
+      try {
+        JSON.parse(candidate);
+        return candidate;
+      } catch {
+        // Balanced but not valid JSON (e.g. `{value}`) — try the next brace.
+      }
+    }
+  }
+  return null;
+}
+
+/** The brace-balanced substring starting at `start` (a `{`), or null if never closed. */
+function balancedObjectAt(raw: string, start: number): string | null {
   let depth = 0;
   let inString = false;
   let escaped = false;
@@ -38,11 +59,11 @@ export function extractJsonObject(raw: string): string | null {
 
 /**
  * Parse the model's response into a Vega-Lite spec fragment and validate it.
- * Throws (with a human-readable message) if there is no JSON object, it doesn't
- * parse, it's missing mark/encoding, or any encoding channel references a
- * `field` that isn't one of `validColumns` — a hallucinated or misspelled
- * field is otherwise valid JSON and would render a blank/broken chart with no
- * error, the exact failure this feature exists to prevent.
+ * Throws (with a human-readable message) if there is no parseable JSON object,
+ * it's missing mark/encoding, sets a disallowed top-level key, or any encoding
+ * channel references a `field` that isn't one of `validColumns` — a
+ * hallucinated or misspelled field is otherwise valid JSON and would render a
+ * blank/broken chart with no error, the exact failure this feature prevents.
  */
 export function parseChartSpec(
   raw: string,
@@ -50,14 +71,9 @@ export function parseChartSpec(
 ): Record<string, unknown> {
   const json = extractJsonObject(raw);
   if (!json) {
-    throw new Error("The model did not return a chart specification.");
+    throw new Error("The model did not return a valid chart specification.");
   }
-  let spec: unknown;
-  try {
-    spec = JSON.parse(json);
-  } catch {
-    throw new Error("The model returned an invalid chart specification.");
-  }
+  const spec: unknown = JSON.parse(json); // extractJsonObject guarantees this parses
   if (
     spec == null ||
     typeof spec !== "object" ||
@@ -78,7 +94,7 @@ export function parseChartSpec(
   const disallowed = Object.keys(spec).filter((k) => !ALLOWED_TOP_LEVEL.has(k));
   if (disallowed.length > 0) {
     throw new Error(
-      `The model's chart set disallowed top-level keys: ${disallowed.join(", ")}. ` +
+      `The model's chart spec included disallowed top-level keys: ${disallowed.join(", ")}. ` +
         `Only mark, encoding, and title are allowed.`,
     );
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -118,6 +118,19 @@ export function parseChartSpec(
     );
   }
 
+  // If a title is present, it must be a string or a plain object (Vega-Lite
+  // TitleParams). No external-resource vector, but validate the shape so the
+  // allowlist genuinely covers every top-level key it permits.
+  if ("title" in spec) {
+    const title = (spec as { title?: unknown }).title;
+    const okTitle =
+      typeof title === "string" ||
+      (title != null && typeof title === "object" && !Array.isArray(title));
+    if (!okTitle) {
+      throw new Error("The model's chart had a malformed title.");
+    }
+  }
+
   // The encoding must be a plain object (map of channels); a string/array/null
   // would otherwise fall through to the "no columns" error with a misleading
   // message.

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -69,21 +69,38 @@ export function parseChartSpec(
     );
   }
 
-  const valid = new Set(validColumns);
-  const bad = new Set<string>();
-  const encoding = (spec as { encoding?: unknown }).encoding;
-  // Collect every `field` reference anywhere under encoding — not just each
-  // channel's top-level field, but nested ones too (e.g. sort: {field: ...},
-  // which the prompt explicitly encourages, or condition: {field: ...}). A
-  // hallucinated field in any of them would otherwise pass and render a broken
-  // chart. Channels/definitions without a `field` (aggregate "count", datum,
-  // value) simply contribute nothing.
-  collectFieldRefs(encoding, (field) => {
-    if (!valid.has(field)) bad.add(field);
-  });
-  if (bad.size > 0) {
+  // Allowlist top-level keys. The chart is rendered over data the host injects,
+  // so the model must not carry its own data/config/width/height — nor a
+  // `transform`/`datasets`/`params` (a Vega-Lite transform can even fetch a
+  // remote data.url). Rejecting anything outside the allowed set makes the "no
+  // data" rule enforced rather than merely requested by the prompt.
+  const ALLOWED_TOP_LEVEL = new Set(["mark", "encoding", "title"]);
+  const disallowed = Object.keys(spec).filter((k) => !ALLOWED_TOP_LEVEL.has(k));
+  if (disallowed.length > 0) {
     throw new Error(
-      `The model's chart referenced unknown column(s): ${[...bad].join(", ")}. ` +
+      `The model's chart set disallowed top-level keys: ${disallowed.join(", ")}. ` +
+        `Only mark, encoding, and title are allowed.`,
+    );
+  }
+
+  // Collect every field reference anywhere under encoding (nested included) and
+  // validate them. A chart that references no column at all (e.g. an empty
+  // encoding, or only datum/value channels) isn't a usable visualization of the
+  // result, so reject that too.
+  const valid = new Set(validColumns);
+  const fields: string[] = [];
+  collectFieldRefs((spec as { encoding?: unknown }).encoding, (f) =>
+    fields.push(f),
+  );
+  if (fields.length === 0) {
+    throw new Error(
+      "The model's chart did not reference any column (empty or field-less encoding).",
+    );
+  }
+  const bad = [...new Set(fields.filter((f) => !valid.has(f)))];
+  if (bad.length > 0) {
+    throw new Error(
+      `The model's chart referenced unknown column(s): ${bad.join(", ")}. ` +
         `Available columns: ${validColumns.join(", ")}.`,
     );
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -136,7 +136,19 @@ export function parseChartSpec(
   // result, so reject that too.
   const valid = new Set(validColumns);
   const fields: string[] = [];
-  collectFieldRefs(encoding, (f) => fields.push(f));
+  const dynamicKeys = new Set<string>();
+  collectFieldRefs(
+    encoding,
+    (f) => fields.push(f),
+    (k) => dynamicKeys.add(k),
+  );
+  // Reject dynamic expressions in the encoding (defense-in-depth beyond Vega's
+  // sandboxed evaluator): the chart should be static over the fetched rows.
+  if (dynamicKeys.size > 0) {
+    throw new Error(
+      `The model's chart used disallowed dynamic expression(s) (${[...dynamicKeys].join(", ")}) in its encoding.`,
+    );
+  }
   if (fields.length === 0) {
     throw new Error(
       "The model's chart did not reference any column (empty or field-less encoding).",
@@ -175,23 +187,28 @@ const ALLOWED_MARKS = new Set([
 /**
  * Walk an encoding subtree and invoke `onField` for every string-valued `field`
  * property found at any depth (channel definitions, arrays like tooltip, and
- * nested defs such as sort/condition). A `field` whose value isn't a string
- * (e.g. a repeat reference) is left for Vega-Lite to handle.
+ * nested defs such as sort/condition), and `onDisallowedKey` for any `expr`/
+ * `signal` key. A `field` whose value isn't a string (e.g. a repeat reference)
+ * is left for Vega-Lite to handle.
  */
 function collectFieldRefs(
   node: unknown,
   onField: (field: string) => void,
+  onDisallowedKey: (key: string) => void,
 ): void {
   if (Array.isArray(node)) {
-    for (const item of node) collectFieldRefs(item, onField);
+    for (const item of node) collectFieldRefs(item, onField, onDisallowedKey);
     return;
   }
   if (node && typeof node === "object") {
     for (const [key, value] of Object.entries(node)) {
+      if (key === "expr" || key === "signal") {
+        onDisallowedKey(key);
+      }
       if (key === "field" && typeof value === "string") {
         onField(value);
       } else {
-        collectFieldRefs(value, onField);
+        collectFieldRefs(value, onField, onDisallowedKey);
       }
     }
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -143,25 +143,25 @@ export function parseChartSpec(
     throw new Error("The model's chart had a malformed encoding.");
   }
 
+  // Reject dynamic expressions anywhere in the spec (defense-in-depth beyond
+  // Vega's sandboxed evaluator): the chart should be static over the fetched
+  // rows. Scans the WHOLE spec — including an object mark/title, not just
+  // encoding — so the guard matches its "static chart" intent.
+  const dynamicKeys = new Set<string>();
+  collectDynamicKeys(spec, (k) => dynamicKeys.add(k));
+  if (dynamicKeys.size > 0) {
+    throw new Error(
+      `The model's chart used disallowed dynamic expression(s) (${[...dynamicKeys].join(", ")}).`,
+    );
+  }
+
   // Collect every field reference anywhere under encoding (nested included) and
   // validate them. A chart that references no column at all (e.g. an empty
   // encoding, or only datum/value channels) isn't a usable visualization of the
   // result, so reject that too.
   const valid = new Set(validColumns);
   const fields: string[] = [];
-  const dynamicKeys = new Set<string>();
-  collectFieldRefs(
-    encoding,
-    (f) => fields.push(f),
-    (k) => dynamicKeys.add(k),
-  );
-  // Reject dynamic expressions in the encoding (defense-in-depth beyond Vega's
-  // sandboxed evaluator): the chart should be static over the fetched rows.
-  if (dynamicKeys.size > 0) {
-    throw new Error(
-      `The model's chart used disallowed dynamic expression(s) (${[...dynamicKeys].join(", ")}) in its encoding.`,
-    );
-  }
+  collectFieldRefs(encoding, (f) => fields.push(f));
   if (fields.length === 0) {
     throw new Error(
       "The model's chart did not reference any column (empty or field-less encoding).",
@@ -207,22 +207,32 @@ const ALLOWED_MARKS = new Set([
 function collectFieldRefs(
   node: unknown,
   onField: (field: string) => void,
-  onDisallowedKey: (key: string) => void,
 ): void {
   if (Array.isArray(node)) {
-    for (const item of node) collectFieldRefs(item, onField, onDisallowedKey);
+    for (const item of node) collectFieldRefs(item, onField);
     return;
   }
   if (node && typeof node === "object") {
     for (const [key, value] of Object.entries(node)) {
-      if (key === "expr" || key === "signal") {
-        onDisallowedKey(key);
-      }
       if (key === "field" && typeof value === "string") {
         onField(value);
       } else {
-        collectFieldRefs(value, onField, onDisallowedKey);
+        collectFieldRefs(value, onField);
       }
+    }
+  }
+}
+
+/** Walk any node and invoke `onKey` for every `expr`/`signal` key (dynamic bindings). */
+function collectDynamicKeys(node: unknown, onKey: (key: string) => void): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectDynamicKeys(item, onKey);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "expr" || key === "signal") onKey(key);
+      collectDynamicKeys(value, onKey);
     }
   }
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/chartSpec.ts
@@ -99,15 +99,44 @@ export function parseChartSpec(
     );
   }
 
+  // Validate the mark itself, not just its presence: Vega-Lite allows an object
+  // mark like {"type":"image","url":"…"} that would pull an external resource,
+  // so restrict it to a known rendering mark (given as a string or {type: …}).
+  // (The webview CSP also blocks that, but the validator shouldn't rely solely
+  // on it to be "the single source of usable chart".)
+  const mark = (spec as { mark?: unknown }).mark;
+  const markType =
+    typeof mark === "string"
+      ? mark
+      : mark && typeof mark === "object"
+        ? (mark as { type?: unknown }).type
+        : undefined;
+  if (typeof markType !== "string" || !ALLOWED_MARKS.has(markType)) {
+    throw new Error(
+      `The model's chart used an unsupported mark (${JSON.stringify(mark)}). ` +
+        `Allowed marks: ${[...ALLOWED_MARKS].join(", ")}.`,
+    );
+  }
+
+  // The encoding must be a plain object (map of channels); a string/array/null
+  // would otherwise fall through to the "no columns" error with a misleading
+  // message.
+  const encoding = (spec as { encoding?: unknown }).encoding;
+  if (
+    encoding == null ||
+    typeof encoding !== "object" ||
+    Array.isArray(encoding)
+  ) {
+    throw new Error("The model's chart had a malformed encoding.");
+  }
+
   // Collect every field reference anywhere under encoding (nested included) and
   // validate them. A chart that references no column at all (e.g. an empty
   // encoding, or only datum/value channels) isn't a usable visualization of the
   // result, so reject that too.
   const valid = new Set(validColumns);
   const fields: string[] = [];
-  collectFieldRefs((spec as { encoding?: unknown }).encoding, (f) =>
-    fields.push(f),
-  );
+  collectFieldRefs(encoding, (f) => fields.push(f));
   if (fields.length === 0) {
     throw new Error(
       "The model's chart did not reference any column (empty or field-less encoding).",
@@ -122,6 +151,26 @@ export function parseChartSpec(
   }
   return spec as Record<string, unknown>;
 }
+
+// Known Vega-Lite rendering marks the Visualize page can produce. Excludes
+// "image" and "geoshape", which reference external URLs.
+const ALLOWED_MARKS = new Set([
+  "bar",
+  "line",
+  "area",
+  "point",
+  "circle",
+  "square",
+  "tick",
+  "rect",
+  "arc",
+  "rule",
+  "text",
+  "trail",
+  "boxplot",
+  "errorbar",
+  "errorband",
+]);
 
 /**
  * Walk an encoding subtree and invoke `onField` for every string-valued `field`

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -42,6 +42,9 @@ type InboundMessage =
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   | { type: "exportChart"; format: "svg" | "png"; content: string }
+  // NOTE: keep this `visualize` shape in sync with OutboundMessage in
+  // webview-ui/src/types.ts (host and webview message types are declared
+  // separately in each project's own `src`).
   | {
       type: "visualize";
       columns: string[];

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -5,6 +5,7 @@ import {
   generateQuery,
   verifyResult,
   analyzeResults,
+  generateChartSpec,
   isModelDownloaded,
   ensureModel,
   setLocalModel,
@@ -41,6 +42,13 @@ type InboundMessage =
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   | { type: "exportChart"; format: "svg" | "png"; content: string }
+  | {
+      type: "visualize";
+      columns: string[];
+      numericColumns: string[];
+      chartType?: string;
+      description: string;
+    }
   | { type: "startListening" }
   | { type: "stopListening" }
   | {
@@ -213,6 +221,8 @@ class ExplorerPanel {
           return await this.onDownloadModel(msg.localModel);
         case "exportChart":
           return await this.onExportChart(msg.format, msg.content);
+        case "visualize":
+          return await this.onVisualize(msg);
         case "startListening":
           return this.onStartListening();
         case "stopListening":
@@ -380,6 +390,40 @@ class ExplorerPanel {
       await vscode.workspace.fs.writeFile(uri, Buffer.from(base64, "base64"));
     }
     vscode.window.showInformationMessage(`Chart saved to ${uri.fsPath}`);
+  }
+
+  /**
+   * Free-text "describe how to visualize" on the Visualize page: ask the model
+   * to map the request onto the fetched columns and return a Vega-Lite spec.
+   * Only column names/types + the description are sent, never the row data.
+   */
+  private async onVisualize(msg: {
+    columns: string[];
+    numericColumns: string[];
+    chartType?: string;
+    description: string;
+  }): Promise<void> {
+    const cfg = readConfig();
+    setLocalModel(cfg.localModel);
+    const credentials = resolveCredentials(cfg.awsProfile);
+    try {
+      const spec = await generateChartSpec({
+        provider: cfg.llmProvider,
+        region: cfg.region,
+        credentials,
+        modelId: cfg.bedrockModelId,
+        columns: msg.columns,
+        numericColumns: msg.numericColumns,
+        chartType: msg.chartType,
+        description: msg.description,
+      });
+      this.post({ type: "chartSpec", spec });
+    } catch (err) {
+      this.post({
+        type: "chartSpecError",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private onStartListening(): void {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -48,6 +48,7 @@ type InboundMessage =
       numericColumns: string[];
       chartType?: string;
       description: string;
+      requestId: number;
     }
   | { type: "startListening" }
   | { type: "stopListening" }
@@ -402,6 +403,7 @@ class ExplorerPanel {
     numericColumns: string[];
     chartType?: string;
     description: string;
+    requestId: number;
   }): Promise<void> {
     const cfg = readConfig();
     setLocalModel(cfg.localModel);
@@ -417,11 +419,12 @@ class ExplorerPanel {
         chartType: msg.chartType,
         description: msg.description,
       });
-      this.post({ type: "chartSpec", spec });
+      this.post({ type: "chartSpec", spec, requestId: msg.requestId });
     } catch (err) {
       this.post({
         type: "chartSpecError",
         message: err instanceof Error ? err.message : String(err),
+        requestId: msg.requestId,
       });
     }
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -404,6 +404,7 @@ interface GenerateOptions {
    */
   agentic?: boolean;
 }
+
 /**
  * Unified LLM interface. Hides the difference between Bedrock (Converse API
  * with tool calling) and VS Code Copilot (Language Model API with text parsing).

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -281,6 +281,151 @@ export async function analyzeResults(opts: AnalyzeOptions): Promise<string> {
   }
 }
 
+// ─── Chart spec generation (Visualize page, free-text prompt) ────────────────
+
+interface ChartSpecOptions {
+  provider: LlmProvider;
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  modelId: string;
+  columns: string[];
+  /** Names of the columns that hold numeric values (a hint for value/axis choice). */
+  numericColumns: string[];
+  /** The chart type the user picked from the dropdown, if any (e.g. "stacked-bar"). */
+  chartType?: string;
+  description: string;
+}
+
+/**
+ * Turn a visualization request into a Vega-Lite spec fragment ({mark, encoding}
+ * plus optional styling) over the columns already fetched. The request is
+ * either a chart type the user picked, a free-text description, or both. The
+ * model decides which column maps to each channel and any styling. Only the
+ * column names/types and the request are sent — never the row data. Throws on
+ * model/parse failure so the caller can surface an error instead of rendering a
+ * silently wrong chart.
+ */
+export async function generateChartSpec(
+  opts: ChartSpecOptions,
+): Promise<Record<string, unknown>> {
+  const prompt = buildChartPrompt(opts);
+  const raw = await completeText(opts, prompt);
+  return parseChartSpec(raw);
+}
+
+function buildChartPrompt(opts: ChartSpecOptions): string {
+  const numeric = opts.numericColumns.length
+    ? opts.numericColumns.join(", ")
+    : "(none detected)";
+  const request = [
+    opts.chartType ? `Chart type: ${opts.chartType}.` : "",
+    opts.description ? `Request: ${opts.description}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return [
+    "You configure a Vega-Lite v5 chart for a result table. Map the request onto the AVAILABLE COLUMNS only, choosing the best column for each channel.",
+    "",
+    `Available columns: ${opts.columns.join(", ")}`,
+    `Numeric columns (usable as quantitative values): ${numeric}`,
+    "",
+    `${request}`,
+    "",
+    "Rules:",
+    "- Use ONLY the listed column names, verbatim, in each `field`. Never invent a column.",
+    "- Put the measure/value on a quantitative encoding (usually y, or theta for a pie); put category/axis columns on x, and a second category on color (or xOffset for a grouped bar).",
+    '- Stacked bar: mark "bar", the value on y with "stack":"zero", one category on x, the other on color.',
+    '- Pick a sensible `type` per field: "quantitative" for numbers, "nominal"/"ordinal" for categories, "temporal" for timestamps.',
+    '- You MAY add styling when it improves readability: an axis `scale` (e.g. "zero":true or "domainMin"/"domainMax"), a color `scale` `scheme` (e.g. "tableau10", "category10"), `sort` on an axis, and short axis `title`s. Keep it valid Vega-Lite v5. Do NOT set width, height, data, or config.',
+    "",
+    'Respond with ONLY a JSON object with "mark" and "encoding" (optionally with the styling above), no prose, no data, no $schema. Example:',
+    '{"mark":"bar","encoding":{"x":{"field":"product_category","type":"nominal","title":"Category"},"y":{"field":"record_count","type":"quantitative","stack":"zero","scale":{"zero":true}},"color":{"field":"hour_bucket","type":"nominal","scale":{"scheme":"tableau10"}}}}',
+  ].join("\n");
+}
+
+function parseChartSpec(raw: string): Record<string, unknown> {
+  // Models sometimes wrap JSON in prose or code fences — grab the first object.
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) {
+    throw new Error("The model did not return a chart specification.");
+  }
+  let spec: unknown;
+  try {
+    spec = JSON.parse(match[0]);
+  } catch {
+    throw new Error("The model returned an invalid chart specification.");
+  }
+  if (
+    spec == null ||
+    typeof spec !== "object" ||
+    !("mark" in spec) ||
+    !("encoding" in spec)
+  ) {
+    throw new Error(
+      "The model's chart specification was missing mark/encoding.",
+    );
+  }
+  return spec as Record<string, unknown>;
+}
+
+/**
+ * Single prompt -> text completion across all three providers. Unlike
+ * analyzeResults (which swallows failures into ""), this surfaces errors to the
+ * caller so a failed chart request can be reported instead of hidden.
+ */
+async function completeText(
+  opts: {
+    provider: LlmProvider;
+    region: string;
+    credentials: AwsCredentialIdentityProvider;
+    modelId: string;
+  },
+  prompt: string,
+): Promise<string> {
+  if (opts.provider === "bedrock") {
+    const client = new BedrockRuntimeClient({
+      region: opts.region,
+      credentials: opts.credentials,
+    });
+    const response = await client.send(
+      new ConverseCommand({
+        modelId: opts.modelId,
+        messages: [{ role: "user", content: [{ text: prompt }] }],
+        inferenceConfig: { maxTokens: 1024, temperature: 0 },
+      }),
+    );
+    const blocks: ContentBlock[] = response.output?.message?.content ?? [];
+    return blocks
+      .map((b) => ("text" in b && b.text ? b.text : ""))
+      .join("")
+      .trim();
+  }
+  if (opts.provider === "copilot") {
+    const models = await vscode.lm.selectChatModels({ vendor: "copilot" });
+    if (models.length === 0) {
+      throw new Error("No Copilot chat model is available.");
+    }
+    const response = await models[0].sendRequest(
+      [vscode.LanguageModelChatMessage.User(prompt)],
+      {},
+      new vscode.CancellationTokenSource().token,
+    );
+    let text = "";
+    for await (const chunk of response.text) text += chunk;
+    return text.trim();
+  }
+  // local
+  const { model } = await getLocalModel();
+  const { LlamaChatSession } = await import("node-llama-cpp");
+  const context = await model.createContext();
+  const session = new LlamaChatSession({
+    contextSequence: context.getSequence(),
+  });
+  const text = await session.prompt(prompt);
+  await context.dispose();
+  return text.trim();
+}
+
 interface GenerateOptions {
   provider: LlmProvider;
   region: string;
@@ -298,7 +443,6 @@ interface GenerateOptions {
    */
   agentic?: boolean;
 }
-
 /**
  * Unified LLM interface. Hides the difference between Bedrock (Converse API
  * with tool calling) and VS Code Copilot (Language Model API with text parsing).

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -280,7 +280,8 @@ export async function generateChartSpec(
 ): Promise<Record<string, unknown>> {
   const prompt = buildChartPrompt(opts);
   // A styled spec (several channels + scales + titles) is still small, but give
-  // headroom beyond the default so it can't truncate into invalid JSON.
+  // headroom beyond the default on the Bedrock/local paths so it doesn't
+  // truncate into invalid JSON (the Copilot path uses its own default).
   const raw = await completeText(opts, prompt, 2048);
   return parseChartSpec(raw, opts.columns);
 }
@@ -319,8 +320,8 @@ function buildChartPrompt(opts: ChartSpecOptions): string {
  * Single prompt -> text completion across all three providers, used by both
  * analyzeResults and generateChartSpec. Surfaces errors to the caller (callers
  * that prefer a soft failure wrap it in their own try/catch). `maxTokens`
- * bounds the Bedrock response; the Copilot/local paths don't take an explicit
- * limit here.
+ * bounds the Bedrock and local (node-llama-cpp) responses; the Copilot path
+ * has no simple per-request token knob and uses the model's own default.
  */
 async function completeText(
   opts: {
@@ -379,7 +380,7 @@ async function completeText(
   // finally: callers (e.g. generateChartSpec) let prompt() errors propagate, so
   // dispose the llama context even on throw to avoid leaking it.
   try {
-    const text = await session.prompt(prompt);
+    const text = await session.prompt(prompt, { maxTokens });
     return text.trim();
   } finally {
     await context.dispose();

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -234,49 +234,10 @@ export async function analyzeResults(opts: AnalyzeOptions): Promise<string> {
     rows: opts.rows,
   });
   try {
-    if (opts.provider === "bedrock") {
-      const client = new BedrockRuntimeClient({
-        region: opts.region,
-        credentials: opts.credentials,
-      });
-      const response = await client.send(
-        new ConverseCommand({
-          modelId: opts.modelId,
-          messages: [{ role: "user", content: [{ text: prompt }] }],
-          inferenceConfig: { maxTokens: 4096, temperature: 0 },
-        }),
-      );
-      const blocks: ContentBlock[] = response.output?.message?.content ?? [];
-      return blocks
-        .map((b) => ("text" in b && b.text ? b.text : ""))
-        .join("")
-        .trim();
-    }
-
-    if (opts.provider === "copilot") {
-      const models = await vscode.lm.selectChatModels({ vendor: "copilot" });
-      if (models.length === 0) return "";
-      const response = await models[0].sendRequest(
-        [vscode.LanguageModelChatMessage.User(prompt)],
-        {},
-        new vscode.CancellationTokenSource().token,
-      );
-      let text = "";
-      for await (const chunk of response.text) text += chunk;
-      return text.trim();
-    }
-
-    // local
-    const { model } = await getLocalModel();
-    const { LlamaChatSession } = await import("node-llama-cpp");
-    const context = await model.createContext();
-    const session = new LlamaChatSession({
-      contextSequence: context.getSequence(),
-    });
-    const text = await session.prompt(prompt);
-    await context.dispose();
-    return text.trim();
+    // Analysis prose can be long, so allow the larger token budget.
+    return await completeText(opts, prompt, 4096);
   } catch {
+    // Never let an analysis failure hide the results; fall back to the table.
     return "";
   }
 }
@@ -310,7 +271,7 @@ export async function generateChartSpec(
 ): Promise<Record<string, unknown>> {
   const prompt = buildChartPrompt(opts);
   const raw = await completeText(opts, prompt);
-  return parseChartSpec(raw);
+  return parseChartSpec(raw, opts.columns);
 }
 
 function buildChartPrompt(opts: ChartSpecOptions): string {
@@ -343,7 +304,10 @@ function buildChartPrompt(opts: ChartSpecOptions): string {
   ].join("\n");
 }
 
-function parseChartSpec(raw: string): Record<string, unknown> {
+function parseChartSpec(
+  raw: string,
+  validColumns: string[],
+): Record<string, unknown> {
   // Models sometimes wrap JSON in prose or code fences — grab the first object.
   const match = raw.match(/\{[\s\S]*\}/);
   if (!match) {
@@ -365,13 +329,41 @@ function parseChartSpec(raw: string): Record<string, unknown> {
       "The model's chart specification was missing mark/encoding.",
     );
   }
+  // Every field an encoding channel references must be a real result column.
+  // A hallucinated or misspelled field name is otherwise valid JSON and would
+  // render a blank/broken chart with no error — the exact failure this feature
+  // exists to prevent — so reject it here. Channels without a `field` (e.g. an
+  // aggregate "count", a datum/value) are fine and skipped.
+  const valid = new Set(validColumns);
+  const bad = new Set<string>();
+  const encoding = (spec as { encoding?: unknown }).encoding;
+  if (encoding && typeof encoding === "object") {
+    for (const channel of Object.values(encoding as Record<string, unknown>)) {
+      // A channel is usually one definition object, but some (tooltip, detail)
+      // can be an array of them.
+      for (const def of Array.isArray(channel) ? channel : [channel]) {
+        const field = (def as { field?: unknown } | null)?.field;
+        if (typeof field === "string" && !valid.has(field)) {
+          bad.add(field);
+        }
+      }
+    }
+  }
+  if (bad.size > 0) {
+    throw new Error(
+      `The model's chart referenced unknown column(s): ${[...bad].join(", ")}. ` +
+        `Available columns: ${validColumns.join(", ")}.`,
+    );
+  }
   return spec as Record<string, unknown>;
 }
 
 /**
- * Single prompt -> text completion across all three providers. Unlike
- * analyzeResults (which swallows failures into ""), this surfaces errors to the
- * caller so a failed chart request can be reported instead of hidden.
+ * Single prompt -> text completion across all three providers, used by both
+ * analyzeResults and generateChartSpec. Surfaces errors to the caller (callers
+ * that prefer a soft failure wrap it in their own try/catch). `maxTokens`
+ * bounds the Bedrock response; the Copilot/local paths don't take an explicit
+ * limit here.
  */
 async function completeText(
   opts: {
@@ -381,6 +373,7 @@ async function completeText(
     modelId: string;
   },
   prompt: string,
+  maxTokens = 1024,
 ): Promise<string> {
   if (opts.provider === "bedrock") {
     const client = new BedrockRuntimeClient({
@@ -391,7 +384,7 @@ async function completeText(
       new ConverseCommand({
         modelId: opts.modelId,
         messages: [{ role: "user", content: [{ text: prompt }] }],
-        inferenceConfig: { maxTokens: 1024, temperature: 0 },
+        inferenceConfig: { maxTokens, temperature: 0 },
       }),
     );
     const blocks: ContentBlock[] = response.output?.message?.content ?? [];

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import { buildSystemPrompt, type DestinationType } from "./schema";
+import { parseChartSpec } from "./chartSpec";
 import {
   parseVerdict,
   buildVerifyInstruction,
@@ -302,60 +303,6 @@ function buildChartPrompt(opts: ChartSpecOptions): string {
     'Respond with ONLY a JSON object with "mark" and "encoding" (optionally with the styling above), no prose, no data, no $schema. Example:',
     '{"mark":"bar","encoding":{"x":{"field":"product_category","type":"nominal","title":"Category"},"y":{"field":"record_count","type":"quantitative","stack":"zero","scale":{"zero":true}},"color":{"field":"hour_bucket","type":"nominal","scale":{"scheme":"tableau10"}}}}',
   ].join("\n");
-}
-
-function parseChartSpec(
-  raw: string,
-  validColumns: string[],
-): Record<string, unknown> {
-  // Models sometimes wrap JSON in prose or code fences — grab the first object.
-  const match = raw.match(/\{[\s\S]*\}/);
-  if (!match) {
-    throw new Error("The model did not return a chart specification.");
-  }
-  let spec: unknown;
-  try {
-    spec = JSON.parse(match[0]);
-  } catch {
-    throw new Error("The model returned an invalid chart specification.");
-  }
-  if (
-    spec == null ||
-    typeof spec !== "object" ||
-    !("mark" in spec) ||
-    !("encoding" in spec)
-  ) {
-    throw new Error(
-      "The model's chart specification was missing mark/encoding.",
-    );
-  }
-  // Every field an encoding channel references must be a real result column.
-  // A hallucinated or misspelled field name is otherwise valid JSON and would
-  // render a blank/broken chart with no error — the exact failure this feature
-  // exists to prevent — so reject it here. Channels without a `field` (e.g. an
-  // aggregate "count", a datum/value) are fine and skipped.
-  const valid = new Set(validColumns);
-  const bad = new Set<string>();
-  const encoding = (spec as { encoding?: unknown }).encoding;
-  if (encoding && typeof encoding === "object") {
-    for (const channel of Object.values(encoding as Record<string, unknown>)) {
-      // A channel is usually one definition object, but some (tooltip, detail)
-      // can be an array of them.
-      for (const def of Array.isArray(channel) ? channel : [channel]) {
-        const field = (def as { field?: unknown } | null)?.field;
-        if (typeof field === "string" && !valid.has(field)) {
-          bad.add(field);
-        }
-      }
-    }
-  }
-  if (bad.size > 0) {
-    throw new Error(
-      `The model's chart referenced unknown column(s): ${[...bad].join(", ")}. ` +
-        `Available columns: ${validColumns.join(", ")}.`,
-    );
-  }
-  return spec as Record<string, unknown>;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -192,11 +192,14 @@ export async function verifyResult(
     const session = new LlamaChatSession({
       contextSequence: context.getSequence(),
     });
-    const text = await session.prompt(
-      `${instruction}\n\nRespond with ONLY JSON: {"satisfied": true|false, "reason": "...", "suggestion": "..."}`,
-    );
-    await context.dispose();
-    return parseVerdict(text);
+    try {
+      const text = await session.prompt(
+        `${instruction}\n\nRespond with ONLY JSON: {"satisfied": true|false, "reason": "...", "suggestion": "..."}`,
+      );
+      return parseVerdict(text);
+    } finally {
+      await context.dispose();
+    }
   } catch {
     // Never let a judge failure hide results or wedge the loop.
     return {
@@ -271,7 +274,9 @@ export async function generateChartSpec(
   opts: ChartSpecOptions,
 ): Promise<Record<string, unknown>> {
   const prompt = buildChartPrompt(opts);
-  const raw = await completeText(opts, prompt);
+  // A styled spec (several channels + scales + titles) is still small, but give
+  // headroom beyond the default so it can't truncate into invalid JSON.
+  const raw = await completeText(opts, prompt, 2048);
   return parseChartSpec(raw, opts.columns);
 }
 
@@ -361,9 +366,14 @@ async function completeText(
   const session = new LlamaChatSession({
     contextSequence: context.getSequence(),
   });
-  const text = await session.prompt(prompt);
-  await context.dispose();
-  return text.trim();
+  // finally: callers (e.g. generateChartSpec) let prompt() errors propagate, so
+  // dispose the llama context even on throw to avoid leaking it.
+  try {
+    const text = await session.prompt(prompt);
+    return text.trim();
+  } finally {
+    await context.dispose();
+  }
 }
 
 interface GenerateOptions {
@@ -722,8 +732,13 @@ async function generateViaLocal(
 
   const prompt = `${systemPrompt}\n\nRespond with ONLY a JSON object: {"query": "...", "explanation": "...", "timeRangeMs": ..., "suggestedCharts": ["...", "..."]}\nFor suggestedCharts pick 2-4 from: bar, stacked-bar, line, area, scatter, heatmap, histogram, pie, boxplot.\nOmit timeRangeMs if not mentioned (default 24h).\n\nUser question: ${opts.question}`;
 
-  const response = await session.prompt(prompt);
-  await context.dispose();
+  let response: string;
+  try {
+    response = await session.prompt(prompt);
+  } finally {
+    // Dispose even if prompt() throws (the error propagates to the caller).
+    await context.dispose();
+  }
 
   const jsonMatch = response.match(/\{[\s\S]*"query"[\s\S]*\}/);
   if (!jsonMatch) {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -171,18 +171,23 @@ export async function verifyResult(
       if (models.length === 0) {
         return { satisfied: true, reason: "No judge model available." };
       }
-      const response = await models[0].sendRequest(
-        [
-          vscode.LanguageModelChatMessage.User(
-            `${instruction}\n\nRespond with ONLY JSON: {"satisfied": true|false, "reason": "...", "suggestion": "..."}`,
-          ),
-        ],
-        {},
-        new vscode.CancellationTokenSource().token,
-      );
-      let text = "";
-      for await (const chunk of response.text) text += chunk;
-      return parseVerdict(text);
+      const cts = new vscode.CancellationTokenSource();
+      try {
+        const response = await models[0].sendRequest(
+          [
+            vscode.LanguageModelChatMessage.User(
+              `${instruction}\n\nRespond with ONLY JSON: {"satisfied": true|false, "reason": "...", "suggestion": "..."}`,
+            ),
+          ],
+          {},
+          cts.token,
+        );
+        let text = "";
+        for await (const chunk of response.text) text += chunk;
+        return parseVerdict(text);
+      } finally {
+        cts.dispose();
+      }
     }
 
     // local
@@ -350,14 +355,19 @@ async function completeText(
     if (models.length === 0) {
       throw new Error("No Copilot chat model is available.");
     }
-    const response = await models[0].sendRequest(
-      [vscode.LanguageModelChatMessage.User(prompt)],
-      {},
-      new vscode.CancellationTokenSource().token,
-    );
-    let text = "";
-    for await (const chunk of response.text) text += chunk;
-    return text.trim();
+    const cts = new vscode.CancellationTokenSource();
+    try {
+      const response = await models[0].sendRequest(
+        [vscode.LanguageModelChatMessage.User(prompt)],
+        {},
+        cts.token,
+      );
+      let text = "";
+      for await (const chunk of response.text) text += chunk;
+      return text.trim();
+    } finally {
+      cts.dispose();
+    }
   }
   // local
   const { model } = await getLocalModel();
@@ -500,16 +510,16 @@ async function generateViaCopilot(
     vscode.LanguageModelChatMessage.User(opts.question),
   ];
 
-  const response = await model.sendRequest(
-    messages,
-    {},
-    new vscode.CancellationTokenSource().token,
-  );
-
+  const cts = new vscode.CancellationTokenSource();
   // Collect the streamed response
   let text = "";
-  for await (const chunk of response.text) {
-    text += chunk;
+  try {
+    const response = await model.sendRequest(messages, {}, cts.token);
+    for await (const chunk of response.text) {
+      text += chunk;
+    }
+  } finally {
+    cts.dispose();
   }
 
   // Parse JSON from the response (handle potential markdown wrapping)

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -36,6 +36,10 @@ const ALL_PRESETS: { id: PresetType; label: string }[] = [
   { id: "boxplot", label: "Box Plot" },
 ];
 
+// Give up on an in-flight visualize request after this long so a hung model
+// call can't wedge the UI (the host normally always replies).
+const REQUEST_TIMEOUT_MS = 60_000;
+
 export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props) {
   const [spec, setSpec] = useState<Record<string, unknown> | null>(null);
   const [customPrompt, setCustomPrompt] = useState("");
@@ -49,13 +53,9 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   // request, so a slow response can't clobber a newer one (Bedrock latency
   // varies, and requests can overlap).
   const reqIdRef = useRef(0);
-  // The chart type of the currently-rendered chart (from a dropdown pick), so a
-  // follow-up free-text refinement can keep it even after selectedType is reset
-  // below. Undefined after a pure free-text render (the model chose the type).
-  const [renderedChartType, setRenderedChartType] = useState<
-    string | undefined
-  >(undefined);
-  const pendingChartTypeRef = useRef<string | undefined>(undefined);
+  // Clears loading if the host never replies (e.g. a hung/stalled model call)
+  // so the UI can't wedge with the Select/Button/Enter all disabled.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Both the chart-type dropdown and the free-text box are answered by the
   // model (see extension host onVisualize). Listen for its reply here rather
@@ -67,13 +67,14 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
       if (msg?.type !== "chartSpec" && msg?.type !== "chartSpecError") return;
       // Ignore stale replies from a superseded request.
       if (msg.requestId !== reqIdRef.current) return;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
       if (msg.type === "chartSpec") {
         setSpec(msg.spec);
         setLlmLoading(false);
         setLlmError("");
-        // Remember the type that produced the rendered chart so a follow-up
-        // free-text refinement keeps it (see requestSpec).
-        setRenderedChartType(pendingChartTypeRef.current);
       } else {
         setLlmError(
           msg.message || "Could not build a chart from that description.",
@@ -88,7 +89,10 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
       setSelectedType(null);
     };
     window.addEventListener("message", handler);
-    return () => window.removeEventListener("message", handler);
+    return () => {
+      window.removeEventListener("message", handler);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
   }, []);
 
   // All chart types are always offered in the dropdown; the ones the model
@@ -135,15 +139,23 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   // model: given the columns (and which are numeric) plus the request, it
   // decides the field for each channel and any styling (axis scale/min, color
   // scheme, sort). Row data is never sent. A dropdown pick sends chartType; the
-  // text box sends a description; both are sent together when both are present
-  // (e.g. picking a type while text is typed, or refining a typed request).
+  // text box sends its description (letting the model choose the type from the
+  // words); both are sent together when a type is picked while text is typed.
   const requestSpec = (req: { chartType?: string; description?: string }) => {
     const description = req.description?.trim() ?? "";
     if (!req.chartType && !description) return;
     const requestId = ++reqIdRef.current;
-    pendingChartTypeRef.current = req.chartType;
     setLlmLoading(true);
     setLlmError("");
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      // Only fire if this is still the in-flight request (no reply arrived).
+      if (reqIdRef.current !== requestId) return;
+      timeoutRef.current = null;
+      setLlmLoading(false);
+      setSelectedType(null);
+      setLlmError("The chart request timed out. Please try again.");
+    }, REQUEST_TIMEOUT_MS);
     postMessage({
       type: "visualize",
       columns,
@@ -207,7 +219,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               onKeyDown={({ detail }) => {
                 if (detail.key === "Enter" && !llmLoading)
                   requestSpec({
-                    chartType: selectedType?.value ?? renderedChartType,
+                    chartType: selectedType?.value,
                     description: customPrompt,
                   });
               }}
@@ -217,7 +229,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
           <Button
             onClick={() =>
               requestSpec({
-                chartType: selectedType?.value ?? renderedChartType,
+                chartType: selectedType?.value,
                 description: customPrompt,
               })
             }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -48,6 +48,13 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   // request, so a slow response can't clobber a newer one (Bedrock latency
   // varies, and requests can overlap).
   const reqIdRef = useRef(0);
+  // The chart type of the currently-rendered chart (from a dropdown pick), so a
+  // follow-up free-text refinement can keep it even after selectedType is reset
+  // below. Undefined after a pure free-text render (the model chose the type).
+  const [renderedChartType, setRenderedChartType] = useState<
+    string | undefined
+  >(undefined);
+  const pendingChartTypeRef = useRef<string | undefined>(undefined);
 
   // Both the chart-type dropdown and the free-text box are answered by the
   // model (see extension host onVisualize). Listen for its reply here rather
@@ -63,6 +70,9 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
         setSpec(msg.spec);
         setLlmLoading(false);
         setLlmError("");
+        // Remember the type that produced the rendered chart so a follow-up
+        // free-text refinement keeps it (see requestSpec).
+        setRenderedChartType(pendingChartTypeRef.current);
       } else {
         setLlmError(
           msg.message || "Could not build a chart from that description.",
@@ -130,6 +140,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     const description = req.description?.trim() ?? "";
     if (!req.chartType && !description) return;
     const requestId = ++reqIdRef.current;
+    pendingChartTypeRef.current = req.chartType;
     setLlmLoading(true);
     setLlmError("");
     postMessage({
@@ -195,7 +206,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               onKeyDown={({ detail }) => {
                 if (detail.key === "Enter" && !llmLoading)
                   requestSpec({
-                    chartType: selectedType?.value,
+                    chartType: selectedType?.value ?? renderedChartType,
                     description: customPrompt,
                   });
               }}
@@ -205,7 +216,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
           <Button
             onClick={() =>
               requestSpec({
-                chartType: selectedType?.value,
+                chartType: selectedType?.value ?? renderedChartType,
                 description: customPrompt,
               })
             }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -8,6 +8,7 @@ import Input from "@cloudscape-design/components/input";
 import Select, { SelectProps } from "@cloudscape-design/components/select";
 import Box from "@cloudscape-design/components/box";
 import Alert from "@cloudscape-design/components/alert";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Modal from "@cloudscape-design/components/modal";
 import Table from "@cloudscape-design/components/table";
 import { VegaChart } from "./VegaChart";
@@ -221,7 +222,6 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               })
             }
             disabled={!customPrompt.trim() || llmLoading}
-            loading={llmLoading}
           >
             Visualize
           </Button>
@@ -235,9 +235,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
       </Container>
 
       {llmLoading && (
-        <Box color="text-status-info" fontSize="body-s">
-          Generating chart…
-        </Box>
+        <StatusIndicator type="loading">Generating chart…</StatusIndicator>
       )}
       {spec && <VegaChart spec={spec} data={data} />}
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
@@ -30,22 +30,33 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   const [selectedType, setSelectedType] = useState<SelectProps.Option | null>(
     null,
   );
+  // Monotonic id per request; a reply is applied only if it matches the latest
+  // request, so a slow response can't clobber a newer one (Bedrock latency
+  // varies, and requests can overlap).
+  const reqIdRef = useRef(0);
 
-  // The free-text box is answered by the model (see extension host onVisualize).
-  // Listen for its reply here rather than routing through App's handler, so the
-  // feature stays self-contained; App ignores these message types.
+  // Both the chart-type dropdown and the free-text box are answered by the
+  // model (see extension host onVisualize). Listen for its reply here rather
+  // than routing through App's handler, so the feature stays self-contained;
+  // App ignores these message types.
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       const msg = event.data;
-      if (msg?.type === "chartSpec") {
+      if (msg?.type !== "chartSpec" && msg?.type !== "chartSpecError") return;
+      // Ignore stale replies from a superseded request.
+      if (msg.requestId !== reqIdRef.current) return;
+      if (msg.type === "chartSpec") {
         setSpec(msg.spec);
         setLlmLoading(false);
         setLlmError("");
-      } else if (msg?.type === "chartSpecError") {
+      } else {
         setLlmError(
           msg.message || "Could not build a chart from that description.",
         );
         setLlmLoading(false);
+        // Clear the selection so re-picking the same type re-fires onChange
+        // (Cloudscape Select only fires when the selection changes).
+        setSelectedType(null);
       }
     };
     window.addEventListener("message", handler);
@@ -102,10 +113,12 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   // model: given the columns (and which are numeric) plus the request, it
   // decides the field for each channel and any styling (axis scale/min, color
   // scheme, sort). Row data is never sent. A dropdown pick sends chartType; the
-  // text box sends a description; either or both may be present.
+  // text box sends a description; both are sent together when both are present
+  // (e.g. picking a type while text is typed, or refining a typed request).
   const requestSpec = (req: { chartType?: string; description?: string }) => {
     const description = req.description?.trim() ?? "";
     if (!req.chartType && !description) return;
+    const requestId = ++reqIdRef.current;
     setLlmLoading(true);
     setLlmError("");
     postMessage({
@@ -114,6 +127,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
       numericColumns: numericCols,
       chartType: req.chartType,
       description,
+      requestId,
     });
   };
 
@@ -142,7 +156,10 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
                 selectedOption={selectedType}
                 onChange={({ detail }) => {
                   setSelectedType(detail.selectedOption);
-                  requestSpec({ chartType: detail.selectedOption.value });
+                  requestSpec({
+                    chartType: detail.selectedOption.value,
+                    description: customPrompt,
+                  });
                 }}
                 options={chartOptions}
                 placeholder="Choose a chart type"
@@ -166,14 +183,22 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               value={customPrompt}
               onChange={({ detail }) => setCustomPrompt(detail.value)}
               onKeyDown={({ detail }) => {
-                if (detail.key === "Enter")
-                  requestSpec({ description: customPrompt });
+                if (detail.key === "Enter" && !llmLoading)
+                  requestSpec({
+                    chartType: selectedType?.value,
+                    description: customPrompt,
+                  });
               }}
               placeholder="stacked bar chart colored by status"
             />
           </FormField>
           <Button
-            onClick={() => requestSpec({ description: customPrompt })}
+            onClick={() =>
+              requestSpec({
+                chartType: selectedType?.value,
+                description: customPrompt,
+              })
+            }
             disabled={!customPrompt.trim() || llmLoading}
             loading={llmLoading}
           >

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -1,14 +1,16 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Button from "@cloudscape-design/components/button";
 import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
+import Select, { SelectProps } from "@cloudscape-design/components/select";
 import Box from "@cloudscape-design/components/box";
 import Modal from "@cloudscape-design/components/modal";
 import Table from "@cloudscape-design/components/table";
 import { VegaChart } from "./VegaChart";
+import { postMessage } from "./vscode";
 
 interface Props {
   columns: string[];
@@ -23,6 +25,32 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   const [spec, setSpec] = useState<Record<string, unknown> | null>(null);
   const [customPrompt, setCustomPrompt] = useState("");
   const [guideOpen, setGuideOpen] = useState(false);
+  const [llmLoading, setLlmLoading] = useState(false);
+  const [llmError, setLlmError] = useState("");
+  const [selectedType, setSelectedType] = useState<SelectProps.Option | null>(
+    null,
+  );
+
+  // The free-text box is answered by the model (see extension host onVisualize).
+  // Listen for its reply here rather than routing through App's handler, so the
+  // feature stays self-contained; App ignores these message types.
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const msg = event.data;
+      if (msg?.type === "chartSpec") {
+        setSpec(msg.spec);
+        setLlmLoading(false);
+        setLlmError("");
+      } else if (msg?.type === "chartSpecError") {
+        setLlmError(
+          msg.message || "Could not build a chart from that description.",
+        );
+        setLlmLoading(false);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   const allPresets: { id: PresetType; label: string }[] = [
     { id: "bar", label: "Bar" },
@@ -36,10 +64,18 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     { id: "boxplot", label: "Box Plot" },
   ];
 
-  // Show only suggested charts if the LLM provided them, otherwise show all
-  const visiblePresets = suggestedCharts && suggestedCharts.length > 0
-    ? allPresets.filter((p) => suggestedCharts.includes(p.id))
-    : allPresets;
+  // All chart types are always offered in the dropdown; the ones the model
+  // suggested for this result are floated to the top and tagged "Recommended"
+  // (previously only the suggested ones were shown, hiding the rest).
+  const recommended = new Set(suggestedCharts ?? []);
+  const chartOptions: SelectProps.Option[] = [
+    ...allPresets.filter((p) => recommended.has(p.id)),
+    ...allPresets.filter((p) => !recommended.has(p.id)),
+  ].map((p) => ({
+    label: p.label,
+    value: p.id,
+    ...(recommended.has(p.id) ? { labelTag: "Recommended" } : {}),
+  }));
 
   // Convert rows to objects with numeric coercion
   const data = useMemo(
@@ -56,137 +92,29 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     [columns, rows],
   );
 
-  // Guess which columns are numeric vs categorical
+  // Guess which columns are numeric (a hint sent to the model).
   const numericCols = columns.filter((col) => {
     const sample = data.find((d) => d[col] !== "" && d[col] != null);
     return sample && typeof sample[col] === "number";
   });
-  const categoricalCols = columns.filter((col) => !numericCols.includes(col));
 
-  const applyCustom = () => {
-    const desc = customPrompt.toLowerCase();
-    // Detect chart type from description
-    let type: PresetType = "bar";
-    if (desc.includes("heatmap")) type = "heatmap";
-    else if (desc.includes("scatter")) type = "scatter";
-    else if (desc.includes("pie") || desc.includes("donut")) type = "pie";
-    else if (desc.includes("histogram") || desc.includes("distribution")) type = "histogram";
-    else if (desc.includes("area")) type = "area";
-    else if (desc.includes("line") || desc.includes("trend")) type = "line";
-    else if (desc.includes("stacked")) type = "stacked-bar";
-    else if (desc.includes("box")) type = "boxplot";
-
-    // Try to extract field names mentioned in the description
-    const mentionedCols = columns.filter((col) => desc.includes(col.toLowerCase()));
-    if (mentionedCols.length >= 2 && type === "heatmap") {
-      setSpec({
-        mark: "rect",
-        encoding: {
-          x: { field: mentionedCols[0], type: "nominal" },
-          y: { field: mentionedCols[1], type: "nominal" },
-          color: { field: mentionedCols[2] ?? numericCols[0] ?? columns[2], type: "quantitative" },
-        },
-      });
-    } else if (mentionedCols.length >= 1) {
-      // Use mentioned columns in the preset
-      applyPreset(type);
-    } else {
-      applyPreset(type);
-    }
-  };
-
-  const applyPreset = (type: PresetType) => {
-    const xCol = categoricalCols[0] ?? columns[0];
-    const yCol = numericCols[0] ?? columns[1];
-    const colorCol = categoricalCols[1] ?? categoricalCols[0];
-
-    switch (type) {
-      case "bar":
-        setSpec({
-          mark: "bar",
-          encoding: {
-            x: { field: xCol, type: "nominal" },
-            y: { field: yCol, type: "quantitative" },
-            color: colorCol !== xCol ? { field: colorCol, type: "nominal" } : undefined,
-          },
-        });
-        break;
-      case "stacked-bar":
-        setSpec({
-          mark: "bar",
-          encoding: {
-            x: { field: xCol, type: "nominal" },
-            y: { field: yCol, type: "quantitative", stack: "zero" },
-            color: { field: colorCol ?? xCol, type: "nominal" },
-          },
-        });
-        break;
-      case "line":
-        setSpec({
-          mark: { type: "line", point: true },
-          encoding: {
-            x: { field: xCol, type: "nominal" },
-            y: { field: yCol, type: "quantitative" },
-          },
-        });
-        break;
-      case "area":
-        setSpec({
-          mark: { type: "area", opacity: 0.7 },
-          encoding: {
-            x: { field: xCol, type: "nominal" },
-            y: { field: yCol, type: "quantitative" },
-          },
-        });
-        break;
-      case "scatter":
-        setSpec({
-          mark: "point",
-          encoding: {
-            x: { field: numericCols[0] ?? columns[0], type: "quantitative" },
-            y: { field: numericCols[1] ?? numericCols[0] ?? columns[1], type: "quantitative" },
-            color: categoricalCols[0] ? { field: categoricalCols[0], type: "nominal" } : undefined,
-          },
-        });
-        break;
-      case "heatmap":
-        setSpec({
-          mark: "rect",
-          encoding: {
-            x: { field: categoricalCols[0] ?? columns[0], type: "nominal" },
-            y: { field: categoricalCols[1] ?? columns[1], type: "nominal" },
-            color: { field: numericCols[0] ?? columns[2], type: "quantitative" },
-          },
-        });
-        break;
-      case "histogram":
-        setSpec({
-          mark: "bar",
-          encoding: {
-            x: { field: numericCols[0] ?? columns[0], bin: true, type: "quantitative" },
-            y: { aggregate: "count", type: "quantitative" },
-          },
-        });
-        break;
-      case "pie":
-        setSpec({
-          mark: { type: "arc", innerRadius: 30 },
-          encoding: {
-            theta: { field: yCol, type: "quantitative" },
-            color: { field: xCol, type: "nominal" },
-          },
-        });
-        break;
-      case "boxplot":
-        setSpec({
-          mark: "boxplot",
-          encoding: {
-            x: { field: categoricalCols[0] ?? columns[0], type: "nominal" },
-            y: { field: numericCols[0] ?? columns[1], type: "quantitative" },
-          },
-        });
-        break;
-    }
+  // Both the chart-type dropdown and the free-text box are answered by the
+  // model: given the columns (and which are numeric) plus the request, it
+  // decides the field for each channel and any styling (axis scale/min, color
+  // scheme, sort). Row data is never sent. A dropdown pick sends chartType; the
+  // text box sends a description; either or both may be present.
+  const requestSpec = (req: { chartType?: string; description?: string }) => {
+    const description = req.description?.trim() ?? "";
+    if (!req.chartType && !description) return;
+    setLlmLoading(true);
+    setLlmError("");
+    postMessage({
+      type: "visualize",
+      columns,
+      numericColumns: numericCols,
+      chartType: req.chartType,
+      description,
+    });
   };
 
   return (
@@ -205,26 +133,60 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
             )}
           </Box>
 
-          <SpaceBetween direction="horizontal" size="s">
-            {visiblePresets.map((p) => (
-              <Button key={p.id} onClick={() => applyPreset(p.id)}>{p.label}</Button>
-            ))}
-            <Button variant="icon" iconName="status-info" onClick={() => setGuideOpen(true)} />
-          </SpaceBetween>
+          <FormField
+            label="Chart type"
+            description="Pick a type and the model builds the chart — choosing the fields and styling for these columns. Types tagged “Recommended” fit best."
+          >
+            <SpaceBetween direction="horizontal" size="s">
+              <Select
+                selectedOption={selectedType}
+                onChange={({ detail }) => {
+                  setSelectedType(detail.selectedOption);
+                  requestSpec({ chartType: detail.selectedOption.value });
+                }}
+                options={chartOptions}
+                placeholder="Choose a chart type"
+                disabled={llmLoading}
+                expandToViewport
+              />
+              <Button
+                variant="icon"
+                iconName="status-info"
+                onClick={() => setGuideOpen(true)}
+              />
+            </SpaceBetween>
+          </FormField>
 
-          <FormField label="Or describe how to visualize" description="e.g. 'heatmap with customerName on x and productCategory on y'">
+          <FormField
+            label="Or describe how to visualize"
+            description="Uses the model to map your request onto the fetched columns — e.g. 'record_count as data, product_category and hour_bucket as axis, stacked bar'."
+            errorText={llmError || undefined}
+          >
             <Input
               value={customPrompt}
               onChange={({ detail }) => setCustomPrompt(detail.value)}
+              onKeyDown={({ detail }) => {
+                if (detail.key === "Enter")
+                  requestSpec({ description: customPrompt });
+              }}
               placeholder="stacked bar chart colored by status"
             />
           </FormField>
-          <Button onClick={() => applyCustom()} disabled={!customPrompt.trim()}>
+          <Button
+            onClick={() => requestSpec({ description: customPrompt })}
+            disabled={!customPrompt.trim() || llmLoading}
+            loading={llmLoading}
+          >
             Visualize
           </Button>
         </SpaceBetween>
       </Container>
 
+      {llmLoading && (
+        <Box color="text-status-info" fontSize="body-s">
+          Generating chart…
+        </Box>
+      )}
       {spec && <VegaChart spec={spec} data={data} />}
 
       <Modal
@@ -234,7 +196,7 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
         size="large"
       >
         <SpaceBetween size="m">
-          <Box>Choose a preset or describe what you want in the text field. The chart renders instantly from the data already fetched — no additional query.</Box>
+          <Box>Pick a chart type or describe what you want in the text field — either way the model maps your request onto the result columns and picks sensible fields and styling. No new data query is run; the chart is built from the rows already fetched.</Box>
 
           <Table
             columnDefinitions={[

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -209,10 +209,11 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
                 selectedOption={selectedType}
                 onChange={({ detail }) => {
                   setSelectedType(detail.selectedOption);
-                  requestSpec({
-                    chartType: detail.selectedOption.value,
-                    description: customPrompt,
-                  });
+                  // A dropdown pick is a self-contained request: send only the
+                  // chosen type (the model picks the fields), not whatever text
+                  // happens to be left in the free-text box. The text box is
+                  // its own explicit "Visualize" action.
+                  requestSpec({ chartType: detail.selectedOption.value });
                 }}
                 options={chartOptions}
                 placeholder="Choose a chart type"

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -7,6 +7,7 @@ import FormField from "@cloudscape-design/components/form-field";
 import Input from "@cloudscape-design/components/input";
 import Select, { SelectProps } from "@cloudscape-design/components/select";
 import Box from "@cloudscape-design/components/box";
+import Alert from "@cloudscape-design/components/alert";
 import Modal from "@cloudscape-design/components/modal";
 import Table from "@cloudscape-design/components/table";
 import { VegaChart } from "./VegaChart";
@@ -67,10 +68,13 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
           msg.message || "Could not build a chart from that description.",
         );
         setLlmLoading(false);
-        // Clear the selection so re-picking the same type re-fires onChange
-        // (Cloudscape Select only fires when the selection changes).
-        setSelectedType(null);
       }
+      // Reset the dropdown selection after every reply (success or error).
+      // Cloudscape Select only fires onChange when the value changes, so
+      // leaving it set would make re-picking the same type a silent no-op;
+      // clearing it lets the user re-generate the same chart type. The chart
+      // itself stays rendered below.
+      setSelectedType(null);
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
@@ -184,7 +188,6 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
           <FormField
             label="Or describe how to visualize"
             description="Uses the model to map your request onto the fetched columns — e.g. 'record_count as data, product_category and hour_bucket as axis, stacked bar'."
-            errorText={llmError || undefined}
           >
             <Input
               value={customPrompt}
@@ -211,6 +214,12 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
           >
             Visualize
           </Button>
+
+          {llmError && (
+            <Alert type="error" header="Couldn't build the chart">
+              {llmError}
+            </Alert>
+          )}
         </SpaceBetween>
       </Container>
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -21,6 +21,19 @@ interface Props {
 
 type PresetType = "bar" | "stacked-bar" | "line" | "area" | "scatter" | "heatmap" | "histogram" | "pie" | "boxplot";
 
+// Constant list of every selectable chart type (order = fallback dropdown order).
+const ALL_PRESETS: { id: PresetType; label: string }[] = [
+  { id: "bar", label: "Bar" },
+  { id: "stacked-bar", label: "Stacked Bar" },
+  { id: "line", label: "Line" },
+  { id: "area", label: "Area" },
+  { id: "scatter", label: "Scatter" },
+  { id: "heatmap", label: "Heatmap" },
+  { id: "histogram", label: "Histogram" },
+  { id: "pie", label: "Pie" },
+  { id: "boxplot", label: "Box Plot" },
+];
+
 export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props) {
   const [spec, setSpec] = useState<Record<string, unknown> | null>(null);
   const [customPrompt, setCustomPrompt] = useState("");
@@ -63,30 +76,20 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     return () => window.removeEventListener("message", handler);
   }, []);
 
-  const allPresets: { id: PresetType; label: string }[] = [
-    { id: "bar", label: "Bar" },
-    { id: "stacked-bar", label: "Stacked Bar" },
-    { id: "line", label: "Line" },
-    { id: "area", label: "Area" },
-    { id: "scatter", label: "Scatter" },
-    { id: "heatmap", label: "Heatmap" },
-    { id: "histogram", label: "Histogram" },
-    { id: "pie", label: "Pie" },
-    { id: "boxplot", label: "Box Plot" },
-  ];
-
   // All chart types are always offered in the dropdown; the ones the model
   // suggested for this result are floated to the top and tagged "Recommended"
   // (previously only the suggested ones were shown, hiding the rest).
-  const recommended = new Set(suggestedCharts ?? []);
-  const chartOptions: SelectProps.Option[] = [
-    ...allPresets.filter((p) => recommended.has(p.id)),
-    ...allPresets.filter((p) => !recommended.has(p.id)),
-  ].map((p) => ({
-    label: p.label,
-    value: p.id,
-    ...(recommended.has(p.id) ? { labelTag: "Recommended" } : {}),
-  }));
+  const chartOptions: SelectProps.Option[] = useMemo(() => {
+    const recommended = new Set(suggestedCharts ?? []);
+    return [
+      ...ALL_PRESETS.filter((p) => recommended.has(p.id)),
+      ...ALL_PRESETS.filter((p) => !recommended.has(p.id)),
+    ].map((p) => ({
+      label: p.label,
+      value: p.id,
+      ...(recommended.has(p.id) ? { labelTag: "Recommended" } : {}),
+    }));
+  }, [suggestedCharts]);
 
   // Convert rows to objects with numeric coercion
   const data = useMemo(
@@ -104,10 +107,14 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
   );
 
   // Guess which columns are numeric (a hint sent to the model).
-  const numericCols = columns.filter((col) => {
-    const sample = data.find((d) => d[col] !== "" && d[col] != null);
-    return sample && typeof sample[col] === "number";
-  });
+  const numericCols = useMemo(
+    () =>
+      columns.filter((col) => {
+        const sample = data.find((d) => d[col] !== "" && d[col] != null);
+        return sample && typeof sample[col] === "number";
+      }),
+    [columns, data],
+  );
 
   // Both the chart-type dropdown and the free-text box are answered by the
   // model: given the columns (and which are numeric) plus the request, it
@@ -239,26 +246,25 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               { chart: "Histogram", best: "Distribution of a single numeric variable", needs: "1 numeric column" },
               { chart: "Pie / Donut", best: "Proportions of a whole (few categories)", needs: "1 categorical + 1 numeric column" },
               { chart: "Box Plot", best: "Statistical distribution (median, quartiles, outliers)", needs: "1 categorical + 1 numeric column" },
-              { chart: "Tick / Strip", best: "Individual data points along an axis", needs: "1 numeric column (+ optional category)" },
             ]}
             variant="embedded"
           />
 
           <Header variant="h3">Tips</Header>
           <Box variant="p">
-            • Presets auto-detect which columns are numeric (used for values) and which are categorical (used for labels/axes).
+            • Pick a chart type from the dropdown or describe what you want; the model chooses which columns map to each axis/value and adds styling.
           </Box>
           <Box variant="p">
-            • For grouped/stacked bar charts, make sure your query returns at least 2 categorical columns (the second becomes the color).
+            • For grouped/stacked bars, make sure your query returns a second categorical column for the model to use as the color/series.
           </Box>
           <Box variant="p">
-            • Heatmaps need exactly 2 categorical columns + 1 numeric. Query example: "count by customerName and productCategory from input".
+            • Heatmaps work best with 2 categorical columns + 1 numeric. Query example: "count by customerName and productCategory from input".
           </Box>
           <Box variant="p">
             • Charts can be exported as PNG or SVG using the "⋯" menu on the chart.
           </Box>
           <Box variant="p">
-            • If the chart looks wrong, go back and adjust your query to return the right columns.
+            • If the chart looks wrong, refine your description, or go back and adjust your query to return the right columns.
           </Box>
         </SpaceBetween>
       </Modal>

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -151,6 +151,9 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     timeoutRef.current = setTimeout(() => {
       // Only fire if this is still the in-flight request (no reply arrived).
       if (reqIdRef.current !== requestId) return;
+      // Advance the id so a reply that lands after the timeout is treated as
+      // stale and ignored (rather than popping a chart in over the error).
+      reqIdRef.current++;
       timeoutRef.current = null;
       setLlmLoading(false);
       setSelectedType(null);
@@ -218,21 +221,13 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
               onChange={({ detail }) => setCustomPrompt(detail.value)}
               onKeyDown={({ detail }) => {
                 if (detail.key === "Enter" && !llmLoading)
-                  requestSpec({
-                    chartType: selectedType?.value,
-                    description: customPrompt,
-                  });
+                  requestSpec({ description: customPrompt });
               }}
               placeholder="stacked bar chart colored by status"
             />
           </FormField>
           <Button
-            onClick={() =>
-              requestSpec({
-                chartType: selectedType?.value,
-                description: customPrompt,
-              })
-            }
+            onClick={() => requestSpec({ description: customPrompt })}
             disabled={!customPrompt.trim() || llmLoading}
           >
             Visualize

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/VisualizePage.tsx
@@ -40,6 +40,12 @@ const ALL_PRESETS: { id: PresetType; label: string }[] = [
 // call can't wedge the UI (the host normally always replies).
 const REQUEST_TIMEOUT_MS = 60_000;
 
+// A cell counts as numeric only if it's non-blank after trimming and parses as
+// a finite number — so a whitespace-only cell isn't silently coerced to 0.
+function isNumericString(v: string): boolean {
+  return v.trim() !== "" && Number.isFinite(Number(v));
+}
+
 export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props) {
   const [spec, setSpec] = useState<Record<string, unknown> | null>(null);
   const [customPrompt, setCustomPrompt] = useState("");
@@ -110,30 +116,39 @@ export function VisualizePage({ columns, rows, suggestedCharts, onBack }: Props)
     }));
   }, [suggestedCharts]);
 
-  // Convert rows to objects with numeric coercion
+  // Convert rows to objects, coercing genuinely-numeric cells to numbers
+  // (whitespace-only stays a string rather than becoming 0).
   const data = useMemo(
     () =>
       rows.map((row) => {
         const obj: Record<string, unknown> = {};
         columns.forEach((col, i) => {
           const val = row[i] ?? "";
-          const num = Number(val);
-          obj[col] = val !== "" && !isNaN(num) ? num : val;
+          obj[col] = isNumericString(val) ? Number(val) : val;
         });
         return obj;
       }),
     [columns, rows],
   );
 
-  // Guess which columns are numeric (a hint sent to the model).
-  const numericCols = useMemo(
-    () =>
-      columns.filter((col) => {
-        const sample = data.find((d) => d[col] !== "" && d[col] != null);
-        return sample && typeof sample[col] === "number";
-      }),
-    [columns, data],
-  );
+  // Guess which columns are numeric (an advisory hint sent to the model).
+  // Classify off a bounded sample by majority rather than a single value, so a
+  // stray non-numeric first cell doesn't mislabel an otherwise-numeric column.
+  const numericCols = useMemo(() => {
+    const SAMPLE = 50;
+    return columns.filter((_, i) => {
+      let numeric = 0;
+      let total = 0;
+      for (const row of rows) {
+        const v = row[i] ?? "";
+        if (v.trim() === "") continue;
+        total++;
+        if (isNumericString(v)) numeric++;
+        if (total >= SAMPLE) break;
+      }
+      return total > 0 && numeric / total > 0.5;
+    });
+  }, [columns, rows]);
 
   // Both the chart-type dropdown and the free-text box are answered by the
   // model: given the columns (and which are numeric) plus the request, it

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -5,6 +5,9 @@ export type OutboundMessage =
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
+  // NOTE: keep this `visualize` shape in sync with the InboundMessage union in
+  // src/extension.ts (host and webview message types are, as existing debt,
+  // declared separately in each project's own `src`).
   | {
       type: "visualize";
       columns: string[];

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -5,6 +5,13 @@ export type OutboundMessage =
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
+  | {
+      type: "visualize";
+      columns: string[];
+      numericColumns: string[];
+      chartType?: string;
+      description: string;
+    }
   | { type: "startListening" }
   | { type: "stopListening" }
   | {
@@ -74,6 +81,8 @@ export type InboundMessage =
       hiddenColumns?: string[];
     }
   | { type: "detailResult"; fields: Record<string, string> }
+  | { type: "chartSpec"; spec: Record<string, unknown> }
+  | { type: "chartSpecError"; message: string }
   | {
       /**
        * One completed iteration of the run→verify→refine loop, streamed so

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -11,6 +11,7 @@ export type OutboundMessage =
       numericColumns: string[];
       chartType?: string;
       description: string;
+      requestId: number;
     }
   | { type: "startListening" }
   | { type: "stopListening" }
@@ -81,8 +82,8 @@ export type InboundMessage =
       hiddenColumns?: string[];
     }
   | { type: "detailResult"; fields: Record<string, string> }
-  | { type: "chartSpec"; spec: Record<string, unknown> }
-  | { type: "chartSpecError"; message: string }
+  | { type: "chartSpec"; spec: Record<string, unknown>; requestId: number }
+  | { type: "chartSpecError"; message: string; requestId: number }
   | {
       /**
        * One completed iteration of the run→verify→refine loop, streamed so


### PR DESCRIPTION
Builds on the conversational Workflow Insight assistant (#690). The Visualize page previously configured charts with a local keyword heuristic that guessed axes from column order and, for the free-text box, only detected the chart TYPE and discarded the fields the user named — so a request like "record_count as data, product_category and hour_bucket as axis, stacked bar" rendered with the wrong encoding. It also hid every chart type the model didn't suggest.

Now the model configures the chart:

- New llm.ts generateChartSpec turns a request (a chosen chart type and/or a free-text description) plus the result's column names and which are numeric into a validated Vega-Lite {mark, encoding} — choosing the field for each channel and optional styling (axis scale/min, color scheme, sort, titles). It dispatches across bedrock/copilot/local via a shared completeText helper and throws on a missing/invalid spec so failures surface instead of rendering a wrong chart. Only column names/types and the request are sent — never rows.
- extension.ts handles a new "visualize" webview message (onVisualize) and replies with "chartSpec" / "chartSpecError".
- VisualizePage: the preset button row is now a dropdown listing ALL chart types with the model-suggested ones tagged "Recommended"; both selecting a type and submitting free text call the model (loading state, inline errors, Enter-to-submit). The local applyPreset/column-guessing heuristic is removed.

Verified live against Bedrock: the example request yields record_count on y (stack:zero), product_category on x, hour_bucket as color; selecting "stacked-bar" with no text picks sensible channels and styling. Typecheck (extension + webview) and build are clean; 98 tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
