### PR TITLE
fix(otel): cross sdk behaviour alignment

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/basic-steps/otel-basic-steps.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/basic-steps/otel-basic-steps.test.ts
@@ -66,7 +66,7 @@ createTests({
         const opSpans = spans.filter(
           (s) =>
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(opSpans).toHaveLength(3);
 
@@ -89,7 +89,7 @@ createTests({
 
         // Attempt spans are children of their respective operation spans
         const attemptSpans = spans.filter(
-          (s) => s.attributes["durable.operation.attempt"] !== undefined,
+          (s) => s.attributes["durable.attempt.outcome"] !== undefined,
         );
         expect(attemptSpans).toHaveLength(3);
 
@@ -99,7 +99,7 @@ createTests({
             (op) => op.spanId === attemptSpan.parentSpanId,
           );
           expect(parentOp).toBeDefined();
-          expect(attemptSpan.attributes["durable.operation.attempt"]).toBe(1);
+          expect(attemptSpan.attributes["durable.attempt.number"]).toBe(1);
         }
       }
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
@@ -84,14 +84,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "before-callback" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(beforeCallbackOp).toBeDefined();
 
         const beforeCallbackAttempt = spans.find(
           (s) =>
             s.parentSpanId === beforeCallbackOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(beforeCallbackAttempt).toBeDefined();
 
@@ -114,14 +114,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "after-callback" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(afterCallbackOp).toBeDefined();
 
         const afterCallbackAttempt = spans.find(
           (s) =>
             s.parentSpanId === afterCallbackOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(afterCallbackAttempt).toBeDefined();
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/combined/otel-combined.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/combined/otel-combined.test.ts
@@ -96,14 +96,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "sequential-step" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(sequentialStepOp).toBeDefined();
 
         const sequentialStepAttempt = spans.find(
           (s) =>
             s.parentSpanId === sequentialStepOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(sequentialStepAttempt).toBeDefined();
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
@@ -129,7 +129,7 @@ createTests({
         const operationSpans = spans.filter(
           (s) =>
             s.attributes["durable.operation.type"] !== undefined &&
-            s.attributes["durable.operation.attempt"] === undefined &&
+            s.attributes["durable.attempt.outcome"] === undefined &&
             s.attributes["durable.operation.subtype"] !== undefined &&
             s.name !== "Workflow" &&
             s.name !== "Invocation",
@@ -176,7 +176,7 @@ createTests({
 
         // Verify attempt spans exist
         const attemptSpans = spans.filter(
-          (s) => s.attributes["durable.operation.attempt"] !== undefined,
+          (s) => s.attributes["durable.attempt.outcome"] !== undefined,
         );
         expect(attemptSpans.length).toBeGreaterThanOrEqual(3);
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
@@ -100,11 +100,11 @@ createTests({
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
 
-        // Filter to operation spans: have durable.operation.type but NOT durable.operation.attempt
+        // Filter to operation spans: have durable.operation.type but NOT durable.attempt.outcome
         const operationSpans = spans.filter(
           (s) =>
             s.attributes["durable.operation.type"] !== undefined &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
 
         // Verify operation spans exist with correct attributes by durable.operation.name

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/invoke/otel-invoke.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/invoke/otel-invoke.test.ts
@@ -91,14 +91,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "before-invoke" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(beforeInvokeOp).toBeDefined();
 
         const beforeInvokeAttempt = spans.find(
           (s) =>
             s.parentSpanId === beforeInvokeOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(beforeInvokeAttempt).toBeDefined();
 
@@ -119,14 +119,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "after-invoke" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(afterInvokeOp).toBeDefined();
 
         const afterInvokeAttempt = spans.find(
           (s) =>
             s.parentSpanId === afterInvokeOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(afterInvokeAttempt).toBeDefined();
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/log-enrichment/otel-log-enrichment.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/log-enrichment/otel-log-enrichment.test.ts
@@ -80,7 +80,7 @@ createTests({
             (s) =>
               s.attributes["durable.operation.name"] === "log-step-1" &&
               s.attributes["durable.operation.type"] === "STEP" &&
-              s.attributes["durable.operation.attempt"] === undefined,
+              s.attributes["durable.attempt.outcome"] === undefined,
           );
           expect(logStep1Op).toBeDefined();
 
@@ -88,7 +88,7 @@ createTests({
             (s) =>
               s.attributes["durable.operation.name"] === "log-step-2" &&
               s.attributes["durable.operation.type"] === "STEP" &&
-              s.attributes["durable.operation.attempt"] === undefined,
+              s.attributes["durable.attempt.outcome"] === undefined,
           );
           expect(logStep2Op).toBeDefined();
 
@@ -96,14 +96,14 @@ createTests({
           const logStep1Attempt = spans.find(
             (s) =>
               s.parentSpanId === logStep1Op!.spanId &&
-              s.attributes["durable.operation.attempt"] === 1,
+              s.attributes["durable.attempt.number"] === 1,
           );
           expect(logStep1Attempt).toBeDefined();
 
           const logStep2Attempt = spans.find(
             (s) =>
               s.parentSpanId === logStep2Op!.spanId &&
-              s.attributes["durable.operation.attempt"] === 1,
+              s.attributes["durable.attempt.number"] === 1,
           );
           expect(logStep2Attempt).toBeDefined();
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/retry-steps/otel-retry-steps.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/retry-steps/otel-retry-steps.test.ts
@@ -57,7 +57,7 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "retry-step" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(retryStepOps).toHaveLength(3);
 
@@ -67,15 +67,15 @@ createTests({
 
         // --- Attempt spans ---
         const attemptSpans = spans.filter(
-          (s) => s.attributes["durable.operation.attempt"] !== undefined,
+          (s) => s.attributes["durable.attempt.outcome"] !== undefined,
         );
         expect(attemptSpans).toHaveLength(3);
 
         // Sort by attempt number
         const sorted = attemptSpans.sort(
           (a, b) =>
-            (a.attributes["durable.operation.attempt"] as number) -
-            (b.attributes["durable.operation.attempt"] as number),
+            (a.attributes["durable.attempt.number"] as number) -
+            (b.attributes["durable.attempt.number"] as number),
         );
 
         // All attempts should be children of their respective operation spans
@@ -93,9 +93,9 @@ createTests({
         }
 
         // Verify attempt numbers
-        expect(sorted[0].attributes["durable.operation.attempt"]).toBe(1);
-        expect(sorted[1].attributes["durable.operation.attempt"]).toBe(2);
-        expect(sorted[2].attributes["durable.operation.attempt"]).toBe(3);
+        expect(sorted[0].attributes["durable.attempt.number"]).toBe(1);
+        expect(sorted[1].attributes["durable.attempt.number"]).toBe(2);
+        expect(sorted[2].attributes["durable.attempt.number"]).toBe(3);
 
         // --- Invocation spans ---
         const invocationSpans = spans.filter((s) => s.name === "invocation");

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-and-resume/otel-wait-and-resume.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-and-resume/otel-wait-and-resume.test.ts
@@ -71,14 +71,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "before-wait" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(beforeWaitOp).toBeDefined();
 
         const beforeWaitAttempt = spans.find(
           (s) =>
             s.parentSpanId === beforeWaitOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(beforeWaitAttempt).toBeDefined();
 
@@ -95,14 +95,14 @@ createTests({
           (s) =>
             s.attributes["durable.operation.name"] === "after-wait" &&
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(afterWaitOp).toBeDefined();
 
         const afterWaitAttempt = spans.find(
           (s) =>
             s.parentSpanId === afterWaitOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(afterWaitAttempt).toBeDefined();
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition.test.ts
@@ -66,7 +66,7 @@ createTests({
         const stepOp = spans.find(
           (s) =>
             s.attributes["durable.operation.type"] === "STEP" &&
-            s.attributes["durable.operation.attempt"] === undefined,
+            s.attributes["durable.attempt.outcome"] === undefined,
         );
         expect(stepOp).toBeDefined();
 
@@ -74,7 +74,7 @@ createTests({
         const attemptSpan = spans.find(
           (s) =>
             s.parentSpanId === stepOp!.spanId &&
-            s.attributes["durable.operation.attempt"] === 1,
+            s.attributes["durable.attempt.number"] === 1,
         );
         expect(attemptSpan).toBeDefined();
       }
@@ -129,7 +129,7 @@ createTests({
           const stepOps = spans.filter(
             (s) =>
               s.attributes["durable.operation.type"] === "STEP" &&
-              s.attributes["durable.operation.attempt"] === undefined,
+              s.attributes["durable.attempt.outcome"] === undefined,
           );
           expect(stepOps).toHaveLength(3);
 
@@ -138,7 +138,7 @@ createTests({
             const attemptSpan = spans.find(
               (s) =>
                 s.parentSpanId === stepOp.spanId &&
-                s.attributes["durable.operation.attempt"] !== undefined,
+                s.attributes["durable.attempt.outcome"] !== undefined,
             );
             expect(attemptSpan).toBeDefined();
           }
@@ -146,23 +146,17 @@ createTests({
           // Attempt numbers increment across polls (1, 2, 3)
           const attemptSpans = spans
             .filter(
-              (s) => s.attributes["durable.operation.attempt"] !== undefined,
+              (s) => s.attributes["durable.attempt.outcome"] !== undefined,
             )
             .sort(
               (a, b) =>
-                (a.attributes["durable.operation.attempt"] as number) -
-                (b.attributes["durable.operation.attempt"] as number),
+                (a.attributes["durable.attempt.number"] as number) -
+                (b.attributes["durable.attempt.number"] as number),
             );
           expect(attemptSpans).toHaveLength(3);
-          expect(attemptSpans[0].attributes["durable.operation.attempt"]).toBe(
-            1,
-          );
-          expect(attemptSpans[1].attributes["durable.operation.attempt"]).toBe(
-            2,
-          );
-          expect(attemptSpans[2].attributes["durable.operation.attempt"]).toBe(
-            3,
-          );
+          expect(attemptSpans[0].attributes["durable.attempt.number"]).toBe(1);
+          expect(attemptSpans[1].attributes["durable.attempt.number"]).toBe(2);
+          expect(attemptSpans[2].attributes["durable.attempt.number"]).toBe(3);
 
           // 3 invocation spans
           const invocationSpans = spans.filter((s) => s.name === "invocation");

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -560,9 +560,9 @@ Cross-invocation operations are correlated via span links to deterministic span 
 ### Span Attributes
 
 - **Workflow_Span**: `durable.execution.arn`, `durable.execution.status`
-- **Invocation_Span**: `faas.invocation_id`, `faas.coldstart`, `cloud.resource_id`, `cloud.provider`, `cloud.platform`, `faas.max_memory`, `durable.execution.arn`
-- **Operation_Span**: `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`
-- **Attempt_Span**: all operation attributes plus `durable.operation.attempt`, `durable.attempt.outcome`
+- **Invocation_Span**: `faas.invocation_id`, `faas.coldstart`, `cloud.resource_id`, `cloud.provider`, `cloud.platform`, `faas.max_memory`, `durable.execution.arn`, `durable.invocation.first`, `durable.invocation.status`
+- **Operation_Span**: `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status`, `durable.attempt.number`
+- **Attempt_Span**: all operation attributes plus `durable.attempt.number`, `durable.attempt.outcome`
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
@@ -212,7 +212,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(workflowSpan!.parentSpanContext).toBeUndefined();
   });
 
-  it("no Invocation_Span is created by the plugin", async () => {
+  it("Invocation_Span is created as child of ambient context", async () => {
     const plugin = new ExecutionOtelPlugin({
       useDefaultTracerProvider: true,
     });
@@ -235,7 +235,13 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     );
 
     const invocationSpans = findSpans(exporter, "Invocation");
-    expect(invocationSpans.length).toBe(0);
+    expect(invocationSpans.length).toBe(1);
+    expect(invocationSpans[0].attributes["durable.execution.arn"]).toBe(
+      TEST_ARN,
+    );
+    expect(invocationSpans[0].attributes["durable.invocation.first"]).toBe(
+      true,
+    );
   });
 
   it("operation and attempt spans have correct parent-child hierarchy under Workflow_Span", async () => {
@@ -284,7 +290,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     );
   });
 
-  it("span links are empty because there is no ambient invocation span in local environment", async () => {
+  it("span links point to the Invocation span when there is no ambient invocation span", async () => {
     const plugin = new ExecutionOtelPlugin({
       useDefaultTracerProvider: true,
     });
@@ -311,13 +317,21 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     const attemptSpan = getExportedSpans(exporter).find(
       (s) => s.attributes["durable.attempt.number"] === 1,
     );
+    const invocationSpan = findSpan(exporter, "Invocation");
 
     expect(opSpan).toBeDefined();
     expect(attemptSpan).toBeDefined();
+    expect(invocationSpan).toBeDefined();
 
-    // No invocation links — there is no ambient invocation span locally
-    expect(opSpan!.links.length).toBe(0);
-    expect(attemptSpan!.links.length).toBe(0);
+    // Links point to the Invocation span we created
+    expect(opSpan!.links.length).toBe(1);
+    expect(opSpan!.links[0].context.spanId).toBe(
+      invocationSpan!.spanContext().spanId,
+    );
+    expect(attemptSpan!.links.length).toBe(1);
+    expect(attemptSpan!.links[0].context.spanId).toBe(
+      invocationSpan!.spanContext().spanId,
+    );
   });
 
   it("no shutdown is called on the globally registered provider", async () => {
@@ -398,8 +412,10 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(validateSpan).toBeDefined();
     expect(processSpan).toBeDefined();
 
-    // No Invocation_Span
-    expect(findSpan(exporter, "Invocation")).toBeUndefined();
+    // No Invocation_Span — actually now we always create one
+    const invocationSpan = findSpan(exporter, "Invocation");
+    expect(invocationSpan).toBeDefined();
+    expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
 
     // Workflow is root
     expect(workflowSpan!.parentSpanContext).toBeUndefined();
@@ -434,10 +450,13 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
       processSpan!.spanContext().spanId,
     );
 
-    // All span links are empty (no ambient invocation span locally)
+    // Operation and attempt spans link to the Invocation span (no ambient invocation span locally)
     for (const span of spans) {
-      if (span.name !== "Workflow") {
-        expect(span.links.length).toBe(0);
+      if (span.name !== "Workflow" && span.name !== "Invocation") {
+        expect(span.links.length).toBe(1);
+        expect(span.links[0].context.spanId).toBe(
+          invocationSpan!.spanContext().spanId,
+        );
       }
     }
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
@@ -184,7 +184,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
 
     // Verify attempt span exists
     const attemptSpan = spans.find(
-      (s) => s.attributes["durable.operation.attempt"] === 1,
+      (s) => s.attributes["durable.attempt.number"] === 1,
     );
     expect(attemptSpan).toBeDefined();
   });
@@ -266,7 +266,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     const workflowSpan = findSpan(exporter, "Workflow");
     const opSpan = findSpan(exporter, "process-item");
     const attemptSpan = getExportedSpans(exporter).find(
-      (s) => s.attributes["durable.operation.attempt"] === 1,
+      (s) => s.attributes["durable.attempt.number"] === 1,
     );
 
     expect(workflowSpan).toBeDefined();
@@ -309,7 +309,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
 
     const opSpan = findSpan(exporter, "my-operation");
     const attemptSpan = getExportedSpans(exporter).find(
-      (s) => s.attributes["durable.operation.attempt"] === 1,
+      (s) => s.attributes["durable.attempt.number"] === 1,
     );
 
     expect(opSpan).toBeDefined();
@@ -414,7 +414,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
 
     // Attempt spans are children of their respective operations
     const attemptSpans = spans.filter(
-      (s) => s.attributes["durable.operation.attempt"] === 1,
+      (s) => s.attributes["durable.attempt.number"] === 1,
     );
     expect(attemptSpans.length).toBe(2);
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -215,9 +215,13 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     // A root span created with ROOT_CONTEXT has no valid parent
     expect(workflowSpan!.parentSpanContext).toBeUndefined();
 
-    // Assertion 3: No Invocation_Span is created by the plugin
+    // Assertion 3: Invocation_Span is created as child of the ambient Lambda span
     const invocationSpan = findSpan(exporter, "Invocation");
-    expect(invocationSpan).toBeUndefined();
+    expect(invocationSpan).toBeDefined();
+    expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
+    expect(invocationSpan!.parentSpanContext?.spanId).toBe(
+      ambientSpanContext.spanId,
+    );
 
     // Assertion 4: Operation span has link to the ambient invocation span
     const opSpan = findSpan(exporter, "fetch-data");

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -228,7 +228,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
 
     // Assertion 5: Attempt span has link to the ambient invocation span
     const attemptSpan = spans.find(
-      (s) => s.attributes["durable.operation.attempt"] === 1,
+      (s) => s.attributes["durable.attempt.number"] === 1,
     );
     expect(attemptSpan).toBeDefined();
     expect(attemptSpan!.links.length).toBeGreaterThan(0);

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -75,8 +75,8 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     propagation.disable();
   });
 
-  describe("No Invocation_Span is created when useDefaultTracerProvider=true", () => {
-    it("does not create an Invocation span when useDefaultTracerProvider is true", async () => {
+  describe("Invocation_Span is created when useDefaultTracerProvider=true", () => {
+    it("creates an Invocation span as child of ambient context when useDefaultTracerProvider is true", async () => {
       const plugin = new ExecutionOtelPlugin({
         useDefaultTracerProvider: true,
       });
@@ -88,9 +88,13 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
       const spans = getExportedSpans(exporter);
       const invocationSpan = findSpan(exporter, "Invocation");
-      expect(invocationSpan).toBeUndefined();
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
+        TEST_ARN,
+      );
+      expect(invocationSpan!.attributes["durable.invocation.first"]).toBe(true);
 
-      // But Workflow_Span should still be created
+      // Workflow_Span should also be created
       const workflowSpan = findSpan(exporter, "Workflow");
       expect(workflowSpan).toBeDefined();
     });
@@ -188,7 +192,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       // No ambient span - just ROOT_CONTEXT
       await plugin.onInvocationStart(makeInvocationInfo());
 
-      // Create an operation - it should have no links since no ambient span exists
+      // Create an operation - it should still have a link to our Invocation span
       await plugin.onOperationStart({
         id: "op-1",
         type: "step",
@@ -208,7 +212,13 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
       const opSpan = findSpan(exporter, "test-op");
       expect(opSpan).toBeDefined();
-      expect(opSpan!.links.length).toBe(0);
+      // Links to the Invocation span we always create
+      const invocationSpan = findSpan(exporter, "Invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(opSpan!.links.length).toBe(1);
+      expect(opSpan!.links[0].context.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
     });
   });
 
@@ -325,8 +335,13 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
       const opSpan = findSpan(exporter, "second-op");
       expect(opSpan).toBeDefined();
-      // No links from previous invocation's ambient context
-      expect(opSpan!.links.length).toBe(0);
+      // Should link to the new Invocation span (not the previous ambient context)
+      const invocationSpan = findSpan(exporter, "Invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(opSpan!.links.length).toBe(1);
+      expect(opSpan!.links[0].context.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
     });
 
     it("clears workflowSpan, invocationSpan, and spanMap after onInvocationEnd", async () => {
@@ -367,9 +382,12 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
         "arn:second",
       );
 
-      // No Invocation span (since useDefaultTracerProvider=true)
+      // Invocation span is created for the second invocation
       const invocationSpans = spans.filter((s) => s.name === "Invocation");
-      expect(invocationSpans.length).toBe(0);
+      expect(invocationSpans.length).toBe(1);
+      expect(invocationSpans[0].attributes["durable.execution.arn"]).toBe(
+        "arn:second",
+      );
     });
 
     it("clears attemptSpan after onInvocationEnd", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
@@ -288,12 +288,12 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
     });
   });
 
-  describe("buildInvocationLinks() returns empty array when no invocation context exists", () => {
+  describe("buildInvocationLinks() links to Invocation span when no ambient invocation context exists", () => {
     /**
      * When useDefaultTracerProvider is true but no ambient span exists,
-     * and there's no explicit Invocation_Span, links should be empty.
+     * links should point to the Invocation span we always create.
      */
-    it("Operation_Span has no links when no ambient invocation span exists", async () => {
+    it("Operation_Span has link to Invocation span when no ambient invocation span exists", async () => {
       const plugin = new ExecutionOtelPlugin({
         tracerProvider: provider,
         useDefaultTracerProvider: true,
@@ -314,11 +314,16 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const opSpan = findSpan(exporter, "no-link-op");
+      const invocationSpan = findSpan(exporter, "Invocation");
       expect(opSpan).toBeDefined();
-      expect(opSpan!.links.length).toBe(0);
+      expect(invocationSpan).toBeDefined();
+      expect(opSpan!.links.length).toBe(1);
+      expect(opSpan!.links[0].context.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
     });
 
-    it("Attempt_Span has no links when no ambient invocation span exists", async () => {
+    it("Attempt_Span has link to Invocation span when no ambient invocation span exists", async () => {
       const plugin = new ExecutionOtelPlugin({
         tracerProvider: provider,
         useDefaultTracerProvider: true,
@@ -355,8 +360,13 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       const attemptSpan = getExportedSpans(exporter).find(
         (s) => s.attributes["durable.attempt.number"] === 1,
       );
+      const invocationSpan = findSpan(exporter, "Invocation");
       expect(attemptSpan).toBeDefined();
-      expect(attemptSpan!.links.length).toBe(0);
+      expect(invocationSpan).toBeDefined();
+      expect(attemptSpan!.links.length).toBe(1);
+      expect(attemptSpan!.links[0].context.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
@@ -202,7 +202,7 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       ambientSpan.end();
 
       const attemptSpan = getExportedSpans(exporter).find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.links.length).toBeGreaterThan(0);
@@ -276,7 +276,7 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans(exporter).find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       const invocationSpan = findSpan(exporter, "Invocation");
       expect(attemptSpan).toBeDefined();
@@ -353,7 +353,7 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans(exporter).find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.links.length).toBe(0);

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
@@ -117,9 +117,13 @@ describe("InvocationOtelPlugin - useDefaultTracerProvider mode", () => {
     // Operation spans are exported via the global provider
     const opSpan = spans.find((s) => s.name === "test-op");
     expect(opSpan).toBeDefined();
-    // No invocation or workflow span in default provider mode
+    // Invocation span is always created (with durable.execution.arn)
     const invocationSpan = spans.find((s) => s.name === "invocation");
-    expect(invocationSpan).toBeUndefined();
+    expect(invocationSpan).toBeDefined();
+    expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123",
+    );
+    // No workflow span in default provider mode
     const workflowSpan = spans.find((s) => s.name === "Workflow");
     expect(workflowSpan).toBeUndefined();
   });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -419,11 +419,10 @@ describe("InvocationOtelPlugin", () => {
 
       const spans = getExportedSpans();
       const opSpan = spans.find(
-        (s) =>
-          s.name === "my-step" && !s.attributes["durable.operation.attempt"],
+        (s) => s.name === "my-step" && !s.attributes["durable.attempt.number"],
       );
       const attemptSpan = spans.find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(opSpan).toBeDefined();
       expect(attemptSpan).toBeDefined();
@@ -454,7 +453,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 2,
+        (s) => s.attributes["durable.attempt.number"] === 2,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
@@ -462,7 +461,7 @@ describe("InvocationOtelPlugin", () => {
       expect(attemptSpan!.attributes["durable.operation.name"]).toBe(
         "attr-step",
       );
-      expect(attemptSpan!.attributes["durable.operation.attempt"]).toBe(2);
+      expect(attemptSpan!.attributes["durable.attempt.number"]).toBe(2);
     });
 
     it("attempt span has Link to deterministic span ID", async () => {
@@ -483,7 +482,7 @@ describe("InvocationOtelPlugin", () => {
 
       const expectedSpanId = deriveSpanIdFromOperationId("op-link", TEST_ARN);
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.links.length).toBeGreaterThan(0);
@@ -507,7 +506,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       // Span should be ended (it's in the exported list)
@@ -536,7 +535,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 3,
+        (s) => s.attributes["durable.attempt.number"] === 3,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.name).toBe("my-step attempt 3");
@@ -561,7 +560,7 @@ describe("InvocationOtelPlugin", () => {
       const attemptSpan = getExportedSpans().find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-type-fmt" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.name).toBe("step attempt 1");
@@ -627,12 +626,12 @@ describe("InvocationOtelPlugin", () => {
       const attemptA = spans.find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-a" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       const attemptB = spans.find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-b" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
 
       expect(attemptA).toBeDefined();
@@ -651,12 +650,10 @@ describe("InvocationOtelPlugin", () => {
 
       // Each attempt should be parented to its own operation span
       const opASpan = spans.find(
-        (s) =>
-          s.name === "step-a" && !s.attributes["durable.operation.attempt"],
+        (s) => s.name === "step-a" && !s.attributes["durable.attempt.number"],
       );
       const opBSpan = spans.find(
-        (s) =>
-          s.name === "step-b" && !s.attributes["durable.operation.attempt"],
+        (s) => s.name === "step-b" && !s.attributes["durable.attempt.number"],
       );
       expect(attemptA!.parentSpanContext?.spanId).toBe(
         opASpan!.spanContext().spanId,
@@ -719,12 +716,12 @@ describe("InvocationOtelPlugin", () => {
       const attempt1 = spans.find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-multi" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       const attempt2 = spans.find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-multi" &&
-          s.attributes["durable.operation.attempt"] === 2,
+          s.attributes["durable.attempt.number"] === 2,
       );
 
       expect(attempt1).toBeDefined();
@@ -773,7 +770,7 @@ describe("InvocationOtelPlugin", () => {
       const attemptSpan = getExportedSpans().find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-outcome-ok" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe(
@@ -814,7 +811,7 @@ describe("InvocationOtelPlugin", () => {
       const attemptSpan = getExportedSpans().find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-outcome-fail" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe("FAILED");
@@ -863,6 +860,7 @@ describe("InvocationOtelPlugin", () => {
         makeAttemptEndInfo({
           id: "op-attemptErr",
           attempt: 1,
+          outcome: "FAILED" as any,
           error: testError,
         }),
       );
@@ -872,7 +870,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.status.code).toBe(SpanStatusCode.ERROR);
@@ -1049,7 +1047,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const attemptSpan = getExportedSpans().find(
-        (s) => s.attributes["durable.operation.attempt"] === 1,
+        (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(capturedSpanId).toBeDefined();
       expect(capturedSpanId).toBe(attemptSpan!.spanContext().spanId);
@@ -1263,7 +1261,7 @@ describe("InvocationOtelPlugin", () => {
       const attemptSpan = getExportedSpans().find(
         (s) =>
           s.attributes["durable.operation.id"] === "op-att-sub" &&
-          s.attributes["durable.operation.attempt"] === 1,
+          s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
       expect(attemptSpan!.attributes["durable.operation.subtype"]).toBe(

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
@@ -293,7 +293,7 @@ describe("ExecutionOtelPlugin integration - provider resolution", () => {
     globalProvider.shutdown();
   });
 
-  it("useDefaultTracerProvider=true does NOT create an Invocation span", async () => {
+  it("useDefaultTracerProvider=true creates an Invocation span with durable.execution.arn", async () => {
     const exporter = new InMemorySpanExporter();
     const globalProvider = new NodeTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(exporter)],
@@ -327,7 +327,10 @@ describe("ExecutionOtelPlugin integration - provider resolution", () => {
 
     const spans = exporter.getFinishedSpans();
     const invocationSpan = spans.find((s) => s.name === "Invocation");
-    expect(invocationSpan).toBeUndefined();
+    expect(invocationSpan).toBeDefined();
+    expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
+      "arn:aws:states:us-east-1:123456789012:execution:sm:exec-2",
+    );
 
     globalProvider.shutdown();
   });

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -140,9 +140,9 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       ROOT_CONTEXT,
     );
 
-    // Create Invocation_Span ONLY when NOT using default provider
+    // 7. Create Invocation_Span
     if (!this.useDefaultTracerProvider) {
-      // 7. Create the Invocation_Span as child of Workflow_Span with Lambda semantic attributes
+      // Non-default mode: child of Workflow_Span with Lambda semantic attributes
       const parentContext = trace.setSpan(context.active(), this.workflowSpan);
 
       const invocationAttributes: Record<string, string | number | boolean> = {
@@ -185,6 +185,22 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         {
           kind: SpanKind.INTERNAL,
           attributes: invocationAttributes,
+        },
+        parentContext,
+      );
+    } else {
+      // Default provider mode: create invocation span as child of the ambient
+      // Lambda invocation span (from the ADOT layer or other auto-instrumentation)
+      const parentContext = this.savedInvocationContext ?? context.active();
+
+      this.invocationSpan = this.tracer.startSpan(
+        "Invocation",
+        {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            "durable.execution.arn": info.executionArn,
+            "durable.invocation.first": info.isFirstInvocation,
+          },
         },
         parentContext,
       );

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -19,6 +19,7 @@ import type {
 import {
   context,
   trace,
+  SpanKind,
   SpanStatusCode,
   ROOT_CONTEXT,
 } from "@opentelemetry/api";
@@ -150,6 +151,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         "cloud.provider": "aws",
         "cloud.platform": "aws_lambda",
         "durable.execution.arn": info.executionArn,
+        "durable.invocation.first": info.isFirstInvocation,
       };
 
       // Set cloud.resource_id from Lambda environment variables
@@ -181,6 +183,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan = this.tracer.startSpan(
         "Invocation",
         {
+          kind: SpanKind.INTERNAL,
           attributes: invocationAttributes,
         },
         parentContext,
@@ -204,6 +207,20 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
     // 1. Always end and export Invocation_Span
     if (this.invocationSpan) {
+      this.invocationSpan.setAttribute(
+        "durable.invocation.status",
+        info.status,
+      );
+
+      // Set span status ERROR when execution has failed
+      if (info.status === "FAILED") {
+        this.invocationSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      }
+      // Otherwise leave status as UNSET (default)
+
       this.invocationSpan.end();
     }
 
@@ -326,6 +343,19 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       // Operation was started in this invocation
       const span = this.spanMap.get(info.id)!;
 
+      // Set operation status attribute
+      if (info.status) {
+        span.setAttribute("durable.operation.status", info.status);
+      }
+
+      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
+      if (
+        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
+        info.attempt != null
+      ) {
+        span.setAttribute("durable.attempt.number", info.attempt);
+      }
+
       if (info.error) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
@@ -352,7 +382,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         ? trace.setSpan(context.active(), parentSpan)
         : context.active();
 
-      const attributes: Record<string, string> = {
+      const attributes: Record<string, string | number> = {
         "durable.execution.arn": this.executionArn,
         "durable.operation.id": info.id,
         "durable.operation.type": info.type,
@@ -362,6 +392,16 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       }
       if (info.subType) {
         attributes["durable.operation.subtype"] = info.subType;
+      }
+      if (info.status) {
+        attributes["durable.operation.status"] = info.status;
+      }
+      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
+      if (
+        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
+        info.attempt != null
+      ) {
+        attributes["durable.attempt.number"] = info.attempt;
       }
 
       const links = this.buildInvocationLinks();
@@ -403,7 +443,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       "durable.execution.arn": this.executionArn,
       "durable.operation.id": info.id,
       "durable.operation.type": info.type,
-      "durable.operation.attempt": info.attempt,
+      "durable.attempt.number": info.attempt,
     };
     if (info.name) {
       attributes["durable.operation.name"] = info.name;
@@ -442,12 +482,14 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     const attemptSpan = this.spanMap.get(key);
     if (attemptSpan) {
       attemptSpan.setAttribute("durable.attempt.outcome", info.outcome);
-      if (info.error) {
+      if (info.outcome === "FAILED") {
         attemptSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: info.error.message,
+          message: info.error?.message ?? "Attempt failed",
         });
-        attemptSpan.recordException(info.error);
+        if (info.error) {
+          attemptSpan.recordException(info.error);
+        }
       }
       attemptSpan.end(info.endTimestamp);
       this.spanMap.delete(key);

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -13,6 +13,7 @@ import type { TracerProvider, Tracer, Span } from "@opentelemetry/api";
 import {
   context,
   trace,
+  SpanKind,
   SpanStatusCode,
   ROOT_CONTEXT,
 } from "@opentelemetry/api";
@@ -108,20 +109,24 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         },
         ROOT_CONTEXT,
       );
-
-      // 5. Create the invocation span as child of workflow span
-      const parentContext = trace.setSpan(context.active(), this.workflowSpan);
-
-      this.invocationSpan = this.tracer.startSpan(
-        "invocation",
-        {
-          attributes: {
-            "durable.execution.arn": info.executionArn,
-          },
-        },
-        parentContext,
-      );
     }
+
+    // 5. Always create the invocation span (regardless of provider mode)
+    const parentContext = this.workflowSpan
+      ? trace.setSpan(context.active(), this.workflowSpan)
+      : context.active();
+
+    this.invocationSpan = this.tracer.startSpan(
+      "invocation",
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+          "durable.execution.arn": info.executionArn,
+          "durable.invocation.first": info.isFirstInvocation,
+        },
+      },
+      parentContext,
+    );
   }
 
   wrapInvocation(
@@ -146,6 +151,20 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
 
     // 2. End the invocation span if it exists
     if (this.invocationSpan) {
+      this.invocationSpan.setAttribute(
+        "durable.invocation.status",
+        info.status,
+      );
+
+      // Set span status ERROR when execution has failed
+      if (info.status === "FAILED") {
+        this.invocationSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      }
+      // Otherwise leave status as UNSET (default)
+
       this.invocationSpan.end();
     }
 
@@ -277,6 +296,19 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       // Operation was started in this invocation
       const span = this.spanMap.get(info.id)!;
 
+      // Set operation status attribute
+      if (info.status) {
+        span.setAttribute("durable.operation.status", info.status);
+      }
+
+      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
+      if (
+        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
+        info.attempt != null
+      ) {
+        span.setAttribute("durable.attempt.number", info.attempt);
+      }
+
       // Record error if present
       if (info.error) {
         span.setStatus({
@@ -308,7 +340,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         ? trace.setSpan(context.active(), this.invocationSpan)
         : context.active();
 
-      const attributes: Record<string, string> = {
+      const attributes: Record<string, string | number> = {
         "durable.execution.arn": this.executionArn,
         "durable.operation.id": info.id,
         "durable.operation.type": info.type,
@@ -318,6 +350,16 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       }
       if (info.subType) {
         attributes["durable.operation.subtype"] = info.subType;
+      }
+      if (info.status) {
+        attributes["durable.operation.status"] = info.status;
+      }
+      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
+      if (
+        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
+        info.attempt != null
+      ) {
+        attributes["durable.attempt.number"] = info.attempt;
       }
 
       const continuationSpan = this.tracer.startSpan(
@@ -371,7 +413,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       "durable.execution.arn": this.executionArn,
       "durable.operation.id": info.id,
       "durable.operation.type": info.type,
-      "durable.operation.attempt": info.attempt,
+      "durable.attempt.number": info.attempt,
     };
     if (info.name) {
       attributes["durable.operation.name"] = info.name;
@@ -417,12 +459,14 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     const attemptSpan = this.spanMap.get(key);
     if (attemptSpan) {
       attemptSpan.setAttribute("durable.attempt.outcome", info.outcome);
-      if (info.error) {
+      if (info.outcome === "FAILED") {
         attemptSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: info.error.message,
+          message: info.error?.message ?? "Attempt failed",
         });
-        attemptSpan.recordException(info.error);
+        if (info.error) {
+          attemptSpan.recordException(info.error);
+        }
       }
       attemptSpan.end(info.endTimestamp);
       this.spanMap.delete(key);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Addressing the following cross SDK behaviour differences found from https://github.com/aws/aws-durable-execution-conformance-tests/issues/23 

1. Invocation spans should use span.kind=INTERNAL.
2. All invocations have span status UNSET when Execution not completed. If Execution is failed, the last Invocation span will have status ERROR. We need to fix this behaviour in Python SDK and Typescript SDK.
3. Add durable.invocation.first and durable.invocation.status to Python and Javascript Otel plugins. Suspends = PENDING. Fails = RETRYING. Succeeded and failed for execution status.
4. `PluginOperationStatus` needs to be implemented for all operations (durable.operation.status). Javascript is missing the field for certain onOperationEnd calls. Java Otel plugin doesn't need to explicitly update spans with `PluginOperationStatus.PENDING` in onInvocationEnd for operations that have not yet completed. We're assuming that they would just be `PluginOperationStatus.STARTED`. Double check for Wait-for-condition.
6. In Python, STEP operation span and WAIT-FOR-CONDITION operation span exports an attribute to the span dubbed `durable.attempt.number` to denote the total number of attempts that happened. Should only be emitted after the operation is completed. 
7. All attributes from operation spans are available in associated attempt spans. Attempt spans additionally have durable.attempt.number and durable.attempt.outcome attributes. 
9. For invocation view using ADOT layer (specifically Typescript), create the "invocation" span regardless and include durable.execution.arn.
10. For Typescript, rename `durable.operation.attempt` attribute to `durable.attempt.number` in attempts span.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
