### PR TITLE
fix(sdk): invoke vsce directly instead of via npm run on Windows

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -203,7 +203,19 @@ jobs:
               .catch(e => { console.error('getLlama() failed:', e.message); process.exit(1); });
           "
           (cd webview-ui && npm ci)
-          npm run package:target
+          # Not `npm run package:target`: npm spawns cmd.exe (not bash) to
+          # execute package.json scripts on Windows by default (this is
+          # npm's own documented behavior — see "npm run" docs), so the
+          # POSIX syntax in that script ($VSCE_TARGET, $(...)) was being
+          # passed to vsce as literal, unexpanded text on the Windows legs.
+          # Invoking vsce directly here keeps it inside the shell this step
+          # already declared (Git Bash), where that syntax works correctly
+          # — verified by the get-Llama() check above succeeding on the
+          # same runner just before this line.
+          mkdir -p vsix
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          npx --yes @vscode/vsce@3.9.2 package --target "$VSCE_TARGET" \
+            --out "vsix/aws-durable-execution-sdk-js-insight-vscode-${PKG_VERSION}-${VSCE_TARGET}.vsix"
           mkdir -p "$WORKSPACE_DIR/vsix"
           cp vsix/*.vsix "$WORKSPACE_DIR/vsix/"
         env:


### PR DESCRIPTION
The win32-x64 leg got further this time (mktemp/pwd fix from #743 worked — tar, npm install, and the getLlama() smoke test all succeeded) but then failed at 'npm run package:target':

  ##[error]'$VSCE_TARGET' is not a valid VS Code target.

Root cause: npm runs package.json scripts through cmd.exe on Windows by default — even when called from within a bash step — this is npm's own documented behavior ('npm run' docs: the script shell is platform- dependent, cmd.exe on Windows, /bin/sh elsewhere). The package:target script uses POSIX syntax ($VSCE_TARGET, $(...)), which cmd.exe doesn't interpret — it passed '$VSCE_TARGET' through to vsce as a literal string instead of expanding it to 'win32-x64'.

This also explains why darwin-arm64 and linux-x64 succeeded already: their default npm script shell (/bin/sh) does understand that syntax.

Fix: invoke vsce directly in the workflow's own bash run: block (the same shell that already runs everything else in this step, including the getLlama() check that just succeeded on this exact runner) instead of going through 'npm run package:target', which re-shells into cmd.exe on Windows. Left the package:target script itself unchanged in package.json for local/manual use on macOS or Linux, where it still works correctly.

Verified locally end-to-end on darwin-arm64: the inlined vsce invocation produces the identical .vsix output as the npm-script version did.
