### PR TITLE
feat(sdk): support custom summaryGenerator in map and parallel config

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.history.json
@@ -1,0 +1,204 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "e53dde61-d8e2-47e2-873b-eab7401d5baa",
+    "EventTimestamp": "2026-07-07T19:44:39.817Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"branchPayloadSize\":10}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Parallel",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "parallel-large",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "parallel-branch-0",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 4,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "parallel-branch-1",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "ParallelBranch",
+    "EventId": 5,
+    "Id": "13cee27a2bd93915",
+    "Name": "parallel-branch-2",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "2f221a18eb863803",
+    "Name": "branch-0",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 7,
+    "Id": "6151f5ab282d90e4",
+    "Name": "branch-1",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "b425e0c75591aa8f",
+    "Name": "branch-2",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 9,
+    "Id": "2f221a18eb863803",
+    "Name": "branch-0",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "ea66c06c1e1c05fa",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"aaaaaaaaaa\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 10,
+    "Id": "6151f5ab282d90e4",
+    "Name": "branch-1",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "98c6f2c2287f4c73",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"bbbbbbbbbb\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 11,
+    "Id": "b425e0c75591aa8f",
+    "Name": "branch-2",
+    "EventTimestamp": "2026-07-07T19:44:39.824Z",
+    "ParentId": "13cee27a2bd93915",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"cccccccccc\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 12,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "parallel-branch-0",
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"aaaaaaaaaa\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 13,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "parallel-branch-1",
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"bbbbbbbbbb\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "ParallelBranch",
+    "EventId": 14,
+    "Id": "13cee27a2bd93915",
+    "Name": "parallel-branch-2",
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"cccccccccc\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Parallel",
+    "EventId": 15,
+    "Id": "c4ca4238a0b92382",
+    "Name": "parallel-large",
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":\"aaaaaaaaaa\",\"index\":0,\"status\":\"SUCCEEDED\"},{\"result\":\"bbbbbbbbbb\",\"index\":1,\"status\":\"SUCCEEDED\"},{\"result\":\"cccccccccc\",\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"ALL_COMPLETED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 16,
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-07T19:44:39.817Z",
+      "EndTimestamp": "2026-07-07T19:44:39.826Z",
+      "Error": {},
+      "RequestId": "a85c5484-f72d-46c3-9892-595eb9aff473"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 17,
+    "Id": "e53dde61-d8e2-47e2-873b-eab7401d5baa",
+    "EventTimestamp": "2026-07-07T19:44:39.826Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalCount\":3,\"successCount\":3,\"resultLengths\":[10,10,10]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.test.ts
@@ -1,0 +1,65 @@
+import {
+  handler,
+  CUSTOM_SUMMARY_MARKER,
+} from "./parallel-custom-summary-generator";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should use the user-provided summaryGenerator for the checkpointed summary", async () => {
+      // Default (large) payload exceeds the 256KB checkpoint limit, so the SDK
+      // enters ReplayChildren mode and checkpoints the summaryGenerator output.
+      const execution = await runner.run();
+
+      const result = execution.getResult() as {
+        totalCount: number;
+        successCount: number;
+        resultLengths: number[];
+      };
+
+      // The full results are still returned to the caller unchanged.
+      expect(result.totalCount).toBe(3);
+      expect(result.successCount).toBe(3);
+      expect(result.resultLengths).toEqual([120000, 120000, 120000]);
+
+      // The CONTEXT operation's checkpointed result is the summaryGenerator
+      // output. Asserting the custom marker proves the user-supplied generator
+      // was used instead of the SDK's default parallel generator (issue #500).
+      const contextResult = runner
+        .getOperation("parallel-large")
+        .getContextDetails()?.result as {
+        marker: string;
+        totalCount: number;
+        successCount: number;
+      };
+
+      expect(contextResult).toMatchObject({
+        marker: CUSTOM_SUMMARY_MARKER,
+        totalCount: 3,
+        successCount: 3,
+      });
+    });
+
+    it("should return correct results for a small payload", async () => {
+      // A small payload stays within a single checkpoint (default behavior).
+      // This case validates event signatures without committing a large
+      // history fixture (large-payload runs replay children and would bloat it).
+      const execution = await runner.run({
+        payload: { branchPayloadSize: 10 },
+      });
+
+      const result = execution.getResult() as {
+        totalCount: number;
+        successCount: number;
+        resultLengths: number[];
+      };
+
+      expect(result.totalCount).toBe(3);
+      expect(result.successCount).toBe(3);
+      expect(result.resultLengths).toEqual([10, 10, 10]);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.ts
@@ -1,0 +1,69 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Parallel Custom Summary Generator",
+  description:
+    "Demonstrates supplying a custom summaryGenerator to context.parallel " +
+    "(issue #500). When the batch result exceeds the checkpoint size limit, " +
+    "the SDK checkpoints the summaryGenerator output instead of the full payload.",
+};
+
+/**
+ * Marker embedded in the custom summary so the test can prove the
+ * user-provided generator was used instead of the SDK default.
+ */
+export const CUSTOM_SUMMARY_MARKER = "custom-parallel-summary";
+
+/**
+ * Each branch returns a string of `branchPayloadSize` characters. Three
+ * branches of ~120KB push the serialized BatchResult past the 256KB checkpoint
+ * limit, which triggers ReplayChildren mode — the only path where
+ * summaryGenerator is invoked. A small size keeps the run within a single
+ * checkpoint (default behavior) and is used to validate event signatures
+ * without committing a large history fixture.
+ */
+const DEFAULT_BRANCH_PAYLOAD_SIZE = 120_000;
+
+interface CustomSummaryEvent {
+  branchPayloadSize?: number;
+}
+
+export const handler = withDurableExecution(
+  async (event: CustomSummaryEvent | undefined, context: DurableContext) => {
+    const branchPayloadSize =
+      event?.branchPayloadSize ?? DEFAULT_BRANCH_PAYLOAD_SIZE;
+
+    const results = await context.parallel(
+      "parallel-large",
+      [
+        async (ctx) =>
+          ctx.step("branch-0", async () => "a".repeat(branchPayloadSize)),
+        async (ctx) =>
+          ctx.step("branch-1", async () => "b".repeat(branchPayloadSize)),
+        async (ctx) =>
+          ctx.step("branch-2", async () => "c".repeat(branchPayloadSize)),
+      ],
+      {
+        maxConcurrency: 3,
+        summaryGenerator: (result) =>
+          JSON.stringify({
+            marker: CUSTOM_SUMMARY_MARKER,
+            totalCount: result.totalCount,
+            successCount: result.successCount,
+          }),
+      },
+    );
+
+    return {
+      totalCount: results.totalCount,
+      successCount: results.successCount,
+      resultLengths: results
+        .getResults()
+        .map((value) => (value as string).length),
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
@@ -422,4 +422,51 @@ describe("Map Handler", () => {
       });
     });
   });
