### PR TITLE
fix(sdk): keep replay mode active after a virtual context

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -252,7 +252,16 @@ export class DurableContextImpl<
     if (this.durableExecutionMode === DurableExecutionMode.ReplayMode) {
       const nextStepId = this.getNextStepId();
       const nextStepData = this._executionContext.getStepData(nextStepId);
-      if (!nextStepData) {
+      // A virtual context (runInChildContext with virtualContext: true) is not
+      // checkpointed itself, so getStepData(nextStepId) returns undefined even
+      // though replay should continue. Its first child operation IS
+      // checkpointed under `${nextStepId}-1`, so probe that before concluding
+      // replay has finished. Without this check, replay mode is prematurely
+      // switched to execution mode after a virtual context (issue #578).
+      const hasCheckpointedChild =
+        !nextStepData &&
+        this._executionContext.getStepData(`${nextStepId}-1`) !== undefined;
+      if (!nextStepData && !hasCheckpointedChild) {
         this.durableExecutionMode = DurableExecutionMode.ExecutionMode;
       }
     }

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -219,6 +219,56 @@ describe("DurableContext", () => {
       expect(executionContext.getStepData).toHaveBeenCalled();
     });
 
+    it("should stay in ReplayMode when the next op is a virtual context whose child is checkpointed", () => {
+      // Virtual contexts are not checkpointed themselves, but their first child
+      // is (under `${nextStepId}-1`). Replay must not end prematurely (#578).
+      const executionContext = createMockExecutionContext({
+        getStepData: jest.fn((id: string) =>
+          id === "1-1"
+            ? ({ Id: "1-1", Status: OperationStatus.SUCCEEDED } as any)
+            : undefined,
+        ),
+      });
+
+      const context = createDurableContext(
+        executionContext,
+        mockContext,
+        DurableExecutionMode.ReplayMode,
+        mockLogger,
+        undefined,
+        mockDurableExecution,
+      ) as any;
+
+      context.checkAndUpdateReplayMode();
+
+      expect(context.durableExecutionMode).toBe(
+        DurableExecutionMode.ReplayMode,
+      );
+      expect(executionContext.getStepData).toHaveBeenCalledWith("1");
+      expect(executionContext.getStepData).toHaveBeenCalledWith("1-1");
+    });
+
+    it("should switch to ExecutionMode when neither the next op nor its first child is checkpointed", () => {
+      const executionContext = createMockExecutionContext({
+        getStepData: jest.fn().mockReturnValue(undefined),
+      });
+
+      const context = createDurableContext(
+        executionContext,
+        mockContext,
+        DurableExecutionMode.ReplayMode,
+        mockLogger,
+        undefined,
+        mockDurableExecution,
+      ) as any;
+
+      context.checkAndUpdateReplayMode();
+
+      expect(context.durableExecutionMode).toBe(
+        DurableExecutionMode.ExecutionMode,
+      );
+    });
+
     it("should switch mode when step is unfinished", async () => {
       const executionContext = createMockExecutionContext({
         getStepData: jest


### PR DESCRIPTION
checkAndUpdateReplayMode() decided replay was finished whenever the next step id had no checkpoint data. A virtual context (runInChildContext with virtualContext: true) is intentionally not checkpointed, so its id has no data even though its first child IS checkpointed under `${nextStepId}-1`. This caused replay mode to switch to execution mode immediately after a virtual context, so operations like logging re-ran (e.g. duplicate logs) during replay.

Fix: when the next step id has no checkpoint data, also probe its first child id before concluding that replay has finished. Composes correctly for root (1 -> 1-1) and nested (2-1 -> 2-1-1) step prefixes.

Adds unit tests covering both the virtual-context case (stays in replay mode) and the genuine end-of-replay case (switches to execution mode).

*Issue #, if available:* #578

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
