### PR TITLE
feat(sdk): expose retry attempt number on waitForCondition context

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.test.ts
@@ -357,6 +357,66 @@ describe("WaitForCondition Handler", () => {
       expect(waitStrategy).toHaveBeenCalledWith("result", 1);
     });
 
+    it("should expose attempt = 1 on WaitForConditionContext on the first execution", async () => {
+      const handler = createWaitForConditionHandler(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        createDefaultLogger(),
+        undefined,
+      );
+
+      const checkFunc = jest.fn().mockResolvedValue("result");
+      const config: WaitForConditionConfig<string> = {
+        waitStrategy: () => ({ shouldContinue: false }),
+        initialState: "initial",
+      };
+
+      await handler(checkFunc, config);
+
+      // Fresh execution: no prior checkpointed attempts -> attempt is 1 (1-based).
+      expect(checkFunc).toHaveBeenCalledTimes(1);
+      expect(checkFunc.mock.calls[0][1]).toHaveProperty("attempt", 1);
+      expect(checkFunc.mock.calls[0][1]).toHaveProperty("logger");
+    });
+
+    it("should expose attempt reflecting prior retries (1-based) on WaitForConditionContext", async () => {
+      const stepId = "step-1";
+      const hashedStepId = hashId(stepId);
+
+      // Mock step data with attempt = 2 (so currentAttempt should be 3)
+      (mockContext as any)._stepData[hashedStepId] = {
+        Id: hashedStepId,
+        Status: OperationStatus.READY,
+        StepDetails: {
+          Attempt: 2,
+          Result: JSON.stringify("previous-state"),
+        },
+      };
+
+      (mockContext.getStepData as jest.Mock).mockReturnValue(
+        (mockContext as any)._stepData[hashedStepId],
+      );
+
+      const handler = createWaitForConditionHandler(
+        mockContext,
+        mockCheckpoint,
+        createStepId,
+        createDefaultLogger(),
+        undefined,
+      );
+
+      const checkFunc = jest.fn().mockResolvedValue("result");
+      const config: WaitForConditionConfig<string> = {
+        waitStrategy: () => ({ shouldContinue: false }),
+        initialState: "initial",
+      };
+
+      await handler(checkFunc, config);
+
+      expect(checkFunc.mock.calls[0][1]).toHaveProperty("attempt", 3);
+    });
+
     it("should calculate currentAttempt correctly based on step data attempt count", async () => {
       const stepId = "step-1";
       const hashedStepId = hashId(stepId);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -55,7 +55,8 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   return <T>(
     nameOrCheck: string | undefined | WaitForConditionCheckFunc<T, Logger>,
     checkOrConfig?:
-      WaitForConditionCheckFunc<T, Logger> | WaitForConditionConfig<T>,
+      | WaitForConditionCheckFunc<T, Logger>
+      | WaitForConditionConfig<T>,
     maybeConfig?: WaitForConditionConfig<T>,
   ): DurablePromise<T> => {
     let name: string | undefined;
@@ -228,6 +229,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
         try {
           const waitForConditionContext: WaitForConditionContext<Logger> = {
             logger,
+            attempt: currentAttempt,
           };
 
           // Mark operation as EXECUTING

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -271,7 +271,10 @@ export interface DurableContext<TLogger extends DurableLogger = DurableLogger> {
   /**
    * Waits for a condition to be met by periodically checking state
    * @param name - Step name for tracking and debugging
-   * @param checkFunc - Function that checks the current state and returns updated state
+   * @param checkFunc - Function that checks the current state and returns updated state. The
+   * second argument is a `WaitForConditionContext` (providing a logger and the current retry
+   * `attempt` number, 1-based) that can be used for attempt-aware logic, e.g. escalating checks
+   * or switching data sources on later attempts.
    * @param config - Configuration for initial state, wait strategy, and serialization
    * @example
    * ```typescript

--- a/packages/aws-durable-execution-sdk-js/src/types/logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/logger.ts
@@ -75,8 +75,19 @@ export interface StepContext<
  * Context for waitForCondition operations.
  * @public
  */
-export type WaitForConditionContext<Logger extends DurableLogger> =
-  OperationContext<DurableContextLogger<Logger>>;
+export interface WaitForConditionContext<
+  Logger extends DurableLogger,
+> extends OperationContext<DurableContextLogger<Logger>> {
+  /**
+   * The current attempt number for this waitForCondition check, starting at
+   * `1` for the first execution and incrementing by `1` on each subsequent
+   * retry (i.e. each time `waitStrategy` decides to continue waiting).
+   *
+   * Use this to implement attempt-aware logic in the check function, for
+   * example escalating checks or switching data sources on later attempts.
+   */
+  attempt: number;
+}
 
 /**
  * Context for step operations.

--- a/packages/aws-durable-execution-sdk-js/src/types/wait-condition.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/wait-condition.ts
@@ -5,7 +5,7 @@ import { DurableLogger, Duration } from "../types";
 /**
  * Function that checks and updates state for waitForCondition operations
  * @param state - Current state value
- * @param context - Context for logging and other operations during state checking
+ * @param context - Context for logging and the current retry attempt number (1-based)
  * @returns Promise resolving to the updated state
  *
  * @public


### PR DESCRIPTION
Add `attempt` field to `WaitForConditionContext` so check functions can read the current retry attempt, mirroring the `StepContext.attempt` field added for step() in #707 (and matching the Java SDK, where waitForCondition's check function already reuses StepContext.getAttempt()).

Previously only the wait strategy's positional `attempt` argument had this information; the check function itself had no way to know which attempt it was on without tracking state manually.

- Convert WaitForConditionContext from a type alias to an interface extending OperationContext, adding attempt: number (1-based).
- Populate it in the wait-for-condition handler from the existing currentAttempt already used for waitStrategy and logging.
- Update the waitForCondition() and WaitForConditionCheckFunc TSDoc.
- Add unit tests covering the first-attempt and post-retry values.
