### PR TITLE
fix(sdk): Use current time for onOperationAttemptStart startTimestamp

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.plugin.test.ts
@@ -78,6 +78,7 @@ describe("Step Handler - plugin hooks", () => {
   });
 
   it("should call onOperationAttemptStart and onOperationAttemptEnd with succeeded outcome on success", async () => {
+    const beforeTime = new Date();
     const stepHandler = createStepHandler(
       mockContext,
       mockCheckpoint,
@@ -92,10 +93,22 @@ describe("Step Handler - plugin hooks", () => {
     const stepFn = jest.fn().mockResolvedValue("result");
 
     await stepHandler("my-step", stepFn);
+    const afterTime = new Date();
 
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledWith(
       expect.objectContaining({ attempt: 1, isReplay: false }),
+    );
+
+    // Verify startTimestamp is the current time, not from stepData
+    const attemptInfo = (mockPlugin.onOperationAttemptStart as jest.Mock).mock
+      .calls[0][0];
+    expect(attemptInfo.startTimestamp).toBeInstanceOf(Date);
+    expect(attemptInfo.startTimestamp.getTime()).toBeGreaterThanOrEqual(
+      beforeTime.getTime(),
+    );
+    expect(attemptInfo.startTimestamp.getTime()).toBeLessThanOrEqual(
+      afterTime.getTime(),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -323,6 +323,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
           );
           const attemptInfo = toAttemptInfo(stepData, currentAttempt);
           backfillOperationInfo(attemptInfo, opInfo);
+          attemptInfo.startTimestamp = new Date();
           await plugin.onOperationAttemptStart?.(attemptInfo);
           let result: T;
           const stepFn = (): Promise<T> => fn(stepContext);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -84,6 +84,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
       (_info: unknown, fn: () => unknown) => fn(),
     );
 
+    const beforeTime = new Date();
     const handler = createWaitForConditionHandler(
       mockContext,
       mockCheckpoint,
@@ -103,10 +104,22 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     };
 
     await handler("my-condition", checkFunc, config);
+    const afterTime = new Date();
 
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(1);
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledWith(
       expect.objectContaining({ attempt: 1, isReplay: false }),
+    );
+
+    // Verify startTimestamp is the current time, not from stepData
+    const attemptInfo = (mockPlugin.onOperationAttemptStart as jest.Mock).mock
+      .calls[0][0];
+    expect(attemptInfo.startTimestamp).toBeInstanceOf(Date);
+    expect(attemptInfo.startTimestamp.getTime()).toBeGreaterThanOrEqual(
+      beforeTime.getTime(),
+    );
+    expect(attemptInfo.startTimestamp.getTime()).toBeLessThanOrEqual(
+      afterTime.getTime(),
     );
 
     expect(mockPlugin.wrapOperationAttemptFn).toHaveBeenCalledTimes(1);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -55,8 +55,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   return <T>(
     nameOrCheck: string | undefined | WaitForConditionCheckFunc<T, Logger>,
     checkOrConfig?:
-      | WaitForConditionCheckFunc<T, Logger>
-      | WaitForConditionConfig<T>,
+      WaitForConditionCheckFunc<T, Logger> | WaitForConditionConfig<T>,
     maybeConfig?: WaitForConditionConfig<T>,
   ): DurablePromise<T> => {
     let name: string | undefined;
@@ -248,6 +247,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
 
           const attemptInfo = toAttemptInfo(stepData, currentAttempt);
           backfillOperationInfo(attemptInfo, opInfo);
+          attemptInfo.startTimestamp = new Date();
           const checkFunc = () => check(currentState, waitForConditionContext);
 
           await plugin.onOperationAttemptStart?.(attemptInfo);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace the startTimestamp derived from stepData (the checkpoint record) with new Date() so that plugins receive the actual wall-clock time when each attempt begins executing.

Updated tests to assert startTimestamp is a recent Date instance.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
