### PR TITLE
chore(sdk): add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      # Produces conventional-commit PR titles like "chore(deps): bump ..."
+      # to satisfy .github/workflows/lintcommit.js. "include: scope" makes
+      # Dependabot append the (deps) / (deps-dev) scope automatically.
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Group all GitHub Actions updates into a single PR to reduce noise.
+      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add .github/dependabot.yml to enable weekly automated version updates for GitHub Actions, mirroring the Java and Python SDK repos. This prevents outdated action versions (e.g. checkout@v4, setup-node@v4) from causing CI failures and deprecation warnings.

All GitHub Actions updates are grouped into a single PR to reduce noise.

*Issue #, if available:*
#573

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
