### PR TITLE
ci: use latest conformance suite (git main) in conformance CI

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -77,7 +77,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install conformance runner
-        run: pip install aws-durable-execution-conformance-tests==0.1.0
+        run: pip install "git+https://github.com/aws/aws-durable-execution-conformance-tests.git@main#subdirectory=packages/aws-durable-execution-conformance-tests"
 
       - name: Get AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_large_payload.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_large_payload.ts
@@ -9,7 +9,10 @@ export const handler = withDurableExecution(
     const largeDataResult = await context.runInChildContext(
       "large-data-processor",
       async (childContext: DurableContext) => {
-        console.log(event);
+        // Replay logging: the child body legitimately re-executes in
+        // ReplaySucceededContext mode, and both executions must be observable.
+        childContext.configureLogger({ modeAware: false });
+        childContext.logger.info(event);
 
         // Step returns a small seed value (under 256KB limit)
         const seed = await childContext.step(async () => {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_print_only.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/child/child_print_only.ts
@@ -1,4 +1,4 @@
-// 3-17: Child context with print only (verify no re-execution on replay)
+// 3-17: Child context with durable logger only (verify no re-execution on replay)
 import {
   DurableContext,
   withDurableExecution,
@@ -9,7 +9,10 @@ export const handler = withDurableExecution(
     const result = await context.runInChildContext(
       "print-child",
       async (childContext: DurableContext) => {
-        console.log(event);
+        // Replay logging: mode-aware suppression is disabled so an incorrect
+        // second child execution would emit a second log and fail the count.
+        childContext.configureLogger({ modeAware: false });
+        childContext.logger.info(event);
         return event as string;
       },
     );

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/step/step_at_most_once_no_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/step/step_at_most_once_no_retry.ts
@@ -10,9 +10,10 @@ export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.step(
       "at_most_once_flaky_step",
-      async () => {
-        // Print input to stdout before crashing
-        console.log(event);
+      async (stepContext) => {
+        // Log input through the step context logger before crashing so the
+        // record carries the execution ARN and is correlated to this execution.
+        stepContext.logger.info(event);
         // Allow time for logs to flush to CloudWatch before crashing
         await new Promise((resolve) => setTimeout(resolve, 1000));
         process.exit(1);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/step/step_at_most_once_with_retry.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/step/step_at_most_once_with_retry.ts
@@ -9,8 +9,9 @@ export const handler = withDurableExecution(
   async (event: any, context: DurableContext) => {
     const result = await context.step(
       async (stepContext) => {
-        // Print input to stdout each time the step body executes.
-        console.log(event);
+        // Log input through the step context logger each time the step body
+        // executes so each record carries the execution ARN.
+        stepContext.logger.info(event);
 
         // Native per-step attempt counter (1-based, increments on each retry).
         if (stepContext.attempt < 2) {


### PR DESCRIPTION
Switches the conformance-tests workflow to install the runner from git main (subdirectory packages/aws-durable-execution-conformance-tests) instead of the pinned ==0.1.0 PyPI release, so new upstream suites/requirements are exercised automatically. Draft until reviewed.