### PR TITLE
feat(testing-sdk): add remaining 7 conformance suites

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -29,7 +29,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [step, wait]
+        suite:
+          [
+            step,
+            wait,
+            child,
+            callback,
+            invoke,
+            wait_for_condition,
+            wait_for_callback,
+            parallel,
+            map,
+          ]
     defaults:
       run:
         working-directory: packages/aws-durable-execution-sdk-js-conformance-tests

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "packages/aws-durable-execution-sdk-js/**"
       - "packages/aws-durable-execution-sdk-js-conformance-tests/**"
       - ".github/workflows/conformance-tests.yml"
   workflow_dispatch:

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -97,6 +97,12 @@ jobs:
             --template template_${{ matrix.suite }}.yaml \
             --role-arn "$ROLE_ARN"
 
+      - name: Compute stack-safe suite slug
+        run: |
+          # CloudFormation stack names allow only [a-zA-Z][-a-zA-Z0-9]*;
+          # suite names like wait_for_condition contain underscores.
+          echo "SUITE_SLUG=$(echo '${{ matrix.suite }}' | tr '_' '-')" >> "$GITHUB_ENV"
+
       - name: Run conformance suite
         env:
           # Same env the SAM-based integration deploy passes. LAMBDA_ENDPOINT is
@@ -110,7 +116,7 @@ jobs:
             --template template_${{ matrix.suite }}.yaml \
             --language js \
             --suite ${{ matrix.suite }} \
