### PR TITLE
feat(sdk): add Amazon Redshift support to Workflow Insight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -624,7 +624,6 @@
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift-data/-/client-redshift-data-3.1076.0.tgz",
       "integrity": "sha512-cXb074wdbGzCyyTnvg+1cGS2nMSxPpMH4cZOL4Rj4dytVEQH1eBkYBc5Q4faTINCS66IvfdRJzuClQ6G3V6gZw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -16256,6 +16255,7 @@
         "@aws-sdk/client-dynamodb": "^3.658.0",
         "@aws-sdk/client-glue": "^3.658.0",
         "@aws-sdk/client-rds-data": "^3.658.0",
+        "@aws-sdk/client-redshift-data": "^3.658.0",
         "@aws-sdk/client-sqs": "^3.658.0",
         "@aws-sdk/credential-providers": "^3.658.0",
         "@aws-sdk/util-dynamodb": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -54,6 +54,7 @@
             "lambda-log-exporter",
             "dynamodb",
             "aurora",
+            "redshift",
             "s3",
             "sqs"
           ],
@@ -62,6 +63,7 @@
             "Function's own log group via LambdaLogExporter — records nested in Lambda JSON envelope (message field)",
             "DynamoDB table via DynamoDBExporter — records queryable via PartiQL",
             "Aurora PostgreSQL/MySQL via AuroraExporter — full SQL with GROUP BY, JOIN, aggregations",
+            "Amazon Redshift via RedshiftExporter — full SQL; record_json is a SUPER column navigated with PartiQL",
             "S3 via S3Exporter — queried through Amazon Athena (Trino/Presto SQL) over a Glue table",
             "Amazon SQS via SQSExporter — live view that listens to the queue as records arrive (no query engine)"
           ],
@@ -101,6 +103,41 @@
           "type": "string",
           "default": "workflow_insight",
           "description": "Aurora table name containing insight records."
