### PR TITLE
fix(ci): scope capacity provider test job to capacity provider functions

### DIFF
--- a/.github/workflows/scripts/integration-test/integration-test.js
+++ b/.github/workflows/scripts/integration-test/integration-test.js
@@ -298,19 +298,48 @@ class IntegrationTestRunner {
   }
 
   // Run Jest integration tests
-  async runJestTests(/** @type {string | undefined} */ testPattern) {
+  async runJestTests(
+    /** @type {string | undefined} */ testPattern,
+    /** @type {{ capacityProviderOnly?: boolean }} */ options = {},
+  ) {
+    const { capacityProviderOnly = false } = options;
     log.info("Running Jest integration tests...");
 
     const examplesDir = CONFIG.EXAMPLES_PACKAGE_PATH;
 
-    // For Jest integration tests, exclude capacity provider functions since they weren't deployed
-    const functionsWithQualifier = Object.fromEntries(
-      Object.entries(
-        this.getFunctionNameMap({ capacityProviderOnly: false }),
-      ).map(([key, { functionName, qualifier }]) => {
-        return [key, `${functionName}:${qualifier}`];
-      }),
-    );
+    /** @type {Record<string, string>} */
+    let functionsWithQualifier;
+
+    if (capacityProviderOnly) {
+      // The capacity provider workflow only deploys the -CapacityProvider
+      // variants of examples that opt in via capacityProviderConfig. Key those
+      // by the example base name (which the test harness resolves) and point
+      // them at the deployed capacity provider function.
+      //
+      // Examples without a capacityProviderConfig are intentionally omitted so
+      // the harness skips them. Otherwise this job would invoke the regular
+      // functions (which it never deploys — they are owned by the parallel
+      // integration-tests workflow), causing a cross-workflow race that
+      // surfaced as a flaky ResourceNotFoundException.
+      functionsWithQualifier = Object.fromEntries(
+        Object.entries(
+          this.getFunctionNameMap({ capacityProviderOnly: true }),
+        ).map(([key, { functionName, qualifier }]) => {
+          const baseKey = key.endsWith(CAPACITY_PROVIDER_FUNCTION_SUFFIX)
+            ? key.slice(0, -CAPACITY_PROVIDER_FUNCTION_SUFFIX.length)
+            : key;
+          return [baseKey, `${functionName}:${qualifier}`];
+        }),
+      );
+    } else {
+      functionsWithQualifier = Object.fromEntries(
+        Object.entries(
+          this.getFunctionNameMap({ capacityProviderOnly: false }),
+        ).map(([key, { functionName, qualifier }]) => {
+          return [key, `${functionName}:${qualifier}`];
+        }),
+      );
+    }
 
     // Set additional environment variables
     const env = {
@@ -429,7 +458,7 @@ class IntegrationTestRunner {
     }
 
     if (!deployOnly) {
-      await this.runJestTests(testPattern);
+      await this.runJestTests(testPattern, { capacityProviderOnly });
     }
 
     log.success("Integration test completed successfully!");

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/step/interrupted-no-retry/step-interrupted-no-retry.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/step/interrupted-no-retry/step-interrupted-no-retry.test.ts
@@ -27,13 +27,15 @@ if (!isIntegrationTest) {
     string
   >;
   const functionName = functionNames[TEST_NAME];
-  if (!functionName) {
-    throw new Error(
-      `Function name ${TEST_NAME} not found in FUNCTION_NAME_MAP`,
-    );
-  }
 
-  describe(`${TEST_NAME} (cloud)`, () => {
+  // Skip (rather than throw) when this example is not deployed for the current
+  // job. The capacity-provider-only job only deploys examples that opt in via
+  // `capacityProviderConfig`; this example does not, so it is legitimately
+  // absent from FUNCTION_NAME_MAP there. Throwing would fail the whole job.
+  // This mirrors the shared `createTests` helper (see utils/test-helper.ts).
+  const describeCloud = functionName ? describe : describe.skip;
+
+  describeCloud(`${TEST_NAME} (cloud)`, () => {
     const runner = new CloudDurableTestRunner({
       client: new LambdaClient({ endpoint: process.env.LAMBDA_ENDPOINT }),
       functionName,


### PR DESCRIPTION
The capacity-provider test job runs integration-test.js with
--test-only --capacity-provider-only, but runJestTests always built the
FUNCTION_NAME_MAP with regular (non capacity provider) function names and
ran the full cloud suite. As a result the job invoked regular $LATEST
functions that this workflow never deploys (they are owned by the
parallel integration-tests workflow), creating a cross-workflow race that
surfaced as a flaky ResourceNotFoundException on PR creation and usually
passed on re-run. It also meant the deployed capacity provider functions
were never actually exercised.

runJestTests now accepts capacityProviderOnly. When set, it builds the
map from capacity-provider examples only, keyed by the example base name
(what the test harness resolves) and pointing at the deployed
-CapacityProvider function. Examples without a capacityProviderConfig are
omitted from the map, removing the dependency on regular functions and
eliminating the race.

Because those examples are now absent from FUNCTION_NAME_MAP in this job,
the bespoke step-interrupted-no-retry cloud test (which does not use the
shared createTests helper) threw at suite-load time when its function was
missing, failing the job. It now uses describe.skip when its function is
absent, mirroring the shared helper, so it is skipped in the
capacity-provider job and still runs in the regular integration workflow.

*Issue #, if available:* #482


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