-            --name conformance-js-${{ matrix.suite }}-${{ github.run_id }} \
+            --name conformance-js-${SUITE_SLUG}-${{ github.run_id }} \
             --region ${{ vars.AWS_REGION }} \
             --history-dir history-${{ matrix.suite }} \
             --report junit \

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/README.md
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/README.md
@@ -26,8 +26,9 @@ rollup.config.mjs           # bundles handlers/<suite>/*.ts -> dist/<name>.js (C
 ```
 
 Each SAM template is a self-contained deployment for one **suite** (operation
-category). Suites are added incrementally; today this package ships `step` and
-`wait`.
+category). This package ships all nine suites: `step`, `wait`, `child`,
+`callback`, `invoke`, `wait_for_condition`, `wait_for_callback`, `parallel`,
+and `map`.
 
 ## How a handler maps to a requirement
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_basic.ts
@@ -1,0 +1,12 @@
+// 4-1: Create callback basic (success via external callback)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_failure.ts
@@ -1,0 +1,13 @@
+// 4-6: Callback failure (external system reports failure)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+    // Do not catch — let the rejection propagate so the execution fails.
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_heartbeat_success.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_heartbeat_success.ts
@@ -1,0 +1,14 @@
+// 4-5: Create callback with heartbeat then success
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      heartbeatTimeout: { seconds: 10 },
+    });
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_heartbeat_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_heartbeat_timeout.ts
@@ -1,0 +1,14 @@
+// 4-4: Create callback heartbeat timeout (no heartbeat sent)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      heartbeatTimeout: { seconds: 5 },
+    });
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_failure.ts
@@ -1,0 +1,22 @@
+// 4-13: Replay - Callback failure caught → Wait → return
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+
+    let outcome: string;
+    try {
+      outcome = await callbackPromise;
+    } catch (e) {
+      outcome = `caught_failure:${(e as Error).message}`;
+    }
+
+    await context.wait("after-cb", { seconds: 2 });
+
+    return outcome;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_timeout.ts
@@ -1,0 +1,24 @@
+// 4-14: Replay - Callback timeout caught → Wait → return
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      timeout: { seconds: 3 },
+    });
+
+    let outcome: string;
+    try {
+      outcome = await callbackPromise;
+    } catch (e) {
+      outcome = `caught_timeout:${(e as Error).message}`;
+    }
+
+    await context.wait("after-cb", { seconds: 2 });
+
+    return outcome;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_with_wait.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_replay_with_wait.ts
@@ -1,0 +1,14 @@
+// 4-12: Callback success → Wait → verify replay
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+    const cbResult = await callbackPromise;
+    await context.wait("after-cb", { seconds: 2 });
+    return cbResult;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_serdes_happy.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_serdes_happy.ts
@@ -1,0 +1,53 @@
+// 4-15: Callback with custom serdes (happy path)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+interface CustomData {
+  id: number;
+  message: string;
+  timestamp: Date;
+}
+
+const customSerdes = {
+  serialize: async (
+    data: CustomData | undefined,
+  ): Promise<string | undefined> => {
+    if (data === undefined) return undefined;
+    return JSON.stringify({
+      ...data,
+      timestamp: data.timestamp.toISOString(),
+    });
+  },
+  deserialize: async (
+    str: string | undefined,
+  ): Promise<CustomData | undefined> => {
+    if (str === undefined) return undefined;
+    const parsed = JSON.parse(str) as {
+      id: number;
+      message: string;
+      timestamp: string;
+    };
+    return {
+      ...parsed,
+      timestamp: new Date(parsed.timestamp),
+    };
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<CustomData>(event, {
+      serdes: customSerdes,
+    });
+    const result = await callbackPromise;
+    return {
+      received: {
+        id: result.id,
+        message: result.message,
+        timestamp: Math.floor(result.timestamp.getTime() / 1000),
+      },
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_serdes_numeric.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_serdes_numeric.ts
@@ -1,0 +1,22 @@
+// 4-16: Callback with custom serdes (numeric)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+const numericSerdes = {
+  serialize: async (n: number | undefined): Promise<string | undefined> =>
+    n === undefined ? undefined : JSON.stringify(n),
+  deserialize: async (s: string | undefined): Promise<number | undefined> =>
+    s === undefined ? undefined : (JSON.parse(s) as number),
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<number>(event, {
+      serdes: numericSerdes,
+    });
+    const value = await callbackPromise;
+    return { count: value, doubled: value * 2 };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_step_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_step_failure.ts
@@ -1,0 +1,15 @@
+// 4-7: Callback + Step + Wait for callback result (failure)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+
+    await context.step("notify-external", async () => "notified");
+
+    return await callbackPromise; // rejects on failure → execution fails
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_step_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_step_timeout.ts
@@ -1,0 +1,17 @@
+// 4-8: Callback + Step + Wait for callback result (timeout)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      timeout: { seconds: 5 },
+    });
+
+    await context.step("notify-external", async () => "notified");
+
+    return await callbackPromise; // rejects on timeout → execution fails
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_timeout.ts
@@ -1,0 +1,14 @@
+// 4-3: Create callback general timeout (no external callback sent)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      timeout: { seconds: 5 },
+    });
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_parallel.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_parallel.ts
@@ -1,0 +1,19 @@
+// 4-18: Two callbacks — create both then wait in order (cbA, cbB, wcbA, wcbB)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [nameA, nameB] = event as [string, string];
+
+    const [callbackPromiseA] = await context.createCallback<string>(nameA);
+    const [callbackPromiseB] = await context.createCallback<string>(nameB);
+
+    const resultA = await callbackPromiseA;
+    const resultB = await callbackPromiseB;
+
+    return { a: resultA, b: resultB };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_parallel_reverse.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_parallel_reverse.ts
@@ -1,0 +1,19 @@
+// 4-19: Two callbacks — create both then wait in reverse order (cbA, cbB, wcbB, wcbA)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [nameA, nameB] = event as [string, string];
+
+    const [callbackPromiseA] = await context.createCallback<string>(nameA);
+    const [callbackPromiseB] = await context.createCallback<string>(nameB);
+
+    const resultB = await callbackPromiseB;
+    const resultA = await callbackPromiseA;
+
+    return { a: resultA, b: resultB };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_sequential.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_two_sequential.ts
@@ -1,0 +1,19 @@
+// 4-17: Two callbacks — sequential create and wait (cbA, wcbA, cbB, wcbB)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [nameA, nameB] = event as [string, string];
+
+    const [callbackPromiseA] = await context.createCallback<string>(nameA);
+    const resultA = await callbackPromiseA;
+
+    const [callbackPromiseB] = await context.createCallback<string>(nameB);
+    const resultB = await callbackPromiseB;
+
+    return { a: resultA, b: resultB };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_failure.ts
@@ -1,0 +1,13 @@
+// 4-10: Callback + Wait + Wait for callback result (failure)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+    await context.wait("delay", { seconds: 5 });
+    return await callbackPromise; // rejects on failure → execution fails
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_success.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_success.ts
@@ -1,0 +1,13 @@
+// 4-9: Callback + Wait + Wait for callback result (success)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event);
+    await context.wait("delay", { seconds: 5 });
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_wait_timeout.ts
@@ -1,0 +1,15 @@
+// 4-11: Callback + Wait + Wait for callback result (timeout)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>(event, {
+      timeout: { seconds: 3 },
+    });
+    await context.wait("delay", { seconds: 6 });
+    return await callbackPromise; // callback timeout < wait → throws after wait completes
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_with_name.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/callback/callback_with_name.ts
@@ -1,0 +1,12 @@
+// 4-2: Create callback with explicit name
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const [callbackPromise] = await context.createCallback<string>("approval");
+    return await callbackPromise;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_basic.ts
@@ -1,0 +1,19 @@
+// 3-1: Child context basic (single step inside)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(async () => {
+          return event as string;
+        });
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_custom_serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_custom_serdes.ts
@@ -1,0 +1,30 @@
+// 3-14: Child context with custom serdes (succeed)
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+
+const uppercaseSerdes: Serdes<string> = {
+  serialize: async (value: string | undefined, _context: SerdesContext) => {
+    if (value === undefined) return undefined;
+    return value.toUpperCase();
+  },
+  deserialize: async (data: string | undefined, _context: SerdesContext) => {
+    return data;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "serdes-child",
+      async (childContext: DurableContext) => {
+        return await childContext.step(async () => event as string);
+      },
+      { serdes: uppercaseSerdes },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error.ts
@@ -1,0 +1,24 @@
+// 3-4: Child context error (step fails, execution fails)
+import {
+  DurableContext,
+  withDurableExecution,
+  retryPresets,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "failing-child",
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(
+          async () => {
+            throw new Error("Child step failed");
+          },
+          { retryStrategy: retryPresets.noRetry },
+        );
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error_caught.ts
@@ -1,0 +1,29 @@
+// 3-5: Child context error caught (try/catch, execution succeeds)
+import {
+  DurableContext,
+  withDurableExecution,
+  retryPresets,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    try {
+      await context.runInChildContext(async (childContext: DurableContext) => {
+        await childContext.step(
+          async () => {
+            throw new Error("Child step failed");
+          },
+          { retryStrategy: retryPresets.noRetry },
+        );
+      });
+    } catch (error) {
+      // Error caught, continue with recovery
+    }
+
+    const result = await context.step(async () => {
+      return event as string;
+    });
+
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error_no_step.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_error_no_step.ts
@@ -1,0 +1,17 @@
+// 3-15: Child context error without step (error thrown directly in child body)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "direct-error",
+      async (childContext: DurableContext) => {
+        throw new Error("direct error");
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_interrupted.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_interrupted.ts
@@ -1,0 +1,61 @@
+// 3-12: Child context interrupted and re-executed
+//
+// NOTE: This handler intentionally keeps DynamoDB-based attempt counting
+// (unlike the retry handlers, which use the SDK-native stepContext.attempt).
+// The step here crashes via process.exit(1) with no retry strategy, and the
+// SDK only checkpoints the attempt counter on FAIL/RETRY decisions — not on a
+// sandbox crash. On re-invocation stepContext.attempt would still read 1,
+// crashing forever. Counting cross-invocation executions requires external
+// state.
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { DynamoDBClient, UpdateItemCommand } from "@aws-sdk/client-dynamodb";
+
+const ddbClient = new DynamoDBClient();
+const TABLE_NAME = process.env.ATTEMPTS_TABLE_NAME || "Attempts";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const executionId = context.executionContext.durableExecutionArn;
+
+    const result = await context.runInChildContext(
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(async () => {
+          // Track invocation count in DynamoDB
+          const response = await ddbClient.send(
+            new UpdateItemCommand({
+              TableName: TABLE_NAME,
+              Key: {
+                executionId: { S: `${executionId}-child-interrupted` },
+              },
+              UpdateExpression:
+                "SET attemptCount = if_not_exists(attemptCount, :zero) + :inc",
+              ExpressionAttributeValues: {
+                ":zero": { N: "0" },
+                ":inc": { N: "1" },
+              },
+              ReturnValues: "UPDATED_NEW",
+            }),
+          );
+
+          const attemptCount = Number(
+            response.Attributes?.attemptCount?.N ?? 0,
+          );
+
+          if (attemptCount < 2) {
+            // Sleep to allow checkpoint to be sent before crash
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            // Simulate Lambda crash/timeout
+            process.exit(1);
+          }
+
+          return event as string;
+        });
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_large_payload.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_large_payload.ts
@@ -1,0 +1,32 @@
+// 3-11: Child context large payload (ReplayChildren mode)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const largeDataResult = await context.runInChildContext(
+      "large-data-processor",
+      async (childContext: DurableContext) => {
+        console.log(event);
+
+        // Step returns a small seed value (under 256KB limit)
+        const seed = await childContext.step(async () => {
+          return "A";
+        });
+
+        // Build large result outside of step — this is just regular code
+        // The child context RETURN value exceeds 256KB, triggering ReplayChildren mode
+        const largeResult = seed.repeat(300 * 1024);
+        return largeResult;
+      },
+    );
+
+    // Wait after child context to force a second invocation and test replay
+    await context.wait({ seconds: 1 });
+
+    // Return the length — proves the large data was reconstructed via replay
+    return largeDataResult.length;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_multiple_steps.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_multiple_steps.ts
@@ -1,0 +1,25 @@
+// 3-3: Child context with multiple sequential steps
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "multi-step",
+      async (childContext: DurableContext) => {
+        const first = await childContext.step(async () => {
+          return event as string;
+        });
+
+        const second = await childContext.step(async () => {
+          return first;
+        });
+
+        return second;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_nested.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_nested.ts
@@ -1,0 +1,31 @@
+// 3-6: Nested child contexts
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "outer",
+      async (outerContext: DurableContext) => {
+        await outerContext.step(async () => {
+          return event as string;
+        });
+
+        const innerResult = await outerContext.runInChildContext(
+          "inner",
+          async (innerContext: DurableContext) => {
+            const innerStep = await innerContext.step(async () => {
+              return event as string;
+            });
+            return innerStep;
+          },
+        );
+
+        return innerResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_null_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_null_result.ts
@@ -1,0 +1,17 @@
+// 3-16: Child context returning null
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "null-child",
+      async (childContext: DurableContext) => {
+        return null;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_print_only.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_print_only.ts
@@ -1,0 +1,21 @@
+// 3-17: Child context with print only (verify no re-execution on replay)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "print-child",
+      async (childContext: DurableContext) => {
+        console.log(event);
+        return event as string;
+      },
+    );
+
+    await context.wait({ seconds: 1 });
+
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_replay.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_replay.ts
@@ -1,0 +1,23 @@
+// 3-9: Child context replay (returns cached result)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const childResult = await context.runInChildContext(
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(async () => {
+          return event as string;
+        });
+        return stepResult;
+      },
+    );
+
+    // Wait after child context to force a second invocation
+    await context.wait({ seconds: 1 });
+
+    return childResult;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_retry.ts
@@ -1,0 +1,34 @@
+// 3-7: Child context with step retry (fails then succeeds)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "retry-child",
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(
+          async (stepContext) => {
+            // SDK-native per-step attempt counter (1-based, +1 per retry).
+            if (stepContext.attempt < 2) {
+              throw new Error(`Attempt ${stepContext.attempt} failed`);
+            }
+            return event as string;
+          },
+          {
+            retryStrategy: (_error: Error, attempts: number) => {
+              if (attempts >= 3) {
+                return { shouldRetry: false };
+              }
+              return { shouldRetry: true, delay: { seconds: 1 } };
+            },
+          },
+        );
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_retry_exhaustion.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_retry_exhaustion.ts
@@ -1,0 +1,32 @@
+// 3-8: Child context with step retry exhaustion (child fails)
+import {
+  DurableContext,
+  withDurableExecution,
+  createRetryStrategy,
+  JitterStrategy,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "exhaust-child",
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(
+          async () => {
+            throw new Error("Always fails");
+          },
+          {
+            retryStrategy: createRetryStrategy({
+              maxAttempts: 2,
+              initialDelay: { seconds: 1 },
+              backoffRate: 1,
+              jitter: JitterStrategy.NONE,
+            }),
+          },
+        );
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_step_and_wait.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_step_and_wait.ts
@@ -1,0 +1,23 @@
+// 3-10: Child context with step and wait inside
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "mixed-ops",
+      async (childContext: DurableContext) => {
+        await childContext.step(async () => {
+          return event as string;
+        });
+
+        await childContext.wait({ seconds: 1 });
+
+        return event as string;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_step_wait_after.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_step_wait_after.ts
@@ -1,0 +1,30 @@
+// 3-18: Child context with step and wait inside, step and wait after
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.runInChildContext(
+      "step-wait-child",
+      async (childContext: DurableContext) => {
+        await childContext.step(async () => {
+          return event as string;
+        });
+
+        await childContext.wait({ seconds: 2 });
+
+        return event as string;
+      },
+    );
+
+    const result = await context.step(async () => {
+      return event as string;
+    });
+
+    await context.wait({ seconds: 2 });
+
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_wait_replay.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_wait_replay.ts
@@ -1,0 +1,23 @@
+// 3-13: Child context with wait inside - verify replay
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.runInChildContext(
+      "wait-child",
+      async (childContext: DurableContext) => {
+        await childContext.wait({ seconds: 1 });
+        return event as string;
+      },
+    );
+
+    const result = await context.step(async () => {
+      return event as string;
+    });
+
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_with_name.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_with_name.ts
@@ -1,0 +1,22 @@
+// 3-2: Child context with name
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const name = event.name as string;
+    const value = event.value as string;
+    const result = await context.runInChildContext(
+      name,
+      async (childContext: DurableContext) => {
+        const stepResult = await childContext.step(async () => {
+          return value;
+        });
+        return stepResult;
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_basic.ts
@@ -1,0 +1,13 @@
+// 5-1: Invoke basic (target function succeeds)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName: string = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(undefined, targetFunctionName, event);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_complex_object.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_complex_object.ts
@@ -1,0 +1,13 @@
+// 5-3: Invoke returning complex object (nested JSON)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, event);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_custom_payload_serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_custom_payload_serdes.ts
@@ -1,0 +1,27 @@
+// 5-15: Invoke with custom payload serdes
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+
+const uppercasePayloadSerdes: Serdes<any> = {
+  serialize: async (value: any, _context: SerdesContext) => {
+    if (value === undefined) return undefined;
+    return JSON.stringify(value).toUpperCase();
+  },
+  deserialize: async (data: string | undefined, _context: SerdesContext) => {
+    return data ? JSON.parse(data) : data;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, event, {
+      payloadSerdes: uppercasePayloadSerdes,
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_custom_result_serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_custom_result_serdes.ts
@@ -1,0 +1,27 @@
+// 5-16: Invoke with custom result serdes
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+
+const uppercaseResultSerdes: Serdes<string> = {
+  serialize: async (value: string | undefined, _context: SerdesContext) => {
+    return value;
+  },
+  deserialize: async (data: string | undefined, _context: SerdesContext) => {
+    if (data === undefined) return undefined;
+    return data.toUpperCase();
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName: string = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(undefined, targetFunctionName, event, {
+      resultSerdes: uppercaseResultSerdes,
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_in_child_context.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_in_child_context.ts
@@ -1,0 +1,15 @@
+// 5-13: Invoke inside child context
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.runInChildContext(async (childCtx) => {
+      return await childCtx.invoke(targetFunctionName, event);
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_large_payload.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_large_payload.ts
@@ -1,0 +1,14 @@
+// 5-7: Invoke large payload (payload near size limit)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const largePayload = { data: "x".repeat(200000) };
+    const result = await context.invoke(targetFunctionName, largePayload);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_multiple_sequential.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_multiple_sequential.ts
@@ -1,0 +1,15 @@
+// 5-14: Multiple sequential invokes
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunction1 = process.env.TARGET_FUNCTION_NAME_1!;
+    const targetFunction2 = process.env.TARGET_FUNCTION_NAME_2!;
+    const result1 = await context.invoke(targetFunction1, event);
+    const result2 = await context.invoke(targetFunction2, result1);
+    return result2;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_null_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_null_result.ts
@@ -1,0 +1,13 @@
+// 5-4: Invoke returning null (target returns null)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, null);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_replay_rethrows.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_replay_rethrows.ts
@@ -1,0 +1,18 @@
+// 5-10: Invoke replay re-throws (failed invoke error re-thrown from cache)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    try {
+      await context.invoke(targetFunctionName, event);
+    } catch (error) {
+      // Error caught, continue
+    }
+    await context.wait({ seconds: 1 });
+    return "completed";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_replay_skips.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_replay_skips.ts
@@ -1,0 +1,14 @@
+// 5-9: Invoke replay skips (invoke result cached on replay)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, event);
+    await context.wait({ seconds: 1 });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_target_fails.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_target_fails.ts
@@ -1,0 +1,13 @@
+// 5-5: Invoke target fails (execution fails with InvokeError)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, event);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_target_fails_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_target_fails_caught.ts
@@ -1,0 +1,17 @@
+// 5-6: Invoke target fails, caught (try/catch, execution succeeds)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    try {
+      await context.invoke(targetFunctionName, event);
+    } catch (error) {
+      // Error caught, continue with fallback
+    }
+    return "fallback_result";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_then_step.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_then_step.ts
@@ -1,0 +1,16 @@
+// 5-12: Invoke then step (invoke result used by subsequent step)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const invokeResult = await context.invoke(targetFunctionName, event);
+    const result = await context.step(async () => {
+      return `processed: ${invokeResult}`;
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_timeout.ts
@@ -1,0 +1,15 @@
+// 5-7: Invoke timeout (target takes too long)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(targetFunctionName, event, {
+      timeout: 5,
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_timeout_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_timeout_caught.ts
@@ -1,0 +1,17 @@
+// 5-8: Invoke timeout, caught (timeout caught, execution continues)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    try {
+      await context.invoke(targetFunctionName, event, { timeout: 5 });
+    } catch (error) {
+      // Timeout caught, continue with fallback
+    }
+    return "fallback_result";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_with_name.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_with_name.ts
@@ -1,0 +1,17 @@
+// 5-2: Invoke with name (explicit name parameter from input)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const result = await context.invoke(
+      event.name,
+      targetFunctionName,
+      event.payload,
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_with_tenant_id.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/invoke_with_tenant_id.ts
@@ -1,0 +1,21 @@
+// 5-8: Invoke with tenantId (tenant-isolated invocation)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName: string = process.env.TARGET_FUNCTION_NAME!;
+    const { tenantId, payload } = event;
+    const result = await context.invoke(
+      undefined,
+      targetFunctionName,
+      payload,
+      {
+        tenantId,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/step_then_invoke.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/step_then_invoke.ts
@@ -1,0 +1,16 @@
+// 5-11: Step then invoke (sequential operations)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const targetFunctionName = process.env.TARGET_FUNCTION_NAME!;
+    const stepResult = await context.step(async () => {
+      return { value: "step_data" };
+    });
+    const result = await context.invoke(targetFunctionName, stepResult);
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_echo.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_echo.ts
@@ -1,0 +1,12 @@
+// Target function that echoes back whatever it receives (with a short wait to ensure caller suspends)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.wait({ seconds: 1 });
+    return event;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_error.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_error.ts
@@ -1,0 +1,12 @@
+// Target function that waits briefly then throws an error (ensures caller suspends first)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.wait({ seconds: 1 });
+    throw new Error("Target function failed");
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_non_durable.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_non_durable.ts
@@ -1,0 +1,4 @@
+// Target function that is NOT wrapped with withDurableExecution (plain Lambda handler)
+export const handler = async (event: any) => {
+  return "non_durable_result";
+};

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_slow.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/invoke/target_slow.ts
@@ -1,0 +1,12 @@
+// Target function that takes longer than timeout (uses wait with long duration)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.wait({ seconds: 600 });
+    return "should_not_reach";
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_basic.ts
@@ -1,0 +1,19 @@
+// 9-1: Map basic (one step per item, all succeed)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items: string[] = Array.isArray(event) ? event : ["World", "Kiro"];
+    const results = await context.map(
+      "map",
+      items,
+      async (ctx: DurableContext, item: string) =>
+        ctx.step(async () => `Hello, ${item}!`),
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_concurrent.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_concurrent.ts
@@ -1,0 +1,17 @@
+// 9-11: Map real concurrency (max-concurrency > 1) preserves index-ordered results
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "concurrent",
+      ["r0", "r1", "r2"],
+      async (_ctx: DurableContext, item: string) => item,
+      { maxConcurrency: 2 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_custom_serde.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_custom_serde.ts
@@ -1,0 +1,28 @@
+// 9-14: Map with a custom per-item serdes
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+
+// Real, non-identity serdes: wraps the value on serialize and unwraps on deserialize,
+// so iteration results round-trip through a custom encoding (not a no-op).
+const wrapSerdes: Serdes<string> = {
+  serialize: async (value: string | undefined, _context: SerdesContext) =>
+    value === undefined ? undefined : `wrapped:${value}`,
+  deserialize: async (data: string | undefined, _context: SerdesContext) =>
+    data === undefined ? undefined : data.replace(/^wrapped:/, ""),
+};
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "serdes",
+      ["x", "y"],
+      async (_ctx: DurableContext, item: string) => item.toUpperCase(),
+      { maxConcurrency: 1, itemSerdes: wrapSerdes },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_empty.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_empty.ts
@@ -1,0 +1,17 @@
+// 9-4: Map with an empty items list
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items: number[] = Array.isArray(event) ? event : [];
+    const results = await context.map(
+      "empty",
+      items,
+      async (_ctx: DurableContext, item: number) => item,
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_fail_fast.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_fail_fast.ts
@@ -1,0 +1,28 @@
+// 9-5: Map fail-fast via tolerated-failure-count=0 stops after first failure
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "failfast",
+      ["ok", "fail", "never"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item === "fail") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 0 } },
+    );
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_fail_then_wait.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_fail_then_wait.ts
@@ -1,0 +1,30 @@
+// 9-18: Suspension after a map that completed with a failure (replay skips the completed map)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "fail-then-wait",
+      ["ok", "fail"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item === "fail") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    // Suspend after the map (which recorded a failure); on replay the completed map is skipped.
+    await context.wait({ seconds: 1 });
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_flat.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_flat.ts
@@ -1,0 +1,18 @@
+// 9-12: Map with FLAT nesting (virtual iteration contexts)
+import {
+  DurableContext,
+  NestingType,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "flat",
+      ["fa", "fb"],
+      async (ctx: DurableContext, item: string) => ctx.step(async () => item),
+      { maxConcurrency: 1, nesting: NestingType.FLAT },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_item_index.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_item_index.ts
@@ -1,0 +1,18 @@
+// 9-3: Map function receives item and index
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items: number[] = Array.isArray(event) ? event : [10, 20, 30];
+    const results = await context.map(
+      "indexed",
+      items,
+      async (_ctx: DurableContext, item: number, index: number) => item + index,
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_item_namer.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_item_namer.ts
@@ -1,0 +1,21 @@
+// 9-13: Map with a custom item namer
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items: number[] = Array.isArray(event) ? event : [1, 2];
+    const results = await context.map(
+      "named-items",
+      items,
+      async (_ctx: DurableContext, item: number) => item * 10,
+      {
+        maxConcurrency: 1,
+        itemNamer: (item: number, index: number) => `item-${item}`,
+      },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_items_only.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_items_only.ts
@@ -1,0 +1,17 @@
+// 9-2: Map items-only form (no operation name), each item returns directly
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const items: number[] = Array.isArray(event) ? event : [1, 2];
+    const results = await context.map(
+      items,
+      async (_ctx: DurableContext, item: number) => item * 2,
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_large_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_large_result.ts
@@ -1,0 +1,22 @@
+// 9-16: Map with a large aggregate result (exceeds the checkpoint size threshold)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    // Each iteration returns ~70KB; 4 items -> ~280KB aggregate, exceeding the 256KB threshold.
+    const big = "x".repeat(70000);
+    const results = await context.map(
+      "large",
+      [0, 1, 2, 3],
+      async (_ctx: DurableContext, _item: number) => big,
+      { maxConcurrency: 1 },
+    );
+    return {
+      successCount: results.successCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_min_successful.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_min_successful.ts
@@ -1,0 +1,21 @@
+// 9-7: Map min-successful early completion
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "min-successful",
+      ["s0", "s1", "s2", "s3"],
+      async (_ctx: DurableContext, item: string) => item,
+      { maxConcurrency: 1, completionConfig: { minSuccessful: 2 } },
+    );
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_op_serde.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_op_serde.ts
@@ -1,0 +1,44 @@
+// 9-19: Map with an operation-level (whole-result) serdes — serialize on a fresh operation
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+  BatchResult,
+  BatchItemStatus,
+} from "@aws/durable-execution-sdk-js";
+
+// Operation-level serde: serializes the whole BatchResult to "OPSERDE:<comma-joined results>"
+// and reconstructs a BatchResult on deserialize. Real, non-identity round-trip.
+const opSerdes: Serdes<BatchResult<string>> = {
+  serialize: async (
+    value: BatchResult<string> | undefined,
+    _c: SerdesContext,
+  ) =>
+    value === undefined ? undefined : `OPSERDE:${value.getResults().join(",")}`,
+  deserialize: async (data: string | undefined, _c: SerdesContext) => {
+    if (data === undefined) return undefined;
+    const vals = data.replace(/^OPSERDE:/, "").split(",");
+    // Return a plain shape; the SDK's restoreBatchResult wraps it with methods.
+    return {
+      all: vals.map((v, i) => ({
+        index: i,
+        status: BatchItemStatus.SUCCEEDED,
+        result: v,
+      })),
+      completionReason: "ALL_COMPLETED",
+    } as unknown as BatchResult<string>;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "op-serde",
+      ["x", "y"],
+      async (_ctx: DurableContext, item: string) => item.toUpperCase(),
+      { maxConcurrency: 1, serdes: opSerdes },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_op_serde_replay.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_op_serde_replay.ts
@@ -1,0 +1,45 @@
+// 9-20: Map with an operation-level serdes — deserialize on replay (wait after the map)
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+  BatchResult,
+  BatchItemStatus,
+} from "@aws/durable-execution-sdk-js";
+
+const opSerdes: Serdes<BatchResult<string>> = {
+  serialize: async (
+    value: BatchResult<string> | undefined,
+    _c: SerdesContext,
+  ) =>
+    value === undefined ? undefined : `OPSERDE:${value.getResults().join(",")}`,
+  deserialize: async (data: string | undefined, _c: SerdesContext) => {
+    if (data === undefined) return undefined;
+    const vals = data.replace(/^OPSERDE:/, "").split(",");
+    // Return a plain shape; the SDK's restoreBatchResult wraps it with methods.
+    return {
+      all: vals.map((v, i) => ({
+        index: i,
+        status: BatchItemStatus.SUCCEEDED,
+        result: v,
+      })),
+      completionReason: "ALL_COMPLETED",
+    } as unknown as BatchResult<string>;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "op-serde-replay",
+      ["x", "y"],
+      async (_ctx: DurableContext, item: string) => item.toUpperCase(),
+      { maxConcurrency: 1, serdes: opSerdes },
+    );
+    // Suspend after the map; on replay the SDK deserializes the checkpointed
+    // map result through opSerdes to reconstruct it before getResults().
+    await context.wait({ seconds: 1 });
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_suspend_iteration.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_suspend_iteration.ts
@@ -1,0 +1,23 @@
+// 9-15: Map suspends inside an iteration and replay skips the completed iteration
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "suspend",
+      ["r0", "r1"],
+      async (ctx: DurableContext, item: string, index: number) => {
+        // Iteration 1 issues a durable wait before its step, suspending mid-map.
+        if (index === 1) {
+          await ctx.wait({ seconds: 1 });
+        }
+        return ctx.step(async () => item);
+      },
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_then_wait.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_then_wait.ts
@@ -1,0 +1,19 @@
+// 9-17: Suspension after a successful map (replay skips the completed map)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "then-wait",
+      ["a", "b"],
+      async (_ctx: DurableContext, item: string) => item.toUpperCase(),
+      { maxConcurrency: 1 },
+    );
+    // Suspend after the map; on replay the completed map is skipped.
+    await context.wait({ seconds: 1 });
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_throw_if_error.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_throw_if_error.ts
@@ -1,0 +1,23 @@
+// 9-6: Map throw-if-error propagates an item failure to the execution
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "throwing",
+      ["fail", "never"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item === "fail") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 0 } },
+    );
+    results.throwIfError();
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_exceeded.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_exceeded.ts
@@ -1,0 +1,27 @@
+// 9-9: Map tolerated-failure-count exceeded (stops early)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "tolerated-exceeded",
+      ["f0", "f1", "never"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item !== "never") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_pct.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_pct.ts
@@ -1,0 +1,30 @@
+// 9-10: Map tolerated-failure-percentage exceeded (stops early)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "tolerated-pct",
+      ["f0", "f1", "never", "never"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item !== "never") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      {
+        maxConcurrency: 1,
+        completionConfig: { toleratedFailurePercentage: 25 },
+      },
+    );
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_within.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/map/map_tolerated_within.ts
@@ -1,0 +1,28 @@
+// 9-8: Map tolerated-failure-count within tolerance (all items complete)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.map(
+      "tolerated",
+      ["s0", "fail", "s2"],
+      async (_ctx: DurableContext, item: string) => {
+        if (item === "fail") {
+          throw new Error("item failed");
+        }
+        return item;
+      },
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_accessors.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_accessors.ts
@@ -1,0 +1,28 @@
+// 8-20: Parallel BatchResult accessors (succeeded/failed/getErrors/hasFailure)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "accessors",
+      [
+        async () => "ok0",
+        async () => {
+          throw new Error("f1");
+        },
+        async () => "ok2",
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    // Exercise the accessor methods rather than the count properties.
+    return {
+      hasFailure: results.hasFailure,
+      successCount: results.succeeded().length,
+      failureCount: results.failed().length,
+      errorCount: results.getErrors().length,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_all_fail.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_all_fail.ts
@@ -1,0 +1,34 @@
+// 8-16: Parallel where all branches fail (within tolerance, ALL_COMPLETED)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "all-fail",
+      [
+        async () => {
+          throw new Error("f0");
+        },
+        async () => {
+          throw new Error("f1");
+        },
+        async () => {
+          throw new Error("f2");
+        },
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 3 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_bad_concurrency.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_bad_concurrency.ts
@@ -1,0 +1,17 @@
+// 8-19: Parallel with invalid max-concurrency raises a validation error
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    // maxConcurrency=0 is invalid; the SDK raises before any branch runs.
+    const results = await context.parallel<string>(
+      "bad-concurrency",
+      [async () => "a", async () => "b"],
+      { maxConcurrency: 0 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_basic.ts
@@ -1,0 +1,19 @@
+// 8-1: Parallel basic (two branches, each a single step, all succeed)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "parallel",
+      [
+        async (ctx: DurableContext) => ctx.step(async () => "task-1"),
+        async (ctx: DurableContext) => ctx.step(async () => "task-2"),
+      ],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_branches_only.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_branches_only.ts
@@ -1,0 +1,15 @@
+// 8-2: Parallel branches-only form (no operation name)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      [async () => "alpha", async () => "beta"],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_combined_config.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_combined_config.ts
@@ -1,0 +1,35 @@
+// 8-18: Parallel with combined completion config (min-successful + tolerated-failure-count)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "combined",
+      [
+        async () => {
+          throw new Error("f0");
+        },
+        async () => {
+          throw new Error("f1");
+        },
+        async () => "ok2",
+        async () => "ok3",
+      ],
+      {
+        maxConcurrency: 1,
+        completionConfig: { minSuccessful: 3, toleratedFailureCount: 1 },
+      },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_concurrent.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_concurrent.ts
@@ -1,0 +1,16 @@
+// 8-11: Parallel real concurrency (max-concurrency > 1) preserves index-ordered results
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "concurrent",
+      [async () => "r0", async () => "r1", async () => "r2"],
+      { maxConcurrency: 2 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_custom_serde.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_custom_serde.ts
@@ -1,0 +1,26 @@
+// 8-15: Parallel with a custom per-branch serde (itemSerdes) round-trips results
+import {
+  DurableContext,
+  Serdes,
+  SerdesContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Symmetric custom serde: serialize wraps the value as {"wrapped": v}; deserialize unwraps it.
+const wrapSerdes: Serdes<string> = {
+  serialize: async (value: string | undefined, _c: SerdesContext) =>
+    JSON.stringify({ wrapped: value }),
+  deserialize: async (data: string | undefined, _c: SerdesContext) =>
+    JSON.parse(data as string).wrapped,
+};
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "serde",
+      [async () => "x", async () => "y"],
+      { maxConcurrency: 1, itemSerdes: wrapSerdes },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_empty.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_empty.ts
@@ -1,0 +1,12 @@
+// 8-5: Parallel with an empty branches list
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>("empty", []);
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_fail_fast.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_fail_fast.ts
@@ -1,0 +1,30 @@
+// 8-6: Parallel fail-fast (tolerated-failure-count=0) stops after first failure
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "failfast",
+      [
+        async () => "ok",
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => "never",
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 0 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_flat.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_flat.ts
@@ -1,0 +1,20 @@
+// 8-12: Parallel with FLAT nesting (virtual branch contexts)
+import {
+  DurableContext,
+  NestingType,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "flat",
+      [
+        async (ctx: DurableContext) => ctx.step(async () => "fa"),
+        async (ctx: DurableContext) => ctx.step(async () => "fb"),
+      ],
+      { maxConcurrency: 1, nesting: NestingType.FLAT },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_heterogeneous.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_heterogeneous.ts
@@ -1,0 +1,16 @@
+// 8-4: Parallel with heterogeneous branch return types
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel(
+      "hetero",
+      [async () => "hello", async () => 42, async () => ({ k: "v" })],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_min_not_reached.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_min_not_reached.ts
@@ -1,0 +1,30 @@
+// 8-17: Parallel min-successful not reached (all branches run)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "min-not-reached",
+      [
+        async () => "ok0",
+        async () => {
+          throw new Error("f1");
+        },
+        async () => "ok2",
+      ],
+      { maxConcurrency: 1, completionConfig: { minSuccessful: 3 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_min_successful.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_min_successful.ts
@@ -1,0 +1,22 @@
+// 8-8: Parallel min-successful early completion
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "min-successful",
+      [async () => "s0", async () => "s1", async () => "s2", async () => "s3"],
+      { maxConcurrency: 1, completionConfig: { minSuccessful: 2 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_named_branches.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_named_branches.ts
@@ -1,0 +1,19 @@
+// 8-3: Parallel with named branch objects
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "named",
+      [
+        { name: "first", func: async () => "one" },
+        { name: "second", func: async () => "two" },
+      ],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_nested.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_nested.ts
@@ -1,0 +1,28 @@
+// 8-21: Nested parallel (a parallel operation inside a parallel branch)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string[]>(
+      "outer",
+      [
+        async (ctx: DurableContext) => {
+          const inner = await ctx.parallel<string>(
+            "inner",
+            [
+              async (c2: DurableContext) => c2.step(async () => "i1"),
+              async (c2: DurableContext) => c2.step(async () => "i2"),
+            ],
+            { maxConcurrency: 1 },
+          );
+          return inner.getResults();
+        },
+      ],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_pct_boundary.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_pct_boundary.ts
@@ -1,0 +1,33 @@
+// 8-22: Parallel tolerated-failure-percentage at the boundary (not exceeded, ALL_COMPLETED)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "pct-boundary",
+      [
+        async () => {
+          throw new Error("f0");
+        },
+        async () => "ok1",
+        async () => "ok2",
+        async () => "ok3",
+      ],
+      {
+        maxConcurrency: 1,
+        completionConfig: { toleratedFailurePercentage: 25 },
+      },
+    );
+    // totalCount = started branches (succeeded + failed).
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_replay_skips_succeeded.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_replay_skips_succeeded.ts
@@ -1,0 +1,22 @@
+// 8-14: Parallel replay skips succeeded branches across a wait suspension
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "replay",
+      [
+        async (ctx: DurableContext) => ctx.step(async () => "b0"),
+        async (ctx: DurableContext) => {
+          await ctx.wait({ seconds: 2 });
+          return "b1";
+        },
+      ],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_throw_if_error.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_throw_if_error.ts
@@ -1,0 +1,22 @@
+// 8-7: Parallel throw-if-error propagates a branch failure to the execution (fail-fast config)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "throwing",
+      [
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => "never",
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 0 } },
+    );
+    results.throwIfError();
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_exceeded.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_exceeded.ts
@@ -1,0 +1,31 @@
+// 8-10: Parallel tolerated-failure-count exceeded (stops early)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "tolerated-exceeded",
+      [
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => "never",
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_pct.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_pct.ts
@@ -1,0 +1,35 @@
+// 8-13: Parallel tolerated-failure-percentage exceeded (stops early)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "tolerated-pct",
+      [
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => "never",
+        async () => "never",
+      ],
+      {
+        maxConcurrency: 1,
+        completionConfig: { toleratedFailurePercentage: 25 },
+      },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_within.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/parallel/parallel_tolerated_within.ts
@@ -1,0 +1,30 @@
+// 8-9: Parallel tolerated-failure-count within tolerance (all branches complete)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const results = await context.parallel<string>(
+      "tolerated",
+      [
+        async () => "s0",
+        async () => {
+          throw new Error("branch failed");
+        },
+        async () => "s2",
+      ],
+      { maxConcurrency: 1, completionConfig: { toleratedFailureCount: 1 } },
+    );
+    // totalCount = started branches (succeeded + failed); early-stopped
+    // branches are not counted, matching Java's succeeded()+failed().
+    return {
+      completionReason: results.completionReason,
+      status: results.status,
+      successCount: results.successCount,
+      failureCount: results.failureCount,
+      totalCount: results.totalCount,
+    };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_anonymous.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_anonymous.ts
@@ -1,0 +1,14 @@
+// 7-3: Wait-for-callback with anonymous submitter (no name)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const result = await context.waitForCallback(async (callbackId) => {
+      // Anonymous submitter — no name provided.
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_basic.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_basic.ts
@@ -1,0 +1,14 @@
+// 7-1: Wait-for-callback basic (success via external callback)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCallback(event, async (callbackId) => {
+      // Submitter receives callbackId; does nothing durable.
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_empty_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_empty_result.ts
@@ -1,0 +1,14 @@
+// 7-15: Wait-for-callback success with empty (null) payload
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCallback(event, async (callbackId) => {
+      // Submitter completes; external system sends success with no payload.
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_explicit_name.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_explicit_name.ts
@@ -1,0 +1,17 @@
+// 7-2: Wait-for-callback with explicit static name
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const result = await context.waitForCallback(
+      "approval",
+      async (callbackId) => {
+        // Submitter completes without side effects.
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_external_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_external_failure.ts
@@ -1,0 +1,15 @@
+// 7-4: Wait-for-callback external failure (uncaught)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // Do not catch — let the external failure propagate so execution fails.
+    const result = await context.waitForCallback(event, async (callbackId) => {
+      // Submitter completes successfully.
+    });
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_failure_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_failure_caught.ts
@@ -1,0 +1,17 @@
+// 7-6: Wait-for-callback external failure caught (recovers)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    try {
+      return await context.waitForCallback(event, async (callbackId) => {
+        // Submitter completes successfully.
+      });
+    } catch (e) {
+      return "recovered";
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_then_success.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_then_success.ts
@@ -1,0 +1,20 @@
+// 7-13: Wait-for-callback with heartbeat then success
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCallback(
+      event,
+      async (callbackId) => {
+        // Submitter completes; external system will heartbeat then succeed.
+      },
+      {
+        heartbeatTimeout: { seconds: 10 },
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_heartbeat_timeout.ts
@@ -1,0 +1,21 @@
+// 7-12: Wait-for-callback heartbeat timeout (no heartbeat sent)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // No heartbeat or terminal callback sent — heartbeat interval times out.
+    const result = await context.waitForCallback(
+      event,
+      async (callbackId) => {
+        // Submitter completes.
+      },
+      {
+        heartbeatTimeout: { seconds: 5 },
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_in_child_context.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_in_child_context.ts
@@ -1,0 +1,19 @@
+// 7-8: Wait-for-callback inside a child context
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.runInChildContext(
+      "wrapper",
+      async (childCtx) => {
+        return await childCtx.waitForCallback(event, async (callbackId) => {
+          // Submitter completes inside child context.
+        });
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_json_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_json_result.ts
@@ -1,0 +1,33 @@
+// 7-11: Wait-for-callback with structured (JSON) result deserialization
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+interface ApprovalResult {
+  status: string;
+}
+
+const jsonSerdes = {
+  deserialize: async (
+    str: string | undefined,
+  ): Promise<ApprovalResult | undefined> => {
+    if (str === undefined) return undefined;
+    return JSON.parse(str) as ApprovalResult;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCallback<ApprovalResult>(
+      event,
+      async (callbackId) => {
+        // Submitter completes.
+      },
+      {
+        serdes: jsonSerdes,
+      },
+    );
+    return result.status;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_mixed_ops.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_mixed_ops.ts
@@ -1,0 +1,24 @@
+// 7-10: Wait-for-callback mixed with wait and step
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // 1-second durable wait
+    await context.wait({ seconds: 1 });
+
+    // Top-level step returning fixed data
+    await context.step(async () => {
+      return "fixed-data";
+    });
+
+    // Wait-for-callback using event as operation name
+    const result = await context.waitForCallback(event, async (callbackId) => {
+      // Submitter completes.
+    });
+
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_submitter_retry_exhaustion.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_submitter_retry_exhaustion.ts
@@ -1,0 +1,24 @@
+// 7-7: Wait-for-callback submitter retry exhaustion
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // Submitter always throws. Retry budget: 2 attempts (1 retry), 1s delay.
+    const result = await context.waitForCallback(
+      event,
+      async (callbackId) => {
+        throw new Error("submitter always fails");
+      },
+      {
+        retryStrategy: (_error: Error, attemptCount: number) => ({
+          shouldRetry: attemptCount < 2,
+          delay: { seconds: 1 },
+        }),
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout.ts
@@ -1,0 +1,21 @@
+// 7-5: Wait-for-callback timeout (no external completion)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    // No external system ever completes the callback — it times out.
+    const result = await context.waitForCallback(
+      event,
+      async (callbackId) => {
+        // Submitter completes successfully.
+      },
+      {
+        timeout: { seconds: 3 },
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_timeout_caught.ts
@@ -1,0 +1,23 @@
+// 7-14: Wait-for-callback timeout caught (recovers)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    try {
+      return await context.waitForCallback(
+        event,
+        async (callbackId) => {
+          // Submitter completes; no external callback arrives.
+        },
+        {
+          timeout: { seconds: 3 },
+        },
+      );
+    } catch (e) {
+      return "timed-out-handled";
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_two_sequential.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_callback/wait_for_callback_two_sequential.ts
@@ -1,0 +1,25 @@
+// 7-9: Multiple sequential wait-for-callback operations
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const firstResult = await context.waitForCallback(
+      "first",
+      async (callbackId) => {
+        // First submitter completes.
+      },
+    );
+
+    const secondResult = await context.waitForCallback(
+      "second",
+      async (callbackId) => {
+        // Second submitter completes.
+      },
+    );
+
+    return secondResult;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_basic_poll.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_basic_poll.ts
@@ -1,0 +1,26 @@
+// 6-1: Wait-for-condition basic (polls until threshold met)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const threshold = typeof event === "number" ? event : Number(event);
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= threshold) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: 0,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_check_throws.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_check_throws.ts
@@ -1,0 +1,22 @@
+// 6-7: Wait-for-condition check function throws (uncaught failure)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        throw new Error("check function error");
+      },
+      {
+        waitStrategy: (_state: number, _attempt: number) => {
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: 0,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_check_throws_caught.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_check_throws_caught.ts
@@ -1,0 +1,25 @@
+// 6-8: Wait-for-condition check throws, caught by handler (recovers)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    try {
+      await context.waitForCondition(
+        async (state: number) => {
+          throw new Error("check function error");
+        },
+        {
+          waitStrategy: (_state: number, _attempt: number) => {
+            return { shouldContinue: true, delay: { seconds: 1 } };
+          },
+          initialState: 0,
+        },
+      );
+    } catch (e) {
+      return "recovered";
+    }
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_complex_object.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_complex_object.ts
@@ -1,0 +1,34 @@
+// 6-9: Wait-for-condition with a complex object state
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+interface PollState {
+  status: string;
+  attempts: number;
+}
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCondition(
+      async (state: PollState) => {
+        const newAttempts = state.attempts + 1;
+        return {
+          status: newAttempts >= 2 ? "DONE" : "PENDING",
+          attempts: newAttempts,
+        };
+      },
+      {
+        waitStrategy: (state: PollState, _attempt: number) => {
+          if (state.status === "DONE") {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: { status: "PENDING", attempts: 0 },
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_custom_initial_state.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_custom_initial_state.ts
@@ -1,0 +1,26 @@
+// 6-4: Wait-for-condition with custom initial state (state threaded across polls)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const threshold = typeof event === "number" ? event : Number(event);
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= threshold) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: 5,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_custom_serdes.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_custom_serdes.ts
@@ -1,0 +1,47 @@
+// 6-11: Wait-for-condition with custom state serdes
+import {
+  DurableContext,
+  withDurableExecution,
+  Serdes,
+  SerdesContext,
+} from "@aws/durable-execution-sdk-js";
+
+const customStringSerdes: Serdes<string> = {
+  serialize: async (
+    value: string | undefined,
+    _context: SerdesContext,
+  ): Promise<string | undefined> => {
+    if (value === undefined) return undefined;
+    // Custom encoding: prefix with "ENC:" to prove custom serdes is used
+    return "ENC:" + value;
+  },
+  deserialize: async (
+    data: string | undefined,
+    _context: SerdesContext,
+  ): Promise<string | undefined> => {
+    if (data === undefined) return undefined;
+    // Custom decoding: strip the "ENC:" prefix
+    return data.startsWith("ENC:") ? data.slice(4) : data;
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCondition(
+      async (state: string) => {
+        return state + "x";
+      },
+      {
+        waitStrategy: (state: string, _attempt: number) => {
+          if (state.length >= 2) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: "",
+        serdes: customStringSerdes,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_fixed_delay.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_fixed_delay.ts
@@ -1,0 +1,26 @@
+// 6-5: Wait-for-condition with fixed-delay wait strategy
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const threshold = typeof event === "number" ? event : Number(event);
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= threshold) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 2 } };
+        },
+        initialState: 0,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_immediate_stop.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_immediate_stop.ts
@@ -1,0 +1,26 @@
+// 6-2: Wait-for-condition immediate stop (condition already met on first check)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const initialValue = typeof event === "number" ? event : Number(event);
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        return state;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= 5) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: initialValue,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_max_attempts.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_max_attempts.ts
@@ -1,0 +1,28 @@
+// 6-6: Wait-for-condition max attempts exceeded (failure)
+import {
+  DurableContext,
+  withDurableExecution,
+  createWaitStrategy,
+  JitterStrategy,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: createWaitStrategy<number>({
+          maxAttempts: 3,
+          shouldContinuePolling: () => true,
+          initialDelay: { seconds: 1 },
+          backoffRate: 1,
+          jitter: JitterStrategy.NONE,
+        }),
+        initialState: 0,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_multiple_sequential.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_multiple_sequential.ts
@@ -1,0 +1,38 @@
+// 6-13: Multiple sequential wait_for_condition operations
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+function makeWaitStrategy(threshold: number) {
+  return (state: number, _attempt: number) => {
+    if (state >= threshold) {
+      return { shouldContinue: false } as const;
+    }
+    return { shouldContinue: true, delay: { seconds: 1 } } as const;
+  };
+}
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    const firstResult = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: makeWaitStrategy(2),
+        initialState: 0,
+      },
+    );
+    const secondResult = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: makeWaitStrategy(4),
+        initialState: firstResult,
+      },
+    );
+    return secondResult;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_null_result.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_null_result.ts
@@ -1,0 +1,22 @@
+// 6-10: Wait-for-condition null result
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.waitForCondition(
+      async (_state: null) => {
+        return null;
+      },
+      {
+        waitStrategy: (_state: null, _attempt: number) => {
+          return { shouldContinue: false };
+        },
+        initialState: null as any,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_then_step.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_then_step.ts
@@ -1,0 +1,29 @@
+// 6-12: Wait-for-condition followed by a step (result passed onward)
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const threshold = typeof event === "number" ? event : Number(event);
+    const pollResult = await context.waitForCondition(
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= threshold) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: 0,
+      },
+    );
+    const stepResult = await context.step(async () => {
+      return pollResult * 10;
+    });
+    return stepResult;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_with_name.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/wait_for_condition/wait_for_condition_with_name.ts
@@ -1,0 +1,27 @@
+// 6-3: Wait-for-condition with explicit name
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const threshold = typeof event === "number" ? event : Number(event);
+    const result = await context.waitForCondition(
+      "poll-status",
+      async (state: number) => {
+        return state + 1;
+      },
+      {
+        waitStrategy: (state: number, _attempt: number) => {
+          if (state >= threshold) {
+            return { shouldContinue: false };
+          }
+          return { shouldContinue: true, delay: { seconds: 1 } };
+        },
+        initialState: 0,
+      },
+    );
+    return result;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/scripts/inject_execution_role.py
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/scripts/inject_execution_role.py
@@ -6,6 +6,9 @@ uses the provided execution role ARN, and removes the self-created
 DurableFunctionRole resource. Used by CI to avoid creating an IAM role per
 deploy; the checked-in template stays self-contained for local runs.
 
+CloudFormation short-form intrinsic tags (!Sub, !GetAtt, !Ref, ...) are
+preserved through a tag-aware load/dump round-trip.
+
 Usage:
     python3 scripts/inject_execution_role.py --template template_step.yaml \
         --role-arn arn:aws:iam::123456789012:role/my-execution-role
@@ -24,10 +27,50 @@ SELF_CREATED_ROLE = "DurableFunctionRole"
 FUNCTION_TYPE = "AWS::Serverless::Function"
 
 
+class CfnTag:
+    """Opaque holder for a CloudFormation short-form tag (e.g. !Sub, !GetAtt)."""
+
+    def __init__(self, tag: str, value: object) -> None:
+        self.tag = tag
+        self.value = value
+
+
+class CfnLoader(yaml.SafeLoader):
+    """SafeLoader that wraps unknown (CloudFormation) tags instead of failing."""
+
+
+def _construct_cfn_tag(loader: CfnLoader, suffix: str, node: yaml.Node) -> CfnTag:
+    if isinstance(node, yaml.ScalarNode):
+        value: object = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    else:
+        value = loader.construct_mapping(node, deep=True)
+    return CfnTag(node.tag, value)
+
+
+CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+
+
+class CfnDumper(yaml.SafeDumper):
+    """SafeDumper that re-emits wrapped CloudFormation tags verbatim."""
+
+
+def _represent_cfn_tag(dumper: CfnDumper, data: CfnTag) -> yaml.Node:
+    if isinstance(data.value, str):
+        return dumper.represent_scalar(data.tag, data.value)
+    if isinstance(data.value, list):
+        return dumper.represent_sequence(data.tag, data.value)
+    return dumper.represent_mapping(data.tag, data.value)
+
+
+CfnDumper.add_representer(CfnTag, _represent_cfn_tag)
+
+
 def inject(template_path: str, role_arn: str) -> int:
     """Rewrite template_path in place; return the number of functions updated."""
     with open(template_path, encoding="utf-8") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.load(f, Loader=CfnLoader)  # noqa: S506 - CfnLoader extends SafeLoader
 
     resources = doc.get("Resources")
     if not isinstance(resources, dict):
@@ -45,7 +88,7 @@ def inject(template_path: str, role_arn: str) -> int:
         raise SystemExit(f"{template_path}: no {FUNCTION_TYPE} resources found")
 
     with open(template_path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(doc, f, sort_keys=False)
+        yaml.dump(doc, f, Dumper=CfnDumper, sort_keys=False)
 
     return updated
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_callback.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_callback.yaml
@@ -1,0 +1,376 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DurableExecutionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:CheckpointDurableExecution
+                  - lambda:GetDurableExecutionState
+                  - lambda:SendDurableExecutionCallbackSuccess
+                  - lambda:SendDurableExecutionCallbackFailure
+                  - lambda:SendDurableExecutionCallbackHeartbeat
+                Resource: '*'
+
+  CallbackBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_basic.handler
+      Description: Create callback basic (anonymous, success via external callback)
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWithName:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_with_name.handler
+      Description: Create callback with explicit name
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_timeout.handler
+      Description: Create callback general timeout
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_heartbeat_timeout.handler
+      Description: Create callback heartbeat timeout
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackHeartbeatSuccess:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_heartbeat_success.handler
+      Description: Create callback with heartbeat then success
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_failure.handler
+      Description: Callback failure (external reports failure)
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitSuccess:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_wait_success.handler
+      Description: Callback + Wait + success
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayWithWait:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_replay_with_wait.handler
+      Description: Callback success then wait, verifies multi-invocation replay
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackSerdesHappy:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_serdes_happy.handler
+      Description: Callback with custom serdes (happy path - Date roundtrip)
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+
+  CallbackStepFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_step_failure.handler
+      Description: Callback + Step + failure
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackStepTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_step_timeout.handler
+      Description: Callback + Step + timeout
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_wait_failure.handler
+      Description: Callback + Wait + failure
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackWaitTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_wait_timeout.handler
+      Description: Callback + Wait + timeout
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_replay_failure.handler
+      Description: Callback failure caught then wait
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackReplayTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_replay_timeout.handler
+      Description: Callback timeout caught then wait
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackSerdesNumeric:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-16"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_serdes_numeric.handler
+      Description: Custom serdes (numeric)
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoSequential:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-17"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_two_sequential.handler
+      Description: Two callbacks - sequential create and wait
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoParallel:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-18"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_two_parallel.handler
+      Description: Two callbacks - create both then wait in order
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  CallbackTwoParallelReverse:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["4-19"]
+    Properties:
+      CodeUri: ./dist
+      Handler: callback_two_parallel_reverse.handler
+      Description: Two callbacks - create both then wait in reverse order
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_child.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_child.yaml
@@ -1,0 +1,368 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+# NOTE: The AttemptsTable (DynamoDB) is required only by ChildRetryExhaustion
+# (3-12, child_interrupted): its step crashes via process.exit with no retry
+# strategy, and the SDK checkpoints the attempt counter only on FAIL/RETRY —
+# never on a crash — so cross-invocation execution counting needs external
+# state. All other retry handlers use the SDK-native stepContext.attempt.
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+      - PolicyName: DynamoDBPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+            Resource:
+              Fn::GetAtt:
+              - AttemptsTable
+              - Arn
+  AttemptsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+      - AttributeName: executionId
+        AttributeType: S
+      KeySchema:
+      - AttributeName: executionId
+        KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+  ChildBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_basic.handler
+      Description: Child context basic with single step inside
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildWithName:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_with_name.handler
+      Description: Child context with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildMultipleSteps:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_multiple_steps.handler
+      Description: Child context with multiple sequential steps
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildError:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_error.handler
+      Description: Child context where step fails and execution fails
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildErrorCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_error_caught.handler
+      Description: Child context error caught with try/catch, execution succeeds
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildNested:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_nested.handler
+      Description: Nested child contexts with inner and outer steps
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildRetry:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_retry.handler
+      Description: Child context with step retry that fails then succeeds
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildRetryExhaustion:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_retry_exhaustion.handler
+      Description: Child context with step retry exhaustion, child fails
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildReplay:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_replay.handler
+      Description: Child context replay returns cached result
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildStepAndWait:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_step_and_wait.handler
+      Description: Child context with step and wait inside
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildLargePayload:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_large_payload.handler
+      Description: Child context large payload triggers ReplayChildren mode
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildInterrupted:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_interrupted.handler
+      Description: Child context interrupted and re-executed
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          ATTEMPTS_TABLE_NAME:
+            Ref: AttemptsTable
+  ChildWaitReplay:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_wait_replay.handler
+      Description: Child context with wait inside - verify replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildCustomSerdes:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_custom_serdes.handler
+      Description: Child context with custom serdes (succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildErrorNoStep:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_error_no_step.handler
+      Description: Child context error without step (error thrown directly in child body)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildNullResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-16"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_null_result.handler
+      Description: Child context returning null
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildPrintOnly:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-17"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_print_only.handler
+      Description: Child context with print only (verify no re-execution on replay)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ChildStepWaitAfter:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["3-18"]
+    Properties:
+      CodeUri: ./dist
+      Handler: child_step_wait_after.handler
+      Description: Child context with step and wait inside, step and wait after
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_invoke.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_invoke.yaml
@@ -1,0 +1,489 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            - lambda:InvokeFunction
+            Resource: '*'
+  TargetEcho:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    Properties:
+      CodeUri: ./dist
+      Handler: target_echo.handler
+      Description: Echo target function — returns whatever it receives
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetEchoTenant:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    Properties:
+      CodeUri: ./dist
+      Handler: target_echo.handler
+      Description: Echo target function with tenancy enabled
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      TenancyConfig:
+        TenantIsolationMode: PER_TENANT
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetError:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    Properties:
+      CodeUri: ./dist
+      Handler: target_error.handler
+      Description: Target function that throws an error
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetSlow:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    Properties:
+      CodeUri: ./dist
+      Handler: target_slow.handler
+      Description: Target function that takes too long (for timeout tests)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+
+  TargetNonDurable:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    Properties:
+      CodeUri: ./dist
+      Handler: target_non_durable.handler
+      Description: Target function without durable execution (plain Lambda)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+
+  # Test Handler Functions
+  InvokeBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_basic.handler
+      Description: Invoke basic (target function succeeds)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithName:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_with_name.handler
+      Description: Invoke with explicit name parameter
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeComplexObject:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_complex_object.handler
+      Description: Invoke returning complex object (nested JSON)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeNullResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_null_result.handler
+      Description: Invoke returning null
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeTargetFails:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_target_fails.handler
+      Description: Invoke target fails (execution fails with InvokeError)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  InvokeTargetFailsCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_target_fails_caught.handler
+      Description: Invoke target fails, caught (try/catch)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  InvokeTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: [] # ["5-17"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_timeout.handler
+      Description: Invoke timeout (target takes too long)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetSlow.Arn}:$LATEST"
+
+  InvokeTimeoutCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: [] # ["5-18"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_timeout_caught.handler
+      Description: Invoke timeout, caught (execution continues)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetSlow.Arn}:$LATEST"
+
+  InvokeReplaySkips:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_replay_skips.handler
+      Description: Invoke replay skips (invoke result cached on replay)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeReplayRethrows:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_replay_rethrows.handler
+      Description: Invoke replay re-throws (failed invoke error re-thrown from cache)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetError.Arn}:$LATEST"
+
+  StepThenInvoke:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: step_then_invoke.handler
+      Description: Step then invoke (sequential operations)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeThenStep:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_then_step.handler
+      Description: Invoke then step (invoke result used by subsequent step)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeInChildContext:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_in_child_context.handler
+      Description: Invoke inside child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeMultipleSequential:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_multiple_sequential.handler
+      Description: Multiple sequential invokes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME_1: !Sub "${TargetEcho.Arn}:$LATEST"
+          TARGET_FUNCTION_NAME_2: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomPayloadSerdes:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_custom_payload_serdes.handler
+      Description: Invoke with custom payload serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeCustomResultSerdes:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-16"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_custom_result_serdes.handler
+      Description: Invoke with custom result serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeLargePayload:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_large_payload.handler
+      Description: Invoke large payload (payload near size limit)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEcho.Arn}:$LATEST"
+
+  InvokeWithTenantId:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["5-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: invoke_with_tenant_id.handler
+      Description: Invoke with tenantId (tenant-isolated invocation)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+      Environment:
+        Variables:
+          TARGET_FUNCTION_NAME: !Sub "${TargetEchoTenant.Arn}:$LATEST"

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_map.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_map.yaml
@@ -1,0 +1,370 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  MapBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_basic.handler
+      Description: Map basic (one step per item, all succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapItemsOnly:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_items_only.handler
+      Description: Map items-only form (no operation name)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapItemIndex:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_item_index.handler
+      Description: Map function receives item and index
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapEmpty:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_empty.handler
+      Description: Map with an empty items list
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapFailFast:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_fail_fast.handler
+      Description: Map fail-fast (tolerated-failure-count=0) stops after first failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapThrowIfError:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_throw_if_error.handler
+      Description: Map throw-if-error propagates an item failure to the execution
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapMinSuccessful:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_min_successful.handler
+      Description: Map min-successful early completion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapToleratedWithin:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_tolerated_within.handler
+      Description: Map tolerated-failure-count within tolerance (all items complete)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapToleratedExceeded:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_tolerated_exceeded.handler
+      Description: Map tolerated-failure-count exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapToleratedPct:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_tolerated_pct.handler
+      Description: Map tolerated-failure-percentage exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapConcurrent:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_concurrent.handler
+      Description: Map real concurrency preserves index-ordered results
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapFlat:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_flat.handler
+      Description: Map with FLAT nesting (virtual iteration contexts)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapItemNamer:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_item_namer.handler
+      Description: Map with a custom item namer
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapItemSerdes:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_custom_serde.handler
+      Description: Map with a custom per-item serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapSuspendIteration:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_suspend_iteration.handler
+      Description: Map suspends inside an iteration; replay skips the completed iteration
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapLargeResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-16"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_large_result.handler
+      Description: Map with a large aggregate result (exceeds checkpoint size threshold)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapThenWait:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-17"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_then_wait.handler
+      Description: Suspension after a successful map (replay skips the completed map)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapFailThenWait:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-18"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_fail_then_wait.handler
+      Description: Suspension after a map that completed with a failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapOpSerde:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-19"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_op_serde.handler
+      Description: Map operation-level serdes - serialize on a fresh operation
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  MapOpSerdeReplay:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["9-20"]
+    Properties:
+      CodeUri: ./dist
+      Handler: map_op_serde_replay.handler
+      Description: Map operation-level serdes - deserialize on replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_parallel.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_parallel.yaml
@@ -1,0 +1,405 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  ParallelBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_basic.handler
+      Description: Parallel basic (two branches, each a single step, all succeed)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelBranchesOnly:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_branches_only.handler
+      Description: Parallel branches-only form (no operation name)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelNamedBranches:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_named_branches.handler
+      Description: Parallel with named branch objects
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelHeterogeneous:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_heterogeneous.handler
+      Description: Parallel with heterogeneous branch return types
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelEmpty:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_empty.handler
+      Description: Parallel with an empty branches list
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelFailFast:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_fail_fast.handler
+      Description: Parallel fail-fast (tolerated-failure-count=0) stops after first failure
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelThrowIfError:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_throw_if_error.handler
+      Description: Parallel throw-if-error propagates a branch failure to the execution
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelMinSuccessful:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_min_successful.handler
+      Description: Parallel min-successful early completion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelToleratedWithin:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_tolerated_within.handler
+      Description: Parallel tolerated-failure-count within tolerance (all branches complete)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelToleratedExceeded:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_tolerated_exceeded.handler
+      Description: Parallel tolerated-failure-count exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelConcurrent:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_concurrent.handler
+      Description: Parallel real concurrency preserves index-ordered results
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelFlat:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_flat.handler
+      Description: Parallel with FLAT nesting (virtual branch contexts)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelToleratedPct:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_tolerated_pct.handler
+      Description: Parallel tolerated-failure-percentage exceeded (stops early)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelReplay:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_replay_skips_succeeded.handler
+      Description: Parallel replay skips succeeded branches across a wait suspension
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelCustomSerde:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_custom_serde.handler
+      Description: Parallel with a custom per-branch serde (itemSerdes)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelAllFail:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-16"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_all_fail.handler
+      Description: Parallel where all branches fail (within tolerance)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelMinNotReached:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-17"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_min_not_reached.handler
+      Description: Parallel min-successful not reached (all branches run)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelCombinedConfig:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-18"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_combined_config.handler
+      Description: Parallel combined completion config (min-successful + tolerated-failure-count)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelBadConcurrency:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-19"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_bad_concurrency.handler
+      Description: Parallel with invalid max-concurrency raises a validation error
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelAccessors:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-20"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_accessors.handler
+      Description: Parallel BatchResult accessors (succeeded/failed/getErrors/hasFailure)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelNested:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-21"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_nested.handler
+      Description: Nested parallel (parallel inside a parallel branch)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  ParallelPctBoundary:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["8-22"]
+    Properties:
+      CodeUri: ./dist
+      Handler: parallel_pct_boundary.handler
+      Description: Parallel tolerated-failure-percentage at the boundary
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_wait_for_callback.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_wait_for_callback.yaml
@@ -1,0 +1,285 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  WfcBasic:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_basic.handler
+      Description: Wait-for-callback basic
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcExplicitName:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_explicit_name.handler
+      Description: Wait-for-callback with explicit static name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcAnonymous:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_anonymous.handler
+      Description: Wait-for-callback anonymous submitter (no name)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcExternalFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_external_failure.handler
+      Description: Wait-for-callback external failure (uncaught)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_timeout.handler
+      Description: Wait-for-callback timeout (no external completion)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcFailureCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_failure_caught.handler
+      Description: Wait-for-callback external failure caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcSubmitterRetryExhaustion:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_submitter_retry_exhaustion.handler
+      Description: Wait-for-callback submitter retry exhaustion
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcInChildContext:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_in_child_context.handler
+      Description: Wait-for-callback inside a child context
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcTwoSequential:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_two_sequential.handler
+      Description: Multiple sequential wait-for-callback operations
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcMixedOps:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_mixed_ops.handler
+      Description: Wait-for-callback mixed with wait and step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcJsonResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_json_result.handler
+      Description: Wait-for-callback with structured JSON result deserialization
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcHeartbeatTimeout:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_heartbeat_timeout.handler
+      Description: Wait-for-callback heartbeat timeout (no heartbeat sent)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcHeartbeatThenSuccess:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_heartbeat_then_success.handler
+      Description: Wait-for-callback with heartbeat then success
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcTimeoutCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-14"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_timeout_caught.handler
+      Description: Wait-for-callback timeout caught (recovers)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WfcNullResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["7-15"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_callback_empty_result.handler
+      Description: Wait-for-callback success with empty (null) payload
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_wait_for_condition.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_wait_for_condition.yaml
@@ -1,0 +1,251 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  WaitForConditionBasicPoll:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_basic_poll.handler
+      Description: Wait-for-condition basic poll
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionImmediateStop:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_immediate_stop.handler
+      Description: Wait-for-condition immediate stop
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionWithName:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_with_name.handler
+      Description: Wait-for-condition with explicit name
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionCustomInitialState:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_custom_initial_state.handler
+      Description: Wait-for-condition custom initial state
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionFixedDelay:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_fixed_delay.handler
+      Description: Wait-for-condition fixed-delay strategy
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionMaxAttempts:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_max_attempts.handler
+      Description: Wait-for-condition max attempts exceeded
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionCheckThrows:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_check_throws.handler
+      Description: Wait-for-condition check throws uncaught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionCheckThrowsCaught:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-8"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_check_throws_caught.handler
+      Description: Wait-for-condition check throws caught
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionComplexObject:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-9"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_complex_object.handler
+      Description: Wait-for-condition complex object state
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionNullResult:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-10"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_null_result.handler
+      Description: Wait-for-condition null result
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionCustomSerdes:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-11"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_custom_serdes.handler
+      Description: Wait-for-condition custom serdes
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionThenStep:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-12"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_then_step.handler
+      Description: Wait-for-condition followed by step
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  WaitForConditionMultipleSequential:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["6-13"]
+    Properties:
+      CodeUri: ./dist
+      Handler: wait_for_condition_multiple_sequential.handler
+      Description: Multiple sequential wait_for_condition operations
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## What
Completes the conformance package: adds handlers + SAM templates for the
remaining seven suites — **child (18), callback (19), invoke (22),
wait_for_condition (13), wait_for_callback (15), parallel (22), map (20)** —
on top of the step + wait suites from #733. The package now ships all nine
suites (154 handlers). The CI matrix runs one parallel job per suite.


## CI expectation
`conformance (child)` deploys the DynamoDB table for 3-12 and therefore
requires DynamoDB permissions on the CI deploy role; the other eight suites
need none.
