### PR TITLE
feat(sdk): test connection button for Workflow Insight destination

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
@@ -1,0 +1,70 @@
+jest.mock("vscode", () => ({ workspace: { getConfiguration: jest.fn() } }), {
+  virtual: true,
+});
+jest.mock("@aws-sdk/credential-providers", () => ({
+  fromIni: jest.fn(),
+  fromNodeProviderChain: jest.fn(),
+}));
+
+import { configFromWireSettings } from "./config";
+
+describe("configFromWireSettings", () => {
+  it("applies defaults for an empty payload", () => {
+    const cfg = configFromWireSettings({});
+    expect(cfg.destinationType).toBe("cloudwatch-logs-exporter");
+    expect(cfg.athenaTable).toBe("workflow_insight");
+    expect(cfg.auroraDatabase).toBe("postgres");
+    expect(cfg.agenticMaxIterations).toBe(8);
+    expect(cfg.logGroupNames).toEqual([]);
+  });
+
+  it("maps Athena/S3 fields from the wire payload", () => {
+    const cfg = configFromWireSettings({
+      destinationType: "s3",
+      athenaDatabase: "db",
+      athenaTable: "t",
+      athenaS3Location: "s3://b/p/",
+      athenaOutputLocation: "s3://b/results/",
+      region: "eu-west-1",
+    });
+    expect(cfg.destinationType).toBe("s3");
+    expect(cfg.athenaDatabase).toBe("db");
+    expect(cfg.athenaTable).toBe("t");
+    expect(cfg.athenaS3Location).toBe("s3://b/p/");
+    expect(cfg.athenaOutputLocation).toBe("s3://b/results/");
+    expect(cfg.region).toBe("eu-west-1");
+  });
+
+  it("splits comma-separated log group names", () => {
+    const cfg = configFromWireSettings({ logGroupName: "/a, /b ,/c" });
+    expect(cfg.logGroupNames).toEqual(["/a", "/b", "/c"]);
+  });
+
+  it("coerces the boolean and numeric fields", () => {
+    expect(
+      configFromWireSettings({ sqsDeleteAfterRead: "true" }).sqsDeleteAfterRead,
+    ).toBe(true);
+    expect(
+      configFromWireSettings({ sqsDeleteAfterRead: "false" })
+        .sqsDeleteAfterRead,
+    ).toBe(false);
+    // clamped to [1, 20]
+    expect(
+      configFromWireSettings({ agenticMaxIterations: "99" })
+        .agenticMaxIterations,
+    ).toBe(20);
+    expect(
+      configFromWireSettings({ agenticMaxIterations: "not-a-number" })
+        .agenticMaxIterations,
+    ).toBe(8);
+  });
+
+  it("leaves awsProfile undefined when blank", () => {
+    expect(
+      configFromWireSettings({ awsProfile: "" }).awsProfile,
+    ).toBeUndefined();
+    expect(configFromWireSettings({ awsProfile: "dev" }).awsProfile).toBe(
+      "dev",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -32,18 +32,55 @@ export interface InsightConfig {
 
 const SECTION = "workflowInsight";
 
+/**
+ * Abstracts where config values come from so the same normalization logic can
+ * run against either the persisted VS Code settings ({@link readConfig}) or the
+ * unsaved values coming from the Settings webview ({@link configFromWireSettings},
+ * used by the "Test connection" button before anything is written).
+ */
+interface ConfigSource {
+  getString(key: string): string | undefined;
+  getBool(key: string): boolean | undefined;
+  getNumber(key: string): number | undefined;
+}
+
 export function readConfig(): InsightConfig {
   const c = vscode.workspace.getConfiguration(SECTION);
+  return normalizeConfig({
+    getString: (k) => c.get<string>(k),
+    getBool: (k) => c.get<boolean>(k),
+    getNumber: (k) => c.get<number>(k),
+  });
+}
+
+/**
+ * Builds an {@link InsightConfig} from the webview's all-string settings payload
+ * without persisting it. Lets the "Test connection" action validate exactly what
+ * the user currently has typed in the modal (which may differ from what's saved).
+ */
+export function configFromWireSettings(
+  settings: Record<string, string>,
+): InsightConfig {
+  const has = (k: string): boolean =>
+    Object.prototype.hasOwnProperty.call(settings, k);
+  return normalizeConfig({
+    getString: (k) => (has(k) ? settings[k] : undefined),
+    getBool: (k) => (has(k) ? settings[k] === "true" : undefined),
+    getNumber: (k) => (has(k) ? Number(settings[k]) : undefined),
+  });
+}
+
+function normalizeConfig(src: ConfigSource): InsightConfig {
   const region =
-    (c.get<string>("region") || "").trim() ||
+    (src.getString("region") || "").trim() ||
     process.env.AWS_REGION ||
     process.env.AWS_DEFAULT_REGION ||
     "us-east-1";
-  const logGroupNames = (c.get<string>("logGroupName") || "")
+  const logGroupNames = (src.getString("logGroupName") || "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
-  const raw = (c.get<string>("destinationType") || "").trim();
+  const raw = (src.getString("destinationType") || "").trim();
   const destinationType =
     raw === "lambda-log-exporter"
       ? ("lambda-log-exporter" as const)
@@ -56,24 +93,24 @@ export function readConfig(): InsightConfig {
             : raw === "s3"
               ? ("s3" as const)
               : ("cloudwatch-logs-exporter" as const);
-  const dynamodbTableName = (c.get<string>("dynamodbTableName") || "").trim();
-  const auroraResourceArn = (c.get<string>("auroraResourceArn") || "").trim();
-  const auroraSecretArn = (c.get<string>("auroraSecretArn") || "").trim();
+  const dynamodbTableName = (src.getString("dynamodbTableName") || "").trim();
+  const auroraResourceArn = (src.getString("auroraResourceArn") || "").trim();
+  const auroraSecretArn = (src.getString("auroraSecretArn") || "").trim();
   const auroraDatabase =
-    (c.get<string>("auroraDatabase") || "").trim() || "postgres";
+    (src.getString("auroraDatabase") || "").trim() || "postgres";
   const auroraTable =
-    (c.get<string>("auroraTable") || "").trim() || "workflow_insight";
-  const sqsQueueUrl = (c.get<string>("sqsQueueUrl") || "").trim();
-  const sqsDeleteAfterRead = c.get<boolean>("sqsDeleteAfterRead") ?? false;
-  const athenaDatabase = (c.get<string>("athenaDatabase") || "").trim();
+    (src.getString("auroraTable") || "").trim() || "workflow_insight";
+  const sqsQueueUrl = (src.getString("sqsQueueUrl") || "").trim();
+  const sqsDeleteAfterRead = src.getBool("sqsDeleteAfterRead") ?? false;
+  const athenaDatabase = (src.getString("athenaDatabase") || "").trim();
   const athenaTable =
-    (c.get<string>("athenaTable") || "").trim() || "workflow_insight";
-  const athenaWorkgroup = (c.get<string>("athenaWorkgroup") || "").trim();
+    (src.getString("athenaTable") || "").trim() || "workflow_insight";
+  const athenaWorkgroup = (src.getString("athenaWorkgroup") || "").trim();
   const athenaOutputLocation = (
-    c.get<string>("athenaOutputLocation") || ""
+    src.getString("athenaOutputLocation") || ""
   ).trim();
-  const athenaS3Location = (c.get<string>("athenaS3Location") || "").trim();
-  const llmProviderRaw = (c.get<string>("llmProvider") || "").trim();
+  const athenaS3Location = (src.getString("athenaS3Location") || "").trim();
+  const llmProviderRaw = (src.getString("llmProvider") || "").trim();
   const llmProvider =
     llmProviderRaw === "copilot"
       ? ("copilot" as const)
@@ -82,27 +119,27 @@ export function readConfig(): InsightConfig {
         : llmProviderRaw === "local-server"
           ? ("local-server" as const)
           : ("bedrock" as const);
-  const awsProfile = (c.get<string>("awsProfile") || "").trim() || undefined;
+  const awsProfile = (src.getString("awsProfile") || "").trim() || undefined;
   const bedrockModelId =
-    (c.get<string>("bedrockModelId") || "").trim() ||
+    (src.getString("bedrockModelId") || "").trim() ||
     "us.anthropic.claude-sonnet-4-20250514-v1:0";
   const localModel =
-    (c.get<string>("localModel") || "").trim() || "llama-3-groq-8b-tool-use";
+    (src.getString("localModel") || "").trim() || "llama-3-groq-8b-tool-use";
   const localServerUrl =
-    (c.get<string>("localServerUrl") || "").trim() ||
+    (src.getString("localServerUrl") || "").trim() ||
     "http://localhost:11434/v1";
   const localServerModel =
-    (c.get<string>("localServerModel") || "").trim() || "llama3.1";
-  const rawMaxIter = c.get<number>("agenticMaxIterations");
+    (src.getString("localServerModel") || "").trim() || "llama3.1";
+  const rawMaxIter = src.getNumber("agenticMaxIterations");
   const agenticMaxIterations =
     typeof rawMaxIter === "number" && Number.isFinite(rawMaxIter)
       ? Math.min(20, Math.max(1, Math.floor(rawMaxIter)))
       : 8;
-  const rawMode = (c.get<string>("queryMode") || "").trim();
+  const rawMode = (src.getString("queryMode") || "").trim();
   const queryMode =
     rawMode === "query" || rawMode === "ask" ? rawMode : ("agent" as const);
   const aiDisclosureAcceptedVersion = (
-    c.get<string>("aiDisclosureAcceptedVersion") || ""
+    src.getString("aiDisclosureAcceptedVersion") || ""
   ).trim();
 
   return {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
@@ -1,0 +1,268 @@
+const ddbSend = jest.fn();
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn(() => ({ send: ddbSend })),
+  DescribeTableCommand: jest.fn((i) => ({ __t: "descTable", i })),
+}));
+const logsSend = jest.fn();
+jest.mock("@aws-sdk/client-cloudwatch-logs", () => ({
+  CloudWatchLogsClient: jest.fn(() => ({ send: logsSend })),
+  DescribeLogGroupsCommand: jest.fn((i) => ({ __t: "descLog", i })),
+}));
+const sqsSend = jest.fn();
+jest.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: jest.fn(() => ({ send: sqsSend })),
+  GetQueueAttributesCommand: jest.fn((i) => ({ __t: "getAttrs", i })),
+}));
+jest.mock("./athena", () => ({
+  tableExists: jest.fn(),
+  runAthenaQuery: jest.fn(),
+}));
+jest.mock("./aurora", () => ({
+  runAuroraQuery: jest.fn(),
+}));
+jest.mock("./config", () => ({
+  resolveCredentials: jest.fn(() => ({})),
+}));
+
+import type { InsightConfig } from "./config";
+import { testDestination } from "./destinationTest";
+import { tableExists, runAthenaQuery } from "./athena";
+import { runAuroraQuery } from "./aurora";
+
+function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
+  return {
+    region: "us-east-1",
+    logGroupNames: [],
+    destinationType: "s3",
+    dynamodbTableName: "",
+    auroraResourceArn: "",
+    auroraSecretArn: "",
+    auroraDatabase: "postgres",
+    auroraTable: "workflow_insight",
+    sqsQueueUrl: "",
+    sqsDeleteAfterRead: false,
+    athenaDatabase: "",
+    athenaTable: "workflow_insight",
+    athenaWorkgroup: "",
+    athenaOutputLocation: "",
+    athenaS3Location: "",
+    llmProvider: "bedrock",
+    awsProfile: undefined,
+    bedrockModelId: "m",
+    localModel: "m",
+    localServerUrl: "u",
+    localServerModel: "m",
+    agenticMaxIterations: 8,
+    queryMode: "agent",
+    aiDisclosureAcceptedVersion: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("testDestination — S3/Athena", () => {
+  const complete = {
+    destinationType: "s3" as const,
+    athenaDatabase: "db",
+    athenaTable: "workflow_insight",
+    athenaS3Location: "s3://bucket/prefix/",
+    athenaOutputLocation: "s3://bucket/athena-results/",
+  };
+
+  it("fails on missing required fields without probing AWS", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "s3" }));
+    expect(r.ok).toBe(false);
+    const required = r.checks.find((c) => c.label === "Required fields");
+    expect(required?.ok).toBe(false);
+    expect(required?.detail).toMatch(/Glue Database/);
+    expect(tableExists).not.toHaveBeenCalled();
+    expect(runAthenaQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes when the table exists and the test query succeeds", async () => {
+    (tableExists as jest.Mock).mockResolvedValue(true);
+    (runAthenaQuery as jest.Mock).mockResolvedValue({ columns: [], rows: [] });
+    const r = await testDestination(baseCfg(complete));
+    expect(r.ok).toBe(true);
+    expect(runAthenaQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "SELECT 1", database: "db" }),
+    );
+  });
+
+  it("still passes (with a note) when the table doesn't exist yet", async () => {
+    (tableExists as jest.Mock).mockResolvedValue(false);
+    (runAthenaQuery as jest.Mock).mockResolvedValue({ columns: [], rows: [] });
+    const r = await testDestination(baseCfg(complete));
+    expect(r.ok).toBe(true);
+    const tbl = r.checks.find((c) => c.label === "Glue table exists");
+    expect(tbl?.ok).toBe(true);
+    expect(tbl?.detail).toMatch(/created automatically when you Save/);
+  });
+
+  it("fails when the Athena test query errors (e.g. no result location)", async () => {
+    (tableExists as jest.Mock).mockResolvedValue(true);
+    (runAthenaQuery as jest.Mock).mockRejectedValue(
+      new Error("No output location provided"),
+    );
+    const r = await testDestination(baseCfg(complete));
+    expect(r.ok).toBe(false);
+    const q = r.checks.find((c) => c.label.startsWith("Athena test query"));
+    expect(q?.ok).toBe(false);
+    expect(q?.detail).toMatch(/No output location/);
+  });
+
+  it("notes primary-workgroup usage when neither workgroup nor location set", async () => {
+    (tableExists as jest.Mock).mockResolvedValue(true);
+    (runAthenaQuery as jest.Mock).mockResolvedValue({ columns: [], rows: [] });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "s3",
+        athenaDatabase: "db",
+        athenaS3Location: "s3://bucket/prefix/",
+      }),
+    );
+    expect(r.checks.some((c) => c.label === "Query result location")).toBe(
+      true,
+    );
+  });
+});
+
+describe("testDestination — DynamoDB", () => {
+  it("fails when table name missing", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "dynamodb" }));
+    expect(r.ok).toBe(false);
+    expect(ddbSend).not.toHaveBeenCalled();
+  });
+
+  it("passes when DescribeTable succeeds", async () => {
+    ddbSend.mockResolvedValue({ Table: { TableStatus: "ACTIVE" } });
+    const r = await testDestination(
+      baseCfg({ destinationType: "dynamodb", dynamodbTableName: "wi" }),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.checks.at(-1)?.detail).toMatch(/ACTIVE/);
+  });
+
+  it("fails when DescribeTable throws", async () => {
+    ddbSend.mockRejectedValue(new Error("ResourceNotFoundException"));
+    const r = await testDestination(
+      baseCfg({ destinationType: "dynamodb", dynamodbTableName: "wi" }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.checks.at(-1)?.detail).toMatch(/ResourceNotFound/);
+  });
+});
+
+describe("testDestination — Aurora", () => {
+  it("fails when ARNs missing", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "aurora" }));
+    expect(r.ok).toBe(false);
+    expect(runAuroraQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes SELECT 1 against the Data API", async () => {
+    (runAuroraQuery as jest.Mock).mockResolvedValue({ columns: [], rows: [] });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "aurora",
+        auroraResourceArn: "arn:rds",
+        auroraSecretArn: "arn:secret",
+        auroraDatabase: "postgres",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(runAuroraQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ sql: "SELECT 1" }),
+    );
+  });
+});
+
+describe("testDestination — SQS", () => {
+  it("fails when queue URL missing", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "sqs" }));
+    expect(r.ok).toBe(false);
+    expect(sqsSend).not.toHaveBeenCalled();
+  });
+
+  it("passes when GetQueueAttributes succeeds", async () => {
+    sqsSend.mockResolvedValue({
+      Attributes: { ApproximateNumberOfMessages: "3" },
+    });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "sqs",
+        sqsQueueUrl: "https://sqs/q",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.checks.at(-1)?.detail).toMatch(/~3 messages/);
+  });
+});
+
+describe("testDestination — CloudWatch Logs", () => {
+  it("fails when no log groups", async () => {
+    const r = await testDestination(
+      baseCfg({ destinationType: "cloudwatch-logs-exporter" }),
+    );
+    expect(r.ok).toBe(false);
+    expect(logsSend).not.toHaveBeenCalled();
+  });
+
+  it("passes when the exact log group is found", async () => {
+    logsSend.mockResolvedValue({
+      logGroups: [{ logGroupName: "/wi/demo" }],
+    });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "cloudwatch-logs-exporter",
+        logGroupNames: ["/wi/demo"],
+      }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("fails when the group name is not an exact match", async () => {
+    logsSend.mockResolvedValue({
+      logGroups: [{ logGroupName: "/wi/demo-2" }],
+    });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "cloudwatch-logs-exporter",
+        logGroupNames: ["/wi/demo"],
+      }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("pages via nextToken to find an exact match beyond the first page", async () => {
+    logsSend
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: "/wi/demo-a" }],
+        nextToken: "t1",
+      })
+      .mockResolvedValueOnce({
+        logGroups: [{ logGroupName: "/wi/demo" }],
+      });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "cloudwatch-logs-exporter",
+        logGroupNames: ["/wi/demo"],
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(logsSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a missing lambda-log-exporter group as a pass (auto-created)", async () => {
+    logsSend.mockResolvedValue({ logGroups: [] });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "lambda-log-exporter",
+        logGroupNames: ["/aws/lambda/my-fn"],
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.checks.at(-1)?.detail).toMatch(/first invocation/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
@@ -1,0 +1,319 @@
+import { DynamoDBClient, DescribeTableCommand } from "@aws-sdk/client-dynamodb";
+import {
+  CloudWatchLogsClient,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { SQSClient, GetQueueAttributesCommand } from "@aws-sdk/client-sqs";
+import type { InsightConfig } from "./config";
+import { resolveCredentials } from "./config";
+import { tableExists, runAthenaQuery } from "./athena";
+import { runAuroraQuery } from "./aurora";
+
+/**
+ * Result of a single check within a destination test (e.g. "Glue table exists",
+ * "Athena test query"). `ok: false` means the check failed; `detail` carries a
+ * human-readable explanation shown under the check.
+ */
+export interface DestinationCheck {
+  label: string;
+  ok: boolean;
+  detail?: string;
+}
+
+/**
+ * Outcome of testing a configured destination end-to-end: an overall pass/fail
+ * plus the individual checks that were run. Surfaced inline in the Settings
+ * modal so users can confirm a destination is reachable and its config complete
+ * BEFORE saving (and before running real queries).
+ */
+export interface DestinationTestReport {
+  ok: boolean;
+  summary: string;
+  checks: DestinationCheck[];
+}
+
+/** Awaits a connectivity probe and turns success/throw into a DestinationCheck. */
+async function probe(
+  label: string,
+  fn: () => Promise<string | undefined>,
+): Promise<DestinationCheck> {
+  try {
+    const detail = await fn();
+    return { label, ok: true, detail };
+  } catch (err) {
+    return {
+      label,
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function report(checks: DestinationCheck[]): DestinationTestReport {
+  const ok = checks.every((c) => c.ok);
+  return {
+    ok,
+    summary: ok
+      ? "All checks passed — this destination is reachable and ready to query."
+      : "Some checks failed. Fix the items marked below, then test again.",
+    checks,
+  };
+}
+
+/**
+ * Runs read-only connectivity + completeness checks for the configured
+ * destination. Never writes data — creating the Glue table stays on Save; the
+ * Athena test only reports whether the table already exists.
+ *
+ * Scope: this is a client-side connectivity/completeness check only. It cannot
+ * fully validate IAM beyond the specific read-only calls it happens to make —
+ * e.g. a role that can DescribeTable but lacks the permissions the actual query
+ * path uses later would still pass here. Treat a green result as "reachable and
+ * configured", not "every downstream operation is authorized".
+ */
+export async function testDestination(
+  cfg: InsightConfig,
+): Promise<DestinationTestReport> {
+  const credentials = resolveCredentials(cfg.awsProfile);
+
+  switch (cfg.destinationType) {
+    case "s3":
+      return testAthena(cfg, credentials);
+    case "dynamodb":
+      return testDynamoDB(cfg, credentials);
+    case "aurora":
+      return testAurora(cfg, credentials);
+    case "sqs":
+      return testSqs(cfg, credentials);
+    case "cloudwatch-logs-exporter":
+    case "lambda-log-exporter":
+      return testCloudWatchLogs(cfg, credentials);
+    default:
+      return report([
+        {
+          label: "Destination type",
+          ok: false,
+          detail: `Unsupported destination type: ${cfg.destinationType}`,
+        },
+      ]);
+  }
+}
+
+async function testAthena(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+
+  const missing: string[] = [];
+  if (!cfg.athenaDatabase) missing.push("Glue Database");
+  if (!cfg.athenaS3Location) missing.push("S3 Location");
+  // Note: athenaTable is never blank here — normalizeConfig() defaults it to
+  // "workflow_insight" — so it can't be reported missing.
+  checks.push({
+    label: "Required fields",
+    ok: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? `Database "${cfg.athenaDatabase}", table "${cfg.athenaTable}".`
+        : `Missing: ${missing.join(", ")}.`,
+  });
+
+  if (!cfg.athenaWorkgroup && !cfg.athenaOutputLocation) {
+    checks.push({
+      label: "Query result location",
+      ok: true,
+      detail:
+        "No workgroup or result location set — the 'primary' workgroup will be used. The test query below confirms whether it has an output location configured.",
+    });
+  }
+
+  // Can't probe further without the identifiers the calls require.
+  if (missing.length > 0) return report(checks);
+
+  checks.push(
+    await probe("Glue table exists", async () => {
+      const exists = await tableExists({
+        region: cfg.region,
+        credentials,
+        database: cfg.athenaDatabase,
+        table: cfg.athenaTable,
+      });
+      return exists
+        ? `${cfg.athenaDatabase}.${cfg.athenaTable} is present.`
+        : `${cfg.athenaDatabase}.${cfg.athenaTable} does not exist yet — it will be created automatically when you Save.`;
+    }),
+  );
+
+  // SELECT 1 exercises the workgroup / output-location / Athena permissions
+  // without scanning the data. This is what catches the common "primary
+  // workgroup with no result location" misconfiguration.
+  checks.push(
+    await probe("Athena test query (SELECT 1)", async () => {
+      await runAthenaQuery({
+        region: cfg.region,
+        credentials,
+        database: cfg.athenaDatabase,
+        workgroup: cfg.athenaWorkgroup || undefined,
+        outputLocation: cfg.athenaOutputLocation || undefined,
+        query: "SELECT 1",
+      });
+      return "Athena executed a query successfully.";
+    }),
+  );
+
+  return report(checks);
+}
+
+async function testDynamoDB(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  checks.push({
+    label: "Required fields",
+    ok: Boolean(cfg.dynamodbTableName),
+    detail: cfg.dynamodbTableName
+      ? `Table "${cfg.dynamodbTableName}".`
+      : "Missing: DynamoDB Table Name.",
+  });
+  if (!cfg.dynamodbTableName) return report(checks);
+
+  checks.push(
+    await probe("DynamoDB table exists", async () => {
+      const client = new DynamoDBClient({ region: cfg.region, credentials });
+      const out = await client.send(
+        new DescribeTableCommand({ TableName: cfg.dynamodbTableName }),
+      );
+      const status = out.Table?.TableStatus ?? "UNKNOWN";
+      return `Table "${cfg.dynamodbTableName}" found (status: ${status}).`;
+    }),
+  );
+  return report(checks);
+}
+
+async function testAurora(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  const missing: string[] = [];
+  if (!cfg.auroraResourceArn) missing.push("Aurora Cluster ARN");
+  if (!cfg.auroraSecretArn) missing.push("Aurora Secret ARN");
+  if (!cfg.auroraDatabase) missing.push("Database");
+  checks.push({
+    label: "Required fields",
+    ok: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? `Database "${cfg.auroraDatabase}".`
+        : `Missing: ${missing.join(", ")}.`,
+  });
+  if (missing.length > 0) return report(checks);
+
+  checks.push(
+    await probe("Aurora Data API connection (SELECT 1)", async () => {
+      await runAuroraQuery({
+        region: cfg.region,
+        credentials,
+        resourceArn: cfg.auroraResourceArn,
+        secretArn: cfg.auroraSecretArn,
+        database: cfg.auroraDatabase,
+        sql: "SELECT 1",
+      });
+      return "Connected to the cluster via the RDS Data API.";
+    }),
+  );
+  return report(checks);
+}
+
+async function testSqs(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  checks.push({
+    label: "Required fields",
+    ok: Boolean(cfg.sqsQueueUrl),
+    detail: cfg.sqsQueueUrl ? cfg.sqsQueueUrl : "Missing: SQS Queue URL.",
+  });
+  if (!cfg.sqsQueueUrl) return report(checks);
+
+  checks.push(
+    await probe("SQS queue reachable", async () => {
+      const client = new SQSClient({ region: cfg.region, credentials });
+      const out = await client.send(
+        new GetQueueAttributesCommand({
+          QueueUrl: cfg.sqsQueueUrl,
+          AttributeNames: ["ApproximateNumberOfMessages"],
+        }),
+      );
+      const n = out.Attributes?.ApproximateNumberOfMessages ?? "unknown";
+      return `Queue reachable (~${n} messages available).`;
+    }),
+  );
+  return report(checks);
+}
+
+async function testCloudWatchLogs(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  checks.push({
+    label: "Required fields",
+    ok: cfg.logGroupNames.length > 0,
+    detail:
+      cfg.logGroupNames.length > 0
+        ? `${cfg.logGroupNames.length} log group(s) configured.`
+        : "Missing: Log Group Name.",
+  });
+  if (cfg.logGroupNames.length === 0) return report(checks);
+
+  // Lambda creates its own log group (/aws/lambda/<fn>) on first invocation, so
+  // a not-yet-existing group is expected rather than a misconfiguration —
+  // mirror the Athena "will be created" nuance and treat it as a pass-with-note.
+  const autoCreated = cfg.destinationType === "lambda-log-exporter";
+
+  const client = new CloudWatchLogsClient({ region: cfg.region, credentials });
+  for (const name of cfg.logGroupNames) {
+    checks.push(
+      await probe(`Log group "${name}"`, async () => {
+        const found = await logGroupExists(client, name);
+        if (found) return "Found and accessible.";
+        if (autoCreated) {
+          return "Not created yet — Lambda creates this group on the function's first invocation.";
+        }
+        throw new Error(
+          "No log group with this exact name was found (records won't be readable until it exists).",
+        );
+      }),
+    );
+  }
+  return report(checks);
+}
+
+/**
+ * Whether a log group with this EXACT name exists. DescribeLogGroups only
+ * filters by prefix, so we page through matches (via nextToken) looking for the
+ * exact name — otherwise an account with >1 page of same-prefix groups could
+ * report a false "not found" if the exact match isn't on the first page.
+ */
+async function logGroupExists(
+  client: CloudWatchLogsClient,
+  name: string,
+): Promise<boolean> {
+  let nextToken: string | undefined;
+  do {
+    const out = await client.send(
+      new DescribeLogGroupsCommand({
+        logGroupNamePrefix: name,
+        limit: 50,
+        nextToken,
+      }),
+    );
+    if ((out.logGroups ?? []).some((g) => g.logGroupName === name)) return true;
+    nextToken = out.nextToken;
+  } while (nextToken);
+  return false;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -1,7 +1,12 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import { randomUUID } from "crypto";
-import { readConfig, resolveCredentials } from "./config";
+import {
+  readConfig,
+  resolveCredentials,
+  configFromWireSettings,
+} from "./config";
+import { testDestination } from "./destinationTest";
 import {
   generateQuery,
   verifyResult,
@@ -44,6 +49,7 @@ type InboundMessage =
   | { type: "setConsent"; version: string }
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
+  | { type: "testDestination"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   | { type: "exportChart"; format: "svg" | "png"; content: string }
   | {
@@ -274,6 +280,8 @@ class ExplorerPanel {
           return;
         case "saveSettings":
           return await this.onSaveSettings(msg.settings);
+        case "testDestination":
+          return await this.onTestDestination(msg.settings);
         case "downloadModel":
           return await this.onDownloadModel(msg.localModel);
         case "exportChart":
@@ -343,6 +351,29 @@ class ExplorerPanel {
       },
       modelDownloaded: isModelDownloaded(),
     });
+  }
+
+  private async onTestDestination(
+    settings: Record<string, string>,
+  ): Promise<void> {
+    // Test exactly what the user has typed in the modal (not the saved config),
+    // so they can validate before committing. Failures are reported as a normal
+    // result payload — not the global `error` toast — so they render inline in
+    // the modal next to the Test button.
+    const cfg = configFromWireSettings(settings);
+    try {
+      const result = await testDestination(cfg);
+      this.post({ type: "destinationTestResult", result });
+    } catch (err) {
+      this.post({
+        type: "destinationTestResult",
+        result: {
+          ok: false,
+          summary: err instanceof Error ? err.message : String(err),
+          checks: [],
+        },
+      });
+    }
   }
 
   private async onSaveSettings(

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -25,10 +25,23 @@ import type {
   AgentStep,
   QueryMode,
   Favorite,
+  DestinationTestReport,
 } from "./types";
 import { DEFAULT_SETTINGS, AI_DISCLOSURE_VERSION } from "./types";
 
 applyMode(Mode.Dark);
+
+/**
+ * Serializes Settings into the all-string payload the extension host expects
+ * (each key maps 1:1 to a VS Code setting; sqsDeleteAfterRead is the only
+ * boolean, coerced here at the boundary). Shared by the Save and Test actions
+ * so their wire encoding can't drift apart.
+ */
+function toWireSettings(s: Settings): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(s).map(([key, value]) => [key, String(value)]),
+  );
+}
 
 /**
  * A simple, ready-to-run starter query for the current destination, used to
@@ -107,6 +120,11 @@ export function App() {
   const [loading, setLoading] = useState(false);
   const [modelDownloaded, setModelDownloaded] = useState(false);
   const [downloadPercent, setDownloadPercent] = useState(0);
+  // Result of a "Test connection" run in the Settings modal (null = not run
+  // yet this session); `destTesting` shows the in-flight spinner.
+  const [destTesting, setDestTesting] = useState(false);
+  const [destTestResult, setDestTestResult] =
+    useState<DestinationTestReport | null>(null);
   const [page, setPage] = useState<Page>("data");
   const [sqsMessages, setSqsMessages] = useState<SqsMessageRow[]>([]);
   const [sqsListening, setSqsListening] = useState(false);
@@ -246,6 +264,10 @@ export function App() {
       case "settingsSaved":
         setSettingsOpen(false);
         break;
+      case "destinationTestResult":
+        setDestTesting(false);
+        setDestTestResult(msg.result);
+        break;
       case "sqsStatus":
         setSqsListening(msg.listening);
         break;
@@ -358,14 +380,18 @@ export function App() {
   };
 
   const handleSave = (s: Settings) => {
-    // The wire contract for saveSettings is all-string (matches every VS Code
-    // setting key it writes through 1:1); sqsDeleteAfterRead is the only
-    // boolean field in Settings, so serialize it here at the boundary.
-    const wire: Record<string, string> = Object.fromEntries(
-      Object.entries(s).map(([key, value]) => [key, String(value)]),
-    );
-    postMessage({ type: "saveSettings", settings: wire });
+    postMessage({ type: "saveSettings", settings: toWireSettings(s) });
   };
+
+  const handleTestDestination = (s: Settings) => {
+    // Tests the current (possibly unsaved) form values; the host normalizes the
+    // same all-string payload without persisting it.
+    setDestTestResult(null);
+    setDestTesting(true);
+    postMessage({ type: "testDestination", settings: toWireSettings(s) });
+  };
+
+  const handleClearTest = useCallback(() => setDestTestResult(null), []);
 
   return (
     <div style={{ padding: "16px" }}>
@@ -575,6 +601,10 @@ export function App() {
           downloadPercent={downloadPercent}
           onDismiss={() => setSettingsOpen(false)}
           onSave={handleSave}
+          testing={destTesting}
+          testResult={destTestResult}
+          onTest={handleTestDestination}
+          onClearTest={handleClearTest}
         />
 
         <AiConsentModal

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -10,7 +10,7 @@ import Alert from "@cloudscape-design/components/alert";
 import Select, { type SelectProps } from "@cloudscape-design/components/select";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Tabs from "@cloudscape-design/components/tabs";
-import type { Settings } from "./types";
+import type { Settings, DestinationTestReport } from "./types";
 import { postMessage } from "./vscode";
 
 interface Props {
@@ -20,6 +20,14 @@ interface Props {
   downloadPercent: number;
   onDismiss: () => void;
   onSave: (settings: Settings) => void;
+  /** True while a "Test connection" run is in flight. */
+  testing: boolean;
+  /** Result of the last test this session, or null if none / cleared. */
+  testResult: DestinationTestReport | null;
+  /** Kick off a connectivity test for the current (unsaved) form values. */
+  onTest: (settings: Settings) => void;
+  /** Clear a stale test result (called on open and on destination change). */
+  onClearTest: () => void;
 }
 
 const DEST_OPTIONS: SelectProps.Option[] = [
@@ -51,7 +59,7 @@ const LOCAL_MODEL_OPTIONS: SelectProps.Option[] = [
   },
 ];
 
-export function SettingsModal({ visible, settings, modelDownloaded, downloadPercent, onDismiss, onSave }: Props) {
+export function SettingsModal({ visible, settings, modelDownloaded, downloadPercent, onDismiss, onSave, testing, testResult, onTest, onClearTest }: Props) {
   const [form, setForm] = useState<Settings>(settings);
   const [downloading, setDownloading] = useState(false);
 
@@ -59,8 +67,17 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
     setForm(settings);
   }, [settings, visible]);
 
-  const update = (field: keyof Settings, value: string | boolean) =>
+  // Drop any prior test result when the modal (re)opens so a stale pass/fail
+  // from a previous session isn't shown against freshly-loaded settings.
+  useEffect(() => {
+    onClearTest();
+  }, [visible, onClearTest]);
+
+  const update = (field: keyof Settings, value: string | boolean) => {
+    // Changing the destination invalidates any existing test result.
+    if (field === "destinationType") onClearTest();
     setForm((f) => ({ ...f, [field]: value }));
+  };
 
   const canSave = form.llmProvider !== "local" || modelDownloaded;
 
@@ -191,6 +208,47 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                     </Box>
                   </SpaceBetween>
                 )}
+
+                <SpaceBetween size="xs">
+                  <div>
+                    <Button
+                      onClick={() => onTest(form)}
+                      loading={testing}
+                      disabled={testing}
+                    >
+                      Test connection
+                    </Button>
+                  </div>
+                  <Box color="text-body-secondary" fontSize="body-s">
+                    Runs read-only checks against this destination (and confirms
+                    the config is complete) without saving. For S3 + Athena it
+                    also verifies the Glue table and runs a test query.
+                  </Box>
+                  {testResult && (
+                    <Alert type={testResult.ok ? "success" : "error"} header={testResult.summary}>
+                      {testResult.checks.length > 0 && (
+                        <SpaceBetween size="xxs">
+                          {testResult.checks.map((c, i) => (
+                            <Box key={i}>
+                              <Box
+                                variant="span"
+                                fontWeight="bold"
+                                color={c.ok ? "text-status-success" : "text-status-error"}
+                              >
+                                {c.ok ? "✓" : "✗"} {c.label}
+                              </Box>
+                              {c.detail && (
+                                <Box variant="span" color="text-body-secondary">
+                                  {" "}— {c.detail}
+                                </Box>
+                              )}
+                            </Box>
+                          ))}
+                        </SpaceBetween>
+                      )}
+                    </Alert>
+                  )}
+                </SpaceBetween>
               </SpaceBetween>
             ),
           },

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -17,6 +17,7 @@ export type OutboundMessage =
   | { type: "setConsent"; version: string }
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
+  | { type: "testDestination"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   // Save the result table to a file (host shows a save dialog). The webview
   // builds the CSV/JSON text; the host just writes it.
@@ -50,6 +51,21 @@ export type OutboundMessage =
       month?: string;
       day?: string;
     };
+
+/** A single check within a destination connectivity test. Mirrors the
+ * DestinationCheck shape produced by the host's destinationTest.ts. */
+export interface DestinationCheck {
+  label: string;
+  ok: boolean;
+  detail?: string;
+}
+
+/** Result of a "Test connection" run, produced by the host. */
+export interface DestinationTestReport {
+  ok: boolean;
+  summary: string;
+  checks: DestinationCheck[];
+}
 
 /** A single SQS message, normalized for display. */
 export interface SqsMessageRow {
@@ -141,6 +157,7 @@ export type InboundMessage =
   | { type: "error"; message: string }
   | { type: "sessionCleared" }
   | { type: "settingsSaved" }
+  | { type: "destinationTestResult"; result: DestinationTestReport }
   | { type: "downloadProgress"; percent: number; done: boolean }
   | { type: "sqsStatus"; listening: boolean }
   | { type: "sqsMessages"; messages: SqsMessageRow[] }


### PR DESCRIPTION
Bug bash feedback: switching the Explorer to S3 + Athena closes the Settings modal almost immediately, with no clear signal that the destination is configured correctly or that the backing resources exist. Adds a "Test connection" button to the Data Source tab that runs read-only checks against the current (unsaved) form values and reports a per-check pass/fail inline — the modal stays open — so users can confirm a destination is reachable and its config complete before saving or querying.

Host:
- New destinationTest.ts: testDestination(cfg) returns { ok, summary, checks[] } and dispatches per destination type. All probes are read-only.
    - S3 + Athena: required-field completeness; a note when neither workgroup nor result location is set (the "primary workgroup with no output location" trap); Glue table existence (reported as "will be created on Save" when absent, not a failure); and a real SELECT 1 that exercises the workgroup / output location / permissions.
    - DynamoDB: DescribeTable. Aurora: SELECT 1 via the RDS Data API. SQS: GetQueueAttributes. CloudWatch Logs: exact-name DescribeLogGroups.
- config.ts: factor the settings normalization out of readConfig into a shared helper and add configFromWireSettings(), so the test can validate the webview's unsaved values without persisting them.
- extension.ts: handle a new "testDestination" message; post the outcome back as a "destinationTestResult" payload (not the global error toast) so it renders inline in the modal.

Webview:
- SettingsModal.tsx: "Test connection" button plus a success/error Alert listing each check; the result clears when the modal reopens or the destination changes. App.tsx/types.ts: message plumbing and shared report types.

Tests: destinationTest.test.ts (per-destination success, connectivity failure, and completeness paths) and config.test.ts (configFromWireSettings mapping, defaults, and coercion). Host suite 156 passing; host + webview builds green.
