### PR TITLE
test: add plugin conformance suite handlers (10-1..10-7)

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -2,9 +2,9 @@ name: Conformance Tests
 
 # Full-integration conformance run: builds the JS handlers, installs the pinned
 # language-agnostic runner from PyPI, then deploys + invokes + validates one SAM
-# stack per suite. Each suite runs as its own parallel matrix job. To add a suite
-# later, add its name to `strategy.matrix.suite` (and ship its template_<suite>.yaml
-# + handlers).
+# stack per suite. Suites are discovered from the package's template_<suite>.yaml
+# files (see scripts/discover_suites.py) and each runs as its own parallel matrix
+# job, so adding a suite only requires shipping its template + handlers.
 
 on:
   pull_request:
@@ -24,8 +24,22 @@ permissions:
   id-token: write # Required for AWS OIDC credentials
 
 jobs:
+  discover_suites:
+    name: discover conformance suites
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.discover.outputs.suites }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Discover suites from templates
+        id: discover
+        working-directory: packages/aws-durable-execution-sdk-js-conformance-tests
+        run: echo "suites=$(python3 scripts/discover_suites.py)" >> "$GITHUB_OUTPUT"
+
   conformance:
     name: conformance (${{ matrix.suite }})
+    needs: discover_suites
     runs-on: ubuntu-latest
     # Global lock per suite stack: runs from different branches/PRs share the
     # persistent conformance-js-<suite> stacks, so deploys to the same stack
