### PR TITLE
fix(sdk): re-prune node-llama-cpp build artifacts on linux-x64

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -242,6 +242,19 @@ jobs:
               .then(() => console.log('getLlama() still resolves after pruning'))
               .catch(e => { console.error('getLlama() failed after pruning:', e.message); process.exit(1); });
           "
+          # This getLlama() call has been observed to itself recreate
+          # llama.cpp/localBuilds/gitRelease.bundle on at least one runner
+          # (ubuntu-latest/linux-x64) even though the prebuilt binary is
+          # present and getLlama() succeeds both before and after — some
+          # internal check in node-llama-cpp re-triggers a redundant
+          # from-source build after the other @node-llama-cpp/* variant
+          # directories are removed. The prebuilt binary still works
+          # correctly (confirmed by this call succeeding), so this isn't a
+          # real failure — just unpruned build byproduct. Sweep once more,
+          # right before packaging, to remove anything this call created.
+          rm -rf node_modules/node-llama-cpp/llama/llama.cpp
+          rm -rf node_modules/node-llama-cpp/llama/localBuilds
+          rm -f node_modules/node-llama-cpp/llama/gitRelease.bundle
           (cd webview-ui && npm ci)
           # Not `npm run package:target`: npm spawns cmd.exe (not bash) to
           # execute package.json scripts on Windows by default (this is
@@ -252,6 +265,13 @@ jobs:
           # already declared (Git Bash), where that syntax works correctly
           # — verified by the get-Llama() check above succeeding on the
           # same runner just before this line.
+          # One more sweep immediately before packaging: cheap insurance
+          # against any of the above steps (webview-ui's own npm ci, etc.)
+          # unexpectedly re-triggering node-llama-cpp's postinstall/build
+          # path again.
+          rm -rf node_modules/node-llama-cpp/llama/llama.cpp
+          rm -rf node_modules/node-llama-cpp/llama/localBuilds
+          rm -f node_modules/node-llama-cpp/llama/gitRelease.bundle
           mkdir -p vsix
           PKG_VERSION=$(node -p "require('./package.json').version")
           npx --yes @vscode/vsce@3.9.2 package --target "$VSCE_TARGET" \


### PR DESCRIPTION
0.1.0-alpha.3 published successfully on all 4 platforms with much smaller .vsix files (darwin-arm64/win32-arm64 ~6.7MB, win32-x64 ~11.3MB) — but linux-x64 was still 97.6MB, down from ~460MB but not matching the other x64 target.

Downloaded and inspected the published linux-x64 asset: it still contains node-llama-cpp's llama.cpp git checkout (with pack objects), test .gguf vocab files, docs, and llama/localBuilds/linux-x64 — the same build artifacts the existing prune step already removes once, but these came back with LATER timestamps than the prebuilt binary (@node-llama-cpp/ linux-x64, which is present, correct, and complete).

Root cause: the getLlama() call used to verify pruning succeeded can itself recreate these files on at least one runner (observed on ubuntu-latest/linux-x64) — some check inside node-llama-cpp re-triggers a redundant from-source build after the other @node-llama-cpp/<variant> directories are removed, even though the prebuilt binary is present and correct and getLlama() succeeds both before and after this happens. The existing prune step only ran once, before this call, so anything it recreated survived into the final .vsix.

Fix: sweep the same three paths (llama.cpp/, localBuilds/, gitRelease.bundle) twice more — immediately after the post-prune getLlama() verification, and again right before packaging — rather than trying to prevent or diagnose the rebuild itself, since the prebuilt binary demonstrably still works correctly when this happens.

Verified locally end-to-end on darwin-arm64: the extra sweeps are no-ops there (this platform never exhibited the rebuild-on-verify behavior) and the .vsix is still the same 6.68MB, confirming the added steps don't affect platforms that already worked correctly. Could not reproduce the actual linux-x64 rebuild trigger locally (no x64 Linux host available) — the fix is an unconditional cleanup that's safe regardless of whether/why the rebuild happens, rather than a fix that depends on correctly diagnosing the trigger.