### PR TITLE
ci(testing-sdk): reuse persistent per-suite conformance stacks

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -117,11 +117,12 @@ jobs:
             --template template_${{ matrix.suite }}.yaml \
             --language js \
             --suite ${{ matrix.suite }} \
-            --name conformance-js-${SUITE_SLUG}-${{ github.run_id }} \
+            --name conformance-js-${SUITE_SLUG} \
             --region ${{ vars.AWS_REGION }} \
             --history-dir history-${{ matrix.suite }} \
             --report junit \
-            --report-file report-${{ matrix.suite }}
+            --report-file report-${{ matrix.suite }} \
+            --no-cleanup
 
       - name: Upload conformance report
         if: always()


### PR DESCRIPTION
## What
Use a stable CloudFormation stack name per suite (`conformance-js-<suite>`, no
run id) and pass `--no-cleanup` so each workflow run updates the same stack in
place instead of creating and deleting one per run.

## Why
- Repeat runs become fast in-place updates; unchanged suites resolve to
  "No changes to deploy", which the runner treats as success
- No stack create/delete churn in the CI account

## Trade-offs
- The per-suite stacks now persist in the CI account by design; teardown
  becomes manual/on-demand
- Conformance runs from two PRs at the same time share the per-suite stack; a
  simultaneous `sam deploy` to the same stack can conflict (the workflow's
  concurrency group serializes per branch only)
