### PR TITLE
feat(sdk): add Amazon OpenSearch support to Workflow Insight extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16248,6 +16248,7 @@
       "version": "0.1.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-athena": "^3.658.0",
         "@aws-sdk/client-bedrock": "^3.1086.0",
         "@aws-sdk/client-bedrock-runtime": "^3.658.0",
@@ -16260,6 +16261,7 @@
         "@aws-sdk/credential-providers": "^3.658.0",
         "@aws-sdk/util-dynamodb": "^3.658.0",
         "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
+        "@smithy/signature-v4": "^5.0.0",
         "node-llama-cpp": "^3.18.1",
         "quickjs-emscripten-core": "^0.32.0"
       },

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -144,7 +144,7 @@
         "workflowInsight.opensearchEndpoint": {
           "type": "string",
           "default": "",
-          "description": "Amazon OpenSearch domain endpoint, e.g. https://my-domain.us-east-1.es.amazonaws.com (required when destinationType is 'opensearch'). Queried via the SQL plugin with SigV4 auth."
+          "description": "Amazon OpenSearch domain endpoint, e.g. https://my-domain.us-east-1.es.amazonaws.com (required when destinationType is 'opensearch'). Queried via the SQL plugin with SigV4 auth. Note: the SQL plugin caps results at ~200 rows by default (plugins.query.size_limit) even without a LIMIT, so prefer aggregations for whole-dataset questions."
         },
         "workflowInsight.opensearchIndex": {
           "type": "string",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -55,6 +55,7 @@
             "dynamodb",
             "aurora",
             "redshift",
+            "opensearch",
             "s3",
             "sqs"
           ],
@@ -64,6 +65,7 @@
             "DynamoDB table via DynamoDBExporter — records queryable via PartiQL",
             "Aurora PostgreSQL/MySQL via AuroraExporter — full SQL with GROUP BY, JOIN, aggregations",
             "Amazon Redshift via RedshiftExporter — full SQL; record_json is a SUPER column navigated with PartiQL",
+            "Amazon OpenSearch via OpenSearchExporter — queried through the SQL plugin (_plugins/_sql), SigV4-signed",
             "S3 via S3Exporter — queried through Amazon Athena (Trino/Presto SQL) over a Glue table",
             "Amazon SQS via SQSExporter — live view that listens to the queue as records arrive (no query engine)"
           ],
@@ -138,6 +140,16 @@
           "type": "string",
           "default": "public",
           "description": "Redshift schema containing the insight table (queried as <schema>.<table>)."
+        },
+        "workflowInsight.opensearchEndpoint": {
+          "type": "string",
+          "default": "",
+          "description": "Amazon OpenSearch domain endpoint, e.g. https://my-domain.us-east-1.es.amazonaws.com (required when destinationType is 'opensearch'). Queried via the SQL plugin with SigV4 auth."
+        },
+        "workflowInsight.opensearchIndex": {
+          "type": "string",
+          "default": "workflow-insight",
+          "description": "OpenSearch index containing the insight records."
         },
         "workflowInsight.athenaDatabase": {
           "type": "string",
@@ -256,6 +268,7 @@
     "clean": "rm -rf dist media/webview.js media/webview.css"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-athena": "^3.658.0",
     "@aws-sdk/client-bedrock": "^3.1086.0",
     "@aws-sdk/client-bedrock-runtime": "^3.658.0",
@@ -268,6 +281,7 @@
     "@aws-sdk/credential-providers": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",
     "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
+    "@smithy/signature-v4": "^5.0.0",
     "node-llama-cpp": "^3.18.1",
     "quickjs-emscripten-core": "^0.32.0"
   },

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.test.ts
@@ -41,6 +41,20 @@ describe("configFromWireSettings", () => {
     expect(cfg.redshiftTable).toBe("wi");
   });
 