+
+  describe("summaryGenerator", () => {
+    it("should forward a user-provided summaryGenerator", async () => {
+      const items = ["item1"];
+      const mapFunc: MapFunc<string, string, DurableLogger> = jest
+        .fn()
+        .mockResolvedValue("result");
+      const customSummaryGenerator = jest.fn(() => "custom-summary");
+
+      mockExecuteConcurrently.mockResolvedValue(
+        new MockBatchResult([
+          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        ]) as any,
+      );
+
+      await mapHandler("test-map", items, mapFunc, {
+        summaryGenerator: customSummaryGenerator,
+      });
+
+      expect(mockExecuteConcurrently).toHaveBeenCalledWith(
+        "test-map",
+        expect.any(Array),
+        expect.any(Function),
+        expect.objectContaining({
+          summaryGenerator: customSummaryGenerator,
+        }),
+      );
+    });
+
+    it("should fall back to the default generator when none is provided", async () => {
+      const items = ["item1"];
+      const mapFunc: MapFunc<string, string, DurableLogger> = jest
+        .fn()
+        .mockResolvedValue("result");
+
+      mockExecuteConcurrently.mockResolvedValue(
+        new MockBatchResult([
+          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        ]) as any,
+      );
+
+      await mapHandler("test-map", items, mapFunc);
+
+      const forwardedConfig = mockExecuteConcurrently.mock.calls[0][3];
+      expect(typeof forwardedConfig.summaryGenerator).toBe("function");
+    });
+  });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
@@ -87,7 +87,8 @@ export const createMapHandler = <Logger extends DurableLogger>(
         maxConcurrency: config?.maxConcurrency,
         topLevelSubType: OperationSubType.MAP,
         iterationSubType: OperationSubType.MAP_ITERATION,
-        summaryGenerator: createMapSummaryGenerator(),
+        summaryGenerator:
+          config?.summaryGenerator ?? createMapSummaryGenerator(),
         completionConfig: config?.completionConfig,
         serdes: config?.serdes,
         itemSerdes: config?.itemSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
@@ -372,4 +372,51 @@ describe("Parallel Handler", () => {
       );
     });
   });
