### PR TITLE
chore(sdk): Workflow Insight follow-ups - exporter tests, Redshift timestamptz, docs

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/src/schema.ts
@@ -300,11 +300,11 @@ const RECORD_SCHEMA_REDSHIFT = `Records are stored in an Amazon Redshift table "
 - execution_name: VARCHAR(256)
 - function_name: VARCHAR(128)
 - status: VARCHAR(20) — values: RUNNING, SUCCEEDED, FAILED
-- start_time: VARCHAR(30) (ISO-8601 string, NOT a native timestamp)
-- end_time: VARCHAR(30) (ISO-8601 string, NULL if still running)
+- start_time: TIMESTAMPTZ (native timestamp)
+- end_time: TIMESTAMPTZ (NULL if still running)
 - duration_ms: BIGINT (NULL if still running)
 - record_json: SUPER — full WorkflowInsightRecord as semi-structured JSON
-- emitted_at: VARCHAR(30) (ISO-8601 string)
+- emitted_at: TIMESTAMPTZ
 
 The record_json SUPER column contains the full record. The workgroup has
 enable_case_sensitive_identifier=true, and the stored JSON keys are camelCase,
@@ -330,9 +330,8 @@ fields they want — do not assume the structure.`;
 
 const DIALECT_REDSHIFT = `Target query language: Amazon Redshift SQL (with PartiQL for SUPER navigation).
 - Table name is TABLE_NAME.
-- Time columns (start_time, end_time, emitted_at) are ISO-8601 STRINGS, not
-  native timestamps. Compare them lexically (ISO-8601 sorts chronologically), or
-  cast with (start_time::timestamptz) when you need date math like NOW()/INTERVAL.
+- Time columns (start_time, end_time, emitted_at) are native TIMESTAMPTZ — use
+  directly with NOW(), INTERVAL, DATE_TRUNC, and comparisons for date math.
 - record_json is SUPER — navigate with dot/bracket paths and UNNEST arrays by
   joining them as a table alias (FROM tbl t, t.record_json."operations" o). The
   JSON keys are camelCase and case-sensitive identifiers are ON, so ALWAYS

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/stack.ts
@@ -400,11 +400,11 @@ export class InsightDestinationsStack extends cdk.Stack {
           execution_name VARCHAR(256),
           function_name VARCHAR(128),
           status VARCHAR(20),
-          start_time VARCHAR(30),
-          end_time VARCHAR(30),
+          start_time TIMESTAMPTZ,
+          end_time TIMESTAMPTZ,
           duration_ms BIGINT,
           record_json SUPER,
-          emitted_at VARCHAR(30)
+          emitted_at TIMESTAMPTZ
         );
         GRANT ALL ON ${fqTable} TO PUBLIC;
       `;

--- a/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/remaining-tasks.md
@@ -131,7 +131,9 @@
 - [x] Unit tests for sampling logic (including replay determinism) — covers
       rate 0 / 1 / omitted, fractional partitioning, invocationId-independence
       (replay stability), stable re-runs, and out-of-range/NaN clamping.
-- [ ] Unit tests for each exporter (mock SDK clients, verify correct API calls)
+- [x] Unit tests for each exporter (mock SDK clients, verify correct API calls) —
+      colocated `*-exporter.test.ts` for all 12 first-party exporters (happy path + one nuance each: SQL dialect, upsert vs history, FIFO, NDJSON, SigV4/basic,
+      OTLP shape, timestamptz MERGE, partitioning, ndjson/json, etc.)
 - [ ] Integration test with the testing SDK (end-to-end plugin lifecycle)
 - [x] Verified end-to-end on deployed Lambda (account 730758745077, `insight-demo-scheduled`)
 
@@ -155,10 +157,12 @@
 - [x] Time range inferred from question by Bedrock
 - [x] Self-correction loop (retry with error feedback on MalformedQueryException)
 - [x] TESTING.md step-by-step guide
-- [ ] Support additional query providers (S3/Athena, DynamoDB)
-- [ ] Model provider abstraction (local LLM option)
-- [ ] Query history and saved queries
-- [ ] CSV export
+- [x] Support additional query providers — S3/Athena, DynamoDB, Aurora,
+      Redshift, and OpenSearch are all supported query destinations now
+- [x] Model provider abstraction — `llmProvider` supports bedrock, GitHub Copilot,
+      local (in-process), and local-server (OpenAI-compatible) options
+- [x] Query history and saved queries
+- [x] CSV export
 
 ## Known Limitations (document, not necessarily fix)
 
@@ -170,6 +174,7 @@
       README (content caveat), `OperationOverride.result` JSDoc, and plugin-contracts.
 - [ ] Document no coverage for backend-initiated events (`STOPPED`, `TIMED_OUT`);
       customers must subscribe to EventBridge lifecycle events themselves
