### PR TITLE
docs: fix Workflow Insight vscode extension source-build setup steps

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -85,6 +85,7 @@ For contributors, or to produce your own `.vsix`:
 ```bash
 cd packages/aws-durable-execution-sdk-js-insight-vscode
 npm install
+npm --prefix webview-ui install   # webview-ui isn't an npm workspace; install it separately
 npm run build
 ```
 
@@ -103,7 +104,31 @@ Publishing a preview to testers: create a GitHub Release and attach that `.vsix`
 ### 1. Launch the extension
 
 - **Installed from the `.vsix`:** run **⌘⇧P** (`Ctrl+Shift+P`) → **Workflow Insight: Open Explorer**.
-- **Running from source:** open this folder in VS Code and press **F5** to start the Extension Development Host, then run the same command in the new window.
+- **Running from source:** open this folder (`packages/aws-durable-execution-sdk-js-insight-vscode`) directly in VS Code — not the monorepo root — then press **F5** to start the Extension Development Host, and run the same command in the new window.
+
+  `.vscode/` is git-ignored, so F5 does nothing until you create
+  `.vscode/launch.json` yourself:
+
+  ```json
+  {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Run Extension",
+        "type": "extensionHost",
+        "request": "launch",
+        "args": [
+          "--extensionDevelopmentPath=${workspaceFolder}",
+          "${workspaceFolder}"
+        ]
+      }
+    ]
+  }
+  ```
+
+  See [TESTING.md](./TESTING.md) for the full source setup, including a
+  `.vscode/settings.json` example for pointing the extension at your own
+  AWS region/log group.
 
 > **⌘⇧P** → **Workflow Insight: Open Explorer**
 


### PR DESCRIPTION
The Workflow Insight Explorer README's "Build from Source" and "Launch the extension" sections were missing two steps required to actually run the extension locally:

- `webview-ui` is a nested package with its own package-lock.json and is not covered by the root npm workspaces glob, so `npm install` at the extension root never installs its deps (react, vega-embed, @cloudscape-design/*). This made `npm run build` fail with esbuild "Could not resolve" errors until `webview-ui` was installed separately.
- Pressing F5 to launch the Extension Development Host silently does nothing because `.vscode/` is git-ignored repo-wide, so no `launch.json` exists until a contributor creates one. The README now includes the exact `launch.json` contents and points to TESTING.md for the accompanying settings.json example.

Also clarifies that VS Code must be opened at the extension's own folder (packages/aws-durable-execution-sdk-js-insight-vscode), not the monorepo root, since ${workspaceFolder} in launch.json resolves from whichever folder is open.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