+
+  describe("summaryGenerator", () => {
+    it("should forward a user-provided summaryGenerator", async () => {
+      const branch1: ParallelFunc<string, DurableLogger> = jest
+        .fn()
+        .mockResolvedValue("result1");
+      const branches = [branch1];
+      const customSummaryGenerator = jest.fn(() => "custom-summary");
+
+      mockExecuteConcurrently.mockResolvedValue(
+        new MockBatchResult([
+          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        ]) as any,
+      );
+
+      await parallelHandler("test-name", branches, {
+        summaryGenerator: customSummaryGenerator,
+      });
+
+      expect(mockExecuteConcurrently).toHaveBeenCalledWith(
+        "test-name",
+        expect.any(Array),
+        expect.any(Function),
+        expect.objectContaining({
+          summaryGenerator: customSummaryGenerator,
+        }),
+      );
+    });
+
+    it("should fall back to the default generator when none is provided", async () => {
+      const branch1: ParallelFunc<string, DurableLogger> = jest
+        .fn()
+        .mockResolvedValue("result1");
+      const branches = [branch1];
+
+      mockExecuteConcurrently.mockResolvedValue(
+        new MockBatchResult([
+          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+        ]) as any,
+      );
+
+      await parallelHandler("test-name", branches);
+
+      const forwardedConfig = mockExecuteConcurrently.mock.calls[0][3];
+      expect(typeof forwardedConfig.summaryGenerator).toBe("function");
+    });
+  });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
@@ -121,7 +121,8 @@ export const createParallelHandler = <Logger extends DurableLogger>(
         maxConcurrency: config?.maxConcurrency,
         topLevelSubType: OperationSubType.PARALLEL,
         iterationSubType: OperationSubType.PARALLEL_BRANCH,
-        summaryGenerator: createParallelSummaryGenerator(),
+        summaryGenerator:
+          config?.summaryGenerator ?? createParallelSummaryGenerator(),
         completionConfig: config?.completionConfig,
         serdes: config?.serdes,
         itemSerdes: config?.itemSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/types/batch.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/batch.ts
@@ -150,6 +150,14 @@ export interface MapConfig<TItem, TResult> {
   /** Configuration for completion behavior */
   completionConfig?: CompletionConfig;
   /**
+   * Function to generate a summary string from the batch result.
+   *
+   * The summary is used as the checkpointed payload when the serialized batch
+   * result exceeds the checkpoint size limit (ReplayChildren mode). When
+   * omitted, a default map summary generator is used.
+   */
+  summaryGenerator?: (result: BatchResult<TResult>) => string;
+  /**
    * Nesting type for map iterations (default: NestingType.NESTED)
    * - NESTED: Create full child contexts with checkpointing
    * - FLAT: Use virtual contexts to skip checkpointing and reduce costs by ~30%
@@ -191,6 +199,14 @@ export interface ParallelConfig<TResult> {
   itemSerdes?: Serdes<TResult>;
   /** Configuration for completion behavior */
   completionConfig?: CompletionConfig;
+  /**
+   * Function to generate a summary string from the batch result.
+   *
+   * The summary is used as the checkpointed payload when the serialized batch
+   * result exceeds the checkpoint size limit (ReplayChildren mode). When
+   * omitted, a default parallel summary generator is used.
+   */
+  summaryGenerator?: (result: BatchResult<TResult>) => string;
   /**
    * Nesting type for parallel branches (default: NestingType.NESTED)
    * - NESTED: Create full child contexts with checkpointing


### PR DESCRIPTION
ParallelConfig and MapConfig now expose an optional summaryGenerator, which the parallel and map handlers forward to executeConcurrently instead of always using the internal default. The default generator is still used when none is supplied, so existing behavior is unchanged (backward compatible).

The summary is used as the checkpointed payload when a batch result exceeds the checkpoint size limit (ReplayChildren mode).

Adds handler unit tests asserting the user-provided generator is forwarded (and the default is used otherwise), plus an integration example under aws-durable-execution-sdk-js-examples that verifies the custom summary is checkpointed for a large parallel result.

*Issue #, if available:* #500 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
