### PR TITLE
chore: bump version to 0.1.0-alpha.1 for release retry

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "aws-durable-execution-sdk-js-insight-vscode",
   "displayName": "Workflow Insight Explorer",
   "description": "Query AWS Durable Execution Workflow Insight data from CloudWatch Logs using plain English.",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "license": "Apache-2.0",
   "publisher": "aws",
   "private": true,


### PR DESCRIPTION
The previous tag/release (workflow-insight-vscode-v0.1.0-alpha.0) failed at npm ci on all 4 platform legs (fixed in #738). Rather than delete and recreate that tag/release, bump the version so this release attempt uses a fresh tag (workflow-insight-vscode-v0.1.0-alpha.1) with no collision or cleanup needed.