### PR TITLE
feat(sdk): default to Claude Sonnet 5 and add a Bedrock model picker in Workflow Insight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -321,6 +321,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-bedrock": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1086.0.tgz",
+      "integrity": "sha512-CQm+NnOY/kVWjeHbkZDwJPipnx9AVdECvPvYZXP5muBAMy2WNO97V4SNrtmcn6vMr0ia//9jFlR6DXUtxRvTxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.67",
+        "@aws-sdk/token-providers": "3.1086.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1076.0.tgz",
@@ -340,6 +360,23 @@
         "@smithy/fetch-http-handler": "^5.6.0",
         "@smithy/node-http-handler": "^4.9.0",
         "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1086.0.tgz",
+      "integrity": "sha512-/d1uB//QrUnIuHmYsB+VByGvezOwiICHZU1JFxLxCcDrmR/zZlfV5sjh91SPvRiK04ckL3GhPeO6L2qG33TKeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -676,17 +713,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
-      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.0",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -720,15 +757,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
-      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -736,17 +773,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.55",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
-      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -754,23 +791,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
-      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-login": "^3.972.59",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -778,16 +815,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
-      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -795,21 +832,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
-      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
+      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.53",
-        "@aws-sdk/credential-provider-http": "^3.972.55",
-        "@aws-sdk/credential-provider-ini": "^3.972.60",
-        "@aws-sdk/credential-provider-process": "^3.972.53",
-        "@aws-sdk/credential-provider-sso": "^3.972.59",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/credential-provider-imds": "^4.4.5",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -817,15 +854,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
-      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -833,17 +870,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
-      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/token-providers": "3.1079.0",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -851,16 +888,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1079.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
-      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -868,16 +905,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
-      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/nested-clients": "^3.997.27",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1116,18 +1153,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
-      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.27",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/core": "^3.29.0",
-        "@smithy/fetch-http-handler": "^5.6.2",
-        "@smithy/node-http-handler": "^4.9.2",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1151,14 +1188,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1183,12 +1220,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1276,12 +1313,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4940,12 +4977,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4953,13 +4990,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
-      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5037,13 +5074,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
-      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5187,13 +5224,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5265,13 +5302,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5297,9 +5334,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16213,6 +16250,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.658.0",
+        "@aws-sdk/client-bedrock": "^3.1086.0",
         "@aws-sdk/client-bedrock-runtime": "^3.658.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
         "@aws-sdk/client-dynamodb": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -198,8 +198,12 @@ Pick a provider under **⚙ → LLM Provider**:
 - **Amazon Bedrock** (default) — set the **Bedrock Model ID** to an inference profile you have access to:
 
   ```
-  us.anthropic.claude-sonnet-4-20250514-v1:0
+  us.anthropic.claude-sonnet-5
   ```
