### PR TITLE
ci(testing-sdk): serialize conformance deploys per suite stack

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -27,6 +27,12 @@ jobs:
   conformance:
     name: conformance (${{ matrix.suite }})
     runs-on: ubuntu-latest
+    # Global lock per suite stack: runs from different branches/PRs share the
+    # persistent conformance-js-<suite> stacks, so deploys to the same stack
+    # must never overlap. Queued (not cancelled) so every run still executes.
+    concurrency:
+      group: conformance-stack-${{ matrix.suite }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -111,13 +111,6 @@ jobs:
           echo "SUITE_SLUG=$(echo '${{ matrix.suite }}' | tr '_' '-')" >> "$GITHUB_ENV"
 
       - name: Run conformance suite
-        env:
-          # Same env the SAM-based integration deploy passes. LAMBDA_ENDPOINT is
-          # the durable-execution endpoint override; the role/account are used by
-          # the SDK/tooling when present.
-          LAMBDA_ENDPOINT: ${{ secrets.LAMBDA_ENDPOINT }}
-          TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
-          TEST_LAMBDA_EXECUTION_ROLE_ARN: ${{ secrets.TEST_LAMBDA_EXECUTION_ROLE_ARN }}
         run: |
           python -m aws_durable_execution_conformance_tests.app \
             --template template_${{ matrix.suite }}.yaml \


### PR DESCRIPTION
## What
Adds a job-level concurrency group keyed on the suite name:

```yaml
concurrency:
  group: conformance-stack-${{ matrix.suite }}
  cancel-in-progress: false
```

## Why
Since #749, all runs share the persistent `conformance-js-<suite>` stacks. Two
runs (e.g. from different PRs) deploying the same stack simultaneously can
conflict mid-`sam deploy`. This lock guarantees at most one job per suite
stack at a time.

## Behavior
- Lock granularity is the **suite stack** (the actual shared resource), so
  different suites from concurrent runs still execute in parallel — no
  whole-workflow serialization
- `cancel-in-progress: false` queues later jobs instead of cancelling them,
  so every run still completes
- The workflow-level per-branch group (cancels superseded runs after new
  pushes to the same branch) is unchanged

## Also in this PR
Drops three unused env vars from the run step (`LAMBDA_ENDPOINT`,
`TEST_ACCOUNT_ID`, `TEST_LAMBDA_EXECUTION_ROLE_ARN`) — carried over from the
integration-tests workflow, but the conformance runner reads none of them and
deployed functions never inherit CI job env. The execution role secret is
still consumed where it matters: the template inject step (`ROLE_ARN`).
