### PR TITLE
feat(sdk): multi-platform .vsix release 

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -1,0 +1,131 @@
+# Builds the Workflow Insight Explorer VS Code extension for each supported
+# platform/arch and attaches the packaged .vsix files to the GitHub Release as
+# assets. This extension is not published to npm (it's "private": true) or,
+# during preview, to the VS Code Marketplace — see
+# packages/aws-durable-execution-sdk-js-insight-vscode/README.md.
+# Testers/customers install it by downloading the .vsix matching their
+# platform from the release and side-loading it with
+# `code --install-extension`.
+#
+# Multiple platform-specific .vsix files are required because the bundled
+# local (on-device) LLM provider depends on node-llama-cpp, which ships
+# native prebuilt binaries per OS/arch. `vsce package --target <target>` must
+# run on a matching host so npm resolves that target's binary via
+# optionalDependencies — there is no cross-compiling this from one runner.
+#
+# Only runs when the release version matches this package's own version, so
+# an unrelated package release (e.g. the core SDK) doesn't attach a stale
+# .vsix that doesn't correspond to the tag being released.
+
+name: vscode extension release
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      vsix_version: ${{ steps.check.outputs.vsix_version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - id: check
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/aws-durable-execution-sdk-js-insight-vscode/package.json').version")
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          echo "vsix_version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$TAG_NAME" == *"$PKG_VERSION"* ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Release tag '$TAG_NAME' does not match insight-vscode version '$PKG_VERSION'; skipping .vsix build."
+          fi
+
+  build-and-attach:
+    needs: [check-version]
+    if: needs.check-version.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # node-llama-cpp ships native prebuilt binaries per OS/arch (resolved
+          # by npm via optionalDependencies at install time based on the HOST
+          # platform) — so each target's .vsix must be built on a runner that
+          # actually matches that target; there is no cross-compiling this.
+          - target: darwin-arm64
+            os: macos-14
+          - target: win32-x64
+            os: windows-latest
+          - target: win32-arm64
+            os: windows-11-arm
+          - target: linux-x64
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # required to upload a release asset
+    defaults:
+      run:
+        working-directory: packages/aws-durable-execution-sdk-js-insight-vscode
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - name: Install webview-ui dependencies
+        # webview-ui is a nested package outside the root workspaces glob
+        # (packages/*), so it needs its own explicit install.
+        working-directory: packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui
+        run: npm ci
+      - run: npm run typecheck
+      - run: npm run test
+      - name: Package (${{ matrix.target }}) in an isolated (non-workspace) copy
+        # `vsce package` cannot run correctly from inside this npm workspace:
+        # - npm hoists node-llama-cpp's resolved per-platform native binary
+        #   (@node-llama-cpp/<platform>) to the repo-root node_modules/, but
+        #   vsce/VS Code require a self-contained package directory.
+        # - vsce's dependency walk also picks up sibling workspace packages
+        #   via `../` and fails outright (`invalid relative path`).
+        # Isolating a copy of just this package (with its own standalone
+        # `npm install --no-workspaces`) outside the workspace tree avoids
+        # both problems — this is the standard workaround for vsce +
+        # npm/yarn workspaces (see microsoft/vscode-vsce#471, #581).
+        shell: bash
+        run: |
+          set -euo pipefail
+          ISOLATED="$RUNNER_TEMP/insight-vscode-pkg"
+          rm -rf "$ISOLATED"
+          mkdir -p "$ISOLATED"
+          # Portable copy (avoids relying on rsync, which isn't preinstalled
+          # on Windows runners): tar streamed through a pipe, excluding
+          # directories we don't want carried into the isolated copy.
+          tar --exclude='./node_modules' --exclude='./vsix' --exclude='./dist' \
+            --exclude='./webview-ui/node_modules' --exclude='./webview-ui/dist' \
+            -cf - . | tar -xf - -C "$ISOLATED"
+          cd "$ISOLATED"
+          npm install --no-workspaces --ignore-scripts
+          (cd webview-ui && npm ci)
+          VER=$(node -p "require('./package.json').version")
+          mkdir -p vsix
+          npx --yes @vscode/vsce@^3 package --target "$VSCE_TARGET" \
+            --out "vsix/aws-durable-execution-sdk-js-insight-vscode-${VER}-${VSCE_TARGET}.vsix"
+          mkdir -p "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix"
+          cp vsix/*.vsix "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix/"
+        env:
+          VSCE_TARGET: ${{ matrix.target }}
+      - name: Upload .vsix to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" vsix/*.vsix --clobber \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -33,7 +33,7 @@ jobs:
       should_release: ${{ steps.check.outputs.should_release }}
       vsix_version: ${{ steps.check.outputs.vsix_version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name }}
       - id: check
@@ -41,11 +41,15 @@ jobs:
           PKG_VERSION=$(node -p "require('./packages/aws-durable-execution-sdk-js-insight-vscode/package.json').version")
           TAG_NAME="${{ github.event.release.tag_name }}"
           echo "vsix_version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
-          if [[ "$TAG_NAME" == *"$PKG_VERSION"* ]]; then
+          # Exact match against a documented tag convention (see this
+          # package's README: `workflow-insight-vscode-v<version>`), not a
+          # substring match — a substring match could false-positive (e.g.
+          # version "0.1.0" matching tag "core-sdk-v0.1.0-unrelated").
+          if [[ "$TAG_NAME" == "workflow-insight-vscode-v${PKG_VERSION}" ]]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "Release tag '$TAG_NAME' does not match insight-vscode version '$PKG_VERSION'; skipping .vsix build."
+            echo "Release tag '$TAG_NAME' does not match expected 'workflow-insight-vscode-v${PKG_VERSION}'; skipping .vsix build."
           fi
 
   build-and-attach:
@@ -74,10 +78,10 @@ jobs:
       run:
         working-directory: packages/aws-durable-execution-sdk-js-insight-vscode
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.release.tag_name }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
       - run: npm ci
@@ -135,10 +139,7 @@ jobs:
               .catch(e => { console.error('getLlama() failed:', e.message); process.exit(1); });
           "
           (cd webview-ui && npm ci)
-          VER=$(node -p "require('./package.json').version")
-          mkdir -p vsix
-          npx --yes @vscode/vsce@^3 package --target "$VSCE_TARGET" \
-            --out "vsix/aws-durable-execution-sdk-js-insight-vscode-${VER}-${VSCE_TARGET}.vsix"
+          npm run package:target
           mkdir -p "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix"
           cp vsix/*.vsix "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix/"
         env:
@@ -150,3 +151,37 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" vsix/*.vsix --clobber \
             --repo "${{ github.repository }}"
+
+  verify-all-platforms:
+    needs: [check-version, build-and-attach]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all 4 platform .vsix files landed on the release
+        # A matrix job upload succeeding doesn't guarantee every leg ran (a
+        # single-leg failure with fail-fast: false lets the others continue,
+        # potentially publishing a release with only some platforms
+        # supported and no one noticing). Explicitly list the release assets
+        # and fail loudly if any expected target is missing.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          VER="${{ needs.check-version.outputs.vsix_version }}"
+          ASSETS=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
+          MISSING=0
+          for target in darwin-arm64 win32-x64 win32-arm64 linux-x64; do
+            EXPECTED="aws-durable-execution-sdk-js-insight-vscode-${VER}-${target}.vsix"
+            if echo "$ASSETS" | grep -qxF "$EXPECTED"; then
+              echo "OK: $EXPECTED present"
+            else
+              echo "MISSING: $EXPECTED"
+              MISSING=1
+            fi
+          done
+          if [ "$MISSING" -ne 0 ]; then
+            echo "One or more platform .vsix files are missing from release '$TAG'."
+            exit 1
+          fi

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -154,7 +154,18 @@ jobs:
 
   verify-all-platforms:
     needs: [check-version, build-and-attach]
-    if: needs.check-version.outputs.should_release == 'true'
+    # !cancelled() (not the implicit if: success()) is required here: with
+    # strategy.fail-fast: false, a single matrix leg failing still marks the
+    # whole build-and-attach job as failed overall, and a downstream job that
+    # only `needs` a failed job is skipped by default — meaning this
+    # verification would never run in exactly the scenario it exists to
+    # catch (a partial release with some platforms missing). We still gate
+    # on check-version's own result explicitly, so this doesn't run at all
+    # for a release this workflow was never supposed to act on.
+    if: |
+      !cancelled() &&
+      needs.check-version.result == 'success' &&
+      needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Confirm all 4 platform .vsix files landed on the release

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -112,7 +112,28 @@ jobs:
             --exclude='./webview-ui/node_modules' --exclude='./webview-ui/dist' \
             -cf - . | tar -xf - -C "$ISOLATED"
           cd "$ISOLATED"
-          npm install --no-workspaces --ignore-scripts
+          # Run node-llama-cpp's postinstall (i.e. don't pass --ignore-scripts)
+          # so binary resolution happens deterministically here, matching
+          # node-llama-cpp's own documented recommendation ("allow scripts...
+          # to ensure resolving the binaries happens during npm install,
+          # instead of on the first time of calling getLlama"). As of the npm
+          # version pinned above, install scripts still run by default (the
+          # package.json "allowScripts" allow-list is advisory-only in this
+          # npm release per `npm help approve-scripts`; a future npm release
+          # is expected to enforce it, at which point this step may need an
+          # explicit allow-list entry for node-llama-cpp).
+          #
+          # The getLlama() smoke test below is the real guardrail: it fails
+          # the build if this platform's native binary didn't resolve,
+          # instead of silently shipping a .vsix that would only fail for an
+          # end user on first use of the local (on-device) LLM provider.
+          npm install --no-workspaces
+          test -d node_modules/node-llama-cpp || { echo "node-llama-cpp did not install"; exit 1; }
+          node --input-type=module -e "
+            import('node-llama-cpp').then(({getLlama}) => getLlama())
+              .then(() => console.log('getLlama() resolved OK'))
+              .catch(e => { console.error('getLlama() failed:', e.message); process.exit(1); });
+          "
           (cd webview-ui && npm ci)
           VER=$(node -p "require('./package.json').version")
           mkdir -p vsix

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/.vscodeignore
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/.vscodeignore
@@ -1,8 +1,14 @@
 .vscode/**
 src/**
 webview-ui/**
-node_modules/**
 vsix/**
+# node_modules is ignored by default except for node-llama-cpp (and its own
+# dependency tree, incl. the resolved @node-llama-cpp/<platform> optional
+# package) — esbuild statically bundles every other dependency into
+# dist/extension.js, so nothing else in node_modules is needed at runtime.
+node_modules/**
+!node_modules/node-llama-cpp/**
+!node_modules/@node-llama-cpp/**
 .gitignore
 esbuild.mjs
 tsconfig.json

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -35,11 +35,22 @@ The extension supports multiple destinations — each with its own query engine:
 > how you give a tester/customer access before the public launch: point them at
 > the release and have them side-load it. No Marketplace account needed.
 
-**1. Download the `.vsix`**
+**1. Download the `.vsix` for your platform**
 
-Grab the latest `aws-durable-execution-sdk-js-insight-vscode-<version>.vsix` from the
-repo's [**Releases**](https://github.com/aws/aws-durable-execution-sdk-js/releases) page
-(look for a `workflow-insight-vscode-*` tag).
+Grab the latest `.vsix` matching your OS/arch from the repo's
+[**Releases**](https://github.com/aws/aws-durable-execution-sdk-js/releases) page
+(look for a `workflow-insight-vscode-*` tag). Each release attaches one `.vsix`
+per supported platform:
+
+| Platform              | Filename suffix      |
+| --------------------- | -------------------- |
+| Apple Silicon (macOS) | `-darwin-arm64.vsix` |
+| Windows (Intel/x64)   | `-win32-x64.vsix`    |
+| Windows (ARM64)       | `-win32-arm64.vsix`  |
+| Linux (x64)           | `-linux-x64.vsix`    |
+
+> Other platforms (Intel macOS, ARM Linux) aren't built yet during preview —
+> [open an issue](https://github.com/aws/aws-durable-execution-sdk-js/issues/new) if you need one.
 
 **2. Install it into VS Code**
 
@@ -48,7 +59,7 @@ repo's [**Releases**](https://github.com/aws/aws-durable-execution-sdk-js/releas
 - **From the command line:**
 
   ```bash
-  code --install-extension aws-durable-execution-sdk-js-insight-vscode-<version>.vsix
+  code --install-extension aws-durable-execution-sdk-js-insight-vscode-<version>-<platform>.vsix
   ```
 
 **3. Open the Explorer**
@@ -61,10 +72,11 @@ region, destination, and model provider, then ask a question (see
 > version), or uninstall the previous one from the Extensions view first.
 >
 > **Model providers in the `.vsix`:** the packaged build supports **Bedrock**
-> (default), **GitHub Copilot**, and **Local server** (an OpenAI-compatible
-> endpoint you run, e.g. Ollama — see [LLM provider](#3-choose-an-llm-provider)).
-> The bundled offline on-device model (`local`) isn't included in the `.vsix`;
-> use it only when running from source.
+> (default), **GitHub Copilot**, **Local server** (an OpenAI-compatible
+> endpoint you run, e.g. Ollama), and **Local (on-device)** — see
+> [LLM provider](#3-choose-an-llm-provider). The on-device provider bundles a
+> native runtime (`node-llama-cpp`) built for the `.vsix`'s specific
+> platform/arch, which is why each platform ships its own `.vsix`.
 
 ## Build from Source
 

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -264,8 +264,8 @@
     "watch": "node esbuild.mjs --watch",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "package": "mkdir -p vsix && npx --yes @vscode/vsce@^3 package --out vsix/",
-    "package:target": "mkdir -p vsix && VER=$(node -p \"require('./package.json').version\") && npx --yes @vscode/vsce@^3 package --target \"$VSCE_TARGET\" --out \"vsix/aws-durable-execution-sdk-js-insight-vscode-${VER}-${VSCE_TARGET}.vsix\"",
+    "package": "mkdir -p vsix && npx --yes @vscode/vsce@3.9.2 package --out vsix/",
+    "package:target": "mkdir -p vsix && VER=$(node -p \"require('./package.json').version\") && npx --yes @vscode/vsce@3.9.2 package --target \"$VSCE_TARGET\" --out \"vsix/aws-durable-execution-sdk-js-insight-vscode-${VER}-${VSCE_TARGET}.vsix\"",
     "clean": "rm -rf dist media/webview.js media/webview.css"
   },
   "dependencies": {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -194,7 +194,7 @@
             "Amazon Bedrock (Converse API) — requires AWS credentials and model access. When you use an AI feature (Ask/Agent/Visualize), your request text and limited data (result column names and a small sample of rows) are sent to Amazon Bedrock in the AWS account and region you configure, and processed under your AWS agreement and the Amazon Bedrock service terms.",
             "GitHub Copilot (VS Code Language Model API) — requires a Copilot subscription. AI requests and the limited data described above are sent to GitHub Copilot via VS Code, and are processed under your GitHub Copilot subscription terms and privacy policy.",
             "Local server — an OpenAI-compatible endpoint you run yourself (Ollama, LM Studio, llama.cpp). AI requests are sent only to the endpoint you run and control (configured via workflowInsight.localServerUrl); nothing is sent to a third-party cloud, provided that endpoint is local/self-hosted.",
-            "Local LLM (on-device) — runs entirely on your machine; your request and data do not leave your computer. Downloads the model on first use (configurable via workflowInsight.localModel). Not available in the packaged .vsix (source builds only)."
+            "Local LLM (on-device) — runs entirely on your machine; your request and data do not leave your computer. Downloads the model on first use (configurable via workflowInsight.localModel). Included in the platform-specific .vsix (darwin-arm64, win32-x64, win32-arm64, linux-x64)."
           ],
           "description": "Which LLM provider converts your natural-language questions into queries and builds summaries/charts. Used only by the AI features — the 'ask' and 'agent' modes and the Visualize page. In those features your request text and, in some cases, limited portions of your data (result column names and a small sample of rows) are sent to the provider selected here; the 'query' mode uses no AI and sends nothing to any provider. Data you send is subject to the terms and privacy policy of the selected provider — review them before sending sensitive data. See each option below for where your data goes."
         },
@@ -264,7 +264,8 @@
     "watch": "node esbuild.mjs --watch",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "package": "mkdir -p vsix && npx --yes @vscode/vsce@^3 package --no-dependencies --out vsix/",
+    "package": "mkdir -p vsix && npx --yes @vscode/vsce@^3 package --out vsix/",
+    "package:target": "mkdir -p vsix && VER=$(node -p \"require('./package.json').version\") && npx --yes @vscode/vsce@^3 package --target \"$VSCE_TARGET\" --out \"vsix/aws-durable-execution-sdk-js-insight-vscode-${VER}-${VSCE_TARGET}.vsix\"",
     "clean": "rm -rf dist media/webview.js media/webview.css"
   },
   "dependencies": {


### PR DESCRIPTION
- Add `.github/workflows/vscode-extension-release.yml`: builds and attaches platform-specific `.vsix` files (`darwin-arm64`, `win32-x64`, `win32-arm64`, `linux-x64`) to a GitHub Release matching this package's version.
- Remove `--no-dependencies` from the `package` script and un-ignore `node_modules/node-llama-cpp` + `@node-llama-cpp` in `.vscodeignore`, so the on-device local LLM provider (previously excluded from the `.vsix`) is now bundled with its platform-specific native binary.
- Package each target from an isolated, non-workspace copy: `vsce`'s dependency walk does not work correctly from inside this npm workspace (hoisted native deps, sibling-package traversal via `../`, case-duplicate file listings) — isolating the package directory and running a standalone `npm install --no-workspaces` avoids all three failure modes.
- Run `node-llama-cpp`'s postinstall during that isolated install (not `--ignore-scripts`) so its native binary resolves deterministically at packaging time, and add a `getLlama()` smoke test right after install that fails the build if the binary didn't resolve for that platform.
- Pin `actions/checkout`, `actions/setup-node`, and `@vscode/vsce` to exact versions/SHAs in the `contents: write` job, given its larger blast radius (write access, 4 OS images, a native dependency) versus the rest of the repo's floating-tag convention.
- Replace the release-tag substring match with an exact match against the documented `workflow-insight-vscode-v<version>` convention (this package's README).
- Add a `verify-all-platforms` job that lists the release's actual assets and fails if any of the 4 expected `.vsix` files is missing — using `if: !cancelled() && ...` so it still runs even if one matrix leg failed (the default `if: success()` would otherwise skip it in exactly that scenario).
- Have the workflow call the existing `package:target` npm script instead of duplicating the same `vsce` invocation inline.
- Update README and the `localModel` config description to reflect that the on-device provider now ships in the packaged `.vsix`, with a per-platform download table.

**Verified locally** (darwin-arm64): isolated install with scripts enabled, `getLlama()` resolves, `vsce package --target darwin-arm64` produces a correct `.vsix` (manifest + `node-llama-cpp`/`@node-llama-cpp` contents inspected). Exact-match tag logic and the asset-verification bash logic checked against several tag/asset-list scenarios.