### PR TITLE
feat(sdk): preserve child-context operations across resume for observability

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.history.json
@@ -1,0 +1,43 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "a791d7c1-9434-4fd3-92da-e0e5869d96d1",
+    "EventTimestamp": "2026-07-13T22:11:27.127Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 2,
+    "EventTimestamp": "2026-07-13T22:11:27.132Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-13T22:11:27.127Z",
+      "EndTimestamp": "2026-07-13T22:11:27.132Z",
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "pluginsConfig.childOperationsDepth must be a non-negative integer or Infinity; got -1.",
+          "ErrorType": "Error"
+        }
+      },
+      "RequestId": "a3c3bcab-38f3-4151-a0d0-a0f723a7bbe6"
+    }
+  },
+  {
+    "EventType": "ExecutionFailed",
+    "EventId": 3,
+    "Id": "a791d7c1-9434-4fd3-92da-e0e5869d96d1",
+    "EventTimestamp": "2026-07-13T22:11:27.132Z",
+    "ExecutionFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "pluginsConfig.childOperationsDepth must be a non-negative integer or Infinity; got -1.",
+          "ErrorType": "Error"
+        }
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.test.ts
@@ -1,0 +1,18 @@
+import { handler } from "./child-operations-invalid-depth";
+import { createTests } from "../../utils/test-helper";
+import { ExecutionStatus } from "@aws/durable-execution-sdk-js-testing";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("fails the execution when childOperationsDepth is invalid", async () => {
+      const result = await runner.run();
+
+      expect(result.getStatus()).toBe(ExecutionStatus.FAILED);
+      const error = result.getError();
+      expect(error?.errorMessage).toMatch(/childOperationsDepth/);
+
+      assertEventSignatures(result);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-invalid-depth/child-operations-invalid-depth.ts
@@ -1,0 +1,25 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+
+export const config: ExampleConfig = {
+  name: "Child Operations Invalid Depth",
+  description:
+    "An invalid pluginsConfig.childOperationsDepth is a non-retryable config " +
+    "error that fails the execution (rather than being silently ignored).",
+};
+
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    await context.step("noop", async () => "ok");
+    return "done";
+  },
+  {
+    // Invalid: must be a non-negative integer or Infinity. This terminates the
+    // execution with a CONFIG_VALIDATION_ERROR (FAILED) before the handler
+    // makes durable progress.
+    pluginsConfig: { childOperationsDepth: -1 },
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.history.json
@@ -1,0 +1,149 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "5e6cf2ac-50e7-4646-a814-a26a8d5e5cc4",
+    "EventTimestamp": "2026-07-13T21:51:04.825Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "failing-branch",
+    "EventTimestamp": "2026-07-13T21:51:04.831Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "child-step-ok",
+    "EventTimestamp": "2026-07-13T21:51:04.831Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 4,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "child-step-ok",
+    "EventTimestamp": "2026-07-13T21:51:04.831Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"ok\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 5,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "child-step-boom",
+    "EventTimestamp": "2026-07-13T21:51:04.833Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepFailed",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "child-step-boom",
+    "EventTimestamp": "2026-07-13T21:51:04.833Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "intentional child failure",
+          "ErrorType": "Error"
+        }
+      },
+      "RetryDetails": {
+        "CurrentAttempt": 1
+      }
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "RunInChildContext",
+    "EventId": 7,
+    "Id": "c4ca4238a0b92382",
+    "Name": "failing-branch",
+    "EventTimestamp": "2026-07-13T21:51:04.836Z",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "StepError",
+          "ErrorMessage": "intentional child failure"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 8,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "cooldown",
+    "EventTimestamp": "2026-07-13T21:51:04.838Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-07-13T21:51:05.838Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 9,
+    "EventTimestamp": "2026-07-13T21:51:04.861Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-13T21:51:04.825Z",
+      "EndTimestamp": "2026-07-13T21:51:04.861Z",
+      "Error": {},
+      "RequestId": "a8977e6f-26c8-4dea-8d4e-3ce4576595e1"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 10,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "cooldown",
+    "EventTimestamp": "2026-07-13T21:51:05.838Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 11,
+    "EventTimestamp": "2026-07-13T21:51:05.839Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-13T21:51:05.838Z",
+      "EndTimestamp": "2026-07-13T21:51:05.839Z",
+      "Error": {},
+      "RequestId": "aa61745b-d699-4f6b-b02c-09ba6475ef62"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 12,
+    "Id": "5e6cf2ac-50e7-4646-a814-a26a8d5e5cc4",
+    "EventTimestamp": "2026-07-13T21:51:05.839Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"branchFailed\":true}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.test.ts
@@ -1,0 +1,37 @@
+import { handler } from "./child-operations-preservation";
+import { createTests } from "../../utils/test-helper";
+import {
+  OperationType,
+  OperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+
+createTests({
+  handler,
+  localRunnerConfig: {
+    skipTime: true,
+  },
+  tests: (runner, { assertEventSignatures }) => {
+    it("preserves the children of a FAILED context across resume", async () => {
+      const execution = await runner.run();
+
+      // The execution succeeds; only the inner context failed.
+      expect(execution.getResult()).toEqual({ branchFailed: true });
+
+      const branch = runner.getOperation("failing-branch");
+      expect(branch.getType()).toBe(OperationType.CONTEXT);
+      expect(branch.getStatus()).toBe(OperationStatus.FAILED);
+
+      // The assertion that matters: after the wait/resume the FAILED context
+      // still carries its children. Locally this always holds; in the cloud
+      // integration run it fails if the backend prunes children of failed
+      // contexts despite ReplayChildren (childOperationsDepth) — which is
+      // exactly the behavior we want to catch.
+      const children = branch.getChildOperations() ?? [];
+      const childNames = children.map((c) => c.getName());
+      expect(childNames).toContain("child-step-ok");
+      expect(childNames).toContain("child-step-boom");
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/child-operations-preservation/child-operations-preservation.ts
@@ -1,0 +1,63 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  createRetryStrategy,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../types";
+
+export const config: ExampleConfig = {
+  name: "Child Operations Preservation",
+  description:
+    "Verifies pluginsConfig.childOperationsDepth preserves the children of a " +
+    "FAILED context across suspend/resume (integration test catches backend " +
+    "behavior differences for failed contexts).",
+};
+
+// No retries — we want the failing step (and its context) to fail once,
+// deterministically, so the run is fast and the shape is predictable.
+const noRetry = createRetryStrategy({ maxAttempts: 1 });
+
+/**
+ * Runs a child context that fails after doing some child work, swallows the
+ * error, then WAITS (forcing a suspend/resume) before finishing.
+ *
+ * The point of interest is what the execution state contains AFTER the resume:
+ * by default the backend prunes a finished context's children, so the failed
+ * context's child operations would disappear. `childOperationsDepth` sets
+ * `ReplayChildren` (including on the FAIL checkpoint) to keep them. The test
+ * asserts the children survive — locally this always holds; against real
+ * Lambda it verifies the backend honors `ReplayChildren` on FAILED contexts.
+ */
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    let branchFailed = false;
+    try {
+      await context.runInChildContext("failing-branch", async (child) => {
+        await child.step("child-step-ok", async () => "ok", {
+          retryStrategy: noRetry,
+        });
+        await child.step(
+          "child-step-boom",
+          async () => {
+            throw new Error("intentional child failure");
+          },
+          { retryStrategy: noRetry },
+        );
+      });
+    } catch {
+      // Swallow so the execution itself succeeds; the CONTEXT is what failed.
+      branchFailed = true;
+    }
+
+    // Force a suspend/resume: on resume the backend hands back a fresh
+    // operations payload, which is where pruning of finished contexts' children
+    // would happen.
+    await context.wait("cooldown", { seconds: 1 });
+
+    return { branchFailed };
+  },
+  {
+    // Preserve one level of nested children (the steps inside failing-branch).
+    pluginsConfig: { childOperationsDepth: 1 },
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-insight/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight/README.md
@@ -189,6 +189,9 @@ const insight = workflowInsight({
   // Sampling rate: 0.0–1.0 (default: 1.0 = all executions)
   samplingRate: 1.0,
 
+  // Which operations to include (default: "top-level")
+  operationDetail: "top-level",
+
   // Where to send records (default: [new LambdaLogExporter()])
   exporters: [new LambdaLogExporter()],
 
@@ -214,6 +217,56 @@ samplingRate: 0.1, // Only 10% of executions emit records
 ```
 
 The decision is **per-execution and all-or-nothing**: a sampled-in execution emits all of its records, a sampled-out execution emits none — you never get fragmented partial data. It is **deterministic across replays**: the decision is derived from a hash of the execution ARN, which is stable across replays, so a resumed execution always reaches the same decision. Values outside `[0, 1]` or non-numeric values are clamped/defaulted to `1.0` with a warning.
+
+### `operationDetail`
+
+Controls which operations appear in each record's `operations` array.
+
+| Mode                    | Behavior                                                                             | Use case                                  |
+| ----------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `"top-level"` (default) | Only top-level operations (anything with a `parentId` is dropped)                    | Consistent, resume-independent snapshots  |
+| `"full-tree"`           | Every operation, including children of contexts (parallel branches, map items, etc.) | Full nested detail (see the caveat below) |
+
+`"top-level"` is the default because it produces the **same set of operations regardless of when a record is emitted**, so an execution that suspends and resumes never yields a partially-populated tree.
+
+> **⚠️ `"full-tree"` and suspend/resume:** by default the backend prunes a
+> finished context's children from the state handed to later invocations (a
+> performance optimization). So for an execution that suspends/resumes, a
+> `"full-tree"` record only contains the children of contexts that were still
+> active in the invocation that emitted it — children of already-finished
+> contexts are missing. To keep the full tree across resume, also set
+> `childOperationsDepth` (below).
+
+### `childOperationsDepth` (on `withDurableExecution`)
+
+To make `"full-tree"` complete across suspend/resume, tell the **core SDK** to
+preserve child operations, via `pluginsConfig.childOperationsDepth` on
+`withDurableExecution` (not on the plugin):
+
+```typescript
+export const handler = withDurableExecution(myWorkflow, {
+  plugins: [workflowInsight({ operationDetail: "full-tree", exporters: [...] })],
+  pluginsConfig: {
+    // Children of top-level contexts = 1; their children = 2; whole tree = Infinity.
+    childOperationsDepth: 1,
+  },
+});
+```
+
+| Value         | Preserved across resume                                      |
+| ------------- | ------------------------------------------------------------ |
+| omitted / `0` | Nothing extra (top-level only survives resume) — **default** |
+| `1`           | Direct children of top-level contexts (map items, branches)  |
+| `2`           | Their children too (e.g. steps inside each map item)         |
+| `Infinity`    | The entire tree                                              |
+
+> **⚠️ Cost:** preservation forces the SDK's `ReplayChildren` mode on each
+> preserved context. This keeps its children in the execution state and, on
+> resume, rebuilds the context's result by **replaying** the already-checkpointed
+> children — the context's orchestration code re-runs, but the children are
+> **not** re-executed (no step bodies or side effects run again). The cost is the
+> extra replay pass over each preserved context plus carrying its children in the
+> state, and it grows with the depth you request. Enable only the depth you need.
 
 ### `exporters`
 

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.test.ts
@@ -285,6 +285,55 @@ describe("operation detail capture", () => {
   });
 });
 
+describe("operationDetail", () => {
+  // A top-level context and its child (parallel-branch/map-item style).
+  const opsWithChildren = {
+    top: op({ id: "top", name: "reserve-inventory", type: "CONTEXT" }),
+    child: op({
+      id: "child",
+      name: "reserve-item",
+      type: "STEP",
+      parentId: "top",
+    }),
+  };
+
+  it("defaults to top-level (drops children)", async () => {
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({ exporters: [exporter] });
+
+    await endAndDrain(plugin, endInfo({ operations: opsWithChildren }));
+
+    const names = exporter.records[0].operations.map((o) => o.name);
+    expect(names).toEqual(["reserve-inventory"]);
+  });
+
+  it("includes children when full-tree", async () => {
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({
+      exporters: [exporter],
+      operationDetail: "full-tree",
+    });
+
+    await endAndDrain(plugin, endInfo({ operations: opsWithChildren }));
+
+    const names = exporter.records[0].operations.map((o) => o.name).sort();
+    expect(names).toEqual(["reserve-inventory", "reserve-item"]);
+  });
+
+  it("drops operations with a parentId when top-level", async () => {
+    const exporter = new CapturingExporter();
+    const plugin = workflowInsight({
+      exporters: [exporter],
+      operationDetail: "top-level",
+    });
+
+    await endAndDrain(plugin, endInfo({ operations: opsWithChildren }));
+
+    const names = exporter.records[0].operations.map((o) => o.name);
+    expect(names).toEqual(["reserve-inventory"]);
+  });
+});
+
 describe("status mapping", () => {
   it("maps a suspended (PENDING) execution to RUNNING", async () => {
     const exporter = new CapturingExporter();

--- a/packages/aws-durable-execution-sdk-js-insight/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/index.ts
@@ -229,6 +229,12 @@ interface OperationContentOptions {
   overridesByName: Map<string, OperationOverride>;
   /** Whether to include per-operation error details. */
   includeErrors: boolean;
+  /**
+   * When true, only top-level operations are emitted; any operation with a
+   * `parentId` (parallel branches, map items, nested steps/contexts) is
+   * dropped. Derived from `operationDetail: "top-level"`.
+   */
+  topLevelOnly: boolean;
 }
 
 /**
@@ -299,6 +305,11 @@ function buildOperationRecords(
 
     // Unnamed operations are excluded by default (can't be targeted or keyed).
     if (!op.name) continue;
+
+    // In "top-level" detail mode, drop anything nested under a context
+    // (parallel branches, map items, nested steps/contexts). Top-level
+    // operations have no parentId. This gives a resume-independent snapshot.
+    if (opts.topLevelOnly && op.parentId) continue;
 
     const override = opts.overridesByName.get(op.name);
     if (override?.exclude) continue;
@@ -439,6 +450,11 @@ export function workflowInsight(
   const opContentOptions: OperationContentOptions = {
     overridesByName,
     includeErrors,
+    // Default to top-level: it yields a consistent snapshot regardless of
+    // suspend/resume. "full-tree" is opt-in because, without child preservation
+    // (pluginsConfig.childOperationsDepth), it can silently miss children of
+    // contexts that finished in an earlier invocation.
+    topLevelOnly: config.operationDetail !== "full-tree",
   };
 
   const exporters =

--- a/packages/aws-durable-execution-sdk-js-insight/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/types.ts
@@ -146,6 +146,29 @@ export interface WorkflowInsightConfig {
   emitMode?: "on-complete" | "on-change" | "on-failure";
 
   /**
+   * Which operations to include in each record's `operations` array.
+   *
+   * - `"top-level"` (default): include only top-level operations (anything with
+   *   a `parentId` is dropped). This yields a consistent, resume-independent
+   *   snapshot — the same set of operations regardless of when it's emitted —
+   *   and never depends on child preservation. It's the default because
+   *   `"full-tree"` can otherwise silently under-report (see below).
+   * - `"full-tree"`: include every operation — top-level operations **and** the
+   *   children of contexts (parallel branches, map items, and their nested
+   *   operations). NOTE: children of a context that already finished in an
+   *   earlier invocation are, by default, pruned by the backend on resume — so
+   *   for an execution that suspends/resumes, a `"full-tree"` record only
+   *   contains children of contexts that were still active in the emitting
+   *   invocation. To keep the full tree across resume, also set
+   *   `DurableExecutionConfig.pluginsConfig.childOperationsDepth` on
+   *   `withDurableExecution` (this replays preserved contexts on resume to keep
+   *   their children in state — see that field's cost note).
+   *
+   * @experimental This field is experimental and may change in future releases.
+   */
+  operationDetail?: "full-tree" | "top-level";
+
+  /**
    * Control what data is included in records (input/output transforms,
    * operation overrides, error inclusion).
    *

--- a/packages/aws-durable-execution-sdk-js/src/config-validation/config-validation.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/config-validation/config-validation.test.ts
@@ -1,0 +1,37 @@
+import { validateDurableExecutionConfig } from "./config-validation";
+
+describe("validateDurableExecutionConfig", () => {
+  it("returns undefined for undefined config", () => {
+    expect(validateDurableExecutionConfig(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty config", () => {
+    expect(validateDurableExecutionConfig({})).toBeUndefined();
+  });
+
+  it("returns undefined for a valid childOperationsDepth", () => {
+    expect(
+      validateDurableExecutionConfig({
+        pluginsConfig: { childOperationsDepth: 2 },
+      }),
+    ).toBeUndefined();
+    expect(
+      validateDurableExecutionConfig({
+        pluginsConfig: { childOperationsDepth: Infinity },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("surfaces an invalid childOperationsDepth", () => {
+    expect(
+      validateDurableExecutionConfig({
+        pluginsConfig: { childOperationsDepth: -1 },
+      }),
+    ).toMatch(/childOperationsDepth/);
+    expect(
+      validateDurableExecutionConfig({
+        pluginsConfig: { childOperationsDepth: 1.5 },
+      }),
+    ).toMatch(/childOperationsDepth/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/config-validation/config-validation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/config-validation/config-validation.ts
@@ -1,0 +1,24 @@
+import { DurableExecutionConfig } from "../types";
+import { validateChildOperationsDepth } from "../utils/child-operations-depth/child-operations-depth";
+
+/**
+ * Validates {@link DurableExecutionConfig} at startup and returns the first
+ * error message found, or `undefined` when the config is valid.
+ *
+ * This is the single place startup config validation lives — add new checks
+ * here as the config surface grows. Callers treat a returned message as a
+ * non-retryable configuration error and fail the execution with it.
+ * @internal
+ */
+export function validateDurableExecutionConfig(
+  config: DurableExecutionConfig | undefined,
+): string | undefined {
+  const childOperationsDepthError = validateChildOperationsDepth(
+    config?.pluginsConfig?.childOperationsDepth,
+  );
+  if (childOperationsDepthError) return childOperationsDepthError;
+
+  // Add further config validations here.
+
+  return undefined;
+}

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -33,6 +33,7 @@ import { EventEmitter } from "events";
 import { createStepHandler } from "../../handlers/step-handler/step-handler";
 import { createInvokeHandler } from "../../handlers/invoke-handler/invoke-handler";
 import { createRunInChildContextHandler } from "../../handlers/run-in-child-context-handler/run-in-child-context-handler";
+import { resolveChildArgs } from "../../handlers/run-in-child-context-handler/resolve-child-args";
 import { createWaitHandler } from "../../handlers/wait-handler/wait-handler";
 import { createWaitForConditionHandler } from "../../handlers/wait-for-condition-handler/wait-for-condition-handler";
 import {
@@ -90,6 +91,17 @@ export class DurableContextImpl<
   private modeManagement: ModeManagement;
   private durableExecution: DurableExecution;
 
+  /**
+   * Remaining depth budget for preserving child-context operations across
+   * suspend/resume. A context sets `ReplayChildren` on a child it runs when the
+   * child's budget (this value minus 1) is >= 1. Decremented by one for each
+   * nested context. `0` (default) disables preservation; `Infinity` preserves
+   * the whole tree. Seeded at the root from
+   * `DurableExecutionConfig.pluginsConfig.childOperationsDepth`.
+   * @internal
+   */
+  private _preserveChildDepth: number = 0;
+
   private _defaultSerdes: AnySerdes = defaultSerdes;
 
   private _defaultCallbackDeserializer: AnySerdesDeserializer =
@@ -113,9 +125,11 @@ export class DurableContextImpl<
     stepPrefix: string | undefined,
     durableExecution: DurableExecution,
     parentId?: string,
+    preserveChildDepth: number = 0,
   ) {
     this._stepPrefix = stepPrefix;
     this._parentId = parentId;
+    this._preserveChildDepth = preserveChildDepth;
     this.durableExecution = durableExecution;
     this.durableLogger = inheritedLogger;
     this.durableLogger.configureDurableLoggingContext?.(
@@ -384,6 +398,30 @@ export class DurableContextImpl<
       this._executionContext.terminationManager,
     );
     return this.withDurableModeManagement(() => {
+      // Budget handed to the child context we're about to run: one level less
+      // than ours (Infinity stays Infinity, and it never goes below 0). This
+      // both (a) decides whether the child's own children are preserved
+      // (ReplayChildren, in executeChildContext) and (b) seeds the child
+      // context so its grandchildren decrement further.
+      //
+      // Virtual contexts (map/parallel FLAT nesting) are the exception: they
+      // don't checkpoint and their children re-parent onto this context's
+      // ancestor, so they add no node to the operation tree. Decrementing for
+      // them would make `childOperationsDepth` count invisible layers and come
+      // up short (off-by-one) for contexts nested inside a FLAT item. So pass
+      // the budget through unchanged for a virtual child, keeping the depth
+      // aligned with the visible operation tree.
+      const { options: childOptions } = resolveChildArgs<T, Logger>(
+        nameOrFn,
+        fnOrOptions,
+        maybeOptions,
+      );
+      const isVirtualChild = childOptions?.virtualContext === true;
+      const childPreserveDepth = isVirtualChild
+        ? this._preserveChildDepth
+        : this._preserveChildDepth === Infinity
+          ? Infinity
+          : Math.max(0, this._preserveChildDepth - 1);
       const blockHandler = createRunInChildContextHandler(
         this._executionContext,
         this.checkpoint,
@@ -408,6 +446,7 @@ export class DurableContextImpl<
             stepPrefix,
             this.durableExecution,
             parentId,
+            childPreserveDepth,
           );
           // Propagate serdes config to child context
           childCtx.configureSerdes({
@@ -421,6 +460,7 @@ export class DurableContextImpl<
         this._parentId,
         () => this._defaultSerdes,
         this.durableExecution.plugin,
+        childPreserveDepth,
       );
       return blockHandler(nameOrFn, fnOrOptions, maybeOptions);
     });
@@ -678,6 +718,7 @@ export const createDurableContext = <Logger extends DurableLogger>(
   stepPrefix: string | undefined,
   durableExecution: DurableExecution,
   parentId?: string,
+  preserveChildDepth: number = 0,
 ): DurableContextImpl<Logger> => {
   return new DurableContextImpl<Logger>(
     executionContext,
@@ -687,5 +728,6 @@ export const createDurableContext = <Logger extends DurableLogger>(
     stepPrefix,
     durableExecution,
     parentId,
+    preserveChildDepth,
   );
 };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/resolve-child-args.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/resolve-child-args.test.ts
@@ -1,0 +1,41 @@
+import { resolveChildArgs } from "./resolve-child-args";
+
+describe("resolveChildArgs", () => {
+  const fn = async (): Promise<string> => "result";
+  const options = { subType: "Step" } as never;
+
+  it("parses the (name, fn, options) form", () => {
+    const r = resolveChildArgs("my-context", fn, options);
+    expect(r.name).toBe("my-context");
+    expect(r.fn).toBe(fn);
+    expect(r.options).toBe(options);
+  });
+
+  it("parses the (name, fn) form", () => {
+    const r = resolveChildArgs("my-context", fn);
+    expect(r.name).toBe("my-context");
+    expect(r.fn).toBe(fn);
+    expect(r.options).toBeUndefined();
+  });
+
+  it("parses the (fn, options) form (anonymous context)", () => {
+    const r = resolveChildArgs(fn, options);
+    expect(r.name).toBeUndefined();
+    expect(r.fn).toBe(fn);
+    expect(r.options).toBe(options);
+  });
+
+  it("parses the (fn) form", () => {
+    const r = resolveChildArgs(fn);
+    expect(r.name).toBeUndefined();
+    expect(r.fn).toBe(fn);
+    expect(r.options).toBeUndefined();
+  });
+
+  it("treats an explicit undefined name as the (name, fn) form", () => {
+    const r = resolveChildArgs(undefined, fn, options);
+    expect(r.name).toBeUndefined();
+    expect(r.fn).toBe(fn);
+    expect(r.options).toBe(options);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/resolve-child-args.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/resolve-child-args.ts
@@ -1,0 +1,35 @@
+import { ChildConfig, ChildFunc } from "../../types/child-context";
+import { DurableLogger } from "../../types/durable-logger";
+
+/**
+ * Disambiguates the `runInChildContext` overloads — `(name, fn, options)` vs
+ * `(fn, options)` — into a single normalized shape. Shared by the child-context
+ * handler and by DurableContext.runInChildContext so the overload logic lives
+ * in exactly one place.
+ *
+ * Kept in its own module (rather than in run-in-child-context-handler.ts) so
+ * callers can use it even when that handler module is mocked in tests.
+ * @internal
+ */
+export function resolveChildArgs<T, Logger extends DurableLogger>(
+  nameOrFn: string | undefined | ChildFunc<T, Logger>,
+  fnOrOptions?: ChildFunc<T, Logger> | ChildConfig<T>,
+  maybeOptions?: ChildConfig<T>,
+): {
+  name: string | undefined;
+  fn: ChildFunc<T, Logger>;
+  options: ChildConfig<T> | undefined;
+} {
+  if (typeof nameOrFn === "string" || nameOrFn === undefined) {
+    return {
+      name: nameOrFn,
+      fn: fnOrOptions as ChildFunc<T, Logger>,
+      options: maybeOptions,
+    };
+  }
+  return {
+    name: undefined,
+    fn: nameOrFn,
+    options: fnOrOptions as ChildConfig<T>,
+  };
+}

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
@@ -246,6 +246,118 @@ describe("Run In Child Context Integration Tests", () => {
     ]);
   });
 
+  describe("child operations preservation depth", () => {
+    // Find the SUCCEED checkpoint for a context by name.
+    const succeedFor = (name: string) =>
+      checkpointCalls
+        .map((c) => c.data.Updates[0])
+        .find(
+          (u: { Name?: string; Action?: string }) =>
+            u?.Name === name && u?.Action === OperationAction.SUCCEED,
+        ) as { ContextOptions?: unknown } | undefined;
+
+    const runTopAndNested = async (
+      ctx: DurableContext<DurableLogger>,
+    ): Promise<void> => {
+      await ctx.runInChildContext("top", async (topCtx) => {
+        await topCtx.runInChildContext("nested", async () => "nested-result");
+        return "top-result";
+      });
+      // Let any fire-and-forget SUCCEED checkpoints settle.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    };
+
+    test("decrements per level: root budget 2 preserves the top level but not the nested one", async () => {
+      // Root budget 2 => top-level context budget 1 (ReplayChildren set),
+      // nested context budget 0 (not set). Mirrors childOperationsDepth = 1.
+      const ctx = createDurableContext(
+        mockExecutionContext,
+        mockParentContext,
+        DurableExecutionMode.ExecutionMode,
+        createDefaultLogger(),
+        undefined,
+        mockDurableExecution,
+        undefined, // parentId
+        2, // preserveChildDepth (root budget)
+      );
+
+      await runTopAndNested(ctx);
+
+      expect(succeedFor("top")?.ContextOptions).toEqual({
+        ReplayChildren: true,
+      });
+      expect(succeedFor("nested")?.ContextOptions).toBeUndefined();
+    });
+
+    test("Infinity preserves every level", async () => {
+      const ctx = createDurableContext(
+        mockExecutionContext,
+        mockParentContext,
+        DurableExecutionMode.ExecutionMode,
+        createDefaultLogger(),
+        undefined,
+        mockDurableExecution,
+        undefined,
+        Infinity,
+      );
+
+      await runTopAndNested(ctx);
+
+      expect(succeedFor("top")?.ContextOptions).toEqual({
+        ReplayChildren: true,
+      });
+      expect(succeedFor("nested")?.ContextOptions).toEqual({
+        ReplayChildren: true,
+      });
+    });
+
+    test("default (no budget) preserves nothing", async () => {
+      // durableContext from beforeEach was created without a preserveChildDepth.
+      await runTopAndNested(durableContext);
+
+      expect(succeedFor("top")?.ContextOptions).toBeUndefined();
+      expect(succeedFor("nested")?.ContextOptions).toBeUndefined();
+    });
+
+    test("virtual (FLAT) contexts do not consume a depth level", async () => {
+      // Root budget 2. A virtual middle context (map/parallel FLAT item) adds
+      // no operation-tree node and re-parents its children onto the root, so it
+      // must NOT consume a budget level. The real "inner" context is therefore
+      // one real level below the root (budget 1) and preserves its children.
+      // (If virtual layers consumed a level, inner would be budget 0 and its
+      // children would NOT be preserved — the off-by-one this guards against.)
+      const ctx = createDurableContext(
+        mockExecutionContext,
+        mockParentContext,
+        DurableExecutionMode.ExecutionMode,
+        createDefaultLogger(),
+        undefined,
+        mockDurableExecution,
+        undefined,
+        2,
+      );
+
+      await ctx.runInChildContext(
+        "virtual-item",
+        async (itemCtx) => {
+          await itemCtx.runInChildContext("inner", async (innerCtx) => {
+            await innerCtx.step("inner-step", async () => "s");
+            return "inner-result";
+          });
+          return "item-result";
+        },
+        { virtualContext: true },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // The virtual middle context never checkpoints; the real "inner" one does
+      // and, because the virtual layer was transparent, still has budget >= 1.
+      expect(succeedFor("inner")?.ContextOptions).toEqual({
+        ReplayChildren: true,
+      });
+    });
+  });
+
   test("should support mixed step and child context operations", async () => {
     const operationOrder: string[] = [];
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -340,6 +340,105 @@ describe("Run In Child Context Handler", () => {
     );
   });
 
+  describe("child operations preservation (ReplayChildren via depth budget)", () => {
+    // Build a handler whose child entity receives the given preserve-child
+    // depth budget (the value executeChildContext uses to force ReplayChildren).
+    const makeHandler = (childPreserveDepth: number) =>
+      createRunInChildContextHandler(
+        mockExecutionContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        jest.fn().mockReturnValue({ log: jest.fn() }),
+        jest
+          .fn()
+          .mockReturnValue({ _stepPrefix: TEST_CONSTANTS.CHILD_CONTEXT_ID }),
+        "parent-step-123",
+        undefined, // getDefaultSerdes
+        undefined, // plugin
+        childPreserveDepth,
+      );
+
+    const succeedCheckpoint = () =>
+      mockCheckpoint.mock.calls.find(
+        (c) =>
+          (c[1] as { Action?: string })?.Action === OperationAction.SUCCEED,
+      )?.[1] as { ContextOptions?: unknown; Payload?: unknown } | undefined;
+
+    test.each([1, 2, Infinity])(
+      "forces ReplayChildren and keeps the full payload when the budget is %p",
+      async (depth) => {
+        const childFn = jest
+          .fn()
+          .mockResolvedValue(TEST_CONSTANTS.CHILD_CONTEXT_RESULT);
+
+        await makeHandler(depth)(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn);
+
+        const succeed = succeedCheckpoint();
+        expect(succeed?.ContextOptions).toEqual({ ReplayChildren: true });
+        // Unlike the large-payload path, the full result stays checkpointed.
+        expect(succeed?.Payload).toBe(
+          JSON.stringify(TEST_CONSTANTS.CHILD_CONTEXT_RESULT),
+        );
+      },
+    );
+
+    test.each([0, -1])(
+      "does not set ReplayChildren when the budget is %p",
+      async (depth) => {
+        const childFn = jest
+          .fn()
+          .mockResolvedValue(TEST_CONSTANTS.CHILD_CONTEXT_RESULT);
+
+        await makeHandler(depth)(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn);
+
+        expect(succeedCheckpoint()?.ContextOptions).toBeUndefined();
+      },
+    );
+
+    test("does not set ReplayChildren by default (no budget passed)", async () => {
+      const childFn = jest
+        .fn()
+        .mockResolvedValue(TEST_CONSTANTS.CHILD_CONTEXT_RESULT);
+
+      // The module-level handler is created without a childPreserveDepth arg
+      // (defaults to 0) — matching the default, opt-out behavior.
+      await runInChildContextHandler(
+        TEST_CONSTANTS.CHILD_CONTEXT_NAME,
+        childFn,
+      );
+
+      expect(succeedCheckpoint()?.ContextOptions).toBeUndefined();
+    });
+
+    const failCheckpoint = () =>
+      mockCheckpoint.mock.calls.find(
+        (c) => (c[1] as { Action?: string })?.Action === OperationAction.FAIL,
+      )?.[1] as { ContextOptions?: unknown } | undefined;
+
+    test("forces ReplayChildren on a FAILED context when the budget is >= 1", async () => {
+      const childFn = jest.fn().mockRejectedValue(new Error("boom"));
+
+      await expect(
+        makeHandler(1)(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn),
+      ).rejects.toThrow();
+
+      expect(failCheckpoint()?.ContextOptions).toEqual({
+        ReplayChildren: true,
+      });
+    });
+
+    test("does not set ReplayChildren on a FAILED context when the budget is 0", async () => {
+      const childFn = jest.fn().mockRejectedValue(new Error("boom"));
+
+      await expect(
+        makeHandler(0)(TEST_CONSTANTS.CHILD_CONTEXT_NAME, childFn),
+      ).rejects.toThrow();
+
+      expect(failCheckpoint()?.ContextOptions).toBeUndefined();
+    });
+  });
+
   test("should return cached result for completed child context", async () => {
     const stepData = mockExecutionContext._stepData;
     stepData[hashId(TEST_CONSTANTS.CHILD_CONTEXT_ID)] = {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -28,6 +28,7 @@ import {
 import { runWithContext } from "../../utils/context-tracker/context-tracker";
 import { DurablePromise } from "../../types/durable-promise";
 import { DurableLogger } from "../../types/durable-logger";
+import { resolveChildArgs } from "./resolve-child-args";
 import {
   DurableInstrumentationPlugin,
   PluginOperationStatus,
@@ -86,24 +87,18 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
 
   getDefaultSerdes?: () => AnySerdes,
   plugin: DurableInstrumentationPlugin = {},
+  childPreserveDepth: number = 0,
 ) => {
   return <T>(
     nameOrFn: string | undefined | ChildFunc<T, Logger>,
     fnOrOptions?: ChildFunc<T, Logger> | ChildConfig<T>,
     maybeOptions?: ChildConfig<T>,
   ): DurablePromise<T> => {
-    let name: string | undefined;
-    let fn: ChildFunc<T, Logger>;
-    let options: ChildConfig<T> | undefined;
-
-    if (typeof nameOrFn === "string" || nameOrFn === undefined) {
-      name = nameOrFn;
-      fn = fnOrOptions as ChildFunc<T, Logger>;
-      options = maybeOptions;
-    } else {
-      fn = nameOrFn;
-      options = fnOrOptions as ChildConfig<T>;
-    }
+    const { name, fn, options } = resolveChildArgs<T, Logger>(
+      nameOrFn,
+      fnOrOptions,
+      maybeOptions,
+    );
 
     const entityId = createStepId();
 
@@ -171,6 +166,7 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
         parentId,
         getDefaultSerdes,
         plugin,
+        childPreserveDepth,
       );
     })()
       .then((result) => {
@@ -324,6 +320,7 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
 
   getDefaultSerdes?: () => AnySerdes,
   plugin: DurableInstrumentationPlugin = {},
+  preserveChildDepth: number = 0,
 ): Promise<T> => {
   const serdes =
     options?.serdes || (getDefaultSerdes ? getDefaultSerdes() : defaultSerdes);
@@ -427,6 +424,20 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       });
     }
 
+    // Preserve this context's children across suspend/resume when the execution
+    // opts in within the configured depth (pluginsConfig.childOperationsDepth).
+    // Setting ReplayChildren tells the backend not to prune this context's
+    // children when it finishes, so a later invocation's snapshot still sees
+    // the full tree. Unlike the large-payload case we keep the FULL result
+    // checkpointed. On replay the context's orchestration re-runs and its
+    // result is rebuilt by replaying the (still-checkpointed) children — the
+    // children themselves are NOT re-executed (their step bodies/side effects
+    // don't run again). See the cost note on
+    // DurableExecutionConfig.pluginsConfig.childOperationsDepth.
+    if (preserveChildDepth >= 1) {
+      replayChildren = true;
+    }
+
     // Mark this run-in-child-context as finished to prevent descendant operations (only for non-virtual)
     if (!isVirtual) {
       checkpoint.markAncestorFinished(entityId);
@@ -506,6 +517,14 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
         SubType: subType,
         Type: OperationType.CONTEXT,
         Error: createErrorObjectFromError(error),
+        // Preserve the children of a FAILED context too when within the
+        // configured depth — failures are often the most important thing to
+        // observe (e.g. emitMode "on-failure"). A failed context throws its
+        // checkpointed error on replay (ReplayMode) and is never re-executed,
+        // so this only asks the backend to retain the children; it adds no
+        // replay cost. See pluginsConfig.childOperationsDepth.
+        ContextOptions:
+          preserveChildDepth >= 1 ? { ReplayChildren: true } : undefined,
         Name: name,
       });
       const currentStepData = context.getStepData(entityId);

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-execution.ts
@@ -141,6 +141,65 @@ export interface DurableExecutionConfig {
    * @experimental This parameter is experimental and may be changed or removed in future releases.
    */
   plugins?: DurableInstrumentationPlugin[];
+
+  /**
+   * Execution-level settings that affect how instrumentation plugins observe
+   * the run.
+   *
+   * @experimental This parameter is experimental and may be changed or removed in future releases.
+   */
+  pluginsConfig?: {
+    /**
+     * How many nested levels of child-context operations to **preserve across
+     * suspend/resume** so instrumentation plugins can observe the full
+     * operation tree.
+     *
+     * By default, when a parent context finishes the backend prunes its child
+     * operations from the state handed to later invocations (a performance
+     * optimization). As a result, a snapshot taken in a *later* invocation
+     * (e.g. after a `wait`) will only contain top-level operations — the
+     * children of already-finished contexts are gone. This setting keeps them.
+     *
+     * Counting (children of the top level = 1):
+     * - `undefined` / `0` — preserve nothing extra (default; top-level only).
+     * - `1` — keep the direct children of top-level contexts (e.g. map items,
+     *   parallel branches).
+     * - `2` — also keep their children (e.g. the steps inside each map item).
+     * - `Infinity` — keep the entire tree.
+     *
+     * Must be a non-negative integer or `Infinity`; any other value (negative,
+     * fractional, or `NaN`) is a configuration error that **fails the execution
+     * immediately** — before the handler runs — rather than being silently
+     * ignored.
+     *
+     * Depth is counted over the **visible operation tree**: virtual wrapper
+     * contexts created by map/parallel with FLAT nesting don't checkpoint and
+     * their children re-parent onto the ancestor, so they are transparent to
+     * this count (they don't consume a level).
+     *
+     * Applies to both **succeeded and failed** contexts (a failed branch's
+     * children are often the most useful to inspect). A failed context still
+     * throws its checkpointed error on replay and is never re-executed, so
+     * preserving its children adds no replay cost.
+     *
+     * ⚠️ **Cost:** preservation is implemented by forcing the SDK's
+     * `ReplayChildren` mode on each preserved context. This keeps that
+     * context's child operations in the execution state (they aren't pruned
+     * when the context finishes) and, on replay, rebuilds the context's result
+     * by **replaying** those already-checkpointed children — i.e. the context's
+     * orchestration code re-runs, but the children themselves are **not**
+     * re-executed: steps and other durable operations inside the context return
+     * their checkpointed results, so no step body or side effect runs again.
+     * The added cost is therefore an extra replay pass over each preserved
+     * context (re-running its orchestration and deserializing its children)
+     * plus carrying those children in the execution state — it grows with the
+     * number of preserved contexts and the depth requested, and is **not** a
+     * re-doing of the children's work. Enable only the depth you actually need.
+     *
+     * @experimental
+     */
+    childOperationsDepth?: number;
+  };
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/child-operations-depth/child-operations-depth.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/child-operations-depth/child-operations-depth.test.ts
@@ -1,0 +1,42 @@
+import {
+  resolveRootPreserveChildDepth,
+  validateChildOperationsDepth,
+} from "./child-operations-depth";
+
+describe("validateChildOperationsDepth", () => {
+  it("accepts undefined, 0, positive integers, and Infinity (no error)", () => {
+    expect(validateChildOperationsDepth(undefined)).toBeUndefined();
+    expect(validateChildOperationsDepth(0)).toBeUndefined();
+    expect(validateChildOperationsDepth(1)).toBeUndefined();
+    expect(validateChildOperationsDepth(5)).toBeUndefined();
+    expect(validateChildOperationsDepth(Infinity)).toBeUndefined();
+  });
+
+  it("rejects negative, fractional, NaN, and non-number values", () => {
+    expect(validateChildOperationsDepth(-1)).toMatch(/non-negative integer/);
+    expect(validateChildOperationsDepth(1.5)).toMatch(/non-negative integer/);
+    expect(validateChildOperationsDepth(NaN)).toMatch(/non-negative integer/);
+    expect(validateChildOperationsDepth("2" as unknown as number)).toMatch(
+      /non-negative integer/,
+    );
+  });
+});
+
+describe("resolveRootPreserveChildDepth", () => {
+  it("returns 0 (off) for undefined and 0", () => {
+    expect(resolveRootPreserveChildDepth(undefined)).toBe(0);
+    expect(resolveRootPreserveChildDepth(0)).toBe(0);
+  });
+
+  it("seeds the root at depth + 1 for positive integers", () => {
+    // depth 1 (children of top-level contexts) => root budget 2, so a
+    // top-level context ends up with budget 1 (preserves its children).
+    expect(resolveRootPreserveChildDepth(1)).toBe(2);
+    expect(resolveRootPreserveChildDepth(2)).toBe(3);
+    expect(resolveRootPreserveChildDepth(5)).toBe(6);
+  });
+
+  it("passes through Infinity", () => {
+    expect(resolveRootPreserveChildDepth(Infinity)).toBe(Infinity);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/child-operations-depth/child-operations-depth.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/child-operations-depth/child-operations-depth.ts
@@ -1,0 +1,46 @@
+// Internal helpers for `pluginsConfig.childOperationsDepth`. Kept in their own
+// module (not re-exported from the package entrypoint) so they can be unit
+// tested without becoming part of the public API.
+
+/**
+ * Validates `pluginsConfig.childOperationsDepth`: it must be `undefined`, a
+ * non-negative integer, or `Infinity`. Returns an error message describing the
+ * problem for an invalid value, or `undefined` when valid. Invalid config is a
+ * non-retryable error — the caller fails the execution with it rather than
+ * silently proceeding.
+ * @internal
+ */
+export function validateChildOperationsDepth(
+  childOperationsDepth: number | undefined,
+): string | undefined {
+  if (childOperationsDepth === undefined) return undefined;
+  if (childOperationsDepth === Infinity) return undefined;
+  if (
+    typeof childOperationsDepth !== "number" ||
+    Number.isNaN(childOperationsDepth) ||
+    !Number.isInteger(childOperationsDepth) ||
+    childOperationsDepth < 0
+  ) {
+    return (
+      `pluginsConfig.childOperationsDepth must be a non-negative integer or ` +
+      `Infinity; got ${String(childOperationsDepth)}.`
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Maps the (already-validated) public `pluginsConfig.childOperationsDepth`
+ * (where 1 = children of top-level contexts) to the root context's internal
+ * preserve-child budget. The budget is decremented once per nesting level
+ * before it governs a context's children, so the root is seeded at `depth + 1`.
+ * `undefined`/`0` disables preservation; `Infinity` preserves the whole tree.
+ * @internal
+ */
+export function resolveRootPreserveChildDepth(
+  childOperationsDepth: number | undefined,
+): number {
+  if (childOperationsDepth === undefined || childOperationsDepth <= 0) return 0;
+  if (childOperationsDepth === Infinity) return Infinity;
+  return childOperationsDepth + 1;
+}

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -9,6 +9,8 @@ import { SerdesFailedError } from "./errors/serdes-errors/serdes-errors";
 import { isUnrecoverableInvocationError } from "./errors/unrecoverable-error/unrecoverable-error";
 import { isNonRetryableCustomerError } from "./errors/non-retryable-errors";
 import { TerminationReason } from "./termination-manager/types";
+import { resolveRootPreserveChildDepth } from "./utils/child-operations-depth/child-operations-depth";
+import { validateDurableExecutionConfig } from "./config-validation/config-validation";
 
 import {
   DurableLogger,
@@ -39,6 +41,7 @@ import {
 
 // Lambda response size limit is 6MB
 const LAMBDA_RESPONSE_SIZE_LIMIT = 6 * 1024 * 1024 - 50; // 6MB in bytes, minus 50 bytes for envelope
+
 async function runHandler<
   Input,
   Output,
@@ -51,6 +54,7 @@ async function runHandler<
   checkpointToken: string,
   handler: DurableExecutionHandler<Input, Output, Logger>,
   plugin: DurableInstrumentationPlugin,
+  config: DurableExecutionConfig | undefined,
 ): Promise<DurableExecutionInvocationOutput> {
   // Create checkpoint manager and step data emitter
   const stepDataEmitter = new EventEmitter();
@@ -101,6 +105,28 @@ async function runHandler<
   };
   await plugin.onInvocationStart?.(invocationInfo);
 
+  // Reject invalid configuration before anything else. It's a non-retryable
+  // error and no durable operations have started yet, so fail fast: return
+  // FAILED without creating the context or invoking the user handler. We return
+  // FAILED (rather than throw) so Lambda does not retry a permanently-broken
+  // configuration.
+  const configError = validateDurableExecutionConfig(config);
+  if (configError) {
+    const error = new Error(configError);
+    await plugin.onInvocationEnd?.({
+      ...invocationBaseInfo,
+      status: PluginInvocationStatus.FAILED,
+      executionInput: customerHandlerEvent,
+      executionError: error,
+      executionResult: undefined,
+      operations: allOperations,
+    });
+    return {
+      Status: InvocationStatus.FAILED,
+      Error: createErrorObjectFromError(error),
+    };
+  }
+
   // Set the checkpoint terminating callback on the termination manager
   executionContext.terminationManager.setCheckpointTerminatingCallback(() => {
     checkpointManager.setTerminating();
@@ -113,6 +139,11 @@ async function runHandler<
     setTerminating: (): void => checkpointManager.setTerminating(),
   };
 
+  // Config was validated above; map childOperationsDepth to the root budget.
+  const rootPreserveChildDepth = resolveRootPreserveChildDepth(
+    config?.pluginsConfig?.childOperationsDepth,
+  );
+
   const durableContext = createDurableContext<Logger>(
     executionContext,
     context,
@@ -124,6 +155,8 @@ async function runHandler<
     ) as Logger,
     undefined,
     durableExecution,
+    undefined,
+    rootPreserveChildDepth,
   );
 
   const executeInvocation =
@@ -492,6 +525,7 @@ export const withDurableExecution = <
         checkpointToken,
         handler,
         plugin,
+        config,
       );
     } catch (error) {
       // Non-retryable customer errors (e.g., KMS key misconfiguration) should


### PR DESCRIPTION
Adds an opt-in way to keep child-context operations (parallel branches, map items, and their nested operations) visible to instrumentation plugins after a suspend/resume, plus a plugin knob to choose how much of the tree to report.

Core (@aws/durable-execution-sdk-js):
- New `DurableExecutionConfig.pluginsConfig.childOperationsDepth`. By default the backend prunes a finished context's children from the state handed to later invocations, so a snapshot taken after a wait only sees top-level operations. This numeric depth preserves them: 1 = children of top-level contexts (map items, parallel branches), 2 = their children, Infinity = whole tree, omitted = off (unchanged behavior).
- Implemented via a per-context depth budget carried on DurableContext: the root is seeded with depth+1, each nested context decrements by one (Infinity stays Infinity, floored at 0), and executeChildContext forces ReplayChildren when a context's budget >= 1. Since parallel/map route through runInChildContext, one change covers branches, map items, and nested steps.
- ReplayChildren keeps the children in execution state and rebuilds the parent result by REPLAYING the already-checkpointed children on resume — the children are not re-executed (no step bodies/side effects run again). Cost is the extra replay pass, documented on the config field. Default behavior is unchanged (budget never reaches >= 1 without opt-in).

Plugin (@aws/durable-execution-sdk-js-insight):
- New `WorkflowInsightConfig.operationDetail`: "full-tree" (default) or "top-level" (drops any operation with a parentId) for a consistent, resume-independent snapshot. Pair "full-tree" with childOperationsDepth to keep the full tree across resume.