### PR TITLE
feat(sdk): Add executionStartTimestamp to InvocationBaseInfo

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
@@ -12,6 +12,7 @@ const baseInfo: InvocationInfo = {
   executionInput: {},
   operations: {},
   updatedOperations: {},
+  executionStartTimestamp: new Date("2024-01-01T00:00:00Z"),
 };
 
 describe("xRayContextExtractor", () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/plugin.test.ts
@@ -42,6 +42,7 @@ function makeInvocationInfo(
     executionInput: {},
     operations: {},
     updatedOperations: {},
+    executionStartTimestamp: new Date("2024-01-01T00:00:00Z"),
     ...overrides,
   };
 }
@@ -57,6 +58,7 @@ function makeInvocationEndInfo(
     status: "SUCCEEDED" as any,
     executionResult: undefined,
     executionError: undefined,
+    executionStartTimestamp: new Date("2024-01-01T00:00:00Z"),
     ...overrides,
   };
 }

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -121,6 +121,12 @@ export interface InvocationBaseInfo {
   executionArn: string;
   executionInput: unknown;
   operations: Record<string, OperationInfo>;
+  /**
+   * The timestamp when the overall durable execution was first started,
+   * as reported by the backend. This remains the same across all
+   * invocations (including replays) of a given execution.
+   */
+  executionStartTimestamp?: Date;
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-runner.test.ts
@@ -28,6 +28,7 @@ describe("createPluginRunner", () => {
     executionInput: { test: true },
     operations: {},
     updatedOperations: {},
+    executionStartTimestamp: new Date("2024-01-01T00:00:00Z"),
   };
 
   const operationInfo: OperationInfo = {
@@ -723,6 +724,7 @@ describe("createPluginRunner", () => {
       executionResult: { data: "test" },
       executionInput: { event: "input" },
       operations: {},
+      executionStartTimestamp: new Date("2024-01-01T00:00:00Z"),
     };
 
     it.each([

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -39,7 +39,14 @@ const mockTerminationManager = {
   setCheckpointTerminatingCallback: jest.fn(),
 };
 const mockExecutionContext = {
-  _stepData: {},
+  _stepData: {
+    "initial-op": {
+      StartTimestamp: new Date("2024-06-01T12:00:00Z"),
+      ExecutionDetails: {
+        InputPayload: "{}",
+      },
+    },
+  },
   durableExecutionArn: "arn:test",
   requestId: "req-123",
   terminationManager: mockTerminationManager,
@@ -89,6 +96,7 @@ describe("plugin hooks", () => {
       executionInput: expect.anything(),
       operations: expect.any(Object),
       updatedOperations: expect.any(Object),
+      executionStartTimestamp: new Date("2024-06-01T12:00:00Z"),
     });
   });
 
@@ -111,6 +119,7 @@ describe("plugin hooks", () => {
       executionInput: expect.anything(),
       operations: expect.any(Object),
       updatedOperations: expect.any(Object),
+      executionStartTimestamp: new Date("2024-06-01T12:00:00Z"),
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -95,6 +95,7 @@ async function runHandler<
     executionArn: executionContext.durableExecutionArn,
     executionInput: customerHandlerEvent,
     operations: allOperations,
+    executionStartTimestamp: initialExecutionEvent?.StartTimestamp ?? undefined,
   };
 
   const invocationInfo: InvocationInfo = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add optional executionStartTimestamp field to InvocationBaseInfo so it is available on all onInvocation* hook parameters (InvocationInfo and InvocationEndInfo). The timestamp is derived from
initialExecutionEvent.StartTimestamp when available (should always be available).

Updated all test fixtures constructing InvocationInfo or InvocationEndInfo to include the new field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