+  it("maps OpenSearch fields and defaults the index", () => {
+    const empty = configFromWireSettings({});
+    expect(empty.opensearchIndex).toBe("workflow-insight");
+    expect(empty.opensearchEndpoint).toBe("");
+    const cfg = configFromWireSettings({
+      destinationType: "opensearch",
+      opensearchEndpoint: "https://d.us-east-1.es.amazonaws.com",
+      opensearchIndex: "wi-index",
+    });
+    expect(cfg.destinationType).toBe("opensearch");
+    expect(cfg.opensearchEndpoint).toBe("https://d.us-east-1.es.amazonaws.com");
+    expect(cfg.opensearchIndex).toBe("wi-index");
+  });
+
   it("maps Athena/S3 fields from the wire payload", () => {
     const cfg = configFromWireSettings({
       destinationType: "s3",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/config.ts
@@ -19,6 +19,8 @@ export interface InsightConfig {
   redshiftDatabase: string;
   redshiftTable: string;
   redshiftSchema: string;
+  opensearchEndpoint: string;
+  opensearchIndex: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
   athenaDatabase: string;
@@ -97,11 +99,13 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
           ? ("aurora" as const)
           : raw === "redshift"
             ? ("redshift" as const)
-            : raw === "sqs"
-              ? ("sqs" as const)
-              : raw === "s3"
-                ? ("s3" as const)
-                : ("cloudwatch-logs-exporter" as const);
+            : raw === "opensearch"
+              ? ("opensearch" as const)
+              : raw === "sqs"
+                ? ("sqs" as const)
+                : raw === "s3"
+                  ? ("s3" as const)
+                  : ("cloudwatch-logs-exporter" as const);
   const dynamodbTableName = (src.getString("dynamodbTableName") || "").trim();
   const auroraResourceArn = (src.getString("auroraResourceArn") || "").trim();
   const auroraSecretArn = (src.getString("auroraSecretArn") || "").trim();
@@ -123,6 +127,9 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
     (src.getString("redshiftTable") || "").trim() || "workflow_insight";
   const redshiftSchema =
     (src.getString("redshiftSchema") || "").trim() || "public";
+  const opensearchEndpoint = (src.getString("opensearchEndpoint") || "").trim();
+  const opensearchIndex =
+    (src.getString("opensearchIndex") || "").trim() || "workflow-insight";
   const sqsQueueUrl = (src.getString("sqsQueueUrl") || "").trim();
   const sqsDeleteAfterRead = src.getBool("sqsDeleteAfterRead") ?? false;
   const athenaDatabase = (src.getString("athenaDatabase") || "").trim();
@@ -181,6 +188,8 @@ function normalizeConfig(src: ConfigSource): InsightConfig {
     redshiftDatabase,
     redshiftTable,
     redshiftSchema,
+    opensearchEndpoint,
+    opensearchIndex,
     sqsQueueUrl,
     sqsDeleteAfterRead,
     athenaDatabase,

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
@@ -23,6 +23,9 @@ jest.mock("./aurora", () => ({
 jest.mock("./redshift", () => ({
   runRedshiftQuery: jest.fn(),
 }));
+jest.mock("./opensearch", () => ({
+  pingOpenSearch: jest.fn(),
+}));
 jest.mock("./config", () => ({
   resolveCredentials: jest.fn(() => ({})),
 }));
@@ -32,6 +35,7 @@ import { testDestination } from "./destinationTest";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
 import { runRedshiftQuery } from "./redshift";
+import { pingOpenSearch } from "./opensearch";
 
 function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
   return {
@@ -50,6 +54,8 @@ function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
     redshiftDatabase: "dev",
     redshiftTable: "workflow_insight",
     redshiftSchema: "public",
+    opensearchEndpoint: "",
+    opensearchIndex: "workflow-insight",
     sqsQueueUrl: "",
     sqsDeleteAfterRead: false,
     athenaDatabase: "",
@@ -231,6 +237,46 @@ describe("testDestination — Redshift", () => {
     );
     expect(r.ok).toBe(false);
     expect(r.checks.at(-1)?.detail).toMatch(/relation does not exist/);
+  });
+});
+
+describe("testDestination — OpenSearch", () => {
+  it("fails when endpoint missing", async () => {
+    const r = await testDestination(baseCfg({ destinationType: "opensearch" }));
+    expect(r.ok).toBe(false);
+    expect(pingOpenSearch).not.toHaveBeenCalled();
+  });
+
+  it("passes when the SigV4 ping succeeds", async () => {
+    (pingOpenSearch as jest.Mock).mockResolvedValue(
+      'Connected to cluster "x".',
+    );
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "opensearch",
+        opensearchEndpoint: "https://d.us-east-1.es.amazonaws.com",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(pingOpenSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "https://d.us-east-1.es.amazonaws.com",
+      }),
+    );
+  });
+
+  it("fails when the ping errors (e.g. 403 not authorized)", async () => {
+    (pingOpenSearch as jest.Mock).mockRejectedValue(
+      new Error("OpenSearch connection failed (403 Forbidden)"),
+    );
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "opensearch",
+        opensearchEndpoint: "https://d.us-east-1.es.amazonaws.com",
+      }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.checks.at(-1)?.detail).toMatch(/403/);
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.test.ts
@@ -25,6 +25,7 @@ jest.mock("./redshift", () => ({
 }));
 jest.mock("./opensearch", () => ({
   pingOpenSearch: jest.fn(),
+  countOpenSearchDocs: jest.fn(),
 }));
 jest.mock("./config", () => ({
   resolveCredentials: jest.fn(() => ({})),
@@ -35,7 +36,7 @@ import { testDestination } from "./destinationTest";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
 import { runRedshiftQuery } from "./redshift";
-import { pingOpenSearch } from "./opensearch";
+import { pingOpenSearch, countOpenSearchDocs } from "./opensearch";
 
 function baseCfg(overrides: Partial<InsightConfig>): InsightConfig {
   return {
@@ -247,10 +248,11 @@ describe("testDestination — OpenSearch", () => {
     expect(pingOpenSearch).not.toHaveBeenCalled();
   });
 
-  it("passes when the SigV4 ping succeeds", async () => {
+  it("passes when the SigV4 ping and index count succeed", async () => {
     (pingOpenSearch as jest.Mock).mockResolvedValue(
       'Connected to cluster "x".',
     );
+    (countOpenSearchDocs as jest.Mock).mockResolvedValue(5);
     const r = await testDestination(
       baseCfg({
         destinationType: "opensearch",
@@ -263,12 +265,29 @@ describe("testDestination — OpenSearch", () => {
         endpoint: "https://d.us-east-1.es.amazonaws.com",
       }),
     );
+    expect(r.checks.at(-1)?.detail).toMatch(/5 document/);
+  });
+
+  it("soft-passes the index check when the index doesn't exist yet (404)", async () => {
+    (pingOpenSearch as jest.Mock).mockResolvedValue(
+      'Connected to cluster "x".',
+    );
+    (countOpenSearchDocs as jest.Mock).mockResolvedValue(undefined);
+    const r = await testDestination(
+      baseCfg({
+        destinationType: "opensearch",
+        opensearchEndpoint: "https://d.us-east-1.es.amazonaws.com",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    expect(r.checks.at(-1)?.detail).toMatch(/not found yet/);
   });
 
   it("fails when the ping errors (e.g. 403 not authorized)", async () => {
     (pingOpenSearch as jest.Mock).mockRejectedValue(
       new Error("OpenSearch connection failed (403 Forbidden)"),
     );
+    (countOpenSearchDocs as jest.Mock).mockResolvedValue(0);
     const r = await testDestination(
       baseCfg({
         destinationType: "opensearch",
@@ -276,7 +295,7 @@ describe("testDestination — OpenSearch", () => {
       }),
     );
     expect(r.ok).toBe(false);
-    expect(r.checks.at(-1)?.detail).toMatch(/403/);
+    expect(r.checks.some((c) => /403/.test(c.detail ?? ""))).toBe(true);
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
@@ -9,6 +9,7 @@ import { resolveCredentials } from "./config";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
 import { runRedshiftQuery } from "./redshift";
+import { pingOpenSearch } from "./opensearch";
 
 /**
  * Result of a single check within a destination test (e.g. "Glue table exists",
@@ -86,6 +87,8 @@ export async function testDestination(
       return testAurora(cfg, credentials);
     case "redshift":
       return testRedshift(cfg, credentials);
+    case "opensearch":
+      return testOpenSearch(cfg, credentials);
     case "sqs":
       return testSqs(cfg, credentials);
     case "cloudwatch-logs-exporter":
@@ -267,6 +270,35 @@ async function testRedshift(
         sql: "SELECT 1",
       });
       return "Connected and ran a statement via the Redshift Data API.";
+    }),
+  );
+  return report(checks);
+}
+
+async function testOpenSearch(
+  cfg: InsightConfig,
+  credentials: ReturnType<typeof resolveCredentials>,
+): Promise<DestinationTestReport> {
+  const checks: DestinationCheck[] = [];
+  const missing: string[] = [];
+  if (!cfg.opensearchEndpoint) missing.push("Domain endpoint");
+  checks.push({
+    label: "Required fields",
+    ok: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? `Endpoint "${cfg.opensearchEndpoint}", index "${cfg.opensearchIndex}".`
+        : `Missing: ${missing.join(", ")}.`,
+  });
+  if (missing.length > 0) return report(checks);
+
+  checks.push(
+    await probe("OpenSearch connection (SigV4)", async () => {
+      return await pingOpenSearch({
+        region: cfg.region,
+        credentials,
+        endpoint: cfg.opensearchEndpoint,
+      });
     }),
   );
   return report(checks);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/destinationTest.ts
@@ -9,7 +9,7 @@ import { resolveCredentials } from "./config";
 import { tableExists, runAthenaQuery } from "./athena";
 import { runAuroraQuery } from "./aurora";
 import { runRedshiftQuery } from "./redshift";
-import { pingOpenSearch } from "./opensearch";
+import { pingOpenSearch, countOpenSearchDocs } from "./opensearch";
 
 /**
  * Result of a single check within a destination test (e.g. "Glue table exists",
@@ -299,6 +299,21 @@ async function testOpenSearch(
         credentials,
         endpoint: cfg.opensearchEndpoint,
       });
+    }),
+  );
+
+  // Second probe: GET <index>/_count. Catches a mistyped index name at test
+  // time (a 404 is a soft pass — the index is created on first export, so an
+  // empty/fresh domain shouldn't hard-fail).
+  checks.push(
+    await probe(`Index "${cfg.opensearchIndex}"`, async () => {
+      const n = await countOpenSearchDocs(
+        { region: cfg.region, credentials, endpoint: cfg.opensearchEndpoint },
+        cfg.opensearchIndex,
+      );
+      return n === undefined
+        ? `Index "${cfg.opensearchIndex}" not found yet — it's created on first export. Double-check the name if you expected data.`
+        : `Index "${cfg.opensearchIndex}" exists with ${n} document(s).`;
     }),
   );
   return report(checks);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/extension.ts
@@ -28,6 +28,7 @@ import { runLogsInsightsQuery, fetchLogsInsightsRecord } from "./logsInsights";
 import { runDynamoDBQuery, fetchDynamoDBRecord } from "./dynamodb";
 import { runAuroraQuery, fetchAuroraRecord } from "./aurora";
 import { runRedshiftQuery, fetchRedshiftRecord } from "./redshift";
+import { runOpenSearchQuery, fetchOpenSearchRecord } from "./opensearch";
 import {
   runAthenaQuery,
   ensureAthenaTable,
@@ -344,6 +345,8 @@ class ExplorerPanel {
         redshiftDatabase: cfg.redshiftDatabase,
         redshiftTable: cfg.redshiftTable,
         redshiftSchema: cfg.redshiftSchema,
+        opensearchEndpoint: cfg.opensearchEndpoint,
+        opensearchIndex: cfg.opensearchIndex,
         sqsQueueUrl: cfg.sqsQueueUrl,
         sqsDeleteAfterRead: cfg.sqsDeleteAfterRead,
         athenaDatabase: cfg.athenaDatabase,
@@ -684,9 +687,11 @@ class ExplorerPanel {
           ? cfg.auroraTable
           : cfg.destinationType === "redshift"
             ? `${cfg.redshiftSchema}.${cfg.redshiftTable}`
-            : cfg.destinationType === "s3"
-              ? cfg.athenaTable
-              : undefined;
+            : cfg.destinationType === "opensearch"
+              ? cfg.opensearchIndex
+              : cfg.destinationType === "s3"
+                ? cfg.athenaTable
+                : undefined;
 
     // Dispatch by the selected mode:
     //  - query: run the text verbatim (no LLM)
@@ -1072,9 +1077,11 @@ class ExplorerPanel {
           ? cfg.auroraTable
           : cfg.destinationType === "redshift"
             ? `${cfg.redshiftSchema}.${cfg.redshiftTable}`
-            : cfg.destinationType === "s3"
-              ? cfg.athenaTable
-              : undefined;
+            : cfg.destinationType === "opensearch"
+              ? cfg.opensearchIndex
+              : cfg.destinationType === "s3"
+                ? cfg.athenaTable
+                : undefined;
 
     let iteration = 0;
     // The most recent successful query execution, so a turn that ends with a
@@ -1428,6 +1435,36 @@ class ExplorerPanel {
         hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
       };
     }
+    if (cfg.destinationType === "opensearch") {
+      if (!cfg.opensearchEndpoint)
+        throw new Error("OpenSearch not configured.");
+      assertReadOnly(generated.query, "OpenSearch SQL");
+      const { query, idColumn, injectedColumns } = inject
+        ? ensureIdentifierColumn(generated.query, "executionArn", "sql")
+        : {
+            query: generated.query,
+            idColumn: undefined,
+            injectedColumns: [] as string[],
+          };
+      const table = await runOnce(query, () =>
+        runOpenSearchQuery({
+          region: cfg.region,
+          credentials,
+          endpoint: cfg.opensearchEndpoint,
+          sql: query,
+        }),
+      );
+      const capped = capRows(table);
+      return {
+        ...table,
+        ...capped,
+        explanation: generated.explanation,
+        suggestedCharts: generated.suggestedCharts,
+        finalQuery: query,
+        idColumn: resolveActualColumnCasing(idColumn, table.columns),
+        hiddenColumns: resolveActualColumns(injectedColumns, table.columns),
+      };
+    }
     if (cfg.destinationType === "s3") {
       if (!cfg.athenaDatabase) throw new Error("Athena not configured.");
       assertReadOnly(generated.query, "Trino/Presto SQL");
@@ -1554,6 +1591,14 @@ class ExplorerPanel {
           dbUser: cfg.redshiftDbUser || undefined,
           secretArn: cfg.redshiftSecretArn || undefined,
           table: `${cfg.redshiftSchema}.${cfg.redshiftTable}`,
+          executionArn: idValue,
+        });
+      } else if (cfg.destinationType === "opensearch") {
+        record = await fetchOpenSearchRecord({
+          region: cfg.region,
+          credentials,
+          endpoint: cfg.opensearchEndpoint,
+          index: cfg.opensearchIndex,
           executionArn: idValue,
         });
       } else if (cfg.destinationType === "s3") {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.test.ts
@@ -12,6 +12,7 @@ import {
   runOpenSearchQuery,
   fetchOpenSearchRecord,
   pingOpenSearch,
+  countOpenSearchDocs,
 } from "./opensearch";
 
 const conn = {
@@ -160,5 +161,37 @@ describe("pingOpenSearch", () => {
       body: "no",
     });
     await expect(pingOpenSearch(conn)).rejects.toThrow(/403/);
+  });
+});
+
+describe("countOpenSearchDocs", () => {
+  it("returns the document count and hits <index>/_count", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({ count: 42 }),
+    });
+    const n = await countOpenSearchDocs(conn, "workflow-insight");
+    expect(n).toBe(42);
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`${conn.endpoint}/workflow-insight/_count`);
+    expect(init.method).toBe("GET");
+  });
+
+  it("returns undefined when the index doesn't exist (404)", async () => {
+    mockFetchOnce({ ok: false, status: 404, body: "" });
+    expect(await countOpenSearchDocs(conn, "missing-index")).toBeUndefined();
+  });
+
+  it("throws on other errors", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      body: "denied",
+    });
+    await expect(countOpenSearchDocs(conn, "workflow-insight")).rejects.toThrow(
+      /403/,
+    );
   });
 });

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.test.ts
@@ -1,0 +1,164 @@
+// Mock the SigV4 signer so no real credentials/crypto are needed; capture the
+// signed request shape. fetch is stubbed per test.
+const signMock = jest.fn().mockResolvedValue({
+  headers: { authorization: "AWS4-HMAC-SHA256 ...", host: "d.example" },
+});
+jest.mock("@smithy/signature-v4", () => ({
+  SignatureV4: jest.fn().mockImplementation(() => ({ sign: signMock })),
+}));
+jest.mock("@aws-crypto/sha256-js", () => ({ Sha256: jest.fn() }));
+
+import {
+  runOpenSearchQuery,
+  fetchOpenSearchRecord,
+  pingOpenSearch,
+} from "./opensearch";
+
+const conn = {
+  region: "us-east-1",
+  credentials: {} as never,
+  endpoint: "https://d.us-east-1.es.amazonaws.com",
+};
+
+function mockFetchOnce(res: {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  body: string;
+}) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: res.ok,
+    status: res.status,
+    statusText: res.statusText ?? "",
+    text: async () => res.body,
+  });
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  signMock.mockClear();
+});
+
+describe("runOpenSearchQuery", () => {
+  it("normalizes schema/datarows into columns, rows, numeric flags", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({
+        schema: [
+          { name: "status", type: "keyword" },
+          { name: "ct", type: "integer" },
+          { name: "avg_ms", type: "double" },
+        ],
+        datarows: [
+          ["SUCCEEDED", 10, 42.5],
+          ["FAILED", 2, 1000],
+        ],
+      }),
+    });
+
+    const res = await runOpenSearchQuery({ ...conn, sql: "SELECT ..." });
+    expect(res.columns).toEqual(["status", "ct", "avg_ms"]);
+    expect(res.numericColumns).toEqual([false, true, true]);
+    expect(res.rows).toEqual([
+      ["SUCCEEDED", "10", "42.5"],
+      ["FAILED", "2", "1000"],
+    ]);
+    expect(res.count).toBe(2);
+    // POSTs to the SQL plugin endpoint
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`${conn.endpoint}/_plugins/_sql`);
+    expect(init.method).toBe("POST");
+  });
+
+  it("throws with the SQL plugin's reason on error responses", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      body: JSON.stringify({
+        error: { reason: "Invalid SQL query", details: "..." },
+      }),
+    });
+    await expect(
+      runOpenSearchQuery({ ...conn, sql: "SELECT bogus" }),
+    ).rejects.toThrow(/Invalid SQL query/);
+  });
+
+  it("serializes object cells as JSON", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({
+        schema: [{ name: "error", type: "object" }],
+        datarows: [[{ name: "Boom", message: "x" }]],
+      }),
+    });
+    const res = await runOpenSearchQuery({ ...conn, sql: "SELECT error" });
+    expect(res.rows[0][0]).toBe(JSON.stringify({ name: "Boom", message: "x" }));
+  });
+});
+
+describe("fetchOpenSearchRecord", () => {
+  it("returns undefined on 404", async () => {
+    mockFetchOnce({ ok: false, status: 404, body: "" });
+    const out = await fetchOpenSearchRecord({
+      ...conn,
+      index: "workflow-insight",
+      executionArn: "arn:missing",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  it("flattens _source into top-level string fields", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({
+        _source: {
+          executionArn: "arn:1",
+          status: "SUCCEEDED",
+          input: { claimType: "auto" },
+        },
+      }),
+    });
+    const out = await fetchOpenSearchRecord({
+      ...conn,
+      index: "workflow-insight",
+      executionArn: "arn:1",
+    });
+    expect(out!.executionArn).toBe("arn:1");
+    expect(out!.status).toBe("SUCCEEDED");
+    expect(out!.input).toBe(JSON.stringify({ claimType: "auto" }));
+    // GET to the _doc endpoint with URL-encoded id
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain("/workflow-insight/_doc/arn%3A1");
+    expect(init.method).toBe("GET");
+  });
+});
+
+describe("pingOpenSearch", () => {
+  it("reports the cluster name/version", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      body: JSON.stringify({
+        cluster_name: "my-cluster",
+        version: { number: "2.11.0" },
+      }),
+    });
+    const msg = await pingOpenSearch(conn);
+    expect(msg).toMatch(/my-cluster/);
+    expect(msg).toMatch(/2\.11\.0/);
+  });
+
+  it("throws on a non-ok response", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      body: "no",
+    });
+    await expect(pingOpenSearch(conn)).rejects.toThrow(/403/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.ts
@@ -38,21 +38,35 @@ function cellToString(value: unknown): string {
   return String(value);
 }
 
+/** Max chars of an error response body to include in a thrown error message. */
+const ERR_DETAIL_MAX = 500;
+
 /**
  * SigV4-sign and send a request to the OpenSearch domain. Amazon OpenSearch
  * Service authorizes with SigV4 over the "es" service; the caller's resolved
  * credentials (profile/instance role) must be allow-listed in the domain's
  * access policy. Uses native fetch — no OpenSearch client library.
  *
- * No query-string params are used (paths only), so the signed canonical
- * request and the fetched URL stay identical.
+ * Callers pass a leading-slash `path` (e.g. "/_plugins/_sql"); the domain
+ * endpoint is normalized (trailing slash stripped) here so that logic lives in
+ * one place. Query strings are intentionally unsupported: they'd be part of the
+ * SigV4 canonical request, so an unsigned one would 403 — fail loudly instead
+ * of shipping a self-inflicted, hard-to-diagnose 403.
  */
 async function signedFetch(
   conn: OpenSearchConnection,
   method: string,
-  url: string,
+  path: string,
   body?: string,
 ): Promise<Response> {
+  const url = `${conn.endpoint.replace(/\/$/, "")}${path}`;
+  const u = new URL(url);
+  if (u.search) {
+    throw new Error(
+      `signedFetch does not support query strings (unsigned params 403 on OpenSearch): ${path}`,
+    );
+  }
+
   const signer = new SignatureV4({
     service: "es",
     region: conn.region,
@@ -60,7 +74,6 @@ async function signedFetch(
     sha256: Sha256,
   });
 
-  const u = new URL(url);
   const headers: Record<string, string> = { host: u.host };
   if (body != null) headers["content-type"] = "application/json";
 
@@ -88,12 +101,10 @@ async function signedFetch(
 export async function runOpenSearchQuery(
   opts: OpenSearchConnection & { sql: string },
 ): Promise<OpenSearchQueryResult> {
-  const endpoint = opts.endpoint.replace(/\/$/, "");
-  const url = `${endpoint}/_plugins/_sql`;
   const res = await signedFetch(
     opts,
     "POST",
-    url,
+    "/_plugins/_sql",
     JSON.stringify({ query: opts.sql }),
   );
 
@@ -101,7 +112,7 @@ export async function runOpenSearchQuery(
   if (!res.ok) {
     // The SQL plugin returns a JSON error body with reason/details — surface it
     // so the model (agent mode) can correct the query.
-    let detail = text.slice(0, 800);
+    let detail = text.slice(0, ERR_DETAIL_MAX);
     try {
       const err = JSON.parse(text);
       detail = err?.error?.reason || err?.error?.details || detail;
@@ -136,17 +147,17 @@ export async function runOpenSearchQuery(
 export async function fetchOpenSearchRecord(
   opts: OpenSearchConnection & { index: string; executionArn: string },
 ): Promise<Record<string, string> | undefined> {
-  const endpoint = opts.endpoint.replace(/\/$/, "");
-  const url = `${endpoint}/${opts.index}/_doc/${encodeURIComponent(
-    opts.executionArn,
-  )}`;
-  const res = await signedFetch(opts, "GET", url);
+  const res = await signedFetch(
+    opts,
+    "GET",
+    `/${opts.index}/_doc/${encodeURIComponent(opts.executionArn)}`,
+  );
 
   if (res.status === 404) return undefined;
   const text = await res.text();
   if (!res.ok) {
     throw new Error(
-      `OpenSearch get failed (${res.status} ${res.statusText}): ${text.slice(0, 500)}`,
+      `OpenSearch get failed (${res.status} ${res.statusText}): ${text.slice(0, ERR_DETAIL_MAX)}`,
     );
   }
 
@@ -170,12 +181,11 @@ export async function fetchOpenSearchRecord(
 export async function pingOpenSearch(
   conn: OpenSearchConnection,
 ): Promise<string> {
-  const endpoint = conn.endpoint.replace(/\/$/, "");
-  const res = await signedFetch(conn, "GET", `${endpoint}/`);
+  const res = await signedFetch(conn, "GET", "/");
   const text = await res.text();
   if (!res.ok) {
     throw new Error(
-      `OpenSearch connection failed (${res.status} ${res.statusText}): ${text.slice(0, 300)}`,
+      `OpenSearch connection failed (${res.status} ${res.statusText}): ${text.slice(0, ERR_DETAIL_MAX)}`,
     );
   }
   try {
@@ -187,4 +197,26 @@ export async function pingOpenSearch(
   } catch {
     return "Connected to the OpenSearch domain.";
   }
+}
+
+/**
+ * Signed GET <index>/_count. Returns the document count, or `undefined` when
+ * the index does not exist yet (404) — which is expected before the first
+ * record is exported. Lets the connection test surface a likely index-name
+ * typo without hard-failing a freshly-provisioned (empty) domain.
+ */
+export async function countOpenSearchDocs(
+  conn: OpenSearchConnection,
+  index: string,
+): Promise<number | undefined> {
+  const res = await signedFetch(conn, "GET", `/${index}/_count`);
+  if (res.status === 404) return undefined;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `OpenSearch count failed (${res.status} ${res.statusText}): ${text.slice(0, ERR_DETAIL_MAX)}`,
+    );
+  }
+  const data = JSON.parse(text) as { count?: number };
+  return data.count ?? 0;
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/opensearch.ts
@@ -1,0 +1,190 @@
+import { SignatureV4 } from "@smithy/signature-v4";
+import { Sha256 } from "@aws-crypto/sha256-js";
+import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+
+export interface OpenSearchQueryResult {
+  columns: string[];
+  rows: string[][];
+  count: number;
+  /** Per-column numeric-type flag (aligned with `columns`) — see AthenaQueryResult.numericColumns. */
+  numericColumns: boolean[];
+}
+
+export interface OpenSearchConnection {
+  region: string;
+  credentials: AwsCredentialIdentityProvider;
+  /** Domain endpoint, e.g. "https://my-domain.us-east-1.es.amazonaws.com". */
+  endpoint: string;
+}
+
+// OpenSearch SQL reports column types via the response `schema[].type`. These
+// are the numeric field types; anything else (keyword/text/date/boolean/...)
+// stays a string. Aligned with the numericColumns flag used by the SQL
+// destinations so the webview right-aligns/plots numbers consistently.
+const NUMERIC_OS_TYPES = new Set([
+  "long",
+  "integer",
+  "short",
+  "byte",
+  "double",
+  "float",
+  "half_float",
+  "scaled_float",
+]);
+
+function cellToString(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * SigV4-sign and send a request to the OpenSearch domain. Amazon OpenSearch
+ * Service authorizes with SigV4 over the "es" service; the caller's resolved
+ * credentials (profile/instance role) must be allow-listed in the domain's
+ * access policy. Uses native fetch — no OpenSearch client library.
+ *
+ * No query-string params are used (paths only), so the signed canonical
+ * request and the fetched URL stay identical.
+ */
+async function signedFetch(
+  conn: OpenSearchConnection,
+  method: string,
+  url: string,
+  body?: string,
+): Promise<Response> {
+  const signer = new SignatureV4({
+    service: "es",
+    region: conn.region,
+    credentials: conn.credentials,
+    sha256: Sha256,
+  });
+
+  const u = new URL(url);
+  const headers: Record<string, string> = { host: u.host };
+  if (body != null) headers["content-type"] = "application/json";
+
+  const signed = await signer.sign({
+    method,
+    protocol: u.protocol,
+    hostname: u.hostname,
+    port: u.port ? Number(u.port) : undefined,
+    path: u.pathname,
+    headers,
+    body,
+  });
+
+  return fetch(url, {
+    method,
+    headers: signed.headers as Record<string, string>,
+    body,
+  });
+}
+
+/**
+ * Run a query via the OpenSearch SQL plugin (POST _plugins/_sql) and normalize
+ * the {schema, datarows} response into the shared tabular result shape.
+ */
+export async function runOpenSearchQuery(
+  opts: OpenSearchConnection & { sql: string },
+): Promise<OpenSearchQueryResult> {
+  const endpoint = opts.endpoint.replace(/\/$/, "");
+  const url = `${endpoint}/_plugins/_sql`;
+  const res = await signedFetch(
+    opts,
+    "POST",
+    url,
+    JSON.stringify({ query: opts.sql }),
+  );
+
+  const text = await res.text();
+  if (!res.ok) {
+    // The SQL plugin returns a JSON error body with reason/details — surface it
+    // so the model (agent mode) can correct the query.
+    let detail = text.slice(0, 800);
+    try {
+      const err = JSON.parse(text);
+      detail = err?.error?.reason || err?.error?.details || detail;
+    } catch {
+      // keep raw text
+    }
+    throw new Error(
+      `OpenSearch SQL error (${res.status} ${res.statusText}): ${detail}`,
+    );
+  }
+
+  const data = JSON.parse(text) as {
+    schema?: { name?: string; alias?: string; type?: string }[];
+    datarows?: unknown[][];
+  };
+  const schema = data.schema ?? [];
+  const columns = schema.map((c) => c.alias || c.name || "?");
+  const numericColumns = schema.map((c) =>
+    c.type != null ? NUMERIC_OS_TYPES.has(c.type) : false,
+  );
+  const rows = (data.datarows ?? []).map((row) => row.map(cellToString));
+
+  return { columns, rows, count: rows.length, numericColumns };
+}
+
+/**
+ * Fetch a single record by executionArn for the row-detail drill-down. The
+ * exporter indexes each record with _id = executionArn, so this is a direct
+ * GET _doc/<id> (precise, no query needed). Unpacks _source into flat
+ * top-level string fields to match the shape RecordDetail.tsx expects.
+ */
+export async function fetchOpenSearchRecord(
+  opts: OpenSearchConnection & { index: string; executionArn: string },
+): Promise<Record<string, string> | undefined> {
+  const endpoint = opts.endpoint.replace(/\/$/, "");
+  const url = `${endpoint}/${opts.index}/_doc/${encodeURIComponent(
+    opts.executionArn,
+  )}`;
+  const res = await signedFetch(opts, "GET", url);
+
+  if (res.status === 404) return undefined;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `OpenSearch get failed (${res.status} ${res.statusText}): ${text.slice(0, 500)}`,
+    );
+  }
+
+  const data = JSON.parse(text) as { _source?: Record<string, unknown> };
+  const src = data._source;
+  if (!src || typeof src !== "object") return undefined;
+
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(src)) {
+    if (val == null) continue;
+    out[key] = typeof val === "object" ? JSON.stringify(val) : String(val);
+  }
+  return out;
+}
+
+/**
+ * Lightweight connectivity/auth probe: signed GET of the cluster root, which
+ * confirms the endpoint is reachable and the caller's SigV4 identity is
+ * authorized by the domain access policy.
+ */
+export async function pingOpenSearch(
+  conn: OpenSearchConnection,
+): Promise<string> {
+  const endpoint = conn.endpoint.replace(/\/$/, "");
+  const res = await signedFetch(conn, "GET", `${endpoint}/`);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(
+      `OpenSearch connection failed (${res.status} ${res.statusText}): ${text.slice(0, 300)}`,
+    );
+  }
+  try {
+    const info = JSON.parse(text) as {
+      cluster_name?: string;
+      version?: { number?: string };
+    };
+    return `Connected to cluster "${info.cluster_name ?? "?"}" (v${info.version?.number ?? "?"}).`;
+  } catch {
+    return "Connected to the OpenSearch domain.";
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -10,6 +10,8 @@
  *   query operations by name via a JSONB/JSONPath predicate on the array.
  * - "redshift": Redshift SQL; record_json is a SUPER column — navigate/unnest it
  *   with PartiQL (dot/bracket paths, `FROM tbl t, t.record_json.operations o`).
+ * - "opensearch": Amazon OpenSearch; queried via the SQL plugin (_plugins/_sql).
+ *   String fields are text+keyword — filter/group on the `.keyword` subfield.
  */
 
 /**
@@ -26,6 +28,7 @@ export type DestinationType =
   | "dynamodb"
   | "aurora"
   | "redshift"
+  | "opensearch"
   | "sqs"
   | "s3";
 
@@ -363,6 +366,69 @@ A: SELECT function_name, AVG(duration_ms) AS avg_ms, COUNT(*) AS ct FROM TABLE_N
 Q: executions where operation "convert_data" took less than 5 seconds
 A: SELECT DISTINCT e.execution_arn, e.function_name FROM TABLE_NAME e, e.record_json."operations" o WHERE o."name" = 'convert_data' AND o."durationMs"::bigint < 5000 LIMIT 50`;
 
+// ─── OPENSEARCH (Amazon OpenSearch SQL plugin: POST _plugins/_sql) ────────────
+
+const RECORD_SCHEMA_OPENSEARCH = `Each record is one OpenSearch document (doc _id = executionArn) in the index
+\`TABLE_NAME\`. The index name contains a hyphen, so it MUST be wrapped in
+backticks in the FROM clause. Documents are the raw WorkflowInsightRecord with
+camelCase fields:
+- recordType: keyword ("WorkflowInsight")
+- schemaVersion, executionArn, executionName, functionName, functionQualifier,
+  region, accountId, status (RUNNING|SUCCEEDED|FAILED): string fields
+- emittedAt, startTime, endTime: ISO-8601 date strings
+- durationMs: numeric (long), null while running
+- input, output: nested objects (structure varies per function)
+- error: object {name, message}
+- operations: array of operation objects (see limitation below)
+
+CRITICAL — query STRING fields by their plain names (status, functionName,
+input.claimType). Although the mapping has a .keyword subfield, the OpenSearch
+SQL plugin does NOT expose it as a column — writing status.keyword fails with
+"can't resolve status.keyword". The plugin filters/groups on the text field
+directly (WHERE status = 'FAILED', GROUP BY status both work). Numeric
+(durationMs) and date (emittedAt/startTime/endTime) fields are used directly.
+Do NOT use ORDER BY on a raw text field (text isn't sortable); order by a
+numeric/date field or an aggregate alias instead.
+
+Limitation: operations is an array of objects. The OpenSearch SQL plugin cannot
+reliably unnest or aggregate array-of-object subfields — do NOT try to query
+individual operations by name/duration here. Answer operation-level questions
+from the top-level fields (status, durationMs, functionName) instead.`;
+
+const DIALECT_OPENSEARCH = `Target query language: Amazon OpenSearch SQL (the _plugins/_sql dialect, a
+subset of standard SQL).
+- FROM \`TABLE_NAME\` (index name — always backtick-quoted).
+- Query string fields by plain name (status, functionName, input.claimType).
+  Do NOT append .keyword — the SQL plugin can't resolve the keyword subfield.
+- durationMs is numeric; emittedAt/startTime/endTime are dates (comparable, orderable).
+- ORDER BY only on numeric/date fields or aggregate aliases, never a raw text field.
+- Supported: SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, and aggregates
+  (COUNT, AVG, SUM, MIN, MAX). No JOINs, no CTEs, no window functions.
+- Always include LIMIT (default 100) unless aggregating.
+- Return ONLY the SQL query. No prose.`;
+
+const FEWSHOTS_OPENSEARCH = `Examples:
+Q: show the most recent failed executions
+A: SELECT executionArn, functionName, durationMs, emittedAt FROM \`TABLE_NAME\` WHERE status = 'FAILED' ORDER BY emittedAt DESC LIMIT 50
+
+Q: average duration of successful executions
+A: SELECT AVG(durationMs) AS avg_duration_ms FROM \`TABLE_NAME\` WHERE status = 'SUCCEEDED'
+
+Q: count executions by status
+A: SELECT status, COUNT(*) AS ct FROM \`TABLE_NAME\` GROUP BY status ORDER BY ct DESC
+
+Q: executions longer than 5 seconds
+A: SELECT executionArn, functionName, durationMs FROM \`TABLE_NAME\` WHERE status = 'SUCCEEDED' AND durationMs > 5000 ORDER BY durationMs DESC LIMIT 50
+
+Q: average duration grouped by function
+A: SELECT functionName, AVG(durationMs) AS avg_ms, COUNT(*) AS ct FROM \`TABLE_NAME\` GROUP BY functionName ORDER BY avg_ms DESC
+
+Q: break down executions by claim type
+A: SELECT input.claimType AS claim_type, COUNT(*) AS ct FROM \`TABLE_NAME\` GROUP BY input.claimType ORDER BY ct DESC
+
+Q: show last 100 records
+A: SELECT executionArn, status, functionName, durationMs, emittedAt FROM \`TABLE_NAME\` ORDER BY emittedAt DESC LIMIT 100`;
+
 // ─── ATHENA (Trino/Presto SQL over S3 via S3Exporter) ────────────────────────
 
 const RECORD_SCHEMA_ATHENA = `Records are stored as one JSON object per file in S3 (via S3Exporter), registered as
@@ -605,6 +671,22 @@ export function buildSystemPrompt(
       DIALECT_REDSHIFT.replace(/TABLE_NAME/g, table),
       "",
       FEWSHOTS_REDSHIFT.replace(/TABLE_NAME/g, table),
+      "",
+      ...closing,
+    ].join("\n");
+  }
+
+  if (destinationType === "opensearch") {
+    const table = options?.tableName || "workflow-insight";
+    return [
+      "You convert a user's plain-English question into a single OpenSearch SQL query",
+      "for querying AWS Durable Execution Workflow Insight records in Amazon OpenSearch.",
+      "",
+      RECORD_SCHEMA_OPENSEARCH.replace(/TABLE_NAME/g, table),
+      "",
+      DIALECT_OPENSEARCH.replace(/TABLE_NAME/g, table),
+      "",
+      FEWSHOTS_OPENSEARCH.replace(/TABLE_NAME/g, table),
       "",
       ...closing,
     ].join("\n");

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -11,7 +11,8 @@
  * - "redshift": Redshift SQL; record_json is a SUPER column — navigate/unnest it
  *   with PartiQL (dot/bracket paths, `FROM tbl t, t.record_json.operations o`).
  * - "opensearch": Amazon OpenSearch; queried via the SQL plugin (_plugins/_sql).
- *   String fields are text+keyword — filter/group on the `.keyword` subfield.
+ *   String fields are text+keyword, but the SQL plugin can't resolve the
+ *   `.keyword` subfield — filter/group on the plain field name.
  */
 
 /**
@@ -404,6 +405,9 @@ subset of standard SQL).
 - ORDER BY only on numeric/date fields or aggregate aliases, never a raw text field.
 - Supported: SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, and aggregates
   (COUNT, AVG, SUM, MIN, MAX). No JOINs, no CTEs, no window functions.
+- The SQL plugin returns at most ~200 rows by default (plugins.query.size_limit),
+  even without a LIMIT — prefer aggregation (COUNT/AVG/GROUP BY) for whole-dataset
+  questions rather than listing rows, so results aren't silently truncated.
 - Always include LIMIT (default 100) unless aggregating.
 - Return ONLY the SQL query. No prose.`;
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/App.tsx
@@ -57,6 +57,8 @@ function starterQueryFor(s: Settings): string {
       return `SELECT * FROM ${s.auroraTable || "workflow_insight"} LIMIT 50`;
     case "redshift":
       return `SELECT * FROM ${s.redshiftSchema || "public"}.${s.redshiftTable || "workflow_insight"} LIMIT 50`;
+    case "opensearch":
+      return `SELECT * FROM \`${s.opensearchIndex || "workflow-insight"}\` LIMIT 50`;
     case "s3":
       return `SELECT * FROM ${s.athenaTable || "workflow_insight"} LIMIT 50`;
     default:

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -46,6 +46,7 @@ const DEST_OPTIONS: SelectProps.Option[] = [
   { value: "dynamodb", label: "DynamoDB" },
   { value: "aurora", label: "Aurora PostgreSQL" },
   { value: "redshift", label: "Amazon Redshift" },
+  { value: "opensearch", label: "Amazon OpenSearch" },
   { value: "s3", label: "S3 + Athena" },
   { value: "sqs", label: "Amazon SQS (live view)" },
 ];
@@ -102,6 +103,7 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
   const showDdb = dest === "dynamodb";
   const showAurora = dest === "aurora";
   const showRedshift = dest === "redshift";
+  const showOpenSearch = dest === "opensearch";
   const showAthena = dest === "s3";
   const showSqs = dest === "sqs";
 
@@ -186,6 +188,17 @@ export function SettingsModal({ visible, settings, modelDownloaded, downloadPerc
                     </FormField>
                     <FormField label="Secret ARN" description="Optional: Secrets Manager ARN for Data API auth (alternative to IAM/DB user).">
                       <Input value={form.redshiftSecretArn} onChange={({ detail }) => update("redshiftSecretArn", detail.value)} placeholder="arn:aws:secretsmanager:..." />
+                    </FormField>
+                  </SpaceBetween>
+                )}
+
+                {showOpenSearch && (
+                  <SpaceBetween size="s">
+                    <FormField label="Domain Endpoint" description="Amazon OpenSearch Service HTTPS endpoint. Authenticated with SigV4 (your AWS identity must be in the domain access policy).">
+                      <Input value={form.opensearchEndpoint} onChange={({ detail }) => update("opensearchEndpoint", detail.value)} placeholder="https://my-domain.us-east-1.es.amazonaws.com" />
+                    </FormField>
+                    <FormField label="Index">
+                      <Input value={form.opensearchIndex} onChange={({ detail }) => update("opensearchIndex", detail.value)} placeholder="workflow-insight" />
                     </FormField>
                   </SpaceBetween>
                 )}

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -199,6 +199,8 @@ export interface Settings {
   redshiftDatabase: string;
   redshiftTable: string;
   redshiftSchema: string;
+  opensearchEndpoint: string;
+  opensearchIndex: string;
   sqsQueueUrl: string;
   sqsDeleteAfterRead: boolean;
   athenaDatabase: string;
@@ -282,6 +284,8 @@ export const DEFAULT_SETTINGS: Settings = {
   redshiftDatabase: "dev",
   redshiftTable: "workflow_insight",
   redshiftSchema: "public",
+  opensearchEndpoint: "",
+  opensearchIndex: "workflow-insight",
   sqsQueueUrl: "",
   sqsDeleteAfterRead: false,
   athenaDatabase: "",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/example-function/index.ts
@@ -9,6 +9,7 @@ import {
   DynamoDBExporter,
   AuroraExporter,
   RedshiftExporter,
+  OpenSearchExporter,
   SQSExporter,
   S3Exporter,
 } from "@aws/durable-execution-sdk-js-insight";
@@ -60,6 +61,15 @@ const exporters = [
           table: process.env.INSIGHT_REDSHIFT_TABLE ?? "workflow_insight",
           schema: process.env.INSIGHT_REDSHIFT_SCHEMA ?? "public",
           region: process.env.AWS_REGION,
+        }),
+      ]
+    : []),
+  ...(process.env.INSIGHT_OPENSEARCH_ENDPOINT
+    ? [
+        new OpenSearchExporter({
+          endpoint: process.env.INSIGHT_OPENSEARCH_ENDPOINT,
+          indexName: process.env.INSIGHT_OPENSEARCH_INDEX ?? "workflow-insight",
+          region: process.env.AWS_REGION!,
         }),
       ]
     : []),

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -482,6 +482,7 @@ export class InsightDestinationsStack extends cdk.Stack {
     }
 
     // --- OpenSearch ---
+    let openSearchEndpoint: string | undefined;
     if (config.destinations.opensearch.enabled) {
       const domain = new opensearch.Domain(this, "InsightOpenSearch", {
         domainName: config.destinations.opensearch.domainName,
@@ -528,6 +529,13 @@ export class InsightDestinationsStack extends cdk.Stack {
           resources: [`${domain.domainArn}/*`],
         }),
       );
+
+      // Endpoint (hostname, no scheme) — exposed to the example function so its
+      // OpenSearchExporter can index records, and output for the extension.
+      openSearchEndpoint = domain.domainEndpoint;
+      new cdk.CfnOutput(this, "OpenSearchEndpoint", {
+        value: `https://${domain.domainEndpoint}`,
+      });
     }
 
     // --- Firehose ---
@@ -672,6 +680,12 @@ export class InsightDestinationsStack extends cdk.Stack {
           config.destinations.redshift.databaseName;
         envVars.INSIGHT_REDSHIFT_TABLE = config.destinations.redshift.tableName;
         envVars.INSIGHT_REDSHIFT_SCHEMA = config.destinations.redshift.schema;
+      }
+      if (config.destinations.opensearch.enabled && openSearchEndpoint) {
+        // OpenSearchExporter signs requests with SigV4 using the function's
+        // role (granted es:ESHttpPut/Post above and allow-listed in the domain
+        // access policy). Endpoint needs the https:// scheme.
+        envVars.INSIGHT_OPENSEARCH_ENDPOINT = `https://${openSearchEndpoint}`;
       }
 
       const exampleFn = new lambdaNode.NodejsFunction(

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.ts
@@ -86,7 +86,15 @@ export class OpenSearchExporter implements InsightExporter {
 
     if (this.auth === "sigv4") {
       const signed = await this.signRequest(url, body);
-      fetchHeaders = { ...headers, ...signed.headers };
+      // Use the signed header set verbatim. Do NOT merge the pre-signing
+      // `headers` on top: that object carries a capital-cased "Content-Type"
+      // while SignatureV4 emits a lowercase "content-type" it included in the
+      // signature. Sending both makes fetch/undici collapse them
+      // case-insensitively into a duplicated value that no longer matches the
+      // canonical request SigV4 signed — OpenSearch then rejects it with 403
+      // Forbidden. signed.headers already includes content-type + host + the
+      // auth/date/security-token headers, so it is complete on its own.
+      fetchHeaders = signed.headers;
       fetchUrl = signed.url;
     }
 
@@ -97,8 +105,9 @@ export class OpenSearchExporter implements InsightExporter {
     });
 
     if (!response.ok && response.status !== 201 && response.status !== 200) {
+      const detail = await response.text().catch(() => "");
       throw new Error(
-        `OpenSearch index failed: ${response.status} ${response.statusText}`,
+        `OpenSearch index failed: ${response.status} ${response.statusText}${detail ? ` — ${detail.slice(0, 500)}` : ""}`,
       );
     }
   }


### PR DESCRIPTION
Adds Amazon OpenSearch as a queryable destination in the Workflow Insight VS Code extension, alongside DynamoDB / Aurora / Redshift / S3-Athena / CloudWatch Logs. OpenSearch isn't SQL-native and Amazon OpenSearch Service requires SigV4-signed HTTPS, so this uses the OpenSearch SQL plugin for tabular queries.

- New src/opensearch.ts: runOpenSearchQuery (POST _plugins/_sql, normalizes {schema, datarows} to the shared result shape), fetchOpenSearchRecord (direct GET <index>/_doc/<executionArn> for the row drill-down), and pingOpenSearch (connectivity probe). All requests are SigV4-signed (service "es") with @smithy/signature-v4 + @aws-crypto/sha256-js over native fetch, using the extension's resolved credentials.
- schema.ts: new "opensearch" DestinationType and an OpenSearch-SQL prompt (record schema, dialect, few-shots). The index name is hyphenated so it is backtick-quoted; string fields are queried by plain name (the SQL plugin does NOT expose the .keyword multifield); the operations array-of-objects cannot be unnested via the SQL plugin.
- config.ts / package.json settings: opensearchEndpoint + opensearchIndex. Wired through extension.ts (query + record-fetch routing, index as table name) and destinationTest.ts (SigV4 ping). Settings webview updated (SettingsModal, types, starter query). Adds @smithy/signature-v4 + @aws-crypto/sha256-js deps.

Example CDK stack + exporter fixes (validated end-to-end against a live OpenSearch Service domain):

- OpenSearchExporter: send the SigV4-signed header set verbatim instead of merging a capital-cased "Content-Type" on top of the signer's lowercase "content-type". Sending both makes fetch collapse them case-insensitively into a value that no longer matches the canonical request SigV4 signed, so the domain rejected every index request with 403 Forbidden (silent, since the plugin runs exporters best-effort). Also include the response body in the thrown error so future failures are diagnosable.
- stack.ts: pass the domain endpoint to the example function (hoisted so the env var can be set) and output it, so the example function's OpenSearchExporter indexes records.

Tests: unit tests for runOpenSearchQuery/fetchOpenSearchRecord/pingOpenSearch (mocked signer + fetch: normalization, error surfacing, 404, _source flatten) and extended config/destinationTest coverage.
