### PR TITLE
fix(sdk): convert Windows paths for Git Bash in release workflow

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -160,22 +160,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # On Windows runners, $RUNNER_TEMP and $GITHUB_WORKSPACE are
-          # native Windows paths (e.g. D:\a\_temp) that Git Bash's own
-          # env-injection can mangle further (observed: colons and
-          # backslashes double-escaped, producing a path tar/mkdir/cp can't
-          # open). cygpath -u (ships with Git Bash/MSYS2 by default)
-          # converts them to clean POSIX paths; on macOS/Linux runners
-          # cygpath doesn't exist, so fall back to the values as-is (they're
-          # already normal POSIX paths there).
-          to_posix() {
-            if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1"; else printf '%s' "$1"; fi
-          }
-          RUNNER_TEMP_POSIX=$(to_posix "$RUNNER_TEMP")
-          GITHUB_WORKSPACE_POSIX=$(to_posix "$GITHUB_WORKSPACE")
-          ISOLATED="$RUNNER_TEMP_POSIX/insight-vscode-pkg"
-          rm -rf "$ISOLATED"
-          mkdir -p "$ISOLATED"
+          # Don't build the isolation/copy-back paths from $RUNNER_TEMP or
+          # $GITHUB_WORKSPACE directly: on Windows runners those are native
+          # Windows-style strings (e.g. D:\a\_temp), and passing them through
+          # Git Bash into a real Windows binary like tar.exe has repeatedly
+          # been observed to mangle them (colons/backslashes double-escaped,
+          # producing a path tar can't open — this matches a known class of
+          # GitHub Actions Windows+bash issues, e.g. actions/runner#1328).
+          # mktemp -d and `pwd` are pure bash/coreutils operations that stay
+          # entirely within Git Bash's own POSIX-path view of the
+          # filesystem, so the string never has to round-trip through a
+          # native Windows path representation.
+          WORKSPACE_DIR="$(pwd)"
+          ISOLATED="$(mktemp -d)"
           # Portable copy (avoids relying on rsync, which isn't preinstalled
           # on Windows runners): tar streamed through a pipe, excluding
           # directories we don't want carried into the isolated copy.
@@ -207,8 +204,8 @@ jobs:
           "
           (cd webview-ui && npm ci)
           npm run package:target
-          mkdir -p "$GITHUB_WORKSPACE_POSIX/packages/aws-durable-execution-sdk-js-insight-vscode/vsix"
-          cp vsix/*.vsix "$GITHUB_WORKSPACE_POSIX/packages/aws-durable-execution-sdk-js-insight-vscode/vsix/"
+          mkdir -p "$WORKSPACE_DIR/vsix"
+          cp vsix/*.vsix "$WORKSPACE_DIR/vsix/"
         env:
           VSCE_TARGET: ${{ matrix.target }}
       - name: Upload .vsix to draft release

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -160,7 +160,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ISOLATED="$RUNNER_TEMP/insight-vscode-pkg"
+          # On Windows runners, $RUNNER_TEMP and $GITHUB_WORKSPACE are
+          # native Windows paths (e.g. D:\a\_temp) that Git Bash's own
+          # env-injection can mangle further (observed: colons and
+          # backslashes double-escaped, producing a path tar/mkdir/cp can't
+          # open). cygpath -u (ships with Git Bash/MSYS2 by default)
+          # converts them to clean POSIX paths; on macOS/Linux runners
+          # cygpath doesn't exist, so fall back to the values as-is (they're
+          # already normal POSIX paths there).
+          to_posix() {
+            if command -v cygpath >/dev/null 2>&1; then cygpath -u "$1"; else printf '%s' "$1"; fi
+          }
+          RUNNER_TEMP_POSIX=$(to_posix "$RUNNER_TEMP")
+          GITHUB_WORKSPACE_POSIX=$(to_posix "$GITHUB_WORKSPACE")
+          ISOLATED="$RUNNER_TEMP_POSIX/insight-vscode-pkg"
           rm -rf "$ISOLATED"
           mkdir -p "$ISOLATED"
           # Portable copy (avoids relying on rsync, which isn't preinstalled
@@ -194,8 +207,8 @@ jobs:
           "
           (cd webview-ui && npm ci)
           npm run package:target
-          mkdir -p "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix"
-          cp vsix/*.vsix "$GITHUB_WORKSPACE/packages/aws-durable-execution-sdk-js-insight-vscode/vsix/"
+          mkdir -p "$GITHUB_WORKSPACE_POSIX/packages/aws-durable-execution-sdk-js-insight-vscode/vsix"
+          cp vsix/*.vsix "$GITHUB_WORKSPACE_POSIX/packages/aws-durable-execution-sdk-js-insight-vscode/vsix/"
         env:
           VSCE_TARGET: ${{ matrix.target }}
       - name: Upload .vsix to draft release


### PR DESCRIPTION
The win32-x64 leg failed at the isolated-packaging step:

  tar: D\:\a\_temp/insight-vscode-pkg: Cannot open: No such file or directory

$RUNNER_TEMP (and $GITHUB_WORKSPACE, used later in the same step) are native Windows paths on Windows runners (e.g. D:\a\_temp). Git Bash's env-injection mangles them further when interpolated directly into a bash string — colons and backslashes end up double-escaped — producing a path tar/mkdir/cp can't open. This is a known class of issue with GitHub Actions Windows runners + bash (see actions/runner#1328, actions/runner-images#480).

Fix: convert both variables to clean POSIX paths via cygpath -u right at the top of the script, before using them anywhere. cygpath ships with Git Bash/MSYS2 by default on Windows runners; on macOS/Linux runners cygpath doesn't exist, so the helper falls back to using the value unchanged (already a normal POSIX path there).

Verified locally: the to_posix() fallback path (no cygpath, as on macOS/Linux) is a no-op passthrough, and the full isolated-packaging script still runs end-to-end correctly on darwin-arm64 with this change (produces a correct 0.1.0-alpha.2-darwin-arm64.vsix). Could not test the actual cygpath conversion path itself, since that requires a real Windows Git Bash environment — confirmed cygpath's behavior and default availability via MSYS2's own documentation instead.