+        },
+        "workflowInsight.redshiftWorkgroupName": {
+          "type": "string",
+          "default": "",
+          "description": "Redshift Serverless workgroup name (required for Serverless when destinationType is 'redshift'). Leave empty if using a provisioned cluster."
+        },
+        "workflowInsight.redshiftClusterIdentifier": {
+          "type": "string",
+          "default": "",
+          "description": "Provisioned Redshift cluster identifier (alternative to redshiftWorkgroupName). Leave empty if using Redshift Serverless."
+        },
+        "workflowInsight.redshiftDbUser": {
+          "type": "string",
+          "default": "",
+          "description": "Database user for a provisioned Redshift cluster (used with GetClusterCredentials). Not needed for Serverless or when redshiftSecretArn is set."
+        },
+        "workflowInsight.redshiftSecretArn": {
+          "type": "string",
+          "default": "",
+          "description": "Secrets Manager ARN for Redshift Data API auth (optional; alternative to IAM/dbUser)."
+        },
+        "workflowInsight.redshiftDatabase": {
+          "type": "string",
+          "default": "dev",
+          "description": "Redshift database name."
+        },
+        "workflowInsight.redshiftTable": {
+          "type": "string",
+          "default": "workflow_insight",
+          "description": "Redshift table name containing insight records."
+        },
+        "workflowInsight.redshiftSchema": {
+          "type": "string",
+          "default": "public",
+          "description": "Redshift schema containing the insight table (queried as <schema>.<table>)."
         },
         "workflowInsight.athenaDatabase": {
           "type": "string",
@@ -226,6 +263,7 @@
     "@aws-sdk/client-dynamodb": "^3.658.0",
     "@aws-sdk/client-glue": "^3.658.0",
     "@aws-sdk/client-rds-data": "^3.658.0",
+    "@aws-sdk/client-redshift-data": "^3.658.0",
     "@aws-sdk/client-sqs": "^3.658.0",
     "@aws-sdk/credential-providers": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
@@ -18,6 +18,29 @@ describe("configFromWireSettings", () => {
     expect(cfg.logGroupNames).toEqual([]);
   });
 
+  it("applies Redshift defaults for an empty payload", () => {
+    const cfg = configFromWireSettings({});
+    expect(cfg.redshiftDatabase).toBe("dev");
+    expect(cfg.redshiftTable).toBe("workflow_insight");
+    expect(cfg.redshiftSchema).toBe("public");
+    expect(cfg.redshiftWorkgroupName).toBe("");
+  });
+
+  it("maps Redshift fields from the wire payload", () => {
+    const cfg = configFromWireSettings({
+      destinationType: "redshift",
+      redshiftWorkgroupName: "insight-workgroup",
+      redshiftDatabase: "prod",
+      redshiftSchema: "analytics",
+      redshiftTable: "wi",
+    });
+    expect(cfg.destinationType).toBe("redshift");
+    expect(cfg.redshiftWorkgroupName).toBe("insight-workgroup");
+    expect(cfg.redshiftDatabase).toBe("prod");
+    expect(cfg.redshiftSchema).toBe("analytics");
+    expect(cfg.redshiftTable).toBe("wi");
+  });
+
   it("maps Athena/S3 fields from the wire payload", () => {
     const cfg = configFromWireSettings({
       destinationType: "s3",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -12,6 +12,13 @@ export interface InsightConfig {
   auroraSecretArn: string;
   auroraDatabase: string;
   auroraTable: string;
+  redshiftWorkgroupName: string;
+  redshiftClusterIdentifier: string;
+  redshiftDbUser: string;
+  redshiftSecretArn: string;
+  redshiftDatabase: string;
+  redshiftTable: string;
+  redshiftSchema: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
   athenaDatabase: string;
@@ -88,11 +95,13 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
         ? ("dynamodb" as const)
         : raw === "aurora"
           ? ("aurora" as const)
-          : raw === "sqs"
-            ? ("sqs" as const)
-            : raw === "s3"
-              ? ("s3" as const)
-              : ("cloudwatch-logs-exporter" as const);
+          : raw === "redshift"
+            ? ("redshift" as const)
+            : raw === "sqs"
+              ? ("sqs" as const)
+              : raw === "s3"
+                ? ("s3" as const)
+                : ("cloudwatch-logs-exporter" as const);
   const dynamodbTableName = (src.getString("dynamodbTableName") || "").trim();
   const auroraResourceArn = (src.getString("auroraResourceArn") || "").trim();
   const auroraSecretArn = (src.getString("auroraSecretArn") || "").trim();
@@ -100,6 +109,20 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
     (src.getString("auroraDatabase") || "").trim() || "postgres";
   const auroraTable =
     (src.getString("auroraTable") || "").trim() || "workflow_insight";
+  const redshiftWorkgroupName = (
+    src.getString("redshiftWorkgroupName") || ""
+  ).trim();
+  const redshiftClusterIdentifier = (
+    src.getString("redshiftClusterIdentifier") || ""
+  ).trim();
+  const redshiftDbUser = (src.getString("redshiftDbUser") || "").trim();
+  const redshiftSecretArn = (src.getString("redshiftSecretArn") || "").trim();
+  const redshiftDatabase =
+    (src.getString("redshiftDatabase") || "").trim() || "dev";
+  const redshiftTable =
+    (src.getString("redshiftTable") || "").trim() || "workflow_insight";
+  const redshiftSchema =
+    (src.getString("redshiftSchema") || "").trim() || "public";
   const sqsQueueUrl = (src.getString("sqsQueueUrl") || "").trim();
   const sqsDeleteAfterRead = src.getBool("sqsDeleteAfterRead") ?? false;
   const athenaDatabase = (src.getString("athenaDatabase") || "").trim();
@@ -151,6 +174,13 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
     auroraSecretArn,
     auroraDatabase,
     auroraTable,
+    redshiftWorkgroupName,
+    redshiftClusterIdentifier,
+    redshiftDbUser,
+    redshiftSecretArn,
+    redshiftDatabase,
+    redshiftTable,
+    redshiftSchema,
     sqsQueueUrl,
     sqsDeleteAfterRead,
     athenaDatabase,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
@@ -20,6 +20,9 @@ jest.mock("./athena", () => ({
 jest.mock("./aurora", () => ({
   runAuroraQuery: jest.fn(),
 }));
+jest.mock("./redshift", () => ({
+  runRedshiftQuery: jest.fn(),
+}));
 jest.mock("./config", () => ({
   resolveCredentials: jest.fn(() => ({})),
 }));
@@ -28,6 +31,7 @@ import type { InsightConfig } from "./config";
 import { testDestination } from "./destinationTest";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
+import { runRedshiftQuery } from "./redshift";
 
 function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
   return {
@@ -39,6 +43,13 @@ function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
     auroraSecretArn: "",
     auroraDatabase: "postgres",
     auroraTable: "workflow_insight",
+    redshiftWorkgroupName: "",
+    redshiftClusterIdentifier: "",
+    redshiftDbUser: "",
+    redshiftSecretArn: "",
+    redshiftDatabase: "dev",
+    redshiftTable: "workflow_insight",
+    redshiftSchema: "public",
     sqsQueueUrl: "",
     sqsDeleteAfterRead: false,
     athenaDatabase: "",
@@ -175,6 +186,51 @@ describe("testDestination — Aurora", () => {
     expect(runAuroraQuery).toHaveBeenCalledWith(
       expect.objectContaining({ sql: "SELECT 1" }),
     );
+  });
+});
+
+describe("testDestination — Redshift", () => {
+  it("fails when neither workgroup nor cluster is set", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "redshift" }));
+    expect(r.ok).toBe(false);
+    expect(runRedshiftQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes SELECT 1 against the Data API (Serverless workgroup)", async () => {
+    (runRedshiftQuery as jest.Mock).mockResolvedValue({
+      columns: [],
+      rows: [],
+    });
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "redshift",
+        redshiftWorkgroupName: "insight-workgroup",
+        redshiftDatabase: "dev",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(runRedshiftQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sql: "SELECT 1",
+        workgroupName: "insight-workgroup",
+        database: "dev",
+      }),
+    );
+  });
+
+  it("fails when the Data API statement errors", async () => {
+    (runRedshiftQuery as jest.Mock).mockRejectedValue(
+      new Error("Redshift statement failed: relation does not exist"),
+    );
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "redshift",
+        redshiftClusterIdentifier: "my-cluster",
+        redshiftDatabase: "dev",
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.checks.at(-1)?.detail).toMatch(/relation does not exist/);
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
@@ -8,6 +8,7 @@ import type { InsightConfig } from "./config";
 import { resolveCredentials } from "./config";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
+import { runRedshiftQuery } from "./redshift";
 
 /**
  * Result of a single check within a destination test (e.g. "Glue table exists",
@@ -83,6 +84,8 @@ export async function testDestination(
       return testDynamoDB(cfg, credentials);
     case "aurora":
       return testAurora(cfg, credentials);
+    case "redshift":
+      return testRedshift(cfg, credentials);
     case "sqs":
       return testSqs(cfg, credentials);
     case "cloudwatch-logs-exporter":
@@ -222,6 +225,48 @@ async function testAurora(
         sql: "SELECT 1",
       });
       return "Connected to the cluster via the RDS Data API.";
+    }),
+  );
+  return report(checks);
+}
+
+async function testRedshift(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  const missing: string[] = [];
+  // Serverless (workgroup) or provisioned (cluster) — need exactly one.
+  if (!cfg.redshiftWorkgroupName && !cfg.redshiftClusterIdentifier)
+    missing.push("Workgroup name or Cluster identifier");
+  if (!cfg.redshiftDatabase) missing.push("Database");
+  checks.push({
+    label: "Required fields",
+    ok: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? `${
+            cfg.redshiftWorkgroupName
+              ? `Workgroup "${cfg.redshiftWorkgroupName}"`
+              : `Cluster "${cfg.redshiftClusterIdentifier}"`
+          }, database "${cfg.redshiftDatabase}", table "${cfg.redshiftSchema}.${cfg.redshiftTable}".`
+        : `Missing: ${missing.join(", ")}.`,
+  });
+  if (missing.length > 0) return report(checks);
+
+  checks.push(
+    await probe("Redshift Data API connection (SELECT 1)", async () => {
+      await runRedshiftQuery({
+        region: cfg.region,
+        credentials,
+        database: cfg.redshiftDatabase,
+        workgroupName: cfg.redshiftWorkgroupName || undefined,
+        clusterIdentifier: cfg.redshiftClusterIdentifier || undefined,
+        dbUser: cfg.redshiftDbUser || undefined,
+        secretArn: cfg.redshiftSecretArn || undefined,
+        sql: "SELECT 1",
+      });
+      return "Connected and ran a statement via the Redshift Data API.";
     }),
   );
   return report(checks);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
 import { runLogsInsightsQuery, fetchLogsInsightsRecord } from "./logsInsights";
 import { runDynamoDBQuery, fetchDynamoDBRecord } from "./dynamodb";
 import { runAuroraQuery, fetchAuroraRecord } from "./aurora";
+import { runRedshiftQuery, fetchRedshiftRecord } from "./redshift";
 import {
   runAthenaQuery,
   ensureAthenaTable,
@@ -336,6 +337,13 @@ class ExplorerPanel {
         auroraSecretArn: cfg.auroraSecretArn,
         auroraDatabase: cfg.auroraDatabase,
         auroraTable: cfg.auroraTable,
+        redshiftWorkgroupName: cfg.redshiftWorkgroupName,
+        redshiftClusterIdentifier: cfg.redshiftClusterIdentifier,
+        redshiftDbUser: cfg.redshiftDbUser,
+        redshiftSecretArn: cfg.redshiftSecretArn,
+        redshiftDatabase: cfg.redshiftDatabase,
+        redshiftTable: cfg.redshiftTable,
+        redshiftSchema: cfg.redshiftSchema,
         sqsQueueUrl: cfg.sqsQueueUrl,
         sqsDeleteAfterRead: cfg.sqsDeleteAfterRead,
         athenaDatabase: cfg.athenaDatabase,
@@ -674,9 +682,11 @@ class ExplorerPanel {
         ? cfg.dynamodbTableName
         : cfg.destinationType === "aurora"
           ? cfg.auroraTable
-          : cfg.destinationType === "s3"
-            ? cfg.athenaTable
-            : undefined;
+          : cfg.destinationType === "redshift"
+            ? `${cfg.redshiftSchema}.${cfg.redshiftTable}`
+            : cfg.destinationType === "s3"
+              ? cfg.athenaTable
+              : undefined;
 
     // Dispatch by the selected mode:
     //  - query: run the text verbatim (no LLM)
@@ -1060,9 +1070,11 @@ class ExplorerPanel {
         ? cfg.dynamodbTableName
         : cfg.destinationType === "aurora"
           ? cfg.auroraTable
-          : cfg.destinationType === "s3"
-            ? cfg.athenaTable
-            : undefined;
+          : cfg.destinationType === "redshift"
+            ? `${cfg.redshiftSchema}.${cfg.redshiftTable}`
+            : cfg.destinationType === "s3"
+              ? cfg.athenaTable
+              : undefined;
 
     let iteration = 0;
     // The most recent successful query execution, so a turn that ends with a
@@ -1382,6 +1394,40 @@ class ExplorerPanel {
         hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
       };
     }
+    if (cfg.destinationType === "redshift") {
+      if (!cfg.redshiftWorkgroupName && !cfg.redshiftClusterIdentifier)
+        throw new Error("Redshift not configured.");
+      assertReadOnly(generated.query, "Redshift SQL");
+      const { query, idColumn, injectedColumns } = inject
+        ? ensureIdentifierColumn(generated.query, "execution_arn", "sql")
+        : {
+            query: generated.query,
+            idColumn: undefined,
+            injectedColumns: [] as string[],
+          };
+      const table = await runOnce(query, () =>
+        runRedshiftQuery({
+          region: cfg.region,
+          credentials,
+          database: cfg.redshiftDatabase,
+          workgroupName: cfg.redshiftWorkgroupName || undefined,
+          clusterIdentifier: cfg.redshiftClusterIdentifier || undefined,
+          dbUser: cfg.redshiftDbUser || undefined,
+          secretArn: cfg.redshiftSecretArn || undefined,
+          sql: query,
+        }),
+      );
+      const capped = capRows(table);
+      return {
+        ...table,
+        ...capped,
+        explanation: generated.explanation,
+        suggestedCharts: generated.suggestedCharts,
+        finalQuery: query,
+        idColumn: resolveActualColumnCasing(idColumn, table.columns),
+        hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
+      };
+    }
     if (cfg.destinationType === "s3") {
       if (!cfg.athenaDatabase) throw new Error("Athena not configured.");
       assertReadOnly(generated.query, "Trino/Presto SQL");
@@ -1496,6 +1542,18 @@ class ExplorerPanel {
           secretArn: cfg.auroraSecretArn,
           database: cfg.auroraDatabase,
           table: cfg.auroraTable,
+          executionArn: idValue,
+        });
+      } else if (cfg.destinationType === "redshift") {
+        record = await fetchRedshiftRecord({
+          region: cfg.region,
+          credentials,
+          database: cfg.redshiftDatabase,
+          workgroupName: cfg.redshiftWorkgroupName || undefined,
+          clusterIdentifier: cfg.redshiftClusterIdentifier || undefined,
+          dbUser: cfg.redshiftDbUser || undefined,
+          secretArn: cfg.redshiftSecretArn || undefined,
+          table: `${cfg.redshiftSchema}.${cfg.redshiftTable}`,
           executionArn: idValue,
         });
       } else if (cfg.destinationType === "s3") {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/redshift.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/redshift.test.ts
@@ -1,0 +1,138 @@
+// Mock the Redshift Data API client so we can drive the async
+// execute→poll→getResult flow deterministically.
+const mockSend = jest.fn();
+jest.mock("@aws-sdk/client-redshift-data", () => ({
+  RedshiftDataClient: jest.fn(() => ({ send: mockSend })),
+  ExecuteStatementCommand: jest.fn((i) => ({ __type: "exec", i })),
+  DescribeStatementCommand: jest.fn((i) => ({ __type: "describe", i })),
+  GetStatementResultCommand: jest.fn((i) => ({ __type: "getResult", i })),
+}));
+
+import { runRedshiftQuery, fetchRedshiftRecord } from "./redshift";
+
+const conn = {
+  region: "us-east-1",
+  credentials: {} as never,
+  database: "dev",
+  workgroupName: "wg",
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("runRedshiftQuery", () => {
+  it("executes, polls to FINISHED, and normalizes rows + numeric flags", async () => {
+    mockSend.mockImplementation((cmd: { __type: string; i: unknown }) => {
+      switch (cmd.__type) {
+        case "exec":
+          return Promise.resolve({ Id: "s1" });
+        case "describe":
+          return Promise.resolve({ Status: "FINISHED" });
+        case "getResult":
+          return Promise.resolve({
+            ColumnMetadata: [
+              { name: "status", typeName: "varchar" },
+              { name: "ct", typeName: "int8" },
+            ],
+            Records: [
+              [{ stringValue: "SUCCEEDED" }, { longValue: 5 }],
+              [{ stringValue: "FAILED" }, { longValue: 2 }],
+            ],
+          });
+        default:
+          throw new Error(`unexpected command ${cmd.__type}`);
+      }
+    });
+
+    const res = await runRedshiftQuery({ ...conn, sql: "SELECT status, ct" });
+    expect(res.columns).toEqual(["status", "ct"]);
+    expect(res.rows).toEqual([
+      ["SUCCEEDED", "5"],
+      ["FAILED", "2"],
+    ]);
+    expect(res.count).toBe(2);
+    // varchar → not numeric, int8 → numeric
+    expect(res.numericColumns).toEqual([false, true]);
+  });
+
+  it("throws when the statement reports FAILED", async () => {
+    mockSend.mockImplementation((cmd: { __type: string }) => {
+      if (cmd.__type === "exec") return Promise.resolve({ Id: "s1" });
+      if (cmd.__type === "describe")
+        return Promise.resolve({ Status: "FAILED", Error: "boom" });
+      throw new Error("getResult should not be called");
+    });
+    await expect(
+      runRedshiftQuery({ ...conn, sql: "SELECT 1" }),
+    ).rejects.toThrow(/failed: boom/i);
+  });
+
+  it("follows NextToken pagination and keeps first-page column metadata", async () => {
+    let getResultCalls = 0;
+    mockSend.mockImplementation((cmd: { __type: string }) => {
+      if (cmd.__type === "exec") return Promise.resolve({ Id: "s1" });
+      if (cmd.__type === "describe")
+        return Promise.resolve({ Status: "FINISHED" });
+      // getResult
+      getResultCalls += 1;
+      if (getResultCalls === 1) {
+        return Promise.resolve({
+          ColumnMetadata: [{ name: "arn", typeName: "varchar" }],
+          Records: [[{ stringValue: "a" }]],
+          NextToken: "n1",
+        });
+      }
+      return Promise.resolve({ Records: [[{ stringValue: "b" }]] });
+    });
+
+    const res = await runRedshiftQuery({ ...conn, sql: "SELECT arn" });
+    expect(getResultCalls).toBe(2);
+    expect(res.columns).toEqual(["arn"]);
+    expect(res.rows).toEqual([["a"], ["b"]]);
+  });
+});
+
+describe("fetchRedshiftRecord", () => {
+  it("parses the record_json SUPER blob into flat top-level fields", async () => {
+    const record = {
+      executionArn: "arn:1",
+      status: "SUCCEEDED",
+      input: { a: 1 },
+      operations: [{ name: "step1" }],
+    };
+    mockSend.mockImplementation((cmd: { __type: string }) => {
+      if (cmd.__type === "exec") return Promise.resolve({ Id: "s1" });
+      if (cmd.__type === "describe")
+        return Promise.resolve({ Status: "FINISHED" });
+      return Promise.resolve({
+        Records: [[{ stringValue: JSON.stringify(record) }]],
+      });
+    });
+
+    const out = await fetchRedshiftRecord({
+      ...conn,
+      table: "public.workflow_insight",
+      executionArn: "arn:1",
+    });
+    expect(out).toBeDefined();
+    expect(out!.executionArn).toBe("arn:1");
+    expect(out!.status).toBe("SUCCEEDED");
+    // objects are JSON-stringified
+    expect(out!.input).toBe(JSON.stringify({ a: 1 }));
+    expect(out!.operations).toBe(JSON.stringify([{ name: "step1" }]));
+  });
+
+  it("returns undefined when there is no matching row", async () => {
+    mockSend.mockImplementation((cmd: { __type: string }) => {
+      if (cmd.__type === "exec") return Promise.resolve({ Id: "s1" });
+      if (cmd.__type === "describe")
+        return Promise.resolve({ Status: "FINISHED" });
+      return Promise.resolve({ Records: [] });
+    });
+    const out = await fetchRedshiftRecord({
+      ...conn,
+      table: "public.workflow_insight",
+      executionArn: "missing",
+    });
+    expect(out).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/redshift.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/redshift.ts
@@ -1,0 +1,205 @@
+import {
+  RedshiftDataClient,
+  ExecuteStatementCommand,
+  DescribeStatementCommand,
+  GetStatementResultCommand,
+  type Field,
+  type ColumnMetadata,
+} from "@aws-sdk/client-redshift-data";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+
+export interface RedshiftQueryResult {
+  columns: string[];
+  rows: string[][];
+  count: number;
+  /** Per-column numeric-type flag (aligned with `columns`) — see AthenaQueryResult.numericColumns. */
+  numericColumns: boolean[];
+}
+
+/**
+ * Connection identity for the Redshift Data API. Redshift Serverless is
+ * addressed by `workgroupName`; a provisioned cluster by `clusterIdentifier`
+ * (+ `dbUser` for GetClusterCredentials, or a `secretArn`). Exactly one of
+ * workgroupName/clusterIdentifier is expected — callers validate that upstream.
+ */
+export interface RedshiftConnection {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  database: string;
+  workgroupName?: string;
+  clusterIdentifier?: string;
+  dbUser?: string;
+  secretArn?: string;
+}
+
+// Redshift's Data API reports column types via columnMetadata.typeName using
+// PostgreSQL type names (int2/int4/int8, float4/float8, numeric, ...). Matched
+// exactly (not by prefix) so types like "interval"/"intervaly2m" don't slip in;
+// anything unmatched simply stays a string. Kept in sync with aurora.ts's set.
+const NUMERIC_REDSHIFT_TYPES = new Set([
+  "int2",
+  "int4",
+  "int8",
+  "float4",
+  "float8",
+  "numeric",
+  "decimal",
+  "oid",
+]);
+function isNumericRedshiftType(typeName?: string): boolean {
+  return (
+    typeName != null &&
+    NUMERIC_REDSHIFT_TYPES.has(typeName.trim().toLowerCase())
+  );
+}
+
+function fieldToString(field: Field): string {
+  if (field.isNull) return "";
+  if (field.stringValue != null) return field.stringValue;
+  if (field.longValue != null) return String(field.longValue);
+  if (field.doubleValue != null) return String(field.doubleValue);
+  if (field.booleanValue != null) return String(field.booleanValue);
+  return JSON.stringify(field);
+}
+
+// The Redshift Data API is asynchronous: ExecuteStatement returns immediately
+// with a statement Id, and results are only available after the statement
+// reaches FINISHED. Poll DescribeStatement until then. Bounded so a hung/very
+// long query surfaces as an error instead of blocking the extension forever.
+const POLL_INTERVAL_MS = 500;
+const MAX_POLL_MS = 120_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run a statement via the Redshift Data API and wait for it to finish.
+ * Returns the finished statement Id (for GetStatementResult), or undefined
+ * when the statement produced no result set (e.g. SELECT 1 on a DDL path —
+ * here callers always SELECT, so a result set is expected).
+ */
+async function executeAndWait(
+  client: RedshiftDataClient,
+  conn: RedshiftConnection,
+  sql: string,
+  parameters?: { name: string; value: string }[],
+): Promise<string> {
+  const exec = await client.send(
+    new ExecuteStatementCommand({
+      WorkgroupName: conn.workgroupName,
+      ClusterIdentifier: conn.clusterIdentifier,
+      Database: conn.database,
+      DbUser: conn.dbUser,
+      SecretArn: conn.secretArn,
+      Sql: sql,
+      Parameters: parameters,
+    }),
+  );
+  const id = exec.Id;
+  if (!id)
+    throw new Error("Redshift ExecuteStatement returned no statement Id.");
+
+  const deadline = Date.now() + MAX_POLL_MS;
+  for (;;) {
+    const desc = await client.send(new DescribeStatementCommand({ Id: id }));
+    const status = desc.Status;
+    if (status === "FINISHED") return id;
+    if (status === "FAILED" || status === "ABORTED") {
+      throw new Error(
+        `Redshift statement ${status.toLowerCase()}: ${desc.Error ?? "no error detail"}`,
+      );
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Redshift statement did not finish within ${MAX_POLL_MS / 1000}s (last status: ${status ?? "unknown"}).`,
+      );
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+/**
+ * Run a read query against Redshift via the Data API and normalize results
+ * into the same shape as AuroraQueryResult/AthenaQueryResult.
+ */
+export async function runRedshiftQuery(
+  opts: RedshiftConnection & { sql: string },
+): Promise<RedshiftQueryResult> {
+  const client = new RedshiftDataClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  const id = await executeAndWait(client, opts, opts.sql);
+
+  // GetStatementResult is paginated via NextToken; columnMetadata is only
+  // returned on the first page.
+  let columnMetadata: ColumnMetadata[] = [];
+  const records: Field[][] = [];
+  let nextToken: string | undefined;
+  do {
+    const page = await client.send(
+      new GetStatementResultCommand({ Id: id, NextToken: nextToken }),
+    );
+    if (columnMetadata.length === 0 && page.ColumnMetadata) {
+      columnMetadata = page.ColumnMetadata;
+    }
+    for (const row of page.Records ?? []) records.push(row);
+    nextToken = page.NextToken;
+  } while (nextToken);
+
+  const columns = columnMetadata.map((col) => col.label || col.name || "?");
+  const numericColumns = columnMetadata.map((col) =>
+    isNumericRedshiftType(col.typeName),
+  );
+  const rows = records.map((row) => row.map(fieldToString));
+
+  return { columns, rows, count: rows.length, numericColumns };
+}
+
+/**
+ * Fetch a single full record by execution_arn, for the row-detail drill-down.
+ * Mirrors fetchAuroraRecord: the only record-shaped column is `record_json`
+ * (a SUPER blob) — the scalar columns are a denormalized subset for
+ * filtering, not the full record. Select record_json and unpack it into
+ * top-level fields (input/output/operations/error) so this matches the
+ * flat-fields shape RecordDetail.tsx expects.
+ *
+ * Uses a parameterized statement so the identifier value (which round-trips
+ * through the webview — treat as untrusted) can't inject SQL.
+ */
+export async function fetchRedshiftRecord(
+  opts: RedshiftConnection & { table: string; executionArn: string },
+): Promise<Record<string, string> | undefined> {
+  const client = new RedshiftDataClient({
+    region: opts.region,
+    credentials: opts.credentials,
+  });
+
+  const id = await executeAndWait(
+    client,
+    opts,
+    `SELECT record_json FROM ${opts.table} WHERE execution_arn = :executionArn LIMIT 1`,
+    [{ name: "executionArn", value: opts.executionArn }],
+  );
+
+  const page = await client.send(new GetStatementResultCommand({ Id: id }));
+  const field = (page.Records ?? [])[0]?.[0];
+  // record_json is SUPER; the Data API returns it as JSON text in stringValue.
+  if (!field || field.isNull || field.stringValue == null) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(field.stringValue);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(parsed as Record<string, unknown>)) {
+    if (val == null) continue;
+    out[key] = typeof val === "object" ? JSON.stringify(val) : String(val);
+  }
+  return out;
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -8,6 +8,8 @@
  * - "dynamodb": record attributes incl. an `operationsByName` map (PartiQL nav).
  * - "aurora": Postgres; only the canonical operations array (no operationsByName) —
  *   query operations by name via a JSONB/JSONPath predicate on the array.
+ * - "redshift": Redshift SQL; record_json is a SUPER column — navigate/unnest it
+ *   with PartiQL (dot/bracket paths, `FROM tbl t, t.record_json.operations o`).
  */
 
 /**
@@ -23,6 +25,7 @@ export type DestinationType =
   | "lambda-log-exporter"
   | "dynamodb"
   | "aurora"
+  | "redshift"
   | "sqs"
   | "s3";
 
@@ -286,6 +289,80 @@ A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_N
 Q: executions where operation "convert_data" took less than 5 seconds
 A: SELECT execution_arn, function_name FROM TABLE_NAME WHERE record_json @? '$.operations[*] ? (@.name == "convert_data" && @.durationMs < 5000)' LIMIT 50`;
 
+// ─── REDSHIFT (Redshift SQL over the Data API; JSON via SUPER/PartiQL) ────────
+
+const RECORD_SCHEMA_REDSHIFT = `Records are stored in an Amazon Redshift table "TABLE_NAME" with columns:
+- execution_arn: VARCHAR(512) PRIMARY KEY
+- execution_name: VARCHAR(256)
+- function_name: VARCHAR(128)
+- status: VARCHAR(20) — values: RUNNING, SUCCEEDED, FAILED
+- start_time: VARCHAR(30) (ISO-8601 string, NOT a native timestamp)
+- end_time: VARCHAR(30) (ISO-8601 string, NULL if still running)
+- duration_ms: BIGINT (NULL if still running)
+- record_json: SUPER — full WorkflowInsightRecord as semi-structured JSON
+- emitted_at: VARCHAR(30) (ISO-8601 string)
+
+The record_json SUPER column contains the full record. The workgroup has
+enable_case_sensitive_identifier=true, and the stored JSON keys are camelCase,
+so SUPER attribute names MUST be double-quoted to preserve case — an unquoted
+path like record_json.functionName is folded to lowercase and resolves to NULL.
+Navigate with PartiQL dot/bracket paths (no JSON functions needed):
+- record_json."input" — execution input (structure varies per function)
+- record_json."output" — execution output (structure varies per function)
+- record_json."error" — error details ("name", "message")
+- record_json."operations" — array of operations
+
+Note: Redshift stores only the canonical operations array (there is no
+operationsByName index here). To filter/aggregate by operation name or fields,
+UNNEST the SUPER array by joining it as a table alias, e.g.
+  SELECT e.execution_arn FROM TABLE_NAME e, e.record_json."operations" o
+  WHERE o."name" = 'convert_data' AND o."durationMs"::bigint < 5000
+
+To read a SUPER value as a normal scalar, cast it (e.g. o."durationMs"::bigint,
+record_json."input"."fieldName"::varchar). Prefer the top-level snake_case
+columns above (execution_arn, function_name, status, duration_ms, ...) when the
+data you need is there — they need no quoting. The user will specify which
+fields they want — do not assume the structure.`;
+
+const DIALECT_REDSHIFT = `Target query language: Amazon Redshift SQL (with PartiQL for SUPER navigation).
+- Table name is TABLE_NAME.
+- Time columns (start_time, end_time, emitted_at) are ISO-8601 STRINGS, not
+  native timestamps. Compare them lexically (ISO-8601 sorts chronologically), or
+  cast with (start_time::timestamptz) when you need date math like NOW()/INTERVAL.
+- record_json is SUPER — navigate with dot/bracket paths and UNNEST arrays by
+  joining them as a table alias (FROM tbl t, t.record_json."operations" o). The
+  JSON keys are camelCase and case-sensitive identifiers are ON, so ALWAYS
+  double-quote SUPER attribute names (record_json."functionName", o."durationMs")
+  — unquoted names resolve to NULL. Cast extracted SUPER values to a concrete
+  type (::bigint, ::varchar) before arithmetic or comparisons.
+- Always include LIMIT (default 100) unless aggregating.
+- Return ONLY the SQL query. No prose.`;
+
+const FEWSHOTS_REDSHIFT = `Examples:
+Q: show the most recent failed executions
+A: SELECT execution_arn, function_name, duration_ms, emitted_at FROM TABLE_NAME WHERE status = 'FAILED' ORDER BY emitted_at DESC LIMIT 50
+
+Q: average duration of successful executions
+A: SELECT AVG(duration_ms) AS avg_duration_ms FROM TABLE_NAME WHERE status = 'SUCCEEDED'
+
+Q: count executions by status
+A: SELECT status, COUNT(*) AS ct FROM TABLE_NAME GROUP BY status ORDER BY ct DESC
+
+Q: executions longer than 5 seconds
+A: SELECT execution_arn, function_name, duration_ms FROM TABLE_NAME WHERE status = 'SUCCEEDED' AND duration_ms > 5000 ORDER BY duration_ms DESC LIMIT 50
+
+Q: failure rate percentage
+A: SELECT COUNT(CASE WHEN status = 'FAILED' THEN 1 END) * 100.0 / COUNT(*) AS failure_pct FROM TABLE_NAME
+
+Q: show last 100 records
+A: SELECT execution_arn, status, function_name, duration_ms, emitted_at FROM TABLE_NAME ORDER BY emitted_at DESC LIMIT 100
+
+Q: average duration grouped by function
+A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_NAME WHERE status = 'SUCCEEDED' GROUP BY function_name ORDER BY avg_ms DESC
+
+Q: executions where operation "convert_data" took less than 5 seconds
+A: SELECT DISTINCT e.execution_arn, e.function_name FROM TABLE_NAME e, e.record_json."operations" o WHERE o."name" = 'convert_data' AND o."durationMs"::bigint < 5000 LIMIT 50`;
+
 // ─── ATHENA (Trino/Presto SQL over S3 via S3Exporter) ────────────────────────
 
 const RECORD_SCHEMA_ATHENA = `Records are stored as one JSON object per file in S3 (via S3Exporter), registered as
@@ -512,6 +589,22 @@ export function buildSystemPrompt(
       DIALECT_AURORA.replace(/TABLE_NAME/g, table),
       "",
       FEWSHOTS_AURORA.replace(/TABLE_NAME/g, table),
+      "",
+      ...closing,
+    ].join("\n");
+  }
+
+  if (destinationType === "redshift") {
+    const table = options?.tableName || "workflow_insight";
+    return [
+      "You convert a user's plain-English question into a single Amazon Redshift SQL query",
+      "for querying AWS Durable Execution Workflow Insight records in Amazon Redshift.",
+      "",
+      RECORD_SCHEMA_REDSHIFT.replace(/TABLE_NAME/g, table),
+      "",
+      DIALECT_REDSHIFT.replace(/TABLE_NAME/g, table),
+      "",
+      FEWSHOTS_REDSHIFT.replace(/TABLE_NAME/g, table),
       "",
       ...closing,
     ].join("\n");

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -55,6 +55,8 @@ function starterQueryFor(s: Settings): string {
       return `SELECT * FROM "${s.dynamodbTableName || "your-table"}" LIMIT 50`;
     case "aurora":
       return `SELECT * FROM ${s.auroraTable || "workflow_insight"} LIMIT 50`;
+    case "redshift":
+      return `SELECT * FROM ${s.redshiftSchema || "public"}.${s.redshiftTable || "workflow_insight"} LIMIT 50`;
     case "s3":
       return `SELECT * FROM ${s.athenaTable || "workflow_insight"} LIMIT 50`;
     default:

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -45,6 +45,7 @@ const DEST_OPTIONS: SelectProps.Option[] = [
   { value: "lambda-log-exporter", label: "CloudWatch Logs (Lambda function log group)" },
   { value: "dynamodb", label: "DynamoDB" },
   { value: "aurora", label: "Aurora PostgreSQL" },
+  { value: "redshift", label: "Amazon Redshift" },
   { value: "s3", label: "S3 + Athena" },
   { value: "sqs", label: "Amazon SQS (live view)" },
 ];
@@ -100,6 +101,7 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
   const showLogGroup = dest === "cloudwatch-logs-exporter" || dest === "lambda-log-exporter";
   const showDdb = dest === "dynamodb";
   const showAurora = dest === "aurora";
+  const showRedshift = dest === "redshift";
   const showAthena = dest === "s3";
   const showSqs = dest === "sqs";
 
@@ -158,6 +160,32 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                     </FormField>
                     <FormField label="Table">
                       <Input value={form.auroraTable} onChange={({ detail }) => update("auroraTable", detail.value)} placeholder="workflow_insight" />
+                    </FormField>
+                  </SpaceBetween>
+                )}
+
+                {showRedshift && (
+                  <SpaceBetween size="s">
+                    <FormField label="Workgroup Name" description="Redshift Serverless workgroup. Leave empty if using a provisioned cluster.">
+                      <Input value={form.redshiftWorkgroupName} onChange={({ detail }) => update("redshiftWorkgroupName", detail.value)} placeholder="insight-workgroup" />
+                    </FormField>
+                    <FormField label="Cluster Identifier" description="Provisioned Redshift cluster (alternative to a Serverless workgroup).">
+                      <Input value={form.redshiftClusterIdentifier} onChange={({ detail }) => update("redshiftClusterIdentifier", detail.value)} placeholder="my-redshift-cluster" />
+                    </FormField>
+                    <FormField label="Database">
+                      <Input value={form.redshiftDatabase} onChange={({ detail }) => update("redshiftDatabase", detail.value)} placeholder="dev" />
+                    </FormField>
+                    <FormField label="Schema">
+                      <Input value={form.redshiftSchema} onChange={({ detail }) => update("redshiftSchema", detail.value)} placeholder="public" />
+                    </FormField>
+                    <FormField label="Table">
+                      <Input value={form.redshiftTable} onChange={({ detail }) => update("redshiftTable", detail.value)} placeholder="workflow_insight" />
+                    </FormField>
+                    <FormField label="DB User" description="Provisioned clusters only (temporary credentials). Leave empty for Serverless or when using a Secret ARN.">
+                      <Input value={form.redshiftDbUser} onChange={({ detail }) => update("redshiftDbUser", detail.value)} placeholder="admin" />
+                    </FormField>
+                    <FormField label="Secret ARN" description="Optional: Secrets Manager ARN for Data API auth (alternative to IAM/DB user).">
+                      <Input value={form.redshiftSecretArn} onChange={({ detail }) => update("redshiftSecretArn", detail.value)} placeholder="arn:aws:secretsmanager:..." />
                     </FormField>
                   </SpaceBetween>
                 )}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -192,6 +192,13 @@ export interface Settings {
   auroraSecretArn: string;
   auroraDatabase: string;
   auroraTable: string;
+  redshiftWorkgroupName: string;
+  redshiftClusterIdentifier: string;
+  redshiftDbUser: string;
+  redshiftSecretArn: string;
+  redshiftDatabase: string;
+  redshiftTable: string;
+  redshiftSchema: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
   athenaDatabase: string;
@@ -268,6 +275,13 @@ export const DEFAULT_SETTINGS: Settings = {
   auroraSecretArn: "",
   auroraDatabase: "postgres",
   auroraTable: "workflow_insight",
+  redshiftWorkgroupName: "",
+  redshiftClusterIdentifier: "",
+  redshiftDbUser: "",
+  redshiftSecretArn: "",
+  redshiftDatabase: "dev",
+  redshiftTable: "workflow_insight",
+  redshiftSchema: "public",
   sqsQueueUrl: "",
   sqsDeleteAfterRead: false,
   athenaDatabase: "",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
@@ -8,6 +8,7 @@ import {
   CloudWatchLogsExporter,
   DynamoDBExporter,
   AuroraExporter,
+  RedshiftExporter,
   SQSExporter,
   S3Exporter,
 } from "@aws/durable-execution-sdk-js-insight";
@@ -47,6 +48,17 @@ const exporters = [
           database: process.env.INSIGHT_AURORA_DATABASE ?? "postgres",
           table: process.env.INSIGHT_AURORA_TABLE ?? "workflow_insight",
           engine: "postgresql",
+          region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+  ...(process.env.INSIGHT_REDSHIFT_WORKGROUP
+    ? [
+        new RedshiftExporter({
+          workgroupName: process.env.INSIGHT_REDSHIFT_WORKGROUP,
+          database: process.env.INSIGHT_REDSHIFT_DATABASE ?? "dev",
+          table: process.env.INSIGHT_REDSHIFT_TABLE ?? "workflow_insight",
+          schema: process.env.INSIGHT_REDSHIFT_SCHEMA ?? "public",
           region: process.env.AWS_REGION,
         }),
       ]

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/redshift-create-table.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/redshift-create-table.ts
@@ -38,6 +38,31 @@ export async function handler(
   const database = event.ResourceProperties.Database;
   const sql = event.ResourceProperties.Sql;
 
+  // The Redshift Data API's ExecuteStatement runs a SINGLE statement, but the
+  // provisioning SQL contains several (CREATE TABLE, GRANT, ...). Split on ';'
+  // and run each in order, polling each to completion.
+  const statements = String(sql)
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  let lastStatementId = "";
+  for (const statement of statements) {
+    lastStatementId = await runStatement(workgroupName, database, statement);
+  }
+
+  return {
+    PhysicalResourceId: `redshift-create-table-${workgroupName}-${database}`,
+    Data: { status: "FINISHED", statementId: lastStatementId },
+  };
+}
+
+/** Execute one SQL statement via the Redshift Data API and poll until done. */
+async function runStatement(
+  workgroupName: string,
+  database: string,
+  sql: string,
+): Promise<string> {
   const executeResp = await client.send(
     new ExecuteStatementCommand({
       WorkgroupName: workgroupName,
@@ -49,7 +74,6 @@ export async function handler(
   const statementId = executeResp.Id!;
   console.log(`ExecuteStatement submitted: ${statementId}`);
 
-  // Poll until finished
   const startTime = Date.now();
   while (Date.now() - startTime < MAX_WAIT_MS) {
     await sleep(POLL_INTERVAL_MS);
@@ -62,21 +86,18 @@ export async function handler(
     console.log(`Statement ${statementId}: ${status}`);
 
     if (status === "FINISHED") {
-      return {
-        PhysicalResourceId: `redshift-create-table-${workgroupName}-${database}`,
-        Data: { status: "FINISHED", statementId },
-      };
+      return statementId;
     }
 
     if (status === "FAILED" || status === "ABORTED") {
       throw new Error(
-        `Redshift CREATE TABLE failed: ${desc.Error ?? "unknown error"} (statement: ${statementId})`,
+        `Redshift statement failed: ${desc.Error ?? "unknown error"} (statement: ${statementId})`,
       );
     }
   }
 
   throw new Error(
-    `Redshift CREATE TABLE timed out after ${MAX_WAIT_MS / 1000}s (statement: ${statementId})`,
+    `Redshift statement timed out after ${MAX_WAIT_MS / 1000}s (statement: ${statementId})`,
   );
 }
 

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -374,6 +374,19 @@ export class InsightDestinationsStack extends cdk.Stack {
           NamespaceName: config.destinations.redshift.namespaceName,
           BaseCapacity: 8,
           PubliclyAccessible: false,
+          // WorkflowInsightRecord uses camelCase JSON keys (functionName,
+          // durationMs, executionArn, input.claimType, ...). Redshift's default
+          // (enable_case_sensitive_identifier=false) folds SUPER path
+          // identifiers to lowercase, so record_json.functionName silently
+          // resolves to NULL. Enabling case-sensitive identifiers lets queries
+          // reach the camelCase attributes via double-quoted paths, e.g.
+          // record_json."functionName", record_json."input"."claimType".
+          ConfigParameters: [
+            {
+              ParameterKey: "enable_case_sensitive_identifier",
+              ParameterValue: "true",
+            },
+          ],
         },
       });
       workgroup.addDependency(namespace);
@@ -393,6 +406,7 @@ export class InsightDestinationsStack extends cdk.Stack {
           record_json SUPER,
           emitted_at VARCHAR(30)
         );
+        GRANT ALL ON ${fqTable} TO PUBLIC;
       `;
 
       // Use a Provider-backed custom resource that polls DescribeStatement
@@ -647,6 +661,17 @@ export class InsightDestinationsStack extends cdk.Stack {
       }
       if (config.destinations.s3.enabled && insightBucket) {
         envVars.INSIGHT_S3_BUCKET = insightBucket.bucketName;
+      }
+      if (config.destinations.redshift.enabled) {
+        // Serverless workgroup — the exporter authenticates via IAM
+        // (redshift-serverless:GetCredentials, granted in the policy block
+        // above), so no secret is passed here.
+        envVars.INSIGHT_REDSHIFT_WORKGROUP =
+          config.destinations.redshift.workgroupName;
+        envVars.INSIGHT_REDSHIFT_DATABASE =
+          config.destinations.redshift.databaseName;
+        envVars.INSIGHT_REDSHIFT_TABLE = config.destinations.redshift.tableName;
+        envVars.INSIGHT_REDSHIFT_SCHEMA = config.destinations.redshift.schema;
       }
 
       const exampleFn = new lambdaNode.NodejsFunction(

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
@@ -115,40 +115,58 @@ export class RedshiftExporter implements InsightExporter {
       { name: "emitted_at", value: record.emittedAt },
     ];
 
-    // Nullable fields: Redshift Data API doesn't support NULL or empty string
-    // in parameters, so we use SQL NULL literals for absent values.
-    const endTimeExpr = record.endTime
+    // Nullable fields: the Redshift Data API doesn't support NULL/empty-string
+    // parameter values, so absent values are emitted as typed SQL NULL literals
+    // in the source projection instead of bound parameters.
+    const endTimeSel = record.endTime
       ? (parameters.push({ name: "end_time", value: record.endTime }),
-        ":end_time")
-      : "NULL";
-    const durationExpr =
+        ":end_time::varchar")
+      : "NULL::varchar";
+    const durationSel =
       record.durationMs != null
         ? (parameters.push({
             name: "duration_ms",
             value: String(record.durationMs),
           }),
-          ":duration_ms")
-        : "NULL";
-    const execNameExpr = record.executionName
+          ":duration_ms::bigint")
+        : "NULL::bigint";
+    const execNameSel = record.executionName
       ? (parameters.push({
           name: "execution_name",
           value: record.executionName,
         }),
-        ":execution_name")
-      : "NULL";
+        ":execution_name::varchar")
+      : "NULL::varchar";
 
-    const sql = `MERGE INTO ${this.fqTable} USING (SELECT 1) AS src
-    ON ${this.fqTable}.execution_arn = :execution_arn
+    // Upsert by executionArn. The source row is projected in a subquery and the
+    // MERGE joins target/source on execution_arn — Redshift's MERGE requires an
+    // equality join on a SOURCE COLUMN (joining on a parameter/constant makes it
+    // plan a NestedLoop join, which MERGE rejects with "NestedLoop join is not
+    // supported in MERGE"). record_json is populated with JSON_PARSE(...) so it
+    // lands in the SUPER column.
+    const sql = `MERGE INTO ${this.fqTable} USING (
+      SELECT
+        :execution_arn::varchar AS execution_arn,
+        ${execNameSel} AS execution_name,
+        :function_name::varchar AS function_name,
+        :status::varchar AS status,
+        :start_time::varchar AS start_time,
+        ${endTimeSel} AS end_time,
+        ${durationSel} AS duration_ms,
+        JSON_PARSE(:record_json) AS record_json,
+        :emitted_at::varchar AS emitted_at
+    ) AS src
+    ON ${this.fqTable}.execution_arn = src.execution_arn
     WHEN MATCHED THEN UPDATE SET
-      status = :status,
-      end_time = ${endTimeExpr},
-      duration_ms = ${durationExpr},
-      record_json = JSON_PARSE(:record_json),
-      emitted_at = :emitted_at
+      status = src.status,
+      end_time = src.end_time,
+      duration_ms = src.duration_ms,
+      record_json = src.record_json,
+      emitted_at = src.emitted_at
     WHEN NOT MATCHED THEN INSERT
       (execution_arn, execution_name, function_name, status, start_time, end_time, duration_ms, record_json, emitted_at)
     VALUES
-      (:execution_arn, ${execNameExpr}, :function_name, :status, :start_time, ${endTimeExpr}, ${durationExpr}, JSON_PARSE(:record_json), :emitted_at)`;
+      (src.execution_arn, src.execution_name, src.function_name, src.status, src.start_time, src.end_time, src.duration_ms, src.record_json, src.emitted_at)`;
 
     await this.client.send(
       new ExecuteStatementCommand({


### PR DESCRIPTION
Adds Amazon Redshift as a queryable destination in the Workflow Insight VS Code extension, alongside the existing DynamoDB / Aurora / S3-Athena / CloudWatch Logs destinations. Redshift is modeled on the Aurora path (SQL over the same record_json + scalar-columns table) with the Redshift-specific differences handled:

- New src/redshift.ts: runRedshiftQuery + fetchRedshiftRecord over the Redshift Data API. Unlike the RDS Data API, the Redshift Data API is asynchronous, so it executes then polls DescribeStatement to completion and pages through GetStatementResult, normalizing to the shared result shape.
- schema.ts: new "redshift" DestinationType and a dedicated NL->SQL prompt (record schema, dialect, few-shots) covering SUPER/PartiQL navigation. JSON keys are camelCase, so the prompt requires double-quoted SUPER paths (record_json."functionName", o."durationMs") and array UNNEST via a joined table alias.
- config.ts / package.json settings: redshift workgroup/cluster, database, schema, table, dbUser, and secretArn (Serverless or provisioned). Wired through extension.ts (query + record-fetch routing) and destinationTest.ts (SELECT 1 connectivity probe). Settings webview updated (SettingsModal, types, starter query). Adds @aws-sdk/client-redshift-data.

Example CDK stack + exporter fixes (validated end-to-end against a live Redshift Serverless workgroup):

- RedshiftExporter: rewrite the upsert MERGE to project the row in the USING subquery and join on src.execution_arn. The previous form joined on a bound parameter, which Redshift plans as a NestedLoop join and rejects with "NestedLoop join is not supported in MERGE" — so every export silently failed.
- redshift-create-table handler: run multiple statements (splits on ';') so the provisioning SQL can CREATE TABLE and GRANT in one custom resource.
- stack.ts: GRANT ALL on the table TO PUBLIC (the table is owned by the create-table role's DB user; the exporter and query identities are different users and were otherwise denied), set enable_case_sensitive_identifier=true on the workgroup so camelCase SUPER keys are reachable, and pass the Redshift env vars to the example function so it emits records via RedshiftExporter.

Tests: unit tests for runRedshiftQuery/fetchRedshiftRecord (polling, pagination, failure, SUPER parse) and extended config/destinationTest coverage.