@@ -36,18 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite:
-          [
-            step,
-            wait,
-            child,
-            callback,
-            invoke,
-            wait_for_condition,
-            wait_for_callback,
-            parallel,
-            map,
-          ]
+        suite: ${{ fromJSON(needs.discover_suites.outputs.suites) }}
     defaults:
       run:
         working-directory: packages/aws-durable-execution-sdk-js-conformance-tests

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
@@ -1,0 +1,49 @@
+// 10-3: Plugin attempt hooks fire per step attempt with attempt number and outcome
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Instrumentation plugin that reports per-attempt step lifecycle via CloudWatch.
+// Filters to step-type operations only. attempt-start fires when a step attempt's
+// user function starts; attempt-end fires when it finishes, carrying the 1-based
+// attempt number and the outcome enum token (SUCCEEDED / FAILED). These hooks run
+// on the same thread as the user function, so their relative order is deterministic.
+const attemptHooksPlugin: DurableInstrumentationPlugin = {
+  async onOperationAttemptStart(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN attempt-start n=${info.attempt}`);
+  },
+  async onOperationAttemptEnd(info) {
+    if (info.subType !== "Step") return;
+    console.log(
+      `CONFPLUGIN attempt-end n=${info.attempt} outcome=${info.outcome}`,
+    );
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(
+      async (stepContext) => {
+        // Native per-step attempt counter (1 on first execution, incremented
+        // by 1 on each retry). Fails once, then succeeds on the second attempt.
+        if (stepContext.attempt < 2) {
+          throw new Error(`Attempt ${stepContext.attempt} failed`);
+        }
+        return "Operation succeeded";
+      },
+      {
+        retryStrategy: (_error: Error, attempts: number) => {
+          if (attempts >= 3) {
+            return { shouldRetry: false };
+          }
+          return { shouldRetry: true, delay: { seconds: 1 } };
+        },
+      },
+    );
+    return result;
+  },
+  { plugins: [attemptHooksPlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
@@ -13,12 +13,12 @@ import {
 const attemptHooksPlugin: DurableInstrumentationPlugin = {
   async onOperationAttemptStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN attempt-start n=${info.attempt}`);
+    console.log(`CONFPLUGIN attempt-start n=${info.attempt} op=${info.id}`);
   },
   async onOperationAttemptEnd(info) {
     if (info.subType !== "Step") return;
     console.log(
-      `CONFPLUGIN attempt-end n=${info.attempt} outcome=${info.outcome}`,
+      `CONFPLUGIN attempt-end n=${info.attempt} outcome=${info.outcome} op=${info.id}`,
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
@@ -5,34 +5,51 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Instrumentation plugin that reports per-attempt step lifecycle via CloudWatch.
 // Filters to step-type operations only. attempt-start fires when a step attempt's
 // user function starts; attempt-end fires when it finishes, carrying the 1-based
 // attempt number and the outcome enum token (SUCCEEDED / FAILED). These hooks run
 // on the same thread as the user function, so their relative order is deterministic.
+// onInvocationStart is present only to capture the execution ARN (it emits
+// nothing) so attempt records can carry it as a top-level field.
 const attemptHooksPlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    capturedArn = info.executionArn;
+  },
   async onOperationAttemptStart(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({
-        plugin: "CONFPLUGIN",
-        hook: "attempt-start",
-        n: info.attempt,
-        op: info.id,
-      }),
-    );
+    emit({
+      plugin: "CONFPLUGIN",
+      hook: "attempt-start",
+      n: info.attempt,
+      op: info.id,
+    });
   },
   async onOperationAttemptEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({
-        plugin: "CONFPLUGIN",
-        hook: "attempt-end",
-        n: info.attempt,
-        outcome: info.outcome,
-        op: info.id,
-      }),
-    );
+    emit({
+      plugin: "CONFPLUGIN",
+      hook: "attempt-end",
+      n: info.attempt,
+      outcome: info.outcome,
+      op: info.id,
+    });
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_hooks_retry.ts
@@ -13,12 +13,25 @@ import {
 const attemptHooksPlugin: DurableInstrumentationPlugin = {
   async onOperationAttemptStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN attempt-start n=${info.attempt} op=${info.id}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "attempt-start",
+        n: info.attempt,
+        op: info.id,
+      }),
+    );
   },
   async onOperationAttemptEnd(info) {
     if (info.subType !== "Step") return;
     console.log(
-      `CONFPLUGIN attempt-end n=${info.attempt} outcome=${info.outcome} op=${info.id}`,
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "attempt-end",
+        n: info.attempt,
+        outcome: info.outcome,
+        op: info.id,
+      }),
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
@@ -1,0 +1,51 @@
+// 10-4: Plugin exceptions are swallowed and never affect the execution outcome
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Faulty instrumentation plugin: every hook first logs its line and then throws.
+// The SDK must catch and ignore every plugin exception, so the execution result
+// and history are identical to running without the plugin. Operation/attempt
+// hooks filter to step-type operations only.
+const faultyPlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart() {
+    console.log(`CONFPLUGIN faulty invocation-start`);
+    throw new Error("faulty invocation-start");
+  },
+  async onInvocationEnd() {
+    console.log(`CONFPLUGIN faulty invocation-end`);
+    throw new Error("faulty invocation-end");
+  },
+  async onOperationStart(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN faulty operation-start`);
+    throw new Error("faulty operation-start");
+  },
+  async onOperationEnd(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN faulty operation-end`);
+    throw new Error("faulty operation-end");
+  },
+  async onOperationAttemptStart(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN faulty attempt-start`);
+    throw new Error("faulty attempt-start");
+  },
+  async onOperationAttemptEnd(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN faulty attempt-end`);
+    throw new Error("faulty attempt-end");
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(async () => {
+      return `Hello, ${event}!`;
+    });
+    return result;
+  },
+  { plugins: [faultyPlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
@@ -11,31 +11,43 @@ import {
 // hooks filter to step-type operations only.
 const faultyPlugin: DurableInstrumentationPlugin = {
   async onInvocationStart() {
-    console.log(`CONFPLUGIN faulty invocation-start`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "invocation-start" }),
+    );
     throw new Error("faulty invocation-start");
   },
   async onInvocationEnd() {
-    console.log(`CONFPLUGIN faulty invocation-end`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "invocation-end" }),
+    );
     throw new Error("faulty invocation-end");
   },
   async onOperationStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN faulty operation-start`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-start" }),
+    );
     throw new Error("faulty operation-start");
   },
   async onOperationEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN faulty operation-end`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-end" }),
+    );
     throw new Error("faulty operation-end");
   },
   async onOperationAttemptStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN faulty attempt-start`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-start" }),
+    );
     throw new Error("faulty attempt-start");
   },
   async onOperationAttemptEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN faulty attempt-end`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-end" }),