-- [ ] `RedshiftExporter` stores time fields as `VARCHAR(30)` — needs `::timestamptz`
-      casts in the MERGE SQL (same fix applied to AuroraExporter). Fix when adding
-      Redshift to the VS Code extension query providers.
+- [x] `RedshiftExporter` now stores time fields as `TIMESTAMPTZ` (table DDL) and
+      casts `:start_time::timestamptz` / `:end_time::timestamptz` /
+      `:emitted_at::timestamptz` in the MERGE SQL, mirroring AuroraExporter — so
+      date math works natively in the VS Code extension's Redshift queries.

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.test.ts
@@ -1,0 +1,125 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-rds-data", () => ({
+  RDSDataClient: jest.fn(() => ({ send: mockSend })),
+  ExecuteStatementCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { AuroraExporter } from "./aurora-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("AuroraExporter", () => {
+  it("upserts via the postgres dialect with typed casts and bound parameters", async () => {
+    const exporter = new AuroraExporter({
+      resourceArn: "arn:aws:rds:us-east-1:123456789012:cluster:c1",
+      secretArn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:s1",
+      database: "insight",
+      engine: "postgresql",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.database).toBe("insight");
+    expect(input.sql).toContain("INSERT INTO workflow_insight");
+    expect(input.sql).toContain("ON CONFLICT (execution_arn) DO UPDATE");
+    expect(input.sql).toContain("::timestamptz");
+    expect(input.sql).toContain("::jsonb");
+
+    const params = Object.fromEntries(
+      input.parameters.map((p: { name: string; value: unknown }) => [
+        p.name,
+        p.value,
+      ]),
+    );
+    expect(params.execution_arn).toEqual({
+      stringValue: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    });
+    expect(params.record_json.stringValue).toContain('"recordType"');
+  });
+
+  it("uses the mysql dialect (ON DUPLICATE KEY, no casts) for engine mysql", async () => {
+    const exporter = new AuroraExporter({
+      resourceArn: "arn:aws:rds:us-east-1:123456789012:cluster:c1",
+      secretArn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:s1",
+      database: "insight",
+      engine: "mysql",
+      table: "custom_table",
+    });
+
+    await exporter.export(makeRecord());
+
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.sql).toContain("INSERT INTO custom_table");
+    expect(input.sql).toContain("ON DUPLICATE KEY UPDATE");
+    expect(input.sql).not.toContain("::timestamptz");
+    expect(input.sql).not.toContain("ON CONFLICT");
+  });
+
+  it("emits isNull for absent nullable fields", async () => {
+    const exporter = new AuroraExporter({
+      resourceArn: "arn:aws:rds:us-east-1:123456789012:cluster:c1",
+      secretArn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:s1",
+      database: "insight",
+      engine: "postgresql",
+    });
+
+    await exporter.export(
+      makeRecord({
+        executionName: undefined,
+        endTime: undefined,
+        durationMs: undefined,
+      }),
+    );
+
+    const input = mockSend.mock.calls[0][0].__input;
+    const params = Object.fromEntries(
+      input.parameters.map((p: { name: string; value: unknown }) => [
+        p.name,
+        p.value,
+      ]),
+    );
+    expect(params.execution_name).toEqual({ isNull: true });
+    expect(params.end_time).toEqual({ isNull: true });
+    expect(params.duration_ms).toEqual({ isNull: true });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/aurora-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-rds-data", () => ({
 }));
 
 import { AuroraExporter } from "./aurora-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockSend.mockReset();

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.test.ts
@@ -15,39 +15,7 @@ jest.mock("@aws-sdk/client-cloudwatch-logs", () => ({
 
 import { CloudWatchLogsExporter } from "./cloudwatch-logs-exporter";
 import { ResourceAlreadyExistsException } from "@aws-sdk/client-cloudwatch-logs";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 function callsByType(type: string): unknown[] {
   return mockSend.mock.calls.filter((c) => c[0].__type === type);

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/cloudwatch-logs-exporter.test.ts
@@ -1,0 +1,129 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-cloudwatch-logs", () => ({
+  CloudWatchLogsClient: jest.fn(() => ({ send: mockSend })),
+  PutLogEventsCommand: jest.fn((input: unknown) => ({
+    __type: "put",
+    __input: input,
+  })),
+  CreateLogStreamCommand: jest.fn((input: unknown) => ({
+    __type: "create",
+    __input: input,
+  })),
+  ResourceAlreadyExistsException: class ResourceAlreadyExistsException extends Error {},
+}));
+
+import { CloudWatchLogsExporter } from "./cloudwatch-logs-exporter";
+import { ResourceAlreadyExistsException } from "@aws-sdk/client-cloudwatch-logs";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function callsByType(type: string): unknown[] {
+  return mockSend.mock.calls.filter((c) => c[0].__type === type);
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("CloudWatchLogsExporter", () => {
+  it("creates the dated stream then writes an operationsByName-rendered event", async () => {
+    const exporter = new CloudWatchLogsExporter({
+      logGroupName: "/insight/records",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    const creates = callsByType("create");
+    const puts = callsByType("put");
+    expect(creates).toHaveLength(1);
+    expect(puts).toHaveLength(1);
+
+    const createInput = (
+      creates[0] as [
+        { __input: { logStreamName: string; logGroupName: string } },
+      ]
+    )[0].__input;
+    expect(createInput.logGroupName).toBe("/insight/records");
+    expect(createInput.logStreamName).toMatch(
+      /^workflow-insight\/\d{4}\/\d{2}\/\d{2}$/,
+    );
+
+    const putInput = (
+      puts[0] as [
+        {
+          __input: { logStreamName: string; logEvents: { message: string }[] };
+        },
+      ]
+    )[0].__input;
+    expect(putInput.logStreamName).toBe(createInput.logStreamName);
+    const message = JSON.parse(putInput.logEvents[0].message);
+    // render = withOperationsByName replaces the array with a name-keyed map.
+    expect(message.operationsByName["fetch-user"].count).toBe(1);
+    expect(message.operations).toBeUndefined();
+  });
+
+  it("creates the stream only once across multiple exports (cache)", async () => {
+    const exporter = new CloudWatchLogsExporter({
+      logGroupName: "/insight/records",
+    });
+
+    await exporter.export(makeRecord());
+    await exporter.export(makeRecord());
+
+    expect(callsByType("create")).toHaveLength(1);
+    expect(callsByType("put")).toHaveLength(2);
+  });
+
+  it("swallows ResourceAlreadyExistsException from CreateLogStream", async () => {
+    const exporter = new CloudWatchLogsExporter({
+      logGroupName: "/insight/records",
+    });
+
+    mockSend.mockImplementation(async (cmd: { __type: string }) => {
+      if (cmd.__type === "create") {
+        const RAE = ResourceAlreadyExistsException as unknown as new (
+          message: string,
+        ) => Error;
+        throw new RAE("exists");
+      }
+      return {};
+    });
+
+    await expect(exporter.export(makeRecord())).resolves.toBeUndefined();
+    expect(callsByType("put")).toHaveLength(1);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.test.ts
@@ -1,0 +1,89 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+  PutItemCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+jest.mock("@aws-sdk/util-dynamodb", () => ({
+  // Pass the item through untouched so tests can inspect the raw shape.
+  marshall: jest.fn((item: unknown) => item),
+}));
+
+import { DynamoDBExporter } from "./dynamodb-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("DynamoDBExporter", () => {
+  it("writes history items keyed by pk=executionArn and sk=emittedAt", async () => {
+    const exporter = new DynamoDBExporter({
+      tableName: "insight",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.TableName).toBe("insight");
+    expect(input.Item.pk).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(input.Item.sk).toBe("2026-07-15T12:00:00.000Z");
+    // render/withOperationsByName folds the operations array into a map.
+    expect(input.Item.operationsByName["fetch-user"].count).toBe(1);
+    expect(input.Item.operations).toBeUndefined();
+  });
+
+  it("upserts (no sort key) when sortKey is disabled and honors a custom partition key", async () => {
+    const exporter = new DynamoDBExporter({
+      tableName: "insight",
+      partitionKey: "executionArnKey",
+      sortKey: "",
+    });
+
+    await exporter.export(makeRecord());
+
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.Item.executionArnKey).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(input.Item.sk).toBeUndefined();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/dynamodb-exporter.test.ts
@@ -11,39 +11,7 @@ jest.mock("@aws-sdk/util-dynamodb", () => ({
 }));
 
 import { DynamoDBExporter } from "./dynamodb-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockSend.mockReset();

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-eventbridge", () => ({
 }));
 
 import { EventBridgeExporter } from "./eventbridge-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockSend.mockReset();

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/eventbridge-exporter.test.ts
@@ -1,0 +1,97 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-eventbridge", () => ({
+  EventBridgeClient: jest.fn(() => ({ send: mockSend })),
+  PutEventsCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { EventBridgeExporter } from "./eventbridge-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({ FailedEntryCount: 0 });
+});
+
+describe("EventBridgeExporter", () => {
+  it("publishes a single event with status DetailType and the record as Detail", async () => {
+    const exporter = new EventBridgeExporter({ region: "us-east-1" });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const entry = mockSend.mock.calls[0][0].__input.Entries[0];
+    expect(entry.EventBusName).toBe("default");
+    expect(entry.Source).toBe("aws.durable-execution.insight");
+    expect(entry.DetailType).toBe("SUCCEEDED");
+    const detail = JSON.parse(entry.Detail);
+    expect(detail.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    // Default operationsFormat is "array".
+    expect(Array.isArray(detail.operations)).toBe(true);
+  });
+
+  it("renders operationsByName when operationsFormat is by-name and uses a custom bus/source", async () => {
+    const exporter = new EventBridgeExporter({
+      eventBusName: "insight-bus",
+      source: "my.source",
+      operationsFormat: "by-name",
+    });
+
+    await exporter.export(makeRecord());
+
+    const entry = mockSend.mock.calls[0][0].__input.Entries[0];
+    expect(entry.EventBusName).toBe("insight-bus");
+    expect(entry.Source).toBe("my.source");
+    const detail = JSON.parse(entry.Detail);
+    expect(detail.operations).toBeUndefined();
+    expect(detail.operationsByName["fetch-user"].count).toBe(1);
+  });
+
+  it("throws when PutEvents reports a failed entry", async () => {
+    mockSend.mockResolvedValue({
+      FailedEntryCount: 1,
+      Entries: [
+        { ErrorCode: "ThrottlingException", ErrorMessage: "slow down" },
+      ],
+    });
+    const exporter = new EventBridgeExporter();
+
+    await expect(exporter.export(makeRecord())).rejects.toThrow(
+      /ThrottlingException/,
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.test.ts
@@ -1,0 +1,90 @@
+const mockAppendFile = jest.fn();
+const mockWriteFile = jest.fn();
+const mockMkdir = jest.fn();
+
+jest.mock("node:fs/promises", () => ({
+  appendFile: (...args: unknown[]): unknown => mockAppendFile(...args),
+  writeFile: (...args: unknown[]): unknown => mockWriteFile(...args),
+  mkdir: (...args: unknown[]): unknown => mockMkdir(...args),
+}));
+
+import { FileExporter } from "./file-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockAppendFile.mockReset().mockResolvedValue(undefined);
+  mockWriteFile.mockReset().mockResolvedValue(undefined);
+  mockMkdir.mockReset().mockResolvedValue(undefined);
+});
+
+describe("FileExporter", () => {
+  it("appends a date-partitioned NDJSON line by default", async () => {
+    const exporter = new FileExporter({ directory: "/tmp/insight" });
+
+    await exporter.export(makeRecord());
+
+    expect(mockMkdir).toHaveBeenCalledWith("/tmp/insight", {
+      recursive: true,
+    });
+    expect(mockAppendFile).toHaveBeenCalledTimes(1);
+    const [filePath, content, encoding] = mockAppendFile.mock.calls[0];
+    expect(filePath).toBe("/tmp/insight/2026-07-15.ndjson");
+    expect(encoding).toBe("utf-8");
+    expect(content.endsWith("\n")).toBe(true);
+    const parsed = JSON.parse(content.trimEnd());
+    expect(parsed.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(Array.isArray(parsed.operations)).toBe(true);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("writes one pretty-printed JSON file per execution in json mode", async () => {
+    const exporter = new FileExporter({
+      directory: "/tmp/insight",
+      mode: "json",
+    });
+
+    await exporter.export(makeRecord({ executionName: "my-exec" }));
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [filePath, content] = mockWriteFile.mock.calls[0];
+    expect(filePath).toBe("/tmp/insight/my-exec.json");
+    // Pretty printed with 2-space indentation.
+    expect(content).toContain("\n  ");
+    expect(JSON.parse(content).executionName).toBe("my-exec");
+    expect(mockAppendFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/file-exporter.test.ts
@@ -9,39 +9,7 @@ jest.mock("node:fs/promises", () => ({
 }));
 
 import { FileExporter } from "./file-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockAppendFile.mockReset().mockResolvedValue(undefined);

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-firehose", () => ({
 }));
 
 import { FirehoseExporter } from "./firehose-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 function decode(data: Uint8Array): string {
   return new TextDecoder().decode(data);

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/firehose-exporter.test.ts
@@ -1,0 +1,90 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-firehose", () => ({
+  FirehoseClient: jest.fn(() => ({ send: mockSend })),
+  PutRecordCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { FirehoseExporter } from "./firehose-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function decode(data: Uint8Array): string {
+  return new TextDecoder().decode(data);
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("FirehoseExporter", () => {
+  it("puts a single NDJSON record with a trailing newline", async () => {
+    const exporter = new FirehoseExporter({
+      deliveryStreamName: "insight-stream",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.DeliveryStreamName).toBe("insight-stream");
+
+    const text = decode(input.Record.Data);
+    expect(text.endsWith("\n")).toBe(true);
+    // Exactly one JSON object followed by the delimiter (NDJSON friendly).
+    expect(text.trimEnd().split("\n")).toHaveLength(1);
+    const parsed = JSON.parse(text);
+    expect(parsed.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(Array.isArray(parsed.operations)).toBe(true);
+  });
+
+  it("renders operationsByName when operationsFormat is by-name", async () => {
+    const exporter = new FirehoseExporter({
+      deliveryStreamName: "insight-stream",
+      operationsFormat: "by-name",
+    });
+
+    await exporter.export(makeRecord());
+
+    const parsed = JSON.parse(
+      decode(mockSend.mock.calls[0][0].__input.Record.Data),
+    );
+    expect(parsed.operations).toBeUndefined();
+    expect(parsed.operationsByName["fetch-user"].count).toBe(1);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.test.ts
@@ -1,0 +1,88 @@
+import { HttpExporter } from "./http-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => "",
+  });
+});
+
+describe("HttpExporter", () => {
+  it("POSTs the record as JSON with a Content-Type header by default", async () => {
+    const exporter = new HttpExporter({ url: "https://hook.example/insight" });
+
+    await exporter.export(makeRecord());
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe("https://hook.example/insight");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(init.body);
+    expect(body.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(Array.isArray(body.operations)).toBe(true);
+  });
+
+  it("uses PUT and merges custom headers when configured", async () => {
+    const exporter = new HttpExporter({
+      url: "https://hook.example/insight",
+      method: "PUT",
+      headers: { Authorization: "Bearer token123" },
+    });
+
+    await exporter.export(makeRecord());
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.method).toBe("PUT");
+    expect(init.headers.Authorization).toBe("Bearer token123");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("throws when the endpoint returns a non-2xx status", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: async () => "",
+    });
+    const exporter = new HttpExporter({ url: "https://hook.example/insight" });
+
+    await expect(exporter.export(makeRecord())).rejects.toThrow(/500/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/http-exporter.test.ts
@@ -1,37 +1,5 @@
 import { HttpExporter } from "./http-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.test.ts
@@ -1,0 +1,121 @@
+// Mock SigV4 signing + crypto + credential provider so no real credentials are
+// needed; capture the signed request shape. fetch is stubbed per test.
+const signMock = jest.fn().mockResolvedValue({
+  headers: {
+    authorization: "AWS4-HMAC-SHA256 ...",
+    host: "d.us-east-1.es.amazonaws.com",
+    "content-type": "application/json",
+  },
+});
+
+jest.mock("@smithy/signature-v4", () => ({
+  SignatureV4: jest.fn().mockImplementation(() => ({ sign: signMock })),
+}));
+jest.mock("@aws-crypto/sha256-js", () => ({ Sha256: jest.fn() }));
+jest.mock("@aws-sdk/credential-provider-node", () => ({
+  defaultProvider: jest.fn(() => jest.fn()),
+}));
+
+import { OpenSearchExporter } from "./opensearch-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  signMock.mockClear();
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => "",
+  });
+});
+
+describe("OpenSearchExporter", () => {
+  it("PUTs the record to the _doc endpoint keyed by the encoded executionArn (sigv4)", async () => {
+    const exporter = new OpenSearchExporter({
+      endpoint: "https://d.us-east-1.es.amazonaws.com/",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(signMock).toHaveBeenCalledTimes(1);
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(
+      "https://d.us-east-1.es.amazonaws.com/workflow-insight/_doc/" +
+        encodeURIComponent(
+          "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+        ),
+    );
+    expect(init.method).toBe("PUT");
+    // Signed header set is used verbatim.
+    expect(init.headers.authorization).toContain("AWS4-HMAC-SHA256");
+    expect(JSON.parse(init.body).executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+  });
+
+  it("uses HTTP basic auth without signing when auth is basic", async () => {
+    const exporter = new OpenSearchExporter({
+      endpoint: "https://d.us-east-1.es.amazonaws.com",
+      region: "us-east-1",
+      auth: "basic",
+      username: "admin",
+      password: "secret",
+      indexName: "custom-index",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(signMock).not.toHaveBeenCalled();
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain("/custom-index/_doc/");
+    expect(init.headers.Authorization).toBe("Basic " + btoa("admin:secret"));
+  });
+
+  it("throws with detail on a non-ok response", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => "denied",
+    });
+    const exporter = new OpenSearchExporter({
+      endpoint: "https://d.us-east-1.es.amazonaws.com",
+      region: "us-east-1",
+    });
+
+    await expect(exporter.export(makeRecord())).rejects.toThrow(/403/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/opensearch-exporter.test.ts
@@ -17,39 +17,7 @@ jest.mock("@aws-sdk/credential-provider-node", () => ({
 }));
 
 import { OpenSearchExporter } from "./opensearch-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   signMock.mockClear();

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.test.ts
@@ -1,37 +1,5 @@
 import { OTelExporter } from "./otel-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/otel-exporter.test.ts
@@ -1,0 +1,103 @@
+import { OTelExporter } from "./otel-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => "",
+  });
+});
+
+describe("OTelExporter", () => {
+  it("POSTs an OTLP ExportLogsServiceRequest with the record embedded in the log body", async () => {
+    const exporter = new OTelExporter({
+      endpoint: "https://otlp.vendor.com/v1/logs",
+      headers: { "x-api-key": "k" },
+    });
+
+    await exporter.export(makeRecord());
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe("https://otlp.vendor.com/v1/logs");
+    expect(init.method).toBe("POST");
+    expect(init.headers["x-api-key"]).toBe("k");
+
+    const payload = JSON.parse(init.body);
+    const logRecord = payload.resourceLogs[0].scopeLogs[0].logRecords[0];
+    // SUCCEEDED maps to severity INFO (9).
+    expect(logRecord.severityNumber).toBe(9);
+    expect(logRecord.severityText).toBe("SUCCEEDED");
+    const body = JSON.parse(logRecord.body.stringValue);
+    expect(body.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    const attrs = Object.fromEntries(
+      logRecord.attributes.map((a: { key: string; value: unknown }) => [
+        a.key,
+        a.value,
+      ]),
+    );
+    expect(attrs["workflow.execution_arn"]).toEqual({
+      stringValue: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    });
+  });
+
+  it("maps a FAILED execution to ERROR severity (17)", async () => {
+    const exporter = new OTelExporter({
+      endpoint: "https://otlp.vendor.com/v1/logs",
+    });
+
+    await exporter.export(makeRecord({ status: "FAILED" }));
+
+    const payload = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body,
+    );
+    const logRecord = payload.resourceLogs[0].scopeLogs[0].logRecords[0];
+    expect(logRecord.severityNumber).toBe(17);
+    expect(logRecord.severityText).toBe("FAILED");
+  });
+
+  it("rejects the unsupported http/protobuf protocol at construction", () => {
+    expect(
+      () =>
+        new OTelExporter({
+          endpoint: "https://otlp.vendor.com/v1/logs",
+          protocol: "http/protobuf",
+        }),
+    ).toThrow(/http\/protobuf/);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-redshift-data", () => ({
 }));
 
 import { RedshiftExporter } from "./redshift-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 function paramMap(
   params: { name: string; value: unknown }[],

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.test.ts
@@ -1,0 +1,121 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-redshift-data", () => ({
+  RedshiftDataClient: jest.fn(() => ({ send: mockSend })),
+  ExecuteStatementCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { RedshiftExporter } from "./redshift-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function paramMap(
+  params: { name: string; value: unknown }[],
+): Record<string, unknown> {
+  return Object.fromEntries(params.map((p) => [p.name, p.value]));
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("RedshiftExporter", () => {
+  it("upserts via a MERGE that joins on a source-column subquery with typed casts", async () => {
+    const exporter = new RedshiftExporter({
+      workgroupName: "insight-wg",
+      database: "insight",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.WorkgroupName).toBe("insight-wg");
+    expect(input.Database).toBe("insight");
+
+    const sql = input.Sql;
+    expect(sql).toContain("MERGE INTO public.workflow_insight");
+    // Joins on the projected source column, NOT a bound parameter/constant.
+    expect(sql).toContain("src.execution_arn");
+    expect(sql).toContain(
+      "ON public.workflow_insight.execution_arn = src.execution_arn",
+    );
+    expect(sql).not.toContain("USING (SELECT 1)");
+    // Time fields cast to timestamptz; SUPER column via JSON_PARSE.
+    expect(sql).toContain(":start_time::timestamptz");
+    expect(sql).toContain(":emitted_at::timestamptz");
+    expect(sql).toContain("JSON_PARSE(:record_json)");
+
+    const params = paramMap(input.Parameters);
+    expect(params.execution_arn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(params.end_time).toBe("2026-07-15T12:00:00.000Z");
+  });
+
+  it("emits typed NULL literals (not bound params) for absent nullable fields", async () => {
+    const exporter = new RedshiftExporter({
+      clusterIdentifier: "insight-cluster",
+      database: "insight",
+      dbUser: "admin",
+    });
+
+    await exporter.export(
+      makeRecord({
+        endTime: undefined,
+        durationMs: undefined,
+        executionName: undefined,
+      }),
+    );
+
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.ClusterIdentifier).toBe("insight-cluster");
+    expect(input.Sql).toContain("NULL::timestamptz AS end_time");
+    expect(input.Sql).toContain("NULL::bigint AS duration_ms");
+    expect(input.Sql).toContain("NULL::varchar AS execution_name");
+
+    const params = paramMap(input.Parameters);
+    expect(params.end_time).toBeUndefined();
+    expect(params.duration_ms).toBeUndefined();
+    expect(params.execution_name).toBeUndefined();
+  });
+
+  it("throws when neither workgroupName nor clusterIdentifier is provided", () => {
+    expect(() => new RedshiftExporter({ database: "insight" })).toThrow(
+      /workgroupName or clusterIdentifier/,
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/redshift-exporter.ts
@@ -120,8 +120,8 @@ export class RedshiftExporter implements InsightExporter {
     // in the source projection instead of bound parameters.
     const endTimeSel = record.endTime
       ? (parameters.push({ name: "end_time", value: record.endTime }),
-        ":end_time::varchar")
-      : "NULL::varchar";
+        ":end_time::timestamptz")
+      : "NULL::timestamptz";
     const durationSel =
       record.durationMs != null
         ? (parameters.push({
@@ -143,18 +143,20 @@ export class RedshiftExporter implements InsightExporter {
     // equality join on a SOURCE COLUMN (joining on a parameter/constant makes it
     // plan a NestedLoop join, which MERGE rejects with "NestedLoop join is not
     // supported in MERGE"). record_json is populated with JSON_PARSE(...) so it
-    // lands in the SUPER column.
+    // lands in the SUPER column. Time fields are cast to timestamptz to match
+    // the TIMESTAMPTZ table columns (ISO-8601 strings parse cleanly), so date
+    // math works natively — mirrors AuroraExporter.
     const sql = `MERGE INTO ${this.fqTable} USING (
       SELECT
         :execution_arn::varchar AS execution_arn,
         ${execNameSel} AS execution_name,
         :function_name::varchar AS function_name,
         :status::varchar AS status,
-        :start_time::varchar AS start_time,
+        :start_time::timestamptz AS start_time,
         ${endTimeSel} AS end_time,
         ${durationSel} AS duration_ms,
         JSON_PARSE(:record_json) AS record_json,
-        :emitted_at::varchar AS emitted_at
+        :emitted_at::timestamptz AS emitted_at
     ) AS src
     ON ${this.fqTable}.execution_arn = src.execution_arn
     WHEN MATCHED THEN UPDATE SET

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.test.ts
@@ -1,0 +1,94 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn(() => ({ send: mockSend })),
+  PutObjectCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { S3Exporter } from "./s3-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "my-exec",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-06-16T11:59:00.000Z",
+    endTime: "2026-06-16T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("S3Exporter", () => {
+  it("writes a Hive-partitioned, execution-named JSON object by default (date partitioning)", async () => {
+    const exporter = new S3Exporter({
+      bucket: "insight-bucket",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.Bucket).toBe("insight-bucket");
+    expect(input.ContentType).toBe("application/json");
+    // startTime = 2026-06-16 → year=2026/month=06/day=16 partition.
+    expect(input.Key).toBe(
+      "workflow-insight/year=2026/month=06/day=16/my-exec.json",
+    );
+    expect(JSON.parse(input.Body).executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+  });
+
+  it("partitions by function name when configured", async () => {
+    const exporter = new S3Exporter({
+      bucket: "insight-bucket",
+      partitioning: "function-name",
+      prefix: "wi/",
+    });
+
+    await exporter.export(makeRecord());
+
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.Key).toBe("wi/function=fn/my-exec.json");
+  });
+
+  it("writes flat under the prefix when partitioning is none", async () => {
+    const exporter = new S3Exporter({
+      bucket: "insight-bucket",
+      partitioning: "none",
+    });
+
+    await exporter.export(makeRecord());
+
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.Key).toBe("workflow-insight/my-exec.json");
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/s3-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-s3", () => ({
 }));
 
 import { S3Exporter } from "./s3-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "my-exec",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-06-16T11:59:00.000Z",
-    endTime: "2026-06-16T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockSend.mockReset();
@@ -52,7 +20,13 @@ describe("S3Exporter", () => {
       region: "us-east-1",
     });
 
-    await exporter.export(makeRecord());
+    await exporter.export(
+      makeRecord({
+        executionName: "my-exec",
+        startTime: "2026-06-16T11:59:00.000Z",
+        endTime: "2026-06-16T12:00:00.000Z",
+      }),
+    );
 
     expect(mockSend).toHaveBeenCalledTimes(1);
     const input = mockSend.mock.calls[0][0].__input;
@@ -74,7 +48,13 @@ describe("S3Exporter", () => {
       prefix: "wi/",
     });
 
-    await exporter.export(makeRecord());
+    await exporter.export(
+      makeRecord({
+        executionName: "my-exec",
+        startTime: "2026-06-16T11:59:00.000Z",
+        endTime: "2026-06-16T12:00:00.000Z",
+      }),
+    );
 
     const input = mockSend.mock.calls[0][0].__input;
     expect(input.Key).toBe("wi/function=fn/my-exec.json");
@@ -86,7 +66,13 @@ describe("S3Exporter", () => {
       partitioning: "none",
     });
 
-    await exporter.export(makeRecord());
+    await exporter.export(
+      makeRecord({
+        executionName: "my-exec",
+        startTime: "2026-06-16T11:59:00.000Z",
+        endTime: "2026-06-16T12:00:00.000Z",
+      }),
+    );
 
     const input = mockSend.mock.calls[0][0].__input;
     expect(input.Key).toBe("workflow-insight/my-exec.json");

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.test.ts
@@ -1,0 +1,101 @@
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: jest.fn(() => ({ send: mockSend })),
+  SendMessageCommand: jest.fn((input: unknown) => ({ __input: input })),
+}));
+
+import { SQSExporter } from "./sqs-exporter";
+import type { WorkflowInsightRecord } from "../types";
+
+function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({});
+});
+
+describe("SQSExporter", () => {
+  it("sends a standard-queue message with attributes and no FIFO fields", async () => {
+    const exporter = new SQSExporter({
+      queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/insight",
+      region: "us-east-1",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const input = mockSend.mock.calls[0][0].__input;
+    expect(input.QueueUrl).toBe(
+      "https://sqs.us-east-1.amazonaws.com/123456789012/insight",
+    );
+    expect(input.MessageGroupId).toBeUndefined();
+    expect(input.MessageDeduplicationId).toBeUndefined();
+    expect(input.MessageAttributes.status.StringValue).toBe("SUCCEEDED");
+    expect(input.MessageAttributes.functionName.StringValue).toBe("fn");
+    const body = JSON.parse(input.MessageBody);
+    expect(body.executionArn).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+  });
+
+  it("sets FIFO group and dedup ids for a .fifo queue", async () => {
+    const exporter = new SQSExporter({
+      queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/insight.fifo",
+    });
+
+    await exporter.export(makeRecord());
+
+    const input = mockSend.mock.calls[0][0].__input;
+    // Defaults the group id to the executionArn.
+    expect(input.MessageGroupId).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    );
+    expect(input.MessageDeduplicationId).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST:2026-07-15T12:00:00.000Z",
+    );
+  });
+
+  it("honors an explicit messageGroupId on a FIFO queue", async () => {
+    const exporter = new SQSExporter({
+      queueUrl: "https://sqs.us-east-1.amazonaws.com/123456789012/insight.fifo",
+      messageGroupId: "custom-group",
+    });
+
+    await exporter.export(makeRecord());
+
+    expect(mockSend.mock.calls[0][0].__input.MessageGroupId).toBe(
+      "custom-group",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.test.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/exporters/sqs-exporter.test.ts
@@ -6,39 +6,7 @@ jest.mock("@aws-sdk/client-sqs", () => ({
 }));
 
 import { SQSExporter } from "./sqs-exporter";
-import type { WorkflowInsightRecord } from "../types";
-
-function makeRecord(
-  overrides: Partial<WorkflowInsightRecord> = {},
-): WorkflowInsightRecord {
-  return {
-    recordType: "WorkflowInsight",
-    schemaVersion: "1.0",
-    emittedAt: "2026-07-15T12:00:00.000Z",
-    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
-    executionName: "exec-1",
-    functionName: "fn",
-    functionQualifier: "$LATEST",
-    region: "us-east-1",
-    accountId: "123456789012",
-    status: "SUCCEEDED",
-    startTime: "2026-07-15T11:59:00.000Z",
-    endTime: "2026-07-15T12:00:00.000Z",
-    durationMs: 60000,
-    input: { orderId: "12345" },
-    output: { ok: true },
-    operations: [
-      {
-        id: "o1",
-        name: "fetch-user",
-        type: "STEP",
-        status: "SUCCEEDED",
-        durationMs: 5,
-      },
-    ],
-    ...overrides,
-  };
-}
+import { makeRecord } from "../test-utils/make-record";
 
 beforeEach(() => {
   mockSend.mockReset();

--- a/packages/aws-durable-execution-sdk-js-insight/src/test-utils/make-record.ts
+++ b/packages/aws-durable-execution-sdk-js-insight/src/test-utils/make-record.ts
@@ -1,0 +1,41 @@
+import type { WorkflowInsightRecord } from "../types";
+
+/**
+ * Shared test fixture: a fully-populated {@link WorkflowInsightRecord}. Pass
+ * `overrides` to vary specific fields per test. Kept in one place so a change
+ * to the record shape only needs updating here (not in every exporter test).
+ *
+ * Test-only — not exported from the package entry point, so it is tree-shaken
+ * out of the published build.
+ */
+export function makeRecord(
+  overrides: Partial<WorkflowInsightRecord> = {},
+): WorkflowInsightRecord {
+  return {
+    recordType: "WorkflowInsight",
+    schemaVersion: "1.0",
+    emittedAt: "2026-07-15T12:00:00.000Z",
+    executionArn: "arn:aws:lambda:us-east-1:123456789012:function:fn:$LATEST",
+    executionName: "exec-1",
+    functionName: "fn",
+    functionQualifier: "$LATEST",
+    region: "us-east-1",
+    accountId: "123456789012",
+    status: "SUCCEEDED",
+    startTime: "2026-07-15T11:59:00.000Z",
+    endTime: "2026-07-15T12:00:00.000Z",
+    durationMs: 60000,
+    input: { orderId: "12345" },
+    output: { ok: true },
+    operations: [
+      {
+        id: "o1",
+        name: "fetch-user",
+        type: "STEP",
+        status: "SUCCEEDED",
+        durationMs: 5,
+      },
+    ],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Follow-ups after the Redshift/OpenSearch query-provider work:

  - test(sdk): unit tests for all 12 first-party exporters (mock SDK client/fetch/fs,
    assert the outbound API call; happy path + one nuance each). Closes the gap that
    let exporter bugs ship previously.
  - fix(sdk): store Redshift Insight time fields as TIMESTAMPTZ (table DDL) and cast
    ::timestamptz in the MERGE, mirroring AuroraExporter, so date math works natively
    in the extension's Redshift queries. Extension prompt updated to match.
  - docs(sdk): refresh remaining-tasks.md (exporter tests, timestamptz, and the VS Code
    items now shipped).

  Verified: SDK 81 tests, CDK tsc, extension tsc/tests, webview build — all green.