### PR TITLE
fix(sdk): stop summarized map/parallel replay from hanging

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.history.json
@@ -1,0 +1,149 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "d4548a00-203a-44a0-a07d-8480dc6408ed",
+    "EventTimestamp": "2026-07-24T19:13:36.435Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"itemPayloadSize\":16}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "Map",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "summarized-map",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "item-0",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 4,
+    "Id": "98c6f2c2287f4c73",
+    "Name": "item-1",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 5,
+    "Id": "ea66c06c1e1c05fa",
+    "Name": "item-0",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"xxxxxxxxxxxxxxxx\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "MapIteration",
+    "EventId": 6,
+    "Id": "13cee27a2bd93915",
+    "Name": "item-2",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "MapIteration",
+    "EventId": 7,
+    "Id": "13cee27a2bd93915",
+    "Name": "item-2",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ParentId": "c4ca4238a0b92382",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"xxxxxxxxxxxxxxxx\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "Map",
+    "EventId": 8,
+    "Id": "c4ca4238a0b92382",
+    "Name": "summarized-map",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "{\"all\":[{\"result\":\"xxxxxxxxxxxxxxxx\",\"index\":0,\"status\":\"SUCCEEDED\"},{\"index\":1,\"status\":\"STARTED\"},{\"result\":\"xxxxxxxxxxxxxxxx\",\"index\":2,\"status\":\"SUCCEEDED\"}],\"completionReason\":\"MIN_SUCCESSFUL_REACHED\"}"
+      }
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 9,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "after-map",
+    "EventTimestamp": "2026-07-24T19:13:36.539Z",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-07-24T19:13:37.539Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-07-24T19:13:36.561Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-24T19:13:36.435Z",
+      "EndTimestamp": "2026-07-24T19:13:36.561Z",
+      "Error": {},
+      "RequestId": "fa363b65-c8c6-4fc4-b3e6-d34b046b096e"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 11,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "after-map",
+    "EventTimestamp": "2026-07-24T19:13:37.540Z",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 12,
+    "EventTimestamp": "2026-07-24T19:13:37.541Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-24T19:13:37.540Z",
+      "EndTimestamp": "2026-07-24T19:13:37.541Z",
+      "Error": {},
+      "RequestId": "7a9cc5d0-a26d-40df-915c-17150946f240"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 13,
+    "Id": "d4548a00-203a-44a0-a07d-8480dc6408ed",
+    "EventTimestamp": "2026-07-24T19:13:37.541Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"totalCount\":3,\"successCount\":2,\"startedCount\":1,\"completionReason\":\"MIN_SUCCESSFUL_REACHED\",\"itemIndexes\":[0,1,2]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.test.ts
@@ -1,0 +1,91 @@
+import {
+  handler,
+  CUSTOM_SUMMARY_PREFIX,
+} from "./map-custom-summary-generator-replay";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  localRunnerConfig: {
+    // Real timers: items complete based on setTimeout so minSuccessful can be
+    // reached while a middle item is still in flight (STARTED).
+    skipTime: false,
+    checkpointDelay: 100,
+  },
+  tests: (runner, { assertEventSignatures }) => {
+    it("replays a summarized map with a free-form custom summary without hanging (issue #751)", async () => {
+      // Default (large) payload: two successes exceed the 256KB checkpoint
+      // limit, so the map is checkpointed as a summary (ReplayChildren) and is
+      // reconstructed from child checkpoints on resume.
+      const execution = await runner.run();
+
+      // Primary regression assertion: the execution completes. On an unpatched
+      // SDK the replay after suspend/resume hangs (a never-resolving promise in
+      // ReplaySucceededContext mode) and this run times out.
+      expect(execution.getStatus()).toBe("SUCCEEDED");
+
+      const result = execution.getResult() as {
+        totalCount: number;
+        successCount: number;
+        startedCount: number;
+        completionReason: string;
+        itemIndexes: number[];
+      };
+
+      // Summarized replay (ReplayChildren) returns only the COMPLETED items;
+      // in-flight items are not rebuilt. The live run completed items 0 and 2
+      // (item 1 still in flight), so replay observes those two. The batch
+      // outcome comes from the recorded completionReason.
+      expect(result.successCount).toBe(2);
+      expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+      expect(result.totalCount).toBe(2);
+      expect(result.startedCount).toBe(0);
+      expect(result.itemIndexes).toEqual([0, 2]);
+
+      // The checkpointed summary is the SDK envelope: the load-bearing metadata
+      // is always recorded, and the customer's free-form string is preserved
+      // verbatim under `summary` (observability-only). The envelope is written
+      // on the live run, so its totalCount reflects the live started set (3).
+      const summary = runner.getOperation("summarized-map").getContextDetails()
+        ?.result as {
+        totalCount: number;
+        successCount: number;
+        completionReason: string;
+        summary: string;
+      };
+      expect(summary.totalCount).toBe(3);
+      expect(summary.successCount).toBe(2);
+      expect(summary.summary.startsWith(CUSTOM_SUMMARY_PREFIX)).toBe(true);
+    }, 30000);
+
+    it("preserves the full live shape (including the in-flight item) when the result fits in one checkpoint", async () => {
+      // A small payload stays within a single checkpoint (no ReplayChildren),
+      // so the full map result is checkpointed and replay returns it from cache
+      // — including the STARTED (in-flight) item. This is the counterpart to the
+      // summarized case above: identical handler, but here totalCount/startedCount
+      // reflect the live run (3/1) rather than the completed-only reconstruction
+      // (2/0). It also validates event signatures against a committed history
+      // without needing a large-payload fixture.
+      const execution = await runner.run({ payload: { itemPayloadSize: 16 } });
+
+      expect(execution.getStatus()).toBe("SUCCEEDED");
+
+      const result = execution.getResult() as {
+        totalCount: number;
+        successCount: number;
+        startedCount: number;
+        completionReason: string;
+        itemIndexes: number[];
+      };
+      expect(result.successCount).toBe(2);
+      expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+      // Full cached result: the in-flight item 1 is preserved (contrast the
+      // summarized test above, which reconstructs completed items only).
+      expect(result.totalCount).toBe(3);
+      expect(result.startedCount).toBe(1);
+      expect(result.itemIndexes).toEqual([0, 1, 2]);
+
+      assertEventSignatures(execution);
+    }, 30000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/custom-summary-generator-replay/map-custom-summary-generator-replay.ts
@@ -1,0 +1,100 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map Custom Summary Generator Replay",
+  description:
+    "A summarized map (aggregate result over the 256KB checkpoint limit) that " +
+    "completes early via minSuccessful, using a custom summaryGenerator whose " +
+    "output is a free-form string with no numeric totalCount. After a " +
+    "suspend/resume the summarized map is replayed. Reproduces issue #751: a " +
+    "custom summaryGenerator without the fields replay depends on must not hang " +
+    "the replay.",
+};
+
+/**
+ * Default per-item payload (~150KB). Two successes (minSuccessful: 2) push the
+ * aggregate BatchResult past the 256KB checkpoint limit, which triggers
+ * ReplayChildren mode — the only path where summaryGenerator is used and where
+ * the batch is reconstructed from child checkpoints on replay. Tests can pass a
+ * small size to stay within a single checkpoint (no summarized replay).
+ */
+const DEFAULT_ITEM_PAYLOAD_SIZE = 150 * 1024;
+
+/**
+ * Prefix of the custom (free-form, non-JSON) summary, so the test can prove the
+ * user-provided generator was used.
+ */
+export const CUSTOM_SUMMARY_PREFIX = "processed";
+
+interface Event {
+  itemPayloadSize?: number;
+}
+
+export const handler = withDurableExecution(
+  async (event: Event | undefined, context: DurableContext) => {
+    const itemPayloadSize = event?.itemPayloadSize ?? DEFAULT_ITEM_PAYLOAD_SIZE;
+
+    const result = await context.map(
+      "summarized-map",
+      [0, 1, 2, 3, 4],
+      async (_ctx, _item, index) => {
+        // With maxConcurrency: 2, items 0 and 1 start first. Item 1 is slow, so
+        // item 0 finishes and frees a slot for item 2, which also finishes —
+        // reaching minSuccessful: 2 (items 0 and 2) while item 1 is still in
+        // flight. The in-flight item therefore sits BETWEEN two completed items
+        // (child step ids: item0=SUCCEEDED, item1=STARTED, item2=SUCCEEDED),
+        // which is the exact shape that hangs replay on an unpatched SDK.
+        //
+        // NOTE: item 1's delay is NEVER actually waited. minSuccessful completes
+        // the batch (via items 0 and 2) and abandons this in-flight item, so the
+        // execution suspends at the `after-map` wait below and finishes in a few
+        // seconds — not 60s. The timer is `unref`'d so it never keeps the
+        // process alive, and a plain setTimeout (not ctx.wait) is used on
+        // purpose: an abandoned *durable* wait makes the local runner block on
+        // its timer. Keep this delay LARGE — it only has to outlast the test
+        // window. Do NOT shorten it: a short delay can fire mid-test, flip
+        // item 1 to SUCCEEDED, and silently break the STARTED-in-the-middle
+        // shape this repro depends on.
+        if (index === 1) {
+          await new Promise((resolve) => {
+            const timer = setTimeout(resolve, 60_000);
+            // Don't let this abandoned timer keep the Node process alive.
+            (timer as unknown as { unref?: () => void }).unref?.();
+          });
+        }
+        return "x".repeat(itemPayloadSize);
+      },
+      {
+        maxConcurrency: 2,
+        completionConfig: { minSuccessful: 2 },
+        itemNamer: (_item: number, index: number) => `item-${index}`,
+        // Free-form summary WITHOUT a numeric totalCount field. The developer
+        // guide calls this payload "for observability only", yet replay depends
+        // on it — the crux of issue #751.
+        summaryGenerator: (r) =>
+          `${CUSTOM_SUMMARY_PREFIX} ${r.successCount}/${r.totalCount} items`,
+      },
+    );
+
+    // Snapshot the aggregate the running code observed.
+    const snapshot = {
+      totalCount: result.totalCount,
+      successCount: result.successCount,
+      startedCount: result.startedCount,
+      completionReason: result.completionReason,
+      itemIndexes: result.all.map((item) => item.index),
+    };
+
+    // Suspend, then resume: on resume the summarized map is replayed. On an
+    // unpatched SDK the replay of a free-form-summary batch falls back to
+    // concurrent execution in ReplaySucceededContext mode, where the in-flight
+    // child yields a never-resolving promise and the invocation hangs.
+    await context.wait("after-map", { seconds: 1 });
+
+    return snapshot;
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/custom-summary-generator/parallel-custom-summary-generator.test.ts
@@ -23,18 +23,25 @@ createTests({
       expect(result.successCount).toBe(3);
       expect(result.resultLengths).toEqual([120000, 120000, 120000]);
 
-      // The CONTEXT operation's checkpointed result is the summaryGenerator
-      // output. Asserting the custom marker proves the user-supplied generator
-      // was used instead of the SDK's default parallel generator (issue #500).
+      // The checkpointed CONTEXT result is now the SDK envelope (issue #751):
+      // it always carries the load-bearing metadata (totalCount/successCount/
+      // ...), and the user-provided generator's output is preserved verbatim
+      // under `summary`. The customer here returns JSON, so `summary` is that
+      // JSON string — asserting the marker inside it proves the user-supplied
+      // generator was used (issue #500) while the SDK metadata is intact.
       const contextResult = runner
         .getOperation("parallel-large")
         .getContextDetails()?.result as {
-        marker: string;
         totalCount: number;
         successCount: number;
+        summary: string;
       };
 
       expect(contextResult).toMatchObject({
+        totalCount: 3,
+        successCount: 3,
+      });
+      expect(JSON.parse(contextResult.summary)).toMatchObject({
         marker: CUSTOM_SUMMARY_MARKER,
         totalCount: 3,
         successCount: 3,

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -260,8 +260,15 @@ export class DurableContextImpl<
   }
 
   /**
-   * Skips the next operation by incrementing the step counter.
-   * Used internally by concurrent execution handler during replay to skip incomplete items.
+   * Advances this context's step cursor by one without running an operation.
+   *
+   * Used by the concurrent-execution handler during summarized replay: when it
+   * reconstructs a batch it reaches this method on the map/parallel child
+   * context (via a narrow internal cast) to skip an item it does not
+   * re-execute — one that was never started, or an in-flight item rebuilt as
+   * STARTED. Advancing THIS context's cursor keeps the next terminal item's
+   * runInChildContext aligned with its own step, so the non-resolving-promise
+   * gate does not fire on the pending in-flight step (issue #751).
    * @internal
    */
   private skipNextOperation(): void {
@@ -690,7 +697,6 @@ export class DurableContextImpl<
       const concurrentExecutionHandler = createConcurrentExecutionHandler(
         this._executionContext,
         this.runInChildContext.bind(this),
-        this.skipNextOperation.bind(this),
         () => this._defaultSerdes,
       );
       const promise = concurrentExecutionHandler(

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler-two-phase.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler-two-phase.test.ts
@@ -10,7 +10,6 @@ import { DurablePromise } from "../../types/durable-promise";
 describe("Concurrent Execution Handler Two-Phase Execution", () => {
   let mockContext: ExecutionContext;
   let mockRunInChildContext: jest.Mock;
-  let mockStep: jest.Mock;
   let executionStarted = false;
 
   beforeEach(() => {
@@ -39,17 +38,12 @@ describe("Concurrent Execution Handler Two-Phase Execution", () => {
         };
         return await fn(mockChildContext);
       });
-
-    mockStep = jest.fn().mockImplementation(async (name, fn) => {
-      return await fn();
-    });
   });
 
   it("should start execution in phase 1 immediately (before await)", async () => {
     const concurrentHandler = createConcurrentExecutionHandler(
       mockContext,
       mockRunInChildContext,
-      mockStep,
     );
 
     const items: ConcurrentExecutionItem<string>[] = [
@@ -85,7 +79,6 @@ describe("Concurrent Execution Handler Two-Phase Execution", () => {
     const concurrentHandler = createConcurrentExecutionHandler(
       mockContext,
       mockRunInChildContext,
-      mockStep,
     );
 
     const items: ConcurrentExecutionItem<string>[] = [

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
@@ -15,13 +15,13 @@ describe("ConcurrencyController - Replay Mode", () => {
   let mockSkipNextOperation: jest.Mock;
 
   beforeEach(() => {
+    // Summarized replay skips items it does not re-execute by advancing the
+    // step cursor of the context runInChildContext runs on (parentContext).
     mockSkipNextOperation = jest.fn();
-    controller = new ConcurrencyController(
-      "test-operation",
-      mockSkipNextOperation,
-    );
+    controller = new ConcurrencyController("test-operation");
     mockParentContext = {
       runInChildContext: jest.fn(),
+      skipNextOperation: mockSkipNextOperation,
     } as any;
     mockExecutionContext = {
       getStepData: jest.fn(),
@@ -297,11 +297,29 @@ describe("ConcurrencyController - Replay Mode", () => {
     expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
   });
 
-  it("should fallback to concurrent execution when no target count found", async () => {
+  it("should reconstruct from checkpoints (not re-run) when no summary is present", async () => {
+    // In ReplaySucceededContext mode the controller must NOT fall back to
+    // concurrent execution — doing so is what caused the replay hang (a
+    // non-terminal child yields a never-resolving promise in this mode). With
+    // no child checkpoints, the single item was never started in the live run,
+    // so it is omitted rather than re-executed.
     const items = [{ id: "item-0", data: "data1", index: 0 }];
     const executor = jest.fn().mockResolvedValue("result");
+    const entityId = "parent-step";
 
-    mockExecutionContext.getStepData.mockReturnValue(undefined);
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: {},
+        };
+      }
+      // No child checkpoints.
+      return undefined;
+    });
     mockParentContext.runInChildContext.mockResolvedValue("result");
 
     const result = await controller.executeItems(
@@ -310,14 +328,17 @@ describe("ConcurrencyController - Replay Mode", () => {
       mockParentContext,
       {},
       DurableExecutionMode.ReplaySucceededContext,
-      "parent-step",
+      entityId,
       mockExecutionContext,
     );
 
-    expect(result.successCount).toBe(1);
+    expect(result.successCount).toBe(0);
+    expect(result.totalCount).toBe(0);
+    // Critically: the item is not re-executed, so no hang is possible.
+    expect(mockParentContext.runInChildContext).not.toHaveBeenCalled();
   });
 
-  it("should fallback to concurrent execution when summary parsing fails", async () => {
+  it("should reconstruct from checkpoints when the summary is unparseable (no concurrent fallback)", async () => {
     const items = [{ id: "item-0", data: "data1", index: 0 }];
     const executor = jest.fn().mockResolvedValue("result");
     const entityId = "parent-step";
@@ -754,5 +775,227 @@ describe("ConcurrencyController - Replay Mode", () => {
     expect(result.successCount).toBe(0);
     expect(result.failureCount).toBe(1);
     expect(result.totalCount).toBe(1);
+  });
+
+  // Regression: GitHub issue #751.
+  // Repro 1 — a summarized map/parallel (aggregate result > checkpoint limit)
+  // with live in-flight items must replay to the SAME BatchResult shape the
+  // live run observed. Previously replay dropped STARTED children, so a run
+  // that observed totalCount:5 / startedCount:3 / indexes [0..4] replayed as
+  // totalCount:2 / startedCount:0 / indexes [0,1].
+  it("should replay a summarized batch that completed early with in-flight items, returning completed items only (issue #751 repro 1)", async () => {
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+      { id: "item-2", data: "d2", index: 2 },
+      { id: "item-3", data: "d3", index: 3 },
+      { id: "item-4", data: "d4", index: 4 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    // Envelope written by the default (composed) generator on the live run.
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 5,
+      successCount: 2,
+      failureCount: 0,
+      completionReason: "MIN_SUCCESSFUL_REACHED",
+      status: "SUCCEEDED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Items 0 and 1 completed; items 2, 3, 4 were started and still in flight
+      // (each wrote a START checkpoint before suspending on a wait).
+      if (id === `${entityId}-1` || id === `${entityId}-2`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      if (
+        id === `${entityId}-3` ||
+        id === `${entityId}-4` ||
+        id === `${entityId}-5`
+      ) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.STARTED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext
+      .mockResolvedValueOnce("result0")
+      .mockResolvedValueOnce("result1");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { completionConfig: { minSuccessful: 2 } },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // Reconstruction returns only the completed items; in-flight (STARTED)
+    // children are not rebuilt. The recorded completionReason carries the
+    // outcome. totalCount reflects the completed items (2), not the live 5.
+    expect(result.totalCount).toBe(2);
+    expect(result.successCount).toBe(2);
+    expect(result.startedCount).toBe(0);
+    expect(result.all.map((i) => i.index)).toEqual([0, 1]);
+    expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+    // Only terminal children are re-driven; in-flight ones are not re-executed.
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  // Repro 2 — a custom summaryGenerator whose output is not JSON with a numeric
+  // totalCount. Previously this made replay fall back to concurrent execution
+  // in ReplaySucceededContext mode, where a non-terminal child yields a
+  // never-resolving promise and the batch could never settle (hang). Replay
+  // must instead reconstruct from child checkpoints and complete.
+  it("should not hang when the summary is a free-form custom string (issue #751 repro 2)", async () => {
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+      { id: "item-2", data: "d2", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    // A legacy/free-form custom-generator payload (pre-fix): not JSON.
+    const initialResultSummary = "processed 2/3 items";
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Items 0 and 2 completed; item 1 still in flight (non-terminal) — the
+      // exact condition that previously hung the replay.
+      if (id === `${entityId}-1` || id === `${entityId}-3`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      if (id === `${entityId}-2`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.STARTED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext
+      .mockResolvedValueOnce("result0")
+      .mockResolvedValueOnce("result2");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { maxConcurrency: 2, completionConfig: { minSuccessful: 2 } },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // Completes (no hang). The in-flight middle item is skipped, not rebuilt,
+    // so the result holds the two completed items (indexes 0 and 2).
+    expect(result.totalCount).toBe(2);
+    expect(result.successCount).toBe(2);
+    expect(result.startedCount).toBe(0);
+    expect(result.all.map((i) => i.index)).toEqual([0, 2]);
+    // No recorded completionReason in the free-form summary, so it is re-inferred.
+    expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores an unrecognised completionReason in the summary and re-infers it", async () => {
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+      { id: "item-2", data: "d2", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    // A malformed / hand-authored summary carrying a bogus completionReason.
+    // "constructor" is deliberate: it is a real Object.prototype key, so a `in`
+    // check would wrongly accept it — validation must use hasOwnProperty.
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 3,
+      successCount: 2,
+      completionReason: "constructor",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Items 0 and 1 completed; item 2 never started.
+      if (id === `${entityId}-1` || id === `${entityId}-2`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext
+      .mockResolvedValueOnce("result0")
+      .mockResolvedValueOnce("result1");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { completionConfig: { minSuccessful: 2 } },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // The bogus value must NOT leak into BatchResult; the reason is re-inferred
+    // (2 successes reached minSuccessful while item 2 never completed).
+    expect(result.completionReason).toBe("MIN_SUCCESSFUL_REACHED");
+    expect(result.completionReason).not.toBe("constructor");
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -33,7 +33,6 @@ describe("Concurrent Execution Handler", () => {
     concurrentExecutionHandler = createConcurrentExecutionHandler(
       mockExecutionContext,
       mockRunInChildContext,
-      jest.fn(),
     );
   });
 
@@ -563,7 +562,7 @@ describe("ConcurrencyController", () => {
   let mockParentContext: jest.Mocked<DurableContext<DurableLogger>>;
 
   beforeEach(() => {
-    controller = new ConcurrencyController("test-operation", jest.fn());
+    controller = new ConcurrencyController("test-operation");
     mockParentContext = {
       runInChildContext: jest.fn(),
     } as any;
@@ -1048,10 +1047,7 @@ describe("ConcurrencyController", () => {
     });
 
     it("should handle verbose logging", async () => {
-      const verboseController = new ConcurrencyController(
-        "verbose-test",
-        jest.fn(),
-      );
+      const verboseController = new ConcurrencyController("verbose-test");
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn();
 
@@ -1181,10 +1177,7 @@ describe("ConcurrencyController", () => {
 
     it("should execute with iterationSubType and cover the actual execution path", async () => {
       // Create a new controller for this test to ensure clean state
-      const testController = new ConcurrencyController(
-        "test-operation",
-        jest.fn(),
-      );
+      const testController = new ConcurrencyController("test-operation");
       const items = [{ id: "item-0", data: "data1", index: 0 }];
       const executor = jest.fn().mockResolvedValue("test-result");
       const config = { iterationSubType: "TEST_ITERATION_TYPE" };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -24,10 +24,29 @@ import {
   restoreBatchResult,
   createBatchResultSerdes,
 } from "./batch-result";
-import { defaultSerdes, AnySerdes } from "../../utils/serdes/serdes";
+import { AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
+
+/**
+ * Valid {@link CompletionReason} values, used to validate a reason read back
+ * from a checkpointed summary. Typed as `Record<CompletionReason, true>` so it
+ * is exhaustive by construction: adding a value to the {@link CompletionReason}
+ * union turns this into a compile error until the new value is listed here — the
+ * validator can never silently omit a reason (and no extra public API is
+ * exported to keep it in sync). A reason not present here (a malformed or
+ * hand-authored summary) is ignored so an arbitrary string can never leak into
+ * {@link BatchResult.completionReason}; replay re-infers the reason from the
+ * reconstructed items instead.
+ */
+const VALID_COMPLETION_REASONS: Record<CompletionReason, true> = {
+  ALL_COMPLETED: true,
+  MIN_SUCCESSFUL_REACHED: true,
+  FAILURE_TOLERANCE_EXCEEDED: true,
+  CUSTOM_COMPLETION_SUCCEEDED: true,
+  CUSTOM_COMPLETION_FAILED: true,
+};
 
 /**
  * Validates that a custom `shouldComplete` predicate is not combined with the
@@ -67,24 +86,28 @@ function validateCompletionConfig(
 export class ConcurrencyController<Logger extends DurableLogger> {
   constructor(
     private readonly operationName: string,
-    private readonly skipNextOperation: () => void,
 
     private readonly getDefaultSerdes?: () => AnySerdes,
   ) {}
 
-  private isChildEntityCompleted(
-    executionContext: ExecutionContext,
-    parentEntityId: string,
-    completedCount: number,
-  ): boolean {
-    const childEntityId = `${parentEntityId}-${completedCount + 1}`;
-    const childStepData = executionContext.getStepData(childEntityId);
-
-    return !!(
-      childStepData &&
-      (childStepData.Status === OperationStatus.SUCCEEDED ||
-        childStepData.Status === OperationStatus.FAILED)
-    );
+  /**
+   * Advance the step cursor of the context that {@link replayItems} re-drives
+   * child operations on, for a non-terminal item that is NOT re-executed on
+   * replay (one that was in flight at suspension, or never started).
+   *
+   * This MUST advance the SAME context that runInChildContext runs on
+   * (`parentContext` — the map/parallel child context), not the outer context
+   * that owns the map/parallel call. If a skipped in-flight item does not
+   * advance this cursor, the next terminal item's runInChildContext peeks the
+   * pending non-terminal step, `checkForNonResolvingPromise` returns a
+   * never-resolving promise, and replay hangs (issue #751). `skipNextOperation`
+   * is internal to the durable context, so it is reached through a narrow cast
+   * (the same pattern used to read `_stepPrefix`/`durableExecutionMode`).
+   */
+  private skipReplayStep(parentContext: DurableContext<Logger>): void {
+    (
+      parentContext as unknown as { skipNextOperation: () => void }
+    ).skipNextOperation();
   }
 
   private getCompletionReason<T, R>(
@@ -170,53 +193,50 @@ export class ConcurrencyController<Logger extends DurableLogger> {
         itemCount: items.length,
       });
 
-      // Try to get the target count from step data
-      let targetTotalCount: number | undefined;
+      // Recover the recorded completion reason from the checkpointed summary.
+      // This is the ONLY field read back from the summary: counts, the started
+      // set, and per-item status are all derived from the child checkpoints in
+      // replayItems (the items array is the same deterministic input, so
+      // items.length is the authoritative total). The completion reason is the
+      // one value that cannot be safely re-derived — for a custom
+      // `shouldComplete` predicate, re-invoking it on the reconstructed
+      // (terminal-only) set is exactly what produced non-deterministic replay,
+      // so we read the value the live run recorded instead.
+      let recordedCompletionReason: CompletionReason | undefined;
       if (entityId && executionContext) {
         const stepData = executionContext.getStepData(entityId);
         const summaryPayload = stepData?.ContextDetails?.Result;
-
         if (summaryPayload) {
-          try {
-            const serdes =
-              config.serdes ||
-              (this.getDefaultSerdes ? this.getDefaultSerdes() : defaultSerdes);
-            const parsedSummary = await serdes.deserialize(summaryPayload, {
-              entityId: entityId,
-              durableExecutionArn: executionContext.durableExecutionArn,
-            });
-            if (
-              parsedSummary &&
-              typeof parsedSummary === "object" &&
-              "totalCount" in parsedSummary
-            ) {
-              // Read totalCount directly from summary metadata
-              targetTotalCount = parsedSummary.totalCount as number;
-              log("📊", "Found initial execution count:", {
-                targetTotalCount,
-              });
-            }
-          } catch (error) {
-            log("⚠️", "Could not parse initial result summary:", error);
-          }
+          recordedCompletionReason =
+            this.parseRecordedCompletionReason(summaryPayload);
+          log("📊", "Recovered completion reason from summary:", {
+            recordedCompletionReason,
+          });
         }
       }
 
-      // If we have target count and required context, use optimized replay; otherwise fallback to concurrent execution
-      if (targetTotalCount !== undefined && entityId && executionContext) {
+      // Always reconstruct from child checkpoints when we have the context to
+      // do so. Deriving from checkpoints — rather than falling back to
+      // concurrent execution while the context is in ReplaySucceededContext
+      // mode — is what prevents the replay hang: in that mode a non-terminal
+      // child yields a never-resolving promise, so any batch with a live
+      // in-flight item could never settle. The fallback below only applies
+      // when there is no context to reconstruct from (which does not happen for
+      // map/parallel).
+      if (entityId && executionContext) {
         return await this.replayItems(
           items,
           executor,
           parentContext,
           config,
-          targetTotalCount,
+          recordedCompletionReason,
           executionContext,
           entityId,
         );
       } else {
         log(
           "⚠️",
-          "No valid target count or context found, falling back to concurrent execution",
+          "No entity id or execution context found, falling back to concurrent execution",
         );
       }
     }
@@ -230,140 +250,188 @@ export class ConcurrencyController<Logger extends DurableLogger> {
     );
   }
 
+  /**
+   * Extracts a recorded `completionReason` from a checkpointed batch summary.
+   *
+   * The summary is stored as a raw JSON string (written by the composed summary
+   * generator), so it is parsed directly rather than routed through a
+   * BatchResult serdes. Returns `undefined` when the payload is missing,
+   * unparseable, or does not carry a string `completionReason` (e.g. an old
+   * checkpoint written by a pre-fix custom generator that returned a free-form
+   * string) — in that case replayItems re-infers the reason from the
+   * reconstructed items.
+   */
+  private parseRecordedCompletionReason(
+    summaryPayload: unknown,
+  ): CompletionReason | undefined {
+    if (typeof summaryPayload !== "string") {
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(summaryPayload);
+      if (parsed && typeof parsed === "object") {
+        const reason = (parsed as Record<string, unknown>).completionReason;
+        // Only trust a recognised CompletionReason. An unknown/arbitrary value
+        // (malformed or hand-authored summary) is ignored so it cannot leak
+        // into BatchResult.completionReason; replayItems re-infers instead.
+        // hasOwnProperty (not `in`) so inherited keys like "constructor" or
+        // "toString" from a crafted summary are not treated as valid.
+        if (
+          typeof reason === "string" &&
+          Object.prototype.hasOwnProperty.call(VALID_COMPLETION_REASONS, reason)
+        ) {
+          return reason as CompletionReason;
+        }
+      }
+    } catch {
+      // Unparseable summary (e.g. a legacy free-form custom-generator string):
+      // fall through and let replayItems re-infer from child checkpoints.
+      log("⚠️", "Could not parse batch summary for completion reason");
+    }
+    return undefined;
+  }
+
   private async replayItems<T, R>(
     items: ConcurrentExecutionItem<T>[],
     executor: ConcurrentExecutor<T, R, Logger>,
     parentContext: DurableContext<Logger>,
     config: ConcurrencyConfig<R>,
-    targetTotalCount: number,
+    recordedCompletionReason: CompletionReason | undefined,
     executionContext: ExecutionContext,
     parentEntityId: string,
   ): Promise<BatchResult<R>> {
     const resultItems: Array<BatchItem<R>> = [];
 
-    log("🔄", `Replaying ${items.length} items sequentially`, {
-      targetTotalCount,
+    log("🔄", `Replaying ${items.length} items from child checkpoints`, {
+      recordedCompletionReason,
     });
 
-    let completedCount = 0;
     let stepCounter = 0;
 
-    // Replay items sequentially until we reach the target count
+    // Reconstruct the completed items from the child checkpoints. Items are
+    // started in strict index order (tryStartNext), so each item at position
+    // `stepCounter` maps to the child entity `${parent}-{n}`. A child that
+    // finished has a terminal checkpoint (its result/error is returned from
+    // cache); any non-terminal child (in flight at suspension, or never
+    // started) is skipped. The recorded completionReason carries the batch
+    // outcome, so the started set does not need to be persisted or rebuilt.
     for (const item of items) {
-      // Stop if we've replayed all items that completed in initial execution
-      if (completedCount >= targetTotalCount) {
-        log("✅", "Reached target count, stopping replay", {
-          completedCount,
-          targetTotalCount,
-        });
-        break;
-      }
-
-      // Calculate the child entity ID that runInChildContext will create
-      // It uses the parent's next step ID, which is parentEntityId-{counter}
       const childEntityId = `${parentEntityId}-${stepCounter + 1}`;
+      const childStepData = executionContext.getStepData(childEntityId);
+      const isTerminal =
+        !!childStepData &&
+        (childStepData.Status === OperationStatus.SUCCEEDED ||
+          childStepData.Status === OperationStatus.FAILED);
 
-      if (
-        !this.isChildEntityCompleted(
-          executionContext,
-          parentEntityId,
-          stepCounter,
-        )
-      ) {
-        log("⏭️", `Skipping incomplete item:`, {
+      if (isTerminal) {
+        // Terminal child: re-drive runInChildContext so it returns the cached
+        // checkpointed result (it is not re-executed) and consumes its step id.
+        try {
+          const result = await parentContext.runInChildContext(
+            item.name || item.id,
+            (childContext) => executor(item, childContext),
+            {
+              subType: config.iterationSubType,
+              serdes: config.itemSerdes,
+              virtualContext: config.nesting === NestingType.FLAT,
+            },
+          );
+
+          resultItems.push({
+            result,
+            index: item.index,
+            status: BatchItemStatus.SUCCEEDED,
+          });
+
+          log("✅", `Replayed ${this.operationName} item:`, {
+            index: item.index,
+            itemId: item.id,
+          });
+        } catch (error) {
+          const err =
+            error instanceof ChildContextError
+              ? error
+              : new ChildContextError(
+                  error instanceof Error ? error.message : String(error),
+                  error instanceof Error ? error : undefined,
+                );
+          resultItems.push({
+            error: err,
+            index: item.index,
+            status: BatchItemStatus.FAILED,
+          });
+
+          log("❌", `Replay failed for ${this.operationName} item:`, {
+            index: item.index,
+            itemId: item.id,
+            error: err.message,
+          });
+        }
+        stepCounter++;
+      } else {
+        // Non-terminal child at suspension (in flight, or never started). It is
+        // NOT re-executed and NOT added to the reconstructed result. Its step
+        // is skipped on THIS context so the next terminal item's
+        // runInChildContext peeks its own step rather than this pending one —
+        // this is what keeps replay from hanging on the non-resolving-promise
+        // gate (issue #751). In-flight items are intentionally not rebuilt as
+        // STARTED placeholders: summarized replay reports the completed items,
+        // and the recorded completionReason is used for the batch outcome.
+        this.skipReplayStep(parentContext);
+        stepCounter++;
+
+        log("⏭️", `Skipping non-terminal item during replay:`, {
           index: item.index,
           itemId: item.id,
           childEntityId,
         });
-        // Increment step counter to maintain consistency
-        this.skipNextOperation();
-        stepCounter++;
-        continue;
-      }
-
-      try {
-        const result = await parentContext.runInChildContext(
-          item.name || item.id,
-          (childContext) => executor(item, childContext),
-          {
-            subType: config.iterationSubType,
-            serdes: config.itemSerdes,
-            virtualContext: config.nesting === NestingType.FLAT,
-          },
-        );
-
-        resultItems.push({
-          result,
-          index: item.index,
-          status: BatchItemStatus.SUCCEEDED,
-        });
-        completedCount++;
-        stepCounter++;
-
-        log("✅", `Replayed ${this.operationName} item:`, {
-          index: item.index,
-          itemId: item.id,
-          completedCount,
-        });
-      } catch (error) {
-        const err =
-          error instanceof ChildContextError
-            ? error
-            : new ChildContextError(
-                error instanceof Error ? error.message : String(error),
-                error instanceof Error ? error : undefined,
-              );
-        resultItems.push({
-          error: err,
-          index: item.index,
-          status: BatchItemStatus.FAILED,
-        });
-        completedCount++;
-        stepCounter++;
-
-        log("❌", `Replay failed for ${this.operationName} item:`, {
-          index: item.index,
-          itemId: item.id,
-          error: err.message,
-          completedCount,
-        });
       }
     }
-
-    log("🎉", `${this.operationName} replay completed:`, {
-      completedCount,
-      totalCount: resultItems.length,
-    });
 
     const successCount = resultItems.filter(
       (item) => item.status === BatchItemStatus.SUCCEEDED,
     ).length;
-    const failureCount = completedCount - successCount;
+    const failureCount = resultItems.filter(
+      (item) => item.status === BatchItemStatus.FAILED,
+    ).length;
+    const completedCount = successCount + failureCount;
 
-    // Per-item snapshot ordered by original index, so shouldComplete can
-    // reason about which specific items/branches finished.
-    // Index results once (O(n)) instead of find() per item (O(n²)).
-    const statusByIndex = new Map<number, BatchItemStatus>();
-    for (const r of resultItems) {
-      statusByIndex.set(r.index, r.status);
-    }
-    const itemStatuses: CompletionItemStatus[] = items.map((item) => ({
-      index: item.index,
-      name: item.name,
-      status: statusByIndex.get(item.index),
-    }));
+    log("🎉", `${this.operationName} replay completed:`, {
+      successCount,
+      failureCount,
+      startedCount: resultItems.filter(
+        (item) => item.status === BatchItemStatus.STARTED,
+      ).length,
+      totalCount: resultItems.length,
+    });
 
-    return new BatchResultImpl(
-      resultItems,
-      this.getCompletionReason(
+    // Prefer the completion reason the live run recorded. Re-inferring it here
+    // would re-invoke a custom shouldComplete predicate against the
+    // reconstructed set, which is not guaranteed to match the live decision.
+    // Only fall back to inference for legacy/malformed summaries that carry no
+    // recorded reason.
+    let completionReason = recordedCompletionReason;
+    if (completionReason === undefined) {
+      const statusByIndex = new Map<number, BatchItemStatus>();
+      for (const r of resultItems) {
+        statusByIndex.set(r.index, r.status);
+      }
+      const itemStatuses: CompletionItemStatus[] = items.map((item) => ({
+        index: item.index,
+        name: item.name,
+        status: statusByIndex.get(item.index),
+      }));
+      completionReason = this.getCompletionReason(
         failureCount,
         successCount,
         completedCount,
         items,
         config,
         itemStatuses,
-      ),
-    );
+      );
+    }
+
+    return new BatchResultImpl(resultItems, completionReason);
   }
 
   private async executeItemsConcurrently<T, R>(
@@ -601,7 +669,6 @@ export class ConcurrencyController<Logger extends DurableLogger> {
 export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   runInChildContext: DurableContext<Logger>["runInChildContext"],
-  skipNextOperation: () => void,
 
   getDefaultSerdes?: () => AnySerdes,
 ) => {
@@ -682,7 +749,6 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
       ): Promise<BatchResult<TResult>> => {
         const concurrencyController = new ConcurrencyController<Logger>(
           "concurrent-execution",
-          skipNextOperation,
           getDefaultSerdes,
         );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.test.ts
@@ -424,31 +424,38 @@ describe("Map Handler", () => {
   });
 
   describe("summaryGenerator", () => {
-    it("should forward a user-provided summaryGenerator", async () => {
+    it("should compose a user-provided summaryGenerator with the SDK record", async () => {
       const items = ["item1"];
       const mapFunc: MapFunc<string, string, DurableLogger> = jest
         .fn()
         .mockResolvedValue("result");
       const customSummaryGenerator = jest.fn(() => "custom-summary");
 
-      mockExecuteConcurrently.mockResolvedValue(
-        new MockBatchResult([
-          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        ]) as any,
-      );
+      const mockResult = new MockBatchResult([
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+      ]);
+      mockExecuteConcurrently.mockResolvedValue(mockResult as any);
 
       await mapHandler("test-map", items, mapFunc, {
         summaryGenerator: customSummaryGenerator,
       });
 
-      expect(mockExecuteConcurrently).toHaveBeenCalledWith(
-        "test-map",
-        expect.any(Array),
-        expect.any(Function),
-        expect.objectContaining({
-          summaryGenerator: customSummaryGenerator,
-        }),
-      );
+      // The handler no longer forwards the raw custom generator. It forwards a
+      // composed generator that always writes the SDK's load-bearing record and
+      // stores the customer output verbatim under `summary` (observability-only).
+      const forwarded = mockExecuteConcurrently.mock.calls[0][3];
+      expect(typeof forwarded.summaryGenerator).toBe("function");
+
+      const payload = JSON.parse(forwarded.summaryGenerator(mockResult));
+      expect(payload).toMatchObject({
+        type: "MapResult",
+        totalCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        completionReason: "ALL_COMPLETED",
+        summary: "custom-summary",
+      });
+      expect(customSummaryGenerator).toHaveBeenCalledWith(mockResult);
     });
 
     it("should fall back to the default generator when none is provided", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/map-handler/map-handler.ts
@@ -11,7 +11,10 @@ import {
   DurableLogger,
 } from "../../types";
 import { log } from "../../utils/logger/logger";
-import { createMapSummaryGenerator } from "../../utils/summary-generators/summary-generators";
+import {
+  createMapSummaryGenerator,
+  composeSummaryGenerator,
+} from "../../utils/summary-generators/summary-generators";
 
 export const createMapHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
@@ -87,8 +90,10 @@ export const createMapHandler = <Logger extends DurableLogger>(
         maxConcurrency: config?.maxConcurrency,
         topLevelSubType: OperationSubType.MAP,
         iterationSubType: OperationSubType.MAP_ITERATION,
-        summaryGenerator:
-          config?.summaryGenerator ?? createMapSummaryGenerator(),
+        summaryGenerator: composeSummaryGenerator(
+          createMapSummaryGenerator(),
+          config?.summaryGenerator,
+        ),
         completionConfig: config?.completionConfig,
         serdes: config?.serdes,
         itemSerdes: config?.itemSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.test.ts
@@ -377,31 +377,38 @@ describe("Parallel Handler", () => {
   });
 
   describe("summaryGenerator", () => {
-    it("should forward a user-provided summaryGenerator", async () => {
+    it("should compose a user-provided summaryGenerator with the SDK record", async () => {
       const branch1: ParallelFunc<string, DurableLogger> = jest
         .fn()
         .mockResolvedValue("result1");
       const branches = [branch1];
       const customSummaryGenerator = jest.fn(() => "custom-summary");
 
-      mockExecuteConcurrently.mockResolvedValue(
-        new MockBatchResult([
-          { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
-        ]) as any,
-      );
+      const mockResult = new MockBatchResult([
+        { index: 0, result: "result1", status: BatchItemStatus.SUCCEEDED },
+      ]);
+      mockExecuteConcurrently.mockResolvedValue(mockResult as any);
 
       await parallelHandler("test-name", branches, {
         summaryGenerator: customSummaryGenerator,
       });
 
-      expect(mockExecuteConcurrently).toHaveBeenCalledWith(
-        "test-name",
-        expect.any(Array),
-        expect.any(Function),
-        expect.objectContaining({
-          summaryGenerator: customSummaryGenerator,
-        }),
-      );
+      // The handler no longer forwards the raw custom generator. It forwards a
+      // composed generator that always writes the SDK's load-bearing record and
+      // stores the customer output verbatim under `summary` (observability-only).
+      const forwarded = mockExecuteConcurrently.mock.calls[0][3];
+      expect(typeof forwarded.summaryGenerator).toBe("function");
+
+      const payload = JSON.parse(forwarded.summaryGenerator(mockResult));
+      expect(payload).toMatchObject({
+        type: "ParallelResult",
+        totalCount: 1,
+        successCount: 1,
+        failureCount: 0,
+        completionReason: "ALL_COMPLETED",
+        summary: "custom-summary",
+      });
+      expect(customSummaryGenerator).toHaveBeenCalledWith(mockResult);
     });
 
     it("should fall back to the default generator when none is provided", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/parallel-handler/parallel-handler.ts
@@ -12,7 +12,10 @@ import {
   DurableLogger,
 } from "../../types";
 import { log } from "../../utils/logger/logger";
-import { createParallelSummaryGenerator } from "../../utils/summary-generators/summary-generators";
+import {
+  createParallelSummaryGenerator,
+  composeSummaryGenerator,
+} from "../../utils/summary-generators/summary-generators";
 
 export const createParallelHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
@@ -121,8 +124,10 @@ export const createParallelHandler = <Logger extends DurableLogger>(
         maxConcurrency: config?.maxConcurrency,
         topLevelSubType: OperationSubType.PARALLEL,
         iterationSubType: OperationSubType.PARALLEL_BRANCH,
-        summaryGenerator:
-          config?.summaryGenerator ?? createParallelSummaryGenerator(),
+        summaryGenerator: composeSummaryGenerator(
+          createParallelSummaryGenerator(),
+          config?.summaryGenerator,
+        ),
         completionConfig: config?.completionConfig,
         serdes: config?.serdes,
         itemSerdes: config?.itemSerdes,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -77,6 +77,49 @@ describe("Run In Child Context Handler", () => {
     );
   });
 
+  describe("Descendant checkpoint gate (issue #751)", () => {
+    test("marks the context finished BEFORE serialization yields the event loop", async () => {
+      // Regression guard: the descendant-checkpoint gate must close synchronously
+      // after fn returns, before the safeSerialize await. Otherwise an in-flight
+      // child of a map/parallel that completed early could settle during
+      // serialization and checkpoint SUCCEEDED after the batch completed.
+      const childFn = jest
+        .fn()
+        .mockResolvedValue(TEST_CONSTANTS.CHILD_CONTEXT_RESULT);
+
+      let markedWhenSerializeRan: boolean | undefined;
+      const orderTrackingSerdes = {
+        serialize: jest.fn(async (value: unknown) => {
+          // Capture whether the gate was already closed at serialize time.
+          markedWhenSerializeRan =
+            (mockCheckpoint.markAncestorFinished as jest.Mock).mock.calls
+              .length > 0;
+          return JSON.stringify(value);
+        }),
+        deserialize: jest.fn(async (data?: string) =>
+          data ? JSON.parse(data) : undefined,
+        ),
+      };
+
+      await runInChildContextHandler(
+        TEST_CONSTANTS.CHILD_CONTEXT_NAME,
+        childFn,
+        {
+          serdes: orderTrackingSerdes as never,
+        },
+      );
+
+      expect(orderTrackingSerdes.serialize).toHaveBeenCalled();
+      // The gate was closed before serialization ran, not after.
+      expect(markedWhenSerializeRan).toBe(true);
+      expect(mockCheckpoint.markAncestorFinished).toHaveBeenCalledWith(
+        TEST_CONSTANTS.CHILD_CONTEXT_ID,
+      );
+      // And it is closed exactly once (not re-marked after serialization).
+      expect(mockCheckpoint.markAncestorFinished).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("Virtual Context", () => {
     test("should not checkpoint when virtualContext is true", async () => {
       const childFn = jest

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -389,6 +389,21 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       name,
     )) as T;
 
+    // Close the descendant-checkpoint gate NOW — synchronously, before the
+    // safeSerialize await below yields the event loop. `fn` has returned, so
+    // this context is logically finished; for a map/parallel that completed
+    // early (e.g. minSuccessful) some child branches may still be in flight.
+    // Marking finished here makes their later terminal checkpoints
+    // deterministically no-op, closing the race where a child that settles
+    // during serialization would otherwise checkpoint SUCCEEDED after the batch
+    // completed — which replay would then reconstruct as a completed item the
+    // live BatchResult never observed (issue #751). Descendant checkpoints are
+    // the only thing this gate affects; this context's own SUCCEED checkpoint
+    // below is unaffected (hasFinishedAncestor only inspects ancestors).
+    if (!isVirtual) {
+      checkpoint.markAncestorFinished(entityId);
+    }
+
     // Serialize the result for consistency
     const serializedResult = await safeSerialize(
       serdes,
@@ -438,10 +453,12 @@ export const executeChildContext = async <T, Logger extends DurableLogger>(
       replayChildren = true;
     }
 
-    // Mark this run-in-child-context as finished to prevent descendant operations (only for non-virtual)
+    // Checkpoint this run-in-child-context as finished (only for non-virtual).
+    // The descendant-checkpoint gate was already closed via
+    // markAncestorFinished immediately after `fn` returned (see above), before
+    // the safeSerialize await, so no in-flight child can slip a terminal
+    // checkpoint through during serialization.
     if (!isVirtual) {
-      checkpoint.markAncestorFinished(entityId);
-
       const subType = options?.subType || OperationSubType.RUN_IN_CHILD_CONTEXT;
       checkpoint.checkpoint(entityId, {
         Id: entityId,

--- a/packages/aws-durable-execution-sdk-js/src/types/batch.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/batch.ts
@@ -39,6 +39,11 @@ export enum NestingType {
 export enum BatchItemStatus {
   SUCCEEDED = "SUCCEEDED",
   FAILED = "FAILED",
+  /**
+   * Item was still in flight when the batch completed early. Observability
+   * only and not guaranteed to survive suspend/resume reconstruction — see
+   * {@link BatchResult.started}.
+   */
   STARTED = "STARTED",
 }
 
@@ -95,13 +100,34 @@ export interface BatchResult<TResult> {
    * filtered views ({@link BatchResult.succeeded}, {@link BatchResult.failed},
    * {@link BatchResult.started}) are computed once and will not reflect
    * mutations made to this array after construction.
+   *
+   * The completed (SUCCEEDED/FAILED) items are stable across suspend/resume.
+   * Any STARTED (in-flight) entries are not guaranteed to be reproduced on
+   * replay — see {@link BatchResult.started}.
    */
   all: Array<BatchItem<TResult>>;
   /** Returns only the items that succeeded */
   succeeded(): Array<BatchItem<TResult> & { result: TResult }>;
   /** Returns only the items that failed */
   failed(): Array<BatchItem<TResult> & { error: ChildContextError }>;
-  /** Returns only the items that are still in progress */
+  /**
+   * Returns only the items that are still in progress (STARTED) — items that
+   * were in flight when the batch completed early (e.g. via
+   * {@link CompletionConfig.minSuccessful} or a custom
+   * {@link CompletionConfig.shouldComplete}).
+   *
+   * @remarks
+   * The STARTED set is observability-only and is **not guaranteed to be stable
+   * across suspend/resume**. On a resumed invocation the batch result is
+   * reconstructed, and when the aggregate result was large enough to be
+   * checkpointed as a summary only the completed (SUCCEEDED/FAILED) items are
+   * rebuilt — in-flight items may be absent, so {@link BatchResult.started},
+   * {@link BatchResult.startedCount} and {@link BatchResult.totalCount} can
+   * differ from what the live run observed (and from a smaller result that fit
+   * in a single checkpoint). Do not branch on the started set across replay;
+   * the completed items and {@link BatchResult.completionReason} are the
+   * stable, deterministic parts of the result.
+   */
   started(): Array<BatchItem<TResult> & { status: BatchItemStatus.STARTED }>;
   /** Overall status of the batch (SUCCEEDED if no failures, FAILED otherwise) */
   status: BatchItemStatus.SUCCEEDED | BatchItemStatus.FAILED;
@@ -119,7 +145,12 @@ export interface BatchResult<TResult> {
   successCount: number;
   /** Number of failed items */
   failureCount: number;
-  /** Number of started but not completed items */
+  /**
+   * Number of started but not completed items.
+   *
+   * Not guaranteed to be stable across suspend/resume — see
+   * {@link BatchResult.started}.
+   */
   startedCount: number;
   /** Total number of items */
   totalCount: number;

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
@@ -1,6 +1,7 @@
 import {
   createParallelSummaryGenerator,
   createMapSummaryGenerator,
+  composeSummaryGenerator,
 } from "./summary-generators";
 import { BatchResultImpl } from "../../handlers/concurrent-execution-handler/batch-result";
 import { BatchItemStatus } from "../../types";
@@ -155,6 +156,68 @@ describe("Summary Generators", () => {
         completionReason: "FAILURE_TOLERANCE_EXCEEDED",
         status: BatchItemStatus.FAILED,
       });
+    });
+  });
+
+  describe("composeSummaryGenerator", () => {
+    it("returns the internal record unchanged when no custom generator is given", () => {
+      const batchResult = new BatchResultImpl(
+        [{ index: 0, result: "r1", status: BatchItemStatus.SUCCEEDED }],
+        "ALL_COMPLETED",
+      );
+      const composed = composeSummaryGenerator(createMapSummaryGenerator());
+
+      expect(composed(batchResult)).toBe(
+        createMapSummaryGenerator()(batchResult),
+      );
+    });
+
+    it("always preserves the SDK record and nests custom output under `summary`", () => {
+      const batchResult = new BatchResultImpl(
+        [
+          { index: 0, result: "r1", status: BatchItemStatus.SUCCEEDED },
+          { index: 1, status: BatchItemStatus.STARTED },
+        ],
+        "MIN_SUCCESSFUL_REACHED",
+      );
+      const custom = (): string => "processed 1/2 items";
+      const composed = composeSummaryGenerator(
+        createMapSummaryGenerator(),
+        custom,
+      );
+
+      const parsed = JSON.parse(composed(batchResult));
+
+      // Load-bearing SDK fields survive regardless of the custom output...
+      expect(parsed).toMatchObject({
+        type: "MapResult",
+        totalCount: 2,
+        successCount: 1,
+        failureCount: 0,
+        completionReason: "MIN_SUCCESSFUL_REACHED",
+      });
+      // ...and the customer string is preserved verbatim, observability-only.
+      expect(parsed.summary).toBe("processed 1/2 items");
+    });
+
+    it("keeps a JSON-shaped custom output as a verbatim string under `summary`", () => {
+      const batchResult = new BatchResultImpl(
+        [{ index: 0, result: "r1", status: BatchItemStatus.SUCCEEDED }],
+        "ALL_COMPLETED",
+      );
+      // A custom generator that itself returns JSON must NOT collide with or
+      // overwrite the SDK metadata keys — it is stored as an opaque string.
+      const custom = (): string =>
+        JSON.stringify({ totalCount: 999, mine: true });
+      const composed = composeSummaryGenerator(
+        createParallelSummaryGenerator(),
+        custom,
+      );
+
+      const parsed = JSON.parse(composed(batchResult));
+
+      expect(parsed.totalCount).toBe(1); // SDK value, not the custom 999
+      expect(parsed.summary).toBe('{"totalCount":999,"mine":true}');
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
@@ -32,3 +32,46 @@ export const createMapSummaryGenerator =
       status: result.status,
     });
   };
+
+/**
+ * Composes the SDK's internal summary generator with an optional
+ * customer-supplied one.
+ *
+ * The internal generator's record is always written to the checkpoint so the
+ * fields replay depends on (`totalCount`, `successCount`, `failureCount`,
+ * `completionReason`, `status`) are present regardless of what a custom
+ * generator returns. When a custom generator is supplied, its output is
+ * preserved verbatim under a `summary` key — observability-only, exactly as the
+ * developer guide documents. This keeps replay correctness independent of the
+ * customer's string: the customer's value can never displace the SDK metadata.
+ *
+ * When no custom generator is supplied, the internal record is returned
+ * unchanged (identical to the previous default behavior).
+ */
+export const composeSummaryGenerator =
+  <T>(
+    internalGenerator: (result: BatchResult<T>) => string,
+    customGenerator?: (result: BatchResult<T>) => string,
+  ) =>
+  (result: BatchResult<T>): string => {
+    const internal = internalGenerator(result);
+    if (!customGenerator) {
+      return internal;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(internal);
+      record =
+        parsed && typeof parsed === "object"
+          ? (parsed as Record<string, unknown>)
+          : {};
+    } catch {
+      record = {};
+    }
+
+    // Customer output is stored verbatim (as a string) so it stays purely
+    // observational and never collides with the SDK metadata keys.
+    record.summary = customGenerator(result);
+    return JSON.stringify(record);
+  };


### PR DESCRIPTION
When a `map`/`parallel` aggregate result exceeds the 256KB checkpoint limit, the
   SDK checkpoints a compact summary and reconstructs the `BatchResult` from child
   checkpoints on replay (ReplayChildren mode). Two failures came out of this path,
   both from issue #751:

   1. **Replay hang.** When the batch completed early (e.g. `minSuccessful`) with an
      item still in flight *between* two completed items, replaying the summarized
      map hung and the execution made no further progress.
   2. **Free-form custom summary hang.** A custom `summaryGenerator` whose output was
      not JSON with a numeric `totalCount` made replay fall back to concurrent
      execution in `ReplaySucceededContext` mode and hang there too.

   Fixes #751.

   ## Root cause (the hang)

   `replayItems` re-drives `runInChildContext` on the map/parallel **child context**,
   but `skipNextOperation` was bound to the **outer context** that owns the `map`
   call. When an in-flight item was skipped, the child context's step cursor was not
   advanced, so the next terminal item's `runInChildContext` peeked the pending
   non-terminal step and `checkForNonResolvingPromise` returned a never-resolving
   promise.

   This path only runs in the summarized (ReplayChildren) case, which no existing
   test covered — and prior unit tests mocked `runInChildContext`, hiding the gate.
   The bug was found and reproduced end-to-end with `LocalDurableTestRunner` via a
   new example (reproduction-first).

   ## Changes

   **Read side (`concurrent-execution-handler`)**
   - Skip on the same context `runInChildContext` runs on (`parentContext`) via
     `skipReplayStep`, so the non-resolving-promise gate no longer fires. Removed the
     misbound `skipNextOperation` parameter from the controller/factory.
   - Read `completionReason` from the summary instead of re-inferring it — this also
     stops re-invoking a custom `shouldComplete` predicate on replay. The recorded
     value is validated against the known `CompletionReason` set; an unrecognized or
     malformed value is ignored and the reason is re-inferred (so a bogus string can
     never leak into `BatchResult.completionReason`).
   - Always reconstruct from child checkpoints in `ReplaySucceededContext` mode rather
     than falling back to concurrent execution. Summarized replay returns the
     **completed** items; in-flight items are not rebuilt (the recorded
     `completionReason` carries the batch outcome).

   **Write side**
   - `composeSummaryGenerator`: always record the SDK's load-bearing metadata
     (`totalCount`/`successCount`/`failureCount`/`completionReason`/`status`) and store
     any custom generator's output verbatim under a `summary` key (observability-only).
     This makes a free-form custom summary parseable so replay takes the reconstruction
     path instead of the concurrent fallback.
   - Public `summaryGenerator?: (result) => string` signature is unchanged.

   ## Behavior note (scope)

   This PR targets the hang. For a batch that **completed early with in-flight items**
   and whose result was large enough to be summarized, replay reconstructs the
   completed items only — it does not rebuild the in-flight (`STARTED`) entries, so
   `startedCount` / the in-flight index list are not reproduced on that path. The
   non-summarized (small-result) path is unchanged and still replays the full cached
   result. This trade-off is intentional: the batch outcome is driven by the recorded
   `completionReason`, and code depending on the exact in-flight set across a
   summarized replay is not a supported pattern.

   ## Testing

   - New `map/custom-summary-generator-replay` example + integ test reproducing the
     hang end-to-end (small committed history fixture).
   - Updated `parallel/custom-summary-generator` test for the new envelope shape (custom
     output now nested under `summary`).
   - Updated `concurrent-execution-handler` unit/replay/two-phase tests for the new
     controller signature and completed-items-only reconstruction; added composer tests
     and a test that a bogus recorded `completionReason` is ignored and re-inferred.

   All green: SDK unit 1065 · examples integ 186 (+1 cloud-only skip) · examples vitest 2
   · `-testing` 1167 · `-otel` 160.

   ## Compatibility

   - The `summaryGenerator` type and the default checkpoint shape are unchanged.
   - For a **custom** `summaryGenerator` on `map`/`parallel`, the checkpointed summary is
     now an SDK envelope with the customer's output under `summary`, instead of the raw
     customer string. The developer guide already documents this payload as "for
     observability only," so no supported programmatic consumer is affected — worth a
     changelog callout.