### PR TITLE
feat(sdk): emit operationName in default logger output

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/log-levels/logger-log-levels.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/logger-test/log-levels/logger-log-levels.test.ts
@@ -51,6 +51,7 @@ createTests({
             executionArn: expect.any(String),
             ...(hasOperationId && {
               operationId: expect.any(String),
+              operationName: expect.any(String),
             }),
             ...(attemptCount && {
               attempt: attemptCount,
@@ -165,6 +166,7 @@ createTests({
               level: "ERROR",
               executionArn: expect.any(String),
               operationId: expect.any(String),
+              operationName: expect.any(String),
               message: expect.stringMatching(
                 /^Error from child context with Error object: Error: Child context error/,
               ),
@@ -206,6 +208,7 @@ createTests({
               level: "ERROR",
               executionArn: expect.any(String),
               operationId: expect.any(String),
+              operationName: expect.any(String),
               message: {
                 errorType: "Error",
                 errorMessage: "Step context direct error",
@@ -233,6 +236,7 @@ createTests({
               level: "ERROR",
               executionArn: expect.any(String),
               operationId: expect.any(String),
+              operationName: expect.any(String),
               message: expect.stringMatching(
                 /^Multiple errors in step: Error: First step error/,
               ),

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.integration.test.ts
@@ -140,6 +140,61 @@ describe("DurableContext Integration Tests", () => {
         );
       });
 
+      it("should include operationName when provided in active context", () => {
+        const { context, executionContext } = createTestDurableContext({
+          durableExecutionMode: DurableExecutionMode.ExecutionMode,
+        });
+
+        const loggingContext = context.getDurableLoggingContext();
+
+        runWithContext(
+          "1",
+          undefined,
+          () => {
+            const logData = loggingContext.getDurableLogData();
+
+            expect(logData).toEqual({
+              executionArn: executionContext.durableExecutionArn,
+              requestId: executionContext.requestId,
+              tenantId: executionContext.tenantId,
+              operationId: hashId("1"),
+              operationName: "fetch-user",
+              attempt: 2,
+            });
+          },
+          2, // attempt number
+          DurableExecutionMode.ExecutionMode,
+          "fetch-user", // operation name
+        );
+      });
+
+      it("should not include operationName in root context", () => {
+        const { context, executionContext } = createTestDurableContext({
+          durableExecutionMode: DurableExecutionMode.ExecutionMode,
+        });
+
+        const loggingContext = context.getDurableLoggingContext();
+
+        runWithContext(
+          "root",
+          undefined,
+          () => {
+            const logData = loggingContext.getDurableLogData();
+
+            expect(logData).toEqual({
+              executionArn: executionContext.durableExecutionArn,
+              requestId: executionContext.requestId,
+              tenantId: executionContext.tenantId,
+              operationId: undefined,
+            });
+            expect(logData.operationName).toBeUndefined();
+          },
+          undefined,
+          DurableExecutionMode.ExecutionMode,
+          "root-op", // operation name should be ignored for root
+        );
+      });
+
       it("should work without active context", () => {
         const { context, executionContext } = createTestDurableContext({
           durableExecutionMode: DurableExecutionMode.ExecutionMode,

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -157,6 +157,14 @@ export class DurableContextImpl<
               : hashId(activeContext.contextId),
         };
 
+        if (
+          activeContext &&
+          activeContext.contextId !== "root" &&
+          activeContext.operationName !== undefined
+        ) {
+          result.operationName = activeContext.operationName;
+        }
+
         if (activeContext?.attempt !== undefined) {
           result.attempt = activeContext.attempt;
         }

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -895,6 +895,7 @@ describe("runWithContext Integration", () => {
       expect.any(Function), // The wrapped child function
       undefined, // No attempt number for child contexts
       DurableExecutionMode.ExecutionMode,
+      "test-child", // operationName (child context name)
     );
   });
 
@@ -941,6 +942,9 @@ describe("runWithContext Integration", () => {
       "child-context-id",
       "child-context-id", // parentId becomes entityId in ReplayChildren mode
       expect.any(Function), // The wrapped child function
+      undefined, // no attempt number
+      undefined, // no explicit replay mode override
+      "test-child", // operationName (child context name)
     );
   });
 
@@ -1011,6 +1015,9 @@ describe("runWithContext Integration", () => {
       "child-context-id", // stepId = entityId
       "child-context-id", // parentId = entityId (not the original parentId)
       expect.any(Function),
+      undefined, // no attempt number
+      undefined, // no explicit replay mode override
+      "test-child", // operationName (child context name)
     );
   });
 
@@ -1025,6 +1032,7 @@ describe("runWithContext Integration", () => {
       expect.any(Function),
       undefined,
       DurableExecutionMode.ExecutionMode,
+      "test-child-1", // operationName (child context name)
     );
 
     // Reset and test with STARTED status (should still be ExecutionMode)
@@ -1044,6 +1052,7 @@ describe("runWithContext Integration", () => {
       expect.any(Function),
       undefined,
       DurableExecutionMode.ExecutionMode,
+      "test-child-2", // operationName (child context name)
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -257,8 +257,13 @@ export const handleCompletedChildContext = async <
       entityId, // parentId
     );
 
-    const replayedResult = await runWithContext(entityId, entityId, () =>
-      fn(durableChildContext),
+    const replayedResult = await runWithContext(
+      entityId,
+      entityId,
+      () => fn(durableChildContext),
+      undefined,
+      undefined,
+      stepName,
     );
 
     // Large payloads re-execute the child function on replay, so apply the
@@ -384,6 +389,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
         : childContextFn,
       undefined,
       childReplayMode,
+      name,
     )) as T;
 
     // Serialize the result for consistency

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -332,6 +332,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
               : stepFn,
             currentAttempt,
             DurableExecutionMode.ExecutionMode,
+            name,
           )) as T;
 
           const serializedResult = await safeSerialize(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
@@ -352,6 +352,7 @@ describe("WaitForCondition Handler", () => {
         expect.any(Function),
         1, // currentAttempt should be 1 on first execution
         expect.any(String), // DurableExecutionMode.ExecutionMode
+        undefined, // operationName (no name configured in test)
       );
       expect(waitStrategy).toHaveBeenCalledWith("result", 1);
     });
@@ -400,6 +401,7 @@ describe("WaitForCondition Handler", () => {
         expect.any(Function),
         3, // currentAttempt should be Attempt + 1 = 2 + 1 = 3
         expect.any(String),
+        undefined, // operationName (no name configured in test)
       );
       expect(waitStrategy).toHaveBeenCalledWith("result", 3);
     });
@@ -481,6 +483,7 @@ describe("WaitForCondition Handler", () => {
         expect.any(Function),
         1,
         expect.any(String),
+        undefined, // operationName (no name configured in test)
       );
       expect(mockRunWithContext).toHaveBeenNthCalledWith(
         2,
@@ -489,6 +492,7 @@ describe("WaitForCondition Handler", () => {
         expect.any(Function),
         2,
         expect.any(String),
+        undefined, // operationName (no name configured in test)
       );
       expect(mockRunWithContext).toHaveBeenNthCalledWith(
         3,
@@ -497,6 +501,7 @@ describe("WaitForCondition Handler", () => {
         expect.any(Function),
         3,
         expect.any(String),
+        undefined, // operationName (no name configured in test)
       );
     });
   });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -260,6 +260,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
               : checkFunc,
             currentAttempt,
             DurableExecutionMode.ExecutionMode,
+            name,
           )) as T;
 
           const serializedState = await safeSerialize(

--- a/packages/aws-durable-execution-sdk-js/src/types/logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/logger.ts
@@ -9,6 +9,7 @@ export interface DurableLogData {
   executionArn: string;
   tenantId?: string;
   operationId?: string;
+  operationName?: string;
   attempt?: number;
   // We aren't attaching any additional properties, but this is
   // added for type-compatibility with popular loggers like powertools

--- a/packages/aws-durable-execution-sdk-js/src/utils/context-tracker/context-tracker.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/context-tracker/context-tracker.ts
@@ -8,6 +8,7 @@ interface ContextInfo {
   parentId?: string;
   attempt?: number;
   durableExecutionMode?: DurableExecutionMode;
+  operationName?: string;
 }
 
 const asyncLocalStorage = new AsyncLocalStorage<ContextInfo>();
@@ -22,9 +23,10 @@ export const runWithContext = <T>(
   fn: () => T,
   attempt?: number,
   durableExecutionMode?: DurableExecutionMode,
+  operationName?: string,
 ): T => {
   return asyncLocalStorage.run(
-    { contextId, parentId, attempt, durableExecutionMode },
+    { contextId, parentId, attempt, durableExecutionMode, operationName },
     fn,
   );
 };

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.test.ts
@@ -194,6 +194,61 @@ describe("Default Logger", () => {
         );
       });
 
+      it("should include operationName field when provided", () => {
+        const logger = createDefaultLogger();
+        const mockDurableLogData: DurableLogData = {
+          requestId: "mock-request-id",
+          executionArn: "test-arn",
+          operationId: "abc123",
+          operationName: "fetch-user",
+        };
+
+        logger.configureDurableLoggingContext?.({
+          getDurableLogData: () => mockDurableLogData,
+        });
+
+        logger.log?.(DurableLogLevel.INFO, "named operation message");
+
+        expect(mockConsole.info).toHaveBeenCalledWith(
+          JSON.stringify({
+            requestId: "mock-request-id",
+            timestamp: "2025-11-21T18:33:33.938Z",
+            level: "INFO",
+            executionArn: "test-arn",
+            operationId: "abc123",
+            operationName: "fetch-user",
+            message: "named operation message",
+          }),
+        );
+      });
+
+      it("should omit operationName when undefined", () => {
+        const logger = createDefaultLogger();
+        const mockDurableLogData: DurableLogData = {
+          requestId: "mock-request-id",
+          executionArn: "test-arn",
+          operationId: "abc123",
+          operationName: undefined,
+        };
+
+        logger.configureDurableLoggingContext?.({
+          getDurableLogData: () => mockDurableLogData,
+        });
+
+        logger.log?.(DurableLogLevel.INFO, "test message");
+
+        expect(mockConsole.info).toHaveBeenCalledWith(
+          JSON.stringify({
+            requestId: "mock-request-id",
+            timestamp: "2025-11-21T18:33:33.938Z",
+            level: "INFO",
+            executionArn: "test-arn",
+            operationId: "abc123",
+            message: "test message",
+          }),
+        );
+      });
+
       it("should omit operationId and attempt when undefined", () => {
         const logger = createDefaultLogger();
         const mockDurableLogData: DurableLogData = {

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
@@ -119,6 +119,10 @@ function formatDurableLogData(
     result.operationId = logData.operationId;
   }
 
+  if (logData.operationName !== undefined) {
+    result.operationName = logData.operationName;
+  }
+
   if (logData.attempt !== undefined) {
     result.attempt = logData.attempt;
   }


### PR DESCRIPTION
The default logger emitted requestId, executionArn, tenantId, operationId, and attempt, but never operationName. This diverged from the documented log format and from the Python and Java SDKs, which both emit operationName.

Thread the operation/step/child-context name through the async-local context tracker (runWithContext) and surface it via getDurableLogData so the default logger includes operationName when available. It is derived from the operation name (like the Java SDK) and is omitted for the root context and when no name is present, keeping the change backward-compatible.

- context-tracker: add operationName to ContextInfo and runWithContext
- step, wait-for-condition, and run-in-child-context handlers pass the name
- DurableLogData: add optional operationName field
- durable-context: populate operationName in getDurableLogData (omit at root)
- default-logger: emit operationName when present
- add unit/integration tests; update runWithContext argument assertions