+    );
     throw new Error("faulty attempt-end");
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_error_isolation.ts
@@ -5,49 +5,60 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Faulty instrumentation plugin: every hook first logs its line and then throws.
 // The SDK must catch and ignore every plugin exception, so the execution result
 // and history are identical to running without the plugin. Operation/attempt
 // hooks filter to step-type operations only.
 const faultyPlugin: DurableInstrumentationPlugin = {
-  async onInvocationStart() {
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "invocation-start" }),
+  async onInvocationStart(info) {
+    capturedArn = info.executionArn;
+    emit(
+      { plugin: "CONFPLUGIN-FAULTY", hook: "invocation-start" },
+      info.executionArn,
     );
     throw new Error("faulty invocation-start");
   },
-  async onInvocationEnd() {
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "invocation-end" }),
+  async onInvocationEnd(info) {
+    emit(
+      { plugin: "CONFPLUGIN-FAULTY", hook: "invocation-end" },
+      info.executionArn,
     );
     throw new Error("faulty invocation-end");
   },
   async onOperationStart(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-start" }),
-    );
+    emit({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-start" });
     throw new Error("faulty operation-start");
   },
   async onOperationEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-end" }),
-    );
+    emit({ plugin: "CONFPLUGIN-FAULTY", hook: "operation-end" });
     throw new Error("faulty operation-end");
   },
   async onOperationAttemptStart(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-start" }),
-    );
+    emit({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-start" });
     throw new Error("faulty attempt-start");
   },
   async onOperationAttemptEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-end" }),
-    );
+    emit({ plugin: "CONFPLUGIN-FAULTY", hook: "attempt-end" });
     throw new Error("faulty attempt-end");
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
@@ -5,6 +5,22 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Instrumentation plugin that reports the first-invocation flag across replay.
 // invocation-start logs first=true on the initial invocation and first=false on
 // the replay that resumes after the wait. The terminal invocation-end carries
