### PR TITLE
chore: bump version to 0.1.0-alpha.2 for release retry

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "aws-durable-execution-sdk-js-insight-vscode",
   "displayName": "Workflow Insight Explorer",
   "description": "Query AWS Durable Execution Workflow Insight data from CloudWatch Logs using plain English.",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "license": "Apache-2.0",
   "publisher": "aws",
   "private": true,


### PR DESCRIPTION
Previous release attempts (0.1.0-alpha.0, 0.1.0-alpha.1) both failed before the draft-first workflow redesign (#741) landed — 0.1.0-alpha.1's tag/release already exists from that failed run. Bump the version so this attempt uses a fresh tag (workflow-insight-vscode-v0.1.0-alpha.2) with no ambiguity about reusing a possibly-published release.