### PR TITLE
chore(sdk): make insight package release-ready for first npm publish

### DIFF
--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -28,6 +28,7 @@ else
     "packages/aws-durable-execution-sdk-js-testing"
     "packages/aws-durable-execution-sdk-js-eslint-plugin"
     "packages/aws-durable-execution-sdk-js-otel"
+    "packages/aws-durable-execution-sdk-js-insight"
   )
 fi
 

--- a/packages/aws-durable-execution-sdk-js-insight/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/package.json
@@ -3,6 +3,7 @@
   "description": "Workflow Insight plugin for AWS Durable Execution SDK — curated execution observability",
   "license": "Apache-2.0",
   "version": "0.1.0-alpha.0",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",
@@ -37,7 +38,7 @@
     "clean": "rm -rf dist dist-cjs dist-types"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=2.0.0-alpha.1",
+    "@aws/durable-execution-sdk-js": ">=2.1.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/util-dynamodb": "^3.0.0",


### PR DESCRIPTION
- Add explicit "private": false to aws-durable-execution-sdk-js-insight package.json, matching the other publishable packages in the repo.
- Widen the @aws/durable-execution-sdk-js peer dependency range from
  >=2.0.0-alpha.1 to >=2.1.0 (current core SDK version) so the floor
  tracks what's actually been released.
- Add packages/aws-durable-execution-sdk-js-insight to the PACKAGES array in iterate-publish-npm.sh so the npm-publish workflow actually publishes it on release (it was previously excluded, so a release would have silently skipped it).

The cdk/ subpackage already has "private": true and is intentionally not published to npm; customers consume it from the GitHub repo.