@@ -12,21 +28,24 @@ import {
 // status and is not asserted by the requirement.
 const firstInvocationPlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(
-      JSON.stringify({
+    capturedArn = info.executionArn;
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-start",
         first: info.isFirstInvocation,
-      }),
+      },
+      info.executionArn,
     );
   },
   async onInvocationEnd(info) {
-    console.log(
-      JSON.stringify({
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-end",
         status: info.status,
-      }),
+      },
+      info.executionArn,
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
@@ -12,10 +12,22 @@ import {
 // status and is not asserted by the requirement.
 const firstInvocationPlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-start",
+        first: info.isFirstInvocation,
+      }),
+    );
   },
   async onInvocationEnd(info) {
-    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-end",
+        status: info.status,
+      }),
+    );
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_first_invocation_flag.ts
@@ -1,0 +1,28 @@
+// 10-6: Plugin sees is-first-invocation true once, then false on replay
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Instrumentation plugin that reports the first-invocation flag across replay.
+// invocation-start logs first=true on the initial invocation and first=false on
+// the replay that resumes after the wait. The terminal invocation-end carries
+// SUCCEEDED; a non-terminal invocation-end on suspend carries a non-SUCCEEDED
+// status and is not asserted by the requirement.
+const firstInvocationPlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+  },
+  async onInvocationEnd(info) {
+    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.wait({ seconds: 2 });
+    return "Wait completed";
+  },
+  { plugins: [firstInvocationPlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
@@ -5,26 +5,45 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Instrumentation plugin that reports the invocation lifecycle via CloudWatch.
 // invocation-start fires (synchronously) before handler code runs; invocation-end
 // fires after the execution result is finalized, carrying the terminal status.
 const invocationLifecyclePlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(
-      JSON.stringify({
+    capturedArn = info.executionArn;
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-start",
         first: info.isFirstInvocation,
-      }),
+      },
+      info.executionArn,
     );
   },
   async onInvocationEnd(info) {
-    console.log(
-      JSON.stringify({
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-end",
         status: info.status,
-      }),
+      },
+      info.executionArn,
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
@@ -1,0 +1,29 @@
+// 10-1: Plugin invocation lifecycle hooks (start and end on a single invocation)
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Instrumentation plugin that reports the invocation lifecycle via CloudWatch.
+// invocation-start fires (synchronously) before handler code runs; invocation-end
+// fires after the execution result is finalized, carrying the terminal status.
+const invocationLifecyclePlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+  },
+  async onInvocationEnd(info) {
+    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(async (stepContext) => {
+      stepContext.logger.info(`Greeting step running for: ${event}`);
+      return `Hello, ${event}!`;
+    });
+    return result;
+  },
+  { plugins: [invocationLifecyclePlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_lifecycle.ts
@@ -10,10 +10,22 @@ import {
 // fires after the execution result is finalized, carrying the terminal status.
 const invocationLifecyclePlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-start",
+        first: info.isFirstInvocation,
+      }),
+    );
   },
   async onInvocationEnd(info) {
-    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-end",
+        status: info.status,
+      }),
+    );
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
@@ -5,39 +5,61 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Two instrumentation plugins registered together (order A, B). Each reports the
 // invocation lifecycle under its own prefix. The SDK delivers hooks to every
 // registered plugin.
 const pluginA: DurableInstrumentationPlugin = {
-  async onInvocationStart() {
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-A", hook: "invocation-start" }),
+  async onInvocationStart(info) {
+    capturedArn = info.executionArn;
+    emit(
+      { plugin: "CONFPLUGIN-A", hook: "invocation-start" },
+      info.executionArn,
     );
   },
   async onInvocationEnd(info) {
-    console.log(
-      JSON.stringify({
+    emit(
+      {
         plugin: "CONFPLUGIN-A",
         hook: "invocation-end",
         status: info.status,
-      }),
+      },
+      info.executionArn,
     );
   },
 };
 
 const pluginB: DurableInstrumentationPlugin = {
-  async onInvocationStart() {
-    console.log(
-      JSON.stringify({ plugin: "CONFPLUGIN-B", hook: "invocation-start" }),
+  async onInvocationStart(info) {
+    capturedArn = info.executionArn;
+    emit(
+      { plugin: "CONFPLUGIN-B", hook: "invocation-start" },
+      info.executionArn,
     );
   },
   async onInvocationEnd(info) {
-    console.log(
-      JSON.stringify({
+    emit(
+      {
         plugin: "CONFPLUGIN-B",
         hook: "invocation-end",
         status: info.status,
-      }),
+      },
+      info.executionArn,
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
@@ -10,19 +10,35 @@ import {
 // registered plugin.
 const pluginA: DurableInstrumentationPlugin = {
   async onInvocationStart() {
-    console.log(`CONFPLUGIN-A invocation-start`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-A", hook: "invocation-start" }),
+    );
   },
   async onInvocationEnd(info) {
-    console.log(`CONFPLUGIN-A invocation-end status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN-A",
+        hook: "invocation-end",
+        status: info.status,
+      }),
+    );
   },
 };
 
 const pluginB: DurableInstrumentationPlugin = {
   async onInvocationStart() {
-    console.log(`CONFPLUGIN-B invocation-start`);
+    console.log(
+      JSON.stringify({ plugin: "CONFPLUGIN-B", hook: "invocation-start" }),
+    );
   },
   async onInvocationEnd(info) {
-    console.log(`CONFPLUGIN-B invocation-end status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN-B",
+        hook: "invocation-end",
+        status: info.status,
+      }),
+    );
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_multiple_plugins.ts
@@ -1,0 +1,37 @@
+// 10-5: Multiple registered plugins all receive lifecycle hooks
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Two instrumentation plugins registered together (order A, B). Each reports the
+// invocation lifecycle under its own prefix. The SDK delivers hooks to every
+// registered plugin.
+const pluginA: DurableInstrumentationPlugin = {
+  async onInvocationStart() {
+    console.log(`CONFPLUGIN-A invocation-start`);
+  },
+  async onInvocationEnd(info) {
+    console.log(`CONFPLUGIN-A invocation-end status=${info.status}`);
+  },
+};
+
+const pluginB: DurableInstrumentationPlugin = {
+  async onInvocationStart() {
+    console.log(`CONFPLUGIN-B invocation-start`);
+  },
+  async onInvocationEnd(info) {
+    console.log(`CONFPLUGIN-B invocation-end status=${info.status}`);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(async () => {
+      return `Hello, ${event}!`;
+    });
+    return result;
+  },
+  { plugins: [pluginA, pluginB] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
@@ -1,0 +1,31 @@
+// 10-2: Plugin operation lifecycle hooks (step start and terminal end)
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Instrumentation plugin that reports step-operation lifecycle via CloudWatch.
+// Filters to step-type operations only (subType === "Step"). operation-start
+// fires when the step's STARTED checkpoint is observed; operation-end fires when
+// the step reaches its terminal status, carrying the operation-status enum token.
+const operationLifecyclePlugin: DurableInstrumentationPlugin = {
+  async onOperationStart(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN operation-start`);
+  },
+  async onOperationEnd(info) {
+    if (info.subType !== "Step") return;
+    console.log(`CONFPLUGIN operation-end status=${info.status}`);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(async () => {
+      return `Hello, ${event}!`;
+    });
+    return result;
+  },
+  { plugins: [operationLifecyclePlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
@@ -12,11 +12,24 @@ import {
 const operationLifecyclePlugin: DurableInstrumentationPlugin = {
   async onOperationStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN operation-start op=${info.id}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "operation-start",
+        op: info.id,
+      }),
+    );
   },
   async onOperationEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN operation-end op=${info.id} status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "operation-end",
+        op: info.id,
+        status: info.status,
+      }),
+    );
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
@@ -12,11 +12,11 @@ import {
 const operationLifecyclePlugin: DurableInstrumentationPlugin = {
   async onOperationStart(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN operation-start`);
+    console.log(`CONFPLUGIN operation-start op=${info.id}`);
   },
   async onOperationEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(`CONFPLUGIN operation-end status=${info.status}`);
+    console.log(`CONFPLUGIN operation-end op=${info.id} status=${info.status}`);
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_lifecycle.ts
@@ -5,31 +5,48 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Instrumentation plugin that reports step-operation lifecycle via CloudWatch.
 // Filters to step-type operations only (subType === "Step"). operation-start
 // fires when the step's STARTED checkpoint is observed; operation-end fires when
 // the step reaches its terminal status, carrying the operation-status enum token.
+// onInvocationStart is present only to capture the execution ARN (it emits
+// nothing) so operation records can carry it as a top-level field.
 const operationLifecyclePlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    capturedArn = info.executionArn;
+  },
   async onOperationStart(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({
-        plugin: "CONFPLUGIN",
-        hook: "operation-start",
-        op: info.id,
-      }),
-    );
+    emit({
+      plugin: "CONFPLUGIN",
+      hook: "operation-start",
+      op: info.id,
+    });
   },
   async onOperationEnd(info) {
     if (info.subType !== "Step") return;
-    console.log(
-      JSON.stringify({
-        plugin: "CONFPLUGIN",
-        hook: "operation-end",
-        op: info.id,
-        status: info.status,
-      }),
-    );
+    emit({
+      plugin: "CONFPLUGIN",
+      hook: "operation-end",
+      op: info.id,
+      status: info.status,
+    });
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
@@ -1,0 +1,32 @@
+// 10-7: Plugin invocation-end hook receives FAILED status when execution fails
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  retryPresets,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+// Instrumentation plugin that reports the invocation lifecycle via CloudWatch.
+// The single step always throws with no retries, so the execution fails and the
+// invocation-end hook fires with the FAILED terminal status.
+const terminalFailurePlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+  },
+  async onInvocationEnd(info) {
+    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    const result = await context.step(
+      async () => {
+        throw new Error("Something went wrong");
+      },
+      { retryStrategy: retryPresets.noRetry },
+    );
+    return result;
+  },
+  { plugins: [terminalFailurePlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
@@ -11,10 +11,22 @@ import {
 // invocation-end hook fires with the FAILED terminal status.
 const terminalFailurePlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(`CONFPLUGIN invocation-start first=${info.isFirstInvocation}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-start",
+        first: info.isFirstInvocation,
+      }),
+    );
   },
   async onInvocationEnd(info) {
-    console.log(`CONFPLUGIN invocation-end status=${info.status}`);
+    console.log(
+      JSON.stringify({
+        plugin: "CONFPLUGIN",
+        hook: "invocation-end",
+        status: info.status,
+      }),
+    );
   },
 };
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_failure.ts
@@ -6,26 +6,45 @@ import {
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
+// Execution ARN captured from the invocation-start hook's info, reused as a
+// top-level field on every emitted record so the runner's CloudWatch JSON
+// filter ($.durableExecutionArn) matches the raw log line.
+let capturedArn: string | undefined;
+
+// Emit one record as a raw top-level JSON line (unwrapped by the Node runtime's
+// JSON log envelope). Adds durableExecutionArn when an ARN is available; omits
+// the field entirely if unset (never invents a value).
+function emit(
+  record: Record<string, unknown>,
+  arn: string | undefined = capturedArn,
+): void {
+  const line = arn === undefined ? record : { ...record, durableExecutionArn: arn };
+  process.stdout.write(JSON.stringify(line) + "\n");
+}
+
 // Instrumentation plugin that reports the invocation lifecycle via CloudWatch.
 // The single step always throws with no retries, so the execution fails and the
 // invocation-end hook fires with the FAILED terminal status.
 const terminalFailurePlugin: DurableInstrumentationPlugin = {
   async onInvocationStart(info) {
-    console.log(
-      JSON.stringify({
+    capturedArn = info.executionArn;
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-start",
         first: info.isFirstInvocation,
-      }),
+      },
+      info.executionArn,
     );
   },
   async onInvocationEnd(info) {
-    console.log(
-      JSON.stringify({
+    emit(
+      {
         plugin: "CONFPLUGIN",
         hook: "invocation-end",
         status: info.status,
-      }),
+      },
+      info.executionArn,
     );
   },
 };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/scripts/discover_suites.py
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/scripts/discover_suites.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Discover conformance suites from template files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+PKG_DIR = Path(__file__).resolve().parents[1]
+TEMPLATE_PREFIX = "template_"
+TEMPLATE_SUFFIX = ".yaml"
+
+
+def discover_suites(package_dir: Path = PKG_DIR) -> tuple[str, ...]:
+    """Return sorted suites with matching templates and non-empty handler dirs."""
+    templates = sorted(package_dir.glob(f"{TEMPLATE_PREFIX}*{TEMPLATE_SUFFIX}"))
+    if not templates:
+        raise SystemExit(f"No {TEMPLATE_PREFIX}<suite>{TEMPLATE_SUFFIX} files found")
+
+    suites: list[str] = []
+    for template in templates:
+        suite = template.name[len(TEMPLATE_PREFIX) : -len(TEMPLATE_SUFFIX)]
+        if not suite:
+            raise SystemExit(f"Invalid conformance template name: {template.name}")
+
+        handlers_dir = package_dir / "handlers" / suite
+        if not handlers_dir.is_dir():
+            raise SystemExit(
+                f"Template {template.name} has no matching handler directory: {handlers_dir}"
+            )
+
+        if not list(handlers_dir.glob("*.ts")):
+            raise SystemExit(f"No handler modules found for suite {suite}: {handlers_dir}")
+
+        suites.append(suite)
+
+    return tuple(suites)
+
+
+def main() -> None:
+    print(json.dumps(discover_suites(), separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
@@ -1,0 +1,149 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  PluginInvocationLifecycle:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_invocation_lifecycle.handler
+      Description: Plugin invocation lifecycle hooks (start and end on a single invocation)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginOperationLifecycle:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-2"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_operation_lifecycle.handler
+      Description: Plugin operation lifecycle hooks (step start and terminal end)
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginAttemptHooksRetry:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-3"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_attempt_hooks_retry.handler
+      Description: Plugin attempt hooks fire per step attempt with attempt number and outcome
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginErrorIsolation:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-4"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_error_isolation.handler
+      Description: Plugin exceptions are swallowed and never affect the execution outcome
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginMultiplePlugins:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-5"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_multiple_plugins.handler
+      Description: Multiple registered plugins all receive lifecycle hooks
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginFirstInvocationFlag:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-6"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_first_invocation_flag.handler
+      Description: Plugin sees is-first-invocation true once, then false on replay
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginTerminalFailure:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-7"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_terminal_failure.handler
+      Description: Plugin invocation-end hook receives FAILED status when execution fails
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## What

7 handlers for the `plugin` conformance suite (instrumentation-plugin lifecycle hooks) in `packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/`, plus `template_plugin.yaml`.

## Validation

CI passing