+
+  Click **List available models** next to the field to fetch the models
+  available for your configured Region and AWS Profile and pick one from the
+  suggestions — or type any model / inference profile ID directly.
 
 - **GitHub Copilot** — uses the VS Code Language Model API; requires an active Copilot subscription. No extra config.
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -151,7 +151,7 @@
         },
         "workflowInsight.bedrockModelId": {
           "type": "string",
-          "default": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+          "default": "us.anthropic.claude-sonnet-5",
           "description": "Amazon Bedrock model id (or inference profile id) used by the AI features when LLM Provider is 'bedrock'. Requests and the limited data described for the AI features are sent to this model in Amazon Bedrock in your configured AWS account and region, and processed under your AWS agreement and the Amazon Bedrock service terms. You are responsible for having access to the model and for the content you submit."
         },
         "workflowInsight.localServerUrl": {
@@ -220,6 +220,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-athena": "^3.658.0",
+    "@aws-sdk/client-bedrock": "^3.1086.0",
     "@aws-sdk/client-bedrock-runtime": "^3.658.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.658.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/agentLoop.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/agentLoop.ts
@@ -1,12 +1,12 @@
 import {
   BedrockRuntimeClient,
-  ConverseCommand,
   type ContentBlock,
   type Message,
   type Tool,
   type ToolUseBlock,
 } from "@aws-sdk/client-bedrock-runtime";
 import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import { sendConverse } from "./bedrockConverse";
 import { buildSystemPrompt, type DestinationType } from "./schema";
 import { runSandboxedJs } from "./sandbox";
 
@@ -412,20 +412,18 @@ export async function runAgentLoop(
   });
 
   for (let i = 0; i < opts.maxIterations; i++) {
-    const response = await client.send(
-      new ConverseCommand({
-        modelId: opts.modelId,
-        system: [{ text: system }],
-        messages,
-        toolConfig: {
-          tools: [RUN_QUERY_TOOL, RUN_JAVASCRIPT_TOOL, FINISH_TOOL],
-        },
-        // Generous cap: a finish call can carry answer + a multi-line query +
-        // explanation + suggestedCharts, plus run_javascript can emit a chunk
-        // of code — 1024 could truncate those mid-tool-call.
-        inferenceConfig: { maxTokens: 4096, temperature: 0 },
-      }),
-    );
+    const response = await sendConverse(client, {
+      modelId: opts.modelId,
+      system: [{ text: system }],
+      messages,
+      toolConfig: {
+        tools: [RUN_QUERY_TOOL, RUN_JAVASCRIPT_TOOL, FINISH_TOOL],
+      },
+      // Generous cap: a finish call can carry answer + a multi-line query +
+      // explanation + suggestedCharts, plus run_javascript can emit a chunk
+      // of code — 1024 could truncate those mid-tool-call.
+      inferenceConfig: { maxTokens: 4096, temperature: 0 },
+    });
     const message = response.output?.message;
     if (!message) break;
     messages.push(message);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockConverse.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockConverse.test.ts
@@ -1,0 +1,102 @@
+const send = jest.fn();
+jest.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  BedrockRuntimeClient: jest.fn(() => ({ send })),
+  ConverseCommand: jest.fn((input) => ({ __t: "converse", input })),
+}));
+
+import { sendConverse, modelRejectsTemperature } from "./bedrockConverse";
+import { ConverseCommand } from "@aws-sdk/client-bedrock-runtime";
+
+const client = { send } as never;
+
+function lastInput() {
+  const calls = (ConverseCommand as unknown as jest.Mock).mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("modelRejectsTemperature", () => {
+  it("flags Claude 5-gen (and newer) models", () => {
+    expect(modelRejectsTemperature("us.anthropic.claude-sonnet-5")).toBe(true);
+    expect(modelRejectsTemperature("anthropic.claude-opus-5")).toBe(true);
+    expect(modelRejectsTemperature("global.anthropic.claude-haiku-9")).toBe(
+      true,
+    );
+    // two-digit versions from 10 up
+    expect(modelRejectsTemperature("anthropic.claude-sonnet-10")).toBe(true);
+    expect(modelRejectsTemperature("anthropic.claude-opus-12")).toBe(true);
+    // Opus 4.7+ rejects temperature despite being a 4-generation id
+    expect(modelRejectsTemperature("us.anthropic.claude-opus-4-7")).toBe(true);
+    expect(modelRejectsTemperature("anthropic.claude-opus-4-9")).toBe(true);
+  });
+
+  it("does not flag older models that accept temperature", () => {
+    expect(
+      modelRejectsTemperature("us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    ).toBe(false);
+    expect(
+      modelRejectsTemperature("anthropic.claude-3-5-sonnet-20241022-v2:0"),
+    ).toBe(false);
+    // Opus 4.5/4.6 still accept temperature (only 4.7+ rejects)
+    expect(modelRejectsTemperature("anthropic.claude-opus-4-5")).toBe(false);
+    // a hypothetical zero-padded low version must not false-match
+    expect(modelRejectsTemperature("anthropic.claude-sonnet-04")).toBe(false);
+  });
+});
+
+describe("sendConverse", () => {
+  it("strips temperature up front for models that reject it (single call)", async () => {
+    send.mockResolvedValue({ ok: true });
+    await sendConverse(client, {
+      modelId: "us.anthropic.claude-sonnet-5",
+      messages: [],
+      inferenceConfig: { maxTokens: 4096, temperature: 0 },
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(lastInput().inferenceConfig).toEqual({ maxTokens: 4096 });
+    expect(lastInput().inferenceConfig.temperature).toBeUndefined();
+  });
+
+  it("keeps temperature for models that accept it", async () => {
+    send.mockResolvedValue({ ok: true });
+    await sendConverse(client, {
+      modelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+      messages: [],
+      inferenceConfig: { maxTokens: 4096, temperature: 0 },
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(lastInput().inferenceConfig).toEqual({
+      maxTokens: 4096,
+      temperature: 0,
+    });
+  });
+
+  it("retries without temperature when the server rejects it (unknown model)", async () => {
+    send
+      .mockRejectedValueOnce(
+        new Error("`temperature` is deprecated for this model."),
+      )
+      .mockResolvedValueOnce({ ok: true });
+    const out = await sendConverse(client, {
+      modelId: "some.future.model",
+      messages: [],
+      inferenceConfig: { maxTokens: 100, temperature: 0 },
+    });
+    expect(out).toEqual({ ok: true });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(lastInput().inferenceConfig).toEqual({ maxTokens: 100 });
+  });
+
+  it("rethrows non-temperature errors without retrying", async () => {
+    send.mockRejectedValue(new Error("AccessDeniedException"));
+    await expect(
+      sendConverse(client, {
+        modelId: "some.model",
+        messages: [],
+        inferenceConfig: { maxTokens: 100, temperature: 0 },
+      }),
+    ).rejects.toThrow("AccessDeniedException");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockConverse.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockConverse.ts
@@ -1,0 +1,70 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type ConverseCommandInput,
+  type ConverseCommandOutput,
+  type InferenceConfiguration,
+} from "@aws-sdk/client-bedrock-runtime";
+
+/**
+ * Whether a Bedrock model rejects the `temperature` inference parameter.
+ * Claude Sonnet/Opus/Haiku 5 (and newer) have adaptive reasoning that is always
+ * on, and the Converse API returns "`temperature` is deprecated for this model"
+ * if it's supplied.
+ */
+export function modelRejectsTemperature(modelId: string): boolean {
+  // Claude family version 5+ (single digit 5-9, or any two-digit version
+  // starting at 10) — e.g. claude-sonnet-5, claude-opus-12. The two-digit
+  // branch starts at 10 (not \d\d) so a hypothetical claude-*-04 wouldn't
+  // false-match.
+  if (/claude-(sonnet|opus|haiku)-([5-9]|[1-9]\d)/i.test(modelId)) return true;
+  // Claude Opus 4.7 and up (claude-opus-4-7 / -8 / -9) also reject temperature
+  // on Bedrock, even though they're a 4-generation id.
+  if (/claude-opus-4-[7-9]/i.test(modelId)) return true;
+  return false;
+}
+
+function stripTemperature(
+  cfg: InferenceConfiguration | undefined,
+): InferenceConfiguration | undefined {
+  if (!cfg) return cfg;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { temperature, ...rest } = cfg;
+  return rest;
+}
+
+/**
+ * Sends a Converse request, transparently handling models that reject the
+ * `temperature` parameter. For models known to reject it we drop temperature up
+ * front (so the common case doesn't waste a guaranteed-failing call); as a
+ * safety net for any other such model, a failure mentioning temperature is
+ * retried once without it.
+ */
+export async function sendConverse(
+  client: BedrockRuntimeClient,
+  input: ConverseCommandInput,
+): Promise<ConverseCommandOutput> {
+  const effective: ConverseCommandInput =
+    input.modelId &&
+    modelRejectsTemperature(input.modelId) &&
+    input.inferenceConfig?.temperature !== undefined
+      ? { ...input, inferenceConfig: stripTemperature(input.inferenceConfig) }
+      : input;
+  try {
+    return await client.send(new ConverseCommand(effective));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      /temperature/i.test(msg) &&
+      effective.inferenceConfig?.temperature !== undefined
+    ) {
+      return await client.send(
+        new ConverseCommand({
+          ...effective,
+          inferenceConfig: stripTemperature(effective.inferenceConfig),
+        }),
+      );
+    }
+    throw err;
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockModels.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockModels.test.ts
@@ -1,0 +1,164 @@
+const send = jest.fn();
+jest.mock("@aws-sdk/client-bedrock", () => ({
+  BedrockClient: jest.fn(() => ({ send, destroy: jest.fn() })),
+  ListInferenceProfilesCommand: jest.fn((i) => ({ __t: "profiles", i })),
+  ListFoundationModelsCommand: jest.fn((i) => ({ __t: "models", i })),
+}));
+
+import { listBedrockModels } from "./bedrockModels";
+
+const creds = {} as never;
+
+beforeEach(() => jest.clearAllMocks());
+
+function route(handlers: {
+  profiles?: unknown[];
+  profilesPages?: Array<{
+    inferenceProfileSummaries: unknown[];
+    nextToken?: string;
+  }>;
+  models?: unknown[];
+}) {
+  let profilePage = 0;
+  send.mockImplementation((cmd: { __t: string }) => {
+    if (cmd.__t === "profiles") {
+      if (handlers.profilesPages) {
+        return Promise.resolve(handlers.profilesPages[profilePage++]);
+      }
+      return Promise.resolve({
+        inferenceProfileSummaries: handlers.profiles ?? [],
+      });
+    }
+    return Promise.resolve({ modelSummaries: handlers.models ?? [] });
+  });
+}
+
+describe("listBedrockModels", () => {
+  it("merges inference profiles and on-demand text models, deduped and sorted", async () => {
+    route({
+      profiles: [
+        {
+          inferenceProfileId: "us.anthropic.claude-sonnet-5",
+          status: "ACTIVE",
+        },
+        { inferenceProfileId: "us.anthropic.claude-opus-5", status: "ACTIVE" },
+      ],
+      models: [
+        {
+          modelId: "anthropic.claude-instant",
+          modelLifecycle: { status: "ACTIVE" },
+          outputModalities: ["TEXT"],
+          inferenceTypesSupported: ["ON_DEMAND"],
+        },
+      ],
+    });
+    const out = await listBedrockModels({
+      region: "us-east-1",
+      credentials: creds,
+    });
+    expect(out).toEqual([
+      "anthropic.claude-instant",
+      "us.anthropic.claude-opus-5",
+      "us.anthropic.claude-sonnet-5",
+    ]);
+  });
+
+  it("excludes inactive, non-text, and non-on-demand foundation models", async () => {
+    route({
+      profiles: [],
+      models: [
+        {
+          modelId: "legacy.model",
+          modelLifecycle: { status: "LEGACY" },
+          outputModalities: ["TEXT"],
+          inferenceTypesSupported: ["ON_DEMAND"],
+        },
+        {
+          modelId: "image.only",
+          modelLifecycle: { status: "ACTIVE" },
+          outputModalities: ["IMAGE"],
+          inferenceTypesSupported: ["ON_DEMAND"],
+        },
+        {
+          modelId: "profile.only",
+          modelLifecycle: { status: "ACTIVE" },
+          outputModalities: ["TEXT"],
+          inferenceTypesSupported: ["INFERENCE_PROFILE"],
+        },
+        {
+          modelId: "good.model",
+          modelLifecycle: { status: "ACTIVE" },
+          outputModalities: ["TEXT"],
+          inferenceTypesSupported: ["ON_DEMAND"],
+        },
+      ],
+    });
+    const out = await listBedrockModels({
+      region: "us-east-1",
+      credentials: creds,
+    });
+    expect(out).toEqual(["good.model"]);
+  });
+
+  it("skips non-active inference profiles", async () => {
+    route({
+      profiles: [
+        { inferenceProfileId: "us.active", status: "ACTIVE" },
+        { inferenceProfileId: "us.inactive", status: "INACTIVE" },
+      ],
+      models: [],
+    });
+    const out = await listBedrockModels({
+      region: "us-east-1",
+      credentials: creds,
+    });
+    expect(out).toEqual(["us.active"]);
+  });
+
+  it("paginates inference profiles via nextToken", async () => {
+    route({
+      profilesPages: [
+        {
+          inferenceProfileSummaries: [
+            { inferenceProfileId: "us.one", status: "ACTIVE" },
+          ],
+          nextToken: "t1",
+        },
+        {
+          inferenceProfileSummaries: [
+            { inferenceProfileId: "us.two", status: "ACTIVE" },
+          ],
+        },
+      ],
+      models: [],
+    });
+    const out = await listBedrockModels({
+      region: "us-east-1",
+      credentials: creds,
+    });
+    expect(out).toEqual(["us.one", "us.two"]);
+    // 2 profile pages + 1 foundation-models call
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops paginating after the page cap even if nextToken never clears", async () => {
+    send.mockImplementation((cmd: { __t: string }) => {
+      if (cmd.__t === "profiles") {
+        return Promise.resolve({
+          inferenceProfileSummaries: [
+            { inferenceProfileId: "us.loop", status: "ACTIVE" },
+          ],
+          nextToken: "always", // never clears
+        });
+      }
+      return Promise.resolve({ modelSummaries: [] });
+    });
+    const out = await listBedrockModels({
+      region: "us-east-1",
+      credentials: creds,
+    });
+    expect(out).toEqual(["us.loop"]);
+    // 20 profile pages (cap) + 1 foundation-models call
+    expect(send).toHaveBeenCalledTimes(21);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockModels.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/bedrockModels.ts
@@ -1,0 +1,86 @@
+import {
+  BedrockClient,
+  ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
+} from "@aws-sdk/client-bedrock";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+
+/** Overall timeout for the model-list calls (button-triggered, so keep it snappy). */
+const MODEL_LIST_TIMEOUT_MS = 15_000;
+/** Safety cap on inference-profile pages (100/page) so a buggy nextToken can't loop forever. */
+const MAX_PROFILE_PAGES = 20;
+
+/**
+ * Lists the Bedrock model identifiers usable for text generation in the given
+ * region, so the Settings UI can offer them as suggestions. Combines two
+ * sources and returns a de-duplicated, sorted list of ids:
+ *
+ *  - System-defined inference profiles (e.g. `us.anthropic.claude-sonnet-5`),
+ *    which are the directly-invokable ids for newer cross-region models.
+ *  - On-demand foundation models (base ids like `anthropic.claude-...`) that are
+ *    ACTIVE and produce TEXT. Models that ONLY support the INFERENCE_PROFILE
+ *    type are skipped here because their base id isn't directly invokable — the
+ *    matching inference profile above covers them.
+ *
+ * Note: this reflects models AVAILABLE in the region; a returned id may still
+ * require model access to be granted in the Bedrock console before it can be
+ * invoked.
+ */
+export async function listBedrockModels(opts: {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+}): Promise<string[]> {
+  const client = new BedrockClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  // Bound the whole operation so a hung socket (expired creds, unreachable
+  // region) surfaces as an error in ~15s instead of spinning for the SDK's
+  // default socket timeout (~minutes).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MODEL_LIST_TIMEOUT_MS);
+  const sendOpts = { abortSignal: controller.signal };
+
+  try {
+    const ids = new Set<string>();
+
+    // System-defined inference profiles (paginated).
+    let nextToken: string | undefined;
+    let page = 0;
+    do {
+      // Guard against a misbehaving API returning the same token forever.
+      if (++page > MAX_PROFILE_PAGES) break;
+      const out = await client.send(
+        new ListInferenceProfilesCommand({
+          typeEquals: "SYSTEM_DEFINED",
+          maxResults: 100,
+          nextToken,
+        }),
+        sendOpts,
+      );
+      for (const p of out.inferenceProfileSummaries ?? []) {
+        if (p.inferenceProfileId && p.status === "ACTIVE") {
+          ids.add(p.inferenceProfileId);
+        }
+      }
+      nextToken = out.nextToken;
+    } while (nextToken);
+
+    // On-demand, active, text-output foundation models. ListFoundationModels is
+    // not paginated (returns all summaries in one response).
+    const fm = await client.send(new ListFoundationModelsCommand({}), sendOpts);
+    for (const m of fm.modelSummaries ?? []) {
+      if (!m.modelId) continue;
+      const active = m.modelLifecycle?.status === "ACTIVE";
+      const text = (m.outputModalities ?? []).includes("TEXT");
+      const onDemand = (m.inferenceTypesSupported ?? []).includes("ON_DEMAND");
+      if (active && text && onDemand) ids.add(m.modelId);
+    }
+
+    return Array.from(ids).sort((a, b) => a.localeCompare(b));
+  } finally {
+    clearTimeout(timer);
+    client.destroy();
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -122,7 +122,7 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
   const awsProfile = (src.getString("awsProfile") || "").trim() || undefined;
   const bedrockModelId =
     (src.getString("bedrockModelId") || "").trim() ||
-    "us.anthropic.claude-sonnet-4-20250514-v1:0";
+    "us.anthropic.claude-sonnet-5";
   const localModel =
     (src.getString("localModel") || "").trim() || "llama-3-groq-8b-tool-use";
   const localServerUrl =

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -7,6 +7,7 @@ import {
   configFromWireSettings,
 } from "./config";
 import { testDestination } from "./destinationTest";
+import { listBedrockModels } from "./bedrockModels";
 import {
   generateQuery,
   verifyResult,
@@ -50,6 +51,7 @@ type InboundMessage =
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "testDestination"; settings: Record<string, string> }
+  | { type: "listModels"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   | { type: "exportChart"; format: "svg" | "png"; content: string }
   | {
@@ -282,6 +284,8 @@ class ExplorerPanel {
           return await this.onSaveSettings(msg.settings);
         case "testDestination":
           return await this.onTestDestination(msg.settings);
+        case "listModels":
+          return await this.onListModels(msg.settings);
         case "downloadModel":
           return await this.onDownloadModel(msg.localModel);
         case "exportChart":
@@ -372,6 +376,28 @@ class ExplorerPanel {
           summary: err instanceof Error ? err.message : String(err),
           checks: [],
         },
+      });
+    }
+  }
+
+  private async onListModels(settings: Record<string, string>): Promise<void> {
+    // Use the region/profile currently in the modal (may be unsaved) so the
+    // list matches what the user is about to save. Errors are reported inline
+    // via the same payload rather than the global error toast.
+    const cfg = configFromWireSettings(settings);
+    try {
+      const models = await listBedrockModels({
+        region: cfg.region,
+        credentials: resolveCredentials(cfg.awsProfile),
+      });
+      this.post({ type: "bedrockModels", models });
+    } catch (err) {
+      // Omit `models` on failure so the webview keeps any previously-fetched
+      // suggestions (e.g. after a retry with a typo'd profile) rather than
+      // clearing the list.
+      this.post({
+        type: "bedrockModels",
+        error: err instanceof Error ? err.message : String(err),
       });
     }
   }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/llm.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import {
   BedrockRuntimeClient,
-  ConverseCommand,
   type ContentBlock,
   type Tool,
 } from "@aws-sdk/client-bedrock-runtime";
 import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import { sendConverse } from "./bedrockConverse";
 import { buildSystemPrompt, type DestinationType } from "./schema";
 import { parseChartSpec } from "./chartSpec";
 import { parseLocalServerQueryResponse } from "./localServerParse";
@@ -220,17 +220,15 @@ export async function verifyResult(
         region: opts.region,
         credentials: opts.credentials,
       });
-      const response = await client.send(
-        new ConverseCommand({
-          modelId: opts.modelId,
-          messages: [{ role: "user", content: [{ text: instruction }] }],
-          toolConfig: {
-            tools: [JUDGE_TOOL],
-            toolChoice: { tool: { name: "judge_result" } },
-          },
-          inferenceConfig: { maxTokens: 4096, temperature: 0 },
-        }),
-      );
+      const response = await sendConverse(client, {
+        modelId: opts.modelId,
+        messages: [{ role: "user", content: [{ text: instruction }] }],
+        toolConfig: {
+          tools: [JUDGE_TOOL],
+          toolChoice: { tool: { name: "judge_result" } },
+        },
+        inferenceConfig: { maxTokens: 4096, temperature: 0 },
+      });
       const blocks: ContentBlock[] = response.output?.message?.content ?? [];
       const toolUse = blocks.find((b) => "toolUse" in b && b.toolUse)?.toolUse;
       const input = toolUse?.input as
@@ -435,13 +433,11 @@ async function completeText(
       region: opts.region,
       credentials: opts.credentials,
     });
-    const response = await client.send(
-      new ConverseCommand({
-        modelId: opts.modelId,
-        messages: [{ role: "user", content: [{ text: prompt }] }],
-        inferenceConfig: { maxTokens, temperature: 0 },
-      }),
-    );
+    const response = await sendConverse(client, {
+      modelId: opts.modelId,
+      messages: [{ role: "user", content: [{ text: prompt }] }],
+      inferenceConfig: { maxTokens, temperature: 0 },
+    });
     const blocks: ContentBlock[] = response.output?.message?.content ?? [];
     return blocks
       .map((b) => ("text" in b && b.text ? b.text : ""))
@@ -556,18 +552,16 @@ async function generateViaBedrock(
     agentic: opts.agentic,
   });
 
-  const response = await client.send(
-    new ConverseCommand({
-      modelId: opts.modelId,
-      system: [{ text: systemPrompt }],
-      messages: [{ role: "user", content: [{ text: opts.question }] }],
-      toolConfig: {
-        tools: [EMIT_QUERY_TOOL],
-        toolChoice: { tool: { name: "emit_query" } },
-      },
-      inferenceConfig: { maxTokens: 4096, temperature: 0 },
-    }),
-  );
+  const response = await sendConverse(client, {
+    modelId: opts.modelId,
+    system: [{ text: systemPrompt }],
+    messages: [{ role: "user", content: [{ text: opts.question }] }],
+    toolConfig: {
+      tools: [EMIT_QUERY_TOOL],
+      toolChoice: { tool: { name: "emit_query" } },
+    },
+    inferenceConfig: { maxTokens: 4096, temperature: 0 },
+  });
 
   const blocks: ContentBlock[] = response.output?.message?.content ?? [];
   const toolUse = blocks.find((b) => "toolUse" in b && b.toolUse)?.toolUse;

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -125,6 +125,11 @@ export function App() {
   const [destTesting, setDestTesting] = useState(false);
   const [destTestResult, setDestTestResult] =
     useState<DestinationTestReport | null>(null);
+  // Bedrock model ids fetched via the "List models" button (suggestions for the
+  // model-id field), plus loading/error state for that fetch.
+  const [bedrockModels, setBedrockModels] = useState<string[]>([]);
+  const [bedrockModelsLoading, setBedrockModelsLoading] = useState(false);
+  const [bedrockModelsError, setBedrockModelsError] = useState("");
   const [page, setPage] = useState<Page>("data");
   const [sqsMessages, setSqsMessages] = useState<SqsMessageRow[]>([]);
   const [sqsListening, setSqsListening] = useState(false);
@@ -268,6 +273,13 @@ export function App() {
         setDestTesting(false);
         setDestTestResult(msg.result);
         break;
+      case "bedrockModels":
+        setBedrockModelsLoading(false);
+        // Only replace the list when the host actually sent one; on error it
+        // omits `models` so we keep any previously-fetched suggestions.
+        if (msg.models) setBedrockModels(msg.models);
+        setBedrockModelsError(msg.error ?? "");
+        break;
       case "sqsStatus":
         setSqsListening(msg.listening);
         break;
@@ -392,6 +404,12 @@ export function App() {
   };
 
   const handleClearTest = useCallback(() => setDestTestResult(null), []);
+
+  const handleListModels = (s: Settings) => {
+    setBedrockModelsError("");
+    setBedrockModelsLoading(true);
+    postMessage({ type: "listModels", settings: toWireSettings(s) });
+  };
 
   return (
     <div style={{ padding: "16px" }}>
@@ -605,6 +623,10 @@ export function App() {
           testResult={destTestResult}
           onTest={handleTestDestination}
           onClearTest={handleClearTest}
+          bedrockModels={bedrockModels}
+          bedrockModelsLoading={bedrockModelsLoading}
+          bedrockModelsError={bedrockModelsError}
+          onListModels={handleListModels}
         />
 
         <AiConsentModal

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -8,6 +8,7 @@ import Input from "@cloudscape-design/components/input";
 import Checkbox from "@cloudscape-design/components/checkbox";
 import Alert from "@cloudscape-design/components/alert";
 import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import Autosuggest from "@cloudscape-design/components/autosuggest";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Tabs from "@cloudscape-design/components/tabs";
 import type { Settings, DestinationTestReport } from "./types";
@@ -28,6 +29,14 @@ interface Props {
   onTest: (settings: Settings) => void;
   /** Clear a stale test result (called on open and on destination change). */
   onClearTest: () => void;
+  /** Bedrock model ids fetched via "List models" (Autosuggest suggestions). */
+  bedrockModels: string[];
+  /** True while the model list is being fetched. */
+  bedrockModelsLoading: boolean;
+  /** Error from the last model-list fetch, or "" if none. */
+  bedrockModelsError: string;
+  /** Fetch the Bedrock models available for the current region/profile. */
+  onListModels: (settings: Settings) => void;
 }
 
 const DEST_OPTIONS: SelectProps.Option[] = [
@@ -59,7 +68,7 @@ const LOCAL_MODEL_OPTIONS: SelectProps.Option[] = [
   },
 ];
 
-export function SettingsModal({ visible, settings, modelDownloaded, downloadPercent, onDismiss, onSave, testing, testResult, onTest, onClearTest }: Props) {
+export function SettingsModal({ visible, settings, modelDownloaded, downloadPercent, onDismiss, onSave, testing, testResult, onTest, onClearTest, bedrockModels, bedrockModelsLoading, bedrockModelsError, onListModels }: Props) {
   const [form, setForm] = useState<Settings>(settings);
   const [downloading, setDownloading] = useState(false);
 
@@ -327,8 +336,49 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                 </Alert>
 
                 {form.llmProvider === "bedrock" && (
-                  <FormField label="Bedrock Model ID" description="Model or inference profile ID">
-                    <Input value={form.bedrockModelId} onChange={({ detail }) => update("bedrockModelId", detail.value)} placeholder="us.anthropic.claude-sonnet-4-20250514-v1:0" />
+                  <FormField
+                    label="Bedrock Model ID"
+                    description="Model or inference profile ID. Pick one your account can access, or type any value."
+                  >
+                    <SpaceBetween size="xs">
+                      <Autosuggest
+                        value={form.bedrockModelId}
+                        onChange={({ detail }) => update("bedrockModelId", detail.value)}
+                        options={bedrockModels.map((m) => ({ value: m }))}
+                        enteredTextLabel={(v) => `Use "${v}"`}
+                        placeholder="us.anthropic.claude-sonnet-5"
+                        empty={
+                          bedrockModelsLoading
+                            ? "Loading models…"
+                            : "No models loaded yet — click List available models, or type an ID."
+                        }
+                        statusType={bedrockModelsLoading ? "loading" : "finished"}
+                        loadingText="Loading models…"
+                        filteringType="auto"
+                        virtualScroll
+                        ariaLabel="Bedrock Model ID"
+                      />
+                      <div>
+                        <Button
+                          onClick={() => onListModels(form)}
+                          loading={bedrockModelsLoading}
+                          iconName="refresh"
+                        >
+                          List available models
+                        </Button>
+                      </div>
+                      <Box color="text-body-secondary" fontSize="body-s">
+                        Uses your configured Region and AWS Profile. Shows models
+                        available in the Region (inference profiles + on-demand
+                        models); some may still need model access granted in the
+                        Bedrock console.
+                      </Box>
+                      {bedrockModelsError && (
+                        <Alert type="error" header="Couldn't list models">
+                          {bedrockModelsError}
+                        </Alert>
+                      )}
+                    </SpaceBetween>
                   </FormField>
                 )}
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -18,6 +18,7 @@ export type OutboundMessage =
   | { type: "newSession" }
   | { type: "saveSettings"; settings: Record<string, string> }
   | { type: "testDestination"; settings: Record<string, string> }
+  | { type: "listModels"; settings: Record<string, string> }
   | { type: "downloadModel"; localModel?: string }
   // Save the result table to a file (host shows a save dialog). The webview
   // builds the CSV/JSON text; the host just writes it.
@@ -158,6 +159,7 @@ export type InboundMessage =
   | { type: "sessionCleared" }
   | { type: "settingsSaved" }
   | { type: "destinationTestResult"; result: DestinationTestReport }
+  | { type: "bedrockModels"; models?: string[]; error?: string }
   | { type: "downloadProgress"; percent: number; done: boolean }
   | { type: "sqsStatus"; listening: boolean }
   | { type: "sqsMessages"; messages: SqsMessageRow[] }
@@ -237,7 +239,7 @@ export const DEFAULT_SETTINGS: Settings = {
   athenaS3Location: "",
   llmProvider: "bedrock",
   awsProfile: "",
-  bedrockModelId: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+  bedrockModelId: "us.anthropic.claude-sonnet-5",
   localModel: "llama-3-groq-8b-tool-use",
   localServerUrl: "http://localhost:11434/v1",
   localServerModel: "llama3.1",


### PR DESCRIPTION
The previous default Bedrock model for the Workflow Insight extension's AI features (us.anthropic.claude-sonnet-4-20250514-v1:0) is deprecated. Updates the default to the Claude Sonnet 5 US inference profile, makes the model field much easier to get right, and adapts the Converse calls to Sonnet 5's inference parameters.

- Default model id is now "us.anthropic.claude-sonnet-5" (the US cross-region inference profile, matching the prior default's shape) in config.ts, DEFAULT_SETTINGS, the package.json setting default, the field placeholder, and the README example.
- The Bedrock Model ID field is now an Autosuggest: it offers the models your account can use as suggestions AND still accepts any value typed directly (useful for profiles/regions the list doesn't surface).
- New "List available models" button fetches models for the currently configured Region and AWS Profile via a new host module (bedrockModels.ts):
    - Combines system-defined inference profiles (ListInferenceProfiles, paginated) with on-demand, ACTIVE, text-output foundation models (ListFoundationModels), de-duplicated and sorted.
    - Base ids that only support the INFERENCE_PROFILE type are skipped (not directly invokable — the matching profile already covers them).
    - Reflects models AVAILABLE in the Region; a listed id may still require model access to be granted in the Bedrock console (noted in the UI).
- Adds the @aws-sdk/client-bedrock dependency for the control-plane list calls.
- Wiring: a "listModels" message resolves the region/profile from the unsaved form (configFromWireSettings) and posts a "bedrockModels" result back; failures render inline in the Settings modal rather than as a global toast.
- Temperature handling: Claude Sonnet 5 (adaptive reasoning always on) rejects the `temperature` inference parameter ("`temperature` is deprecated for this model"). A new bedrockConverse.ts wraps every Converse call: it drops temperature up front for models known to reject it (Claude 5-gen and newer) and, as a safety net, retries once without temperature on any error that mentions it. All three llm.ts call sites and the agentLoop.ts call route through this helper. The helper lives in its own vscode-free module so the agent loop doesn't pull the VS Code API into its import graph.

Tests: bedrockModels.test.ts (merge/dedupe/sort, filtering, pagination) and bedrockConverse.test.ts (model detection, up-front strip, error-retry, and non-temperature errors rethrown). Host suite 168 passing; host + webview typecheck and builds green.