### PR TITLE
refactor(sdk): rename getNextStepId to peekStepId for clarity

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -232,7 +232,13 @@ export class DurableContextImpl<
       : `${this._stepCounter}`;
   }
 
-  private getNextStepId(): string {
+  /**
+   * Returns the step ID that the next {@link createStepId} call will mint,
+   * WITHOUT advancing the counter. At operation boundaries (before the current
+   * operation has claimed its ID) this is the ID of the current pending
+   * operation — the one about to run.
+   */
+  private peekStepId(): string {
     const nextCounter = this._stepCounter + 1;
     return this._stepPrefix
       ? `${this._stepPrefix}-${nextCounter}`
@@ -250,18 +256,19 @@ export class DurableContextImpl<
 
   private checkAndUpdateReplayMode(): void {
     if (this.durableExecutionMode === DurableExecutionMode.ReplayMode) {
-      const nextStepId = this.getNextStepId();
-      const nextStepData = this._executionContext.getStepData(nextStepId);
+      const pendingStepId = this.peekStepId();
+      const pendingStepData = this._executionContext.getStepData(pendingStepId);
       // A virtual context (runInChildContext with virtualContext: true) is not
-      // checkpointed itself, so getStepData(nextStepId) returns undefined even
-      // though replay should continue. Its first child operation IS
-      // checkpointed under `${nextStepId}-1`, so probe that before concluding
-      // replay has finished. Without this check, replay mode is prematurely
-      // switched to execution mode after a virtual context (issue #578).
+      // checkpointed itself, so getStepData(pendingStepId) returns undefined
+      // even though replay should continue. Its first child operation IS
+      // checkpointed under `${pendingStepId}-1`, so probe that before
+      // concluding replay has finished. Without this check, replay mode is
+      // prematurely switched to execution mode after a virtual context (issue
+      // #578).
       const hasCheckpointedChild =
-        !nextStepData &&
-        this._executionContext.getStepData(`${nextStepId}-1`) !== undefined;
-      if (!nextStepData && !hasCheckpointedChild) {
+        !pendingStepData &&
+        this._executionContext.getStepData(`${pendingStepId}-1`) !== undefined;
+      if (!pendingStepData && !hasCheckpointedChild) {
         this.durableExecutionMode = DurableExecutionMode.ExecutionMode;
       }
     }
@@ -270,8 +277,8 @@ export class DurableContextImpl<
   private captureExecutionState(): boolean {
     const wasInReplayMode =
       this.durableExecutionMode === DurableExecutionMode.ReplayMode;
-    const nextStepId = this.getNextStepId();
-    const stepData = this._executionContext.getStepData(nextStepId);
+    const pendingStepId = this.peekStepId();
+    const stepData = this._executionContext.getStepData(pendingStepId);
     const wasNotFinished = !!(
       stepData &&
       stepData.Status !== OperationStatus.SUCCEEDED &&
@@ -284,12 +291,12 @@ export class DurableContextImpl<
     if (
       this.durableExecutionMode === DurableExecutionMode.ReplaySucceededContext
     ) {
-      const nextStepId = this.getNextStepId();
-      const nextStepData = this._executionContext.getStepData(nextStepId);
+      const pendingStepId = this.peekStepId();
+      const pendingStepData = this._executionContext.getStepData(pendingStepId);
       if (
-        nextStepData &&
-        nextStepData.Status !== OperationStatus.SUCCEEDED &&
-        nextStepData.Status !== OperationStatus.FAILED
+        pendingStepData &&
+        pendingStepData.Status !== OperationStatus.SUCCEEDED &&
+        pendingStepData.Status !== OperationStatus.FAILED
       ) {
         return new Promise<never>(() => {}); // Non-resolving promise
       }
@@ -519,7 +526,7 @@ export class DurableContextImpl<
     return this.withDurableModeManagement(() => {
       const waitForCallbackHandler = createWaitForCallbackHandler(
         this._executionContext,
-        this.getNextStepId.bind(this),
+        this.peekStepId.bind(this),
         this.runInChildContext.bind(this),
         // Only pass the getter when the user has explicitly configured a custom
         // deserializer. The default is createPassThroughSerdes() which matches

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.unit.test.ts
@@ -221,7 +221,7 @@ describe("DurableContext", () => {
 
     it("should stay in ReplayMode when the next op is a virtual context whose child is checkpointed", () => {
       // Virtual contexts are not checkpointed themselves, but their first child
-      // is (under `${nextStepId}-1`). Replay must not end prematurely (#578).
+      // is (under `${pendingStepId}-1`). Replay must not end prematurely (#578).
       const executionContext = createMockExecutionContext({
         getStepData: jest.fn((id: string) =>
           id === "1-1"

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -20,7 +20,7 @@ import {
 } from "../../errors/durable-error/durable-error";
 export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
-  getNextStepId: () => string,
+  peekStepId: () => string,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
   getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
 ) => {
@@ -134,7 +134,7 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
         return await callbackPromise;
       };
 
-      const stepId = getNextStepId();
+      const stepId = peekStepId();
       return {
         result: await runInChildContext(name, childFunction, {
           subType: OperationSubType.WAIT_FOR_CALLBACK,


### PR DESCRIPTION
`getNextStepId()` returns `_stepCounter + 1` without advancing the counter, so at operation boundaries (before the current operation has claimed its ID via createStepId) it actually resolves to the CURRENT pending operation's step ID, not a later one. The "next" name obscured this and caused confusion about the replay-mode boundary check (issue #586).

Rename it to `peekStepId()` to pair with `createStepId()`: "create" mints the next ID and advances the counter, "peek" returns what the next mint would be without advancing. Also rename the `nextStepId` / `nextStepData` locals at the mode-management call sites to `pendingStepId` / `pendingStepData`, the injected `getNextStepId` parameter in the wait-for-callback handler, and the related comments.

This is a naming-only change to private/internal members with no behavioral or public API impact. It does not change the current-vs-next step lookup semantics discussed in #586.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
