### PR TITLE
fix(sdk): skip repo-root prepare script in release workflow

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -84,7 +84,15 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - run: npm ci
+      - name: Install root dependencies
+        # --ignore-scripts avoids the repo-root "prepare" script (husky
+        # install), which can fail on a fresh CI checkout (observed:
+        # "sh: husky: command not found", exit 127) — likely a PATH-timing
+        # issue with npm's lifecycle-script execution, not anything this
+        # job needs. Git hooks are irrelevant in CI, and nothing below
+        # (typecheck, test, or the isolated packaging step) depends on any
+        # other root-level lifecycle script.
+        run: npm ci --ignore-scripts
       - name: Install webview-ui dependencies
         # webview-ui is a nested package outside the root workspaces glob
         # (packages/*), so it needs its own explicit install.


### PR DESCRIPTION
The first real run of vscode-extension-release.yml (https://github.com/aws/aws-durable-execution-sdk-js/actions/runs/29800665083) failed identically on all 4 matrix legs at the plain 'npm ci' step, before reaching the isolated packaging logic:

  > aws-durable-execution-sdk-js@0.0.1 prepare
  > husky install
  sh: husky: command not found
  npm error code 127

Reproduced 'npm ci' (no --ignore-scripts) succeeding on a fresh clone with local npm 10.9.4, but the failing run used npm 11.16.0 (via actions/setup-node node-version: 24) — consistent with an npm-version-specific timing issue in when the 'prepare' lifecycle script runs relative to node_modules/.bin being on PATH, rather than anything wrong with husky's own config.

Fix: pass --ignore-scripts to this job's root 'npm ci'. Git hooks are irrelevant in CI, and nothing downstream (typecheck, test, the isolated packaging step, or webview-ui's separate install) depends on any other root-level lifecycle script — verified locally: 'npm ci --ignore-scripts' at the repo root, then 'npm run typecheck' and 'npm run test' in packages/aws-durable-execution-sdk-js-insight-vscode both pass (194/194 tests) exactly as they would in the workflow.