### PR TITLE
feat(sdk): recommend vetted Bedrock models by default in Workflow Insight

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -12,6 +12,7 @@ import Autosuggest from "@cloudscape-design/components/autosuggest";
 import ProgressBar from "@cloudscape-design/components/progress-bar";
 import Tabs from "@cloudscape-design/components/tabs";
 import type { Settings, DestinationTestReport } from "./types";
+import { RECOMMENDED_BEDROCK_MODELS } from "./types";
 import { postMessage } from "./vscode";
 
 interface Props {
@@ -344,7 +345,27 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                       <Autosuggest
                         value={form.bedrockModelId}
                         onChange={({ detail }) => update("bedrockModelId", detail.value)}
-                        options={bedrockModels.map((m) => ({ value: m }))}
+                        options={[
+                          {
+                            label: "Recommended",
+                            options: RECOMMENDED_BEDROCK_MODELS,
+                          },
+                          ...(bedrockModels.length
+                            ? [
+                                {
+                                  label: "All available in your account",
+                                  options: bedrockModels
+                                    .filter(
+                                      (m) =>
+                                        !RECOMMENDED_BEDROCK_MODELS.some(
+                                          (r) => r.value === m,
+                                        ),
+                                    )
+                                    .map((m) => ({ value: m })),
+                                },
+                              ]
+                            : []),
+                        ]}
                         enteredTextLabel={(v) => `Use "${v}"`}
                         placeholder="us.anthropic.claude-sonnet-5"
                         empty={
@@ -368,10 +389,12 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                         </Button>
                       </div>
                       <Box color="text-body-secondary" fontSize="body-s">
-                        Uses your configured Region and AWS Profile. Shows models
-                        available in the Region (inference profiles + on-demand
-                        models); some may still need model access granted in the
-                        Bedrock console.
+                        A curated set of recommended models is shown by default.
+                        Click List available models to fetch everything your
+                        Region and AWS Profile can use (inference profiles +
+                        on-demand models); some may still need model access
+                        granted in the Bedrock console. You can also type any
+                        model / inference profile ID directly.
                       </Box>
                       {bedrockModelsError && (
                         <Alert type="error" header="Couldn't list models">

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -221,6 +221,44 @@ export interface Settings {
  */
 export const AI_DISCLOSURE_VERSION = "2";
 
+/**
+ * Curated Bedrock models shown as suggestions by default (before/without
+ * fetching the full account list). Hand-picked from an internal benchmark of
+ * the agent-mode query task ("group by … in execution input") run against real
+ * data on BOTH the Aurora (PostgreSQL) and S3/Athena (Trino) destinations:
+ * these reliably discovered the right JSON keys and produced correct,
+ * multi-dimension grouped SQL in both dialects. (Some models that did well only
+ * on Aurora — e.g. Mistral Pixtral Large — were excluded because they were weak
+ * on Athena.) The full account list is still available via the "List available
+ * models" button. `us.` (US cross-region) inference profiles are used;
+ * `global.`/`eu.` equivalents work too if you prefer.
+ */
+export const RECOMMENDED_BEDROCK_MODELS: {
+  value: string;
+  description: string;
+}[] = [
+  {
+    value: "us.anthropic.claude-sonnet-5",
+    description: "Recommended default — top accuracy on query tasks",
+  },
+  {
+    value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    description: "Excellent; a lower-cost alternative to Sonnet 5",
+  },
+  {
+    value: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    description: "Fast and accurate — strong low-cost pick",
+  },
+  {
+    value: "us.anthropic.claude-opus-4-5-20251101-v1:0",
+    description: "Highest capability (slower/pricier)",
+  },
+  {
+    value: "us.amazon.nova-pro-v1:0",
+    description: "Strong non-Claude option (correct on Aurora + Athena)",
+  },
+];
+
 export const DEFAULT_SETTINGS: Settings = {
   region: "us-east-1",
   destinationType: "cloudwatch-logs-exporter",


### PR DESCRIPTION
Surfaces a curated set of Bedrock models as suggestions in the Settings model picker, shown by default before/without fetching the full account list, so users land on a model that reliably handles the extension's query-generation task.

- New RECOMMENDED_BEDROCK_MODELS list (Claude Sonnet 5 [default], Sonnet 4.5, Haiku 4.5, Opus 4.5, and Amazon Nova Pro), each with a short description.
- The Bedrock Model ID Autosuggest now shows a "Recommended" group by default; clicking "List available models" adds an "All available in your account" group with the recommended entries pinned on top. Free-text entry still works.
- Helper text updated to explain the recommended-by-default behavior.

Curation is evidence-based: the models were benchmarked on the real agent-mode task ("count of executions grouped by productName and customerName in execution input") against real data on BOTH the Aurora (PostgreSQL) and S3/Athena (Trino) destinations. The listed models discovered the correct JSON keys and produced correct multi-dimension grouped SQL in both dialects. Models that only did well on one dialect (e.g. Mistral Pixtral Large — correct on Aurora but produced no aggregation on Athena) or couldn't drive the tool loop (DeepSeek R1, Llama 3.3) were intentionally excluded from the defaults.