### PR TITLE
chore(sdk): bump version to 0.1.0-alpha.3 for release retry

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "aws-durable-execution-sdk-js-insight-vscode",
   "displayName": "Workflow Insight Explorer",
   "description": "Query AWS Durable Execution Workflow Insight data from CloudWatch Logs using plain English.",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "license": "Apache-2.0",
   "publisher": "aws",
   "private": true,


### PR DESCRIPTION
0.1.0-alpha.2 published successfully on all 4 platforms, but linux-x64 and win32-x64 shipped bloated .vsix files (~360-460MB) due to unpruned node-llama-cpp variants and build tooling (fixed in #745). Bump the version for a fresh, slimmer release attempt — 0.1.0-alpha.2's tag/release is already published (immutable), so it can't be reused or overwritten.