### PR TITLE
chore(sdk): bump core SDK to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14355,7 +14355,7 @@
     },
     "packages/aws-durable-execution-sdk-js": {
       "name": "@aws/durable-execution-sdk-js",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.1014.0"
@@ -19148,7 +19148,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.1.0"
+        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.2.0"
       }
     },
     "packages/aws-durable-execution-sdk-js-testing/node_modules/@sinonjs/fake-timers": {

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -64,7 +64,7 @@
     "commander": "^14.0.2"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.1.0"
+    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.2.0"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",


### PR DESCRIPTION
Bump @aws/durable-execution-sdk-js from 2.1.0 to 2.2.0.

Also widen @aws/durable-execution-sdk-js-testing's peer dependency upper bound (>=1.0.1 <=2.1.0 -> <=2.2.0) so it stays installable alongside the new core version; npm install was failing with an ERESOLVE conflict otherwise.

Verified: build + full test suites pass for both packages (sdk: 89/89 suites, 1059/1059 tests; testing: 69/69 suites, 1167/1170, 3 pre-existing skips).