### PR TITLE
feat(otel): link to plugin invocation span

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -223,24 +223,28 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
       ambientSpanContext.spanId,
     );
 
-    // Assertion 4: Operation span has link to the ambient invocation span
+    // Assertion 4: Operation span has link to the plugin-created Invocation_Span
     const opSpan = findSpan(exporter, "fetch-data");
     expect(opSpan).toBeDefined();
     expect(opSpan!.links.length).toBeGreaterThan(0);
-    expect(opSpan!.links[0].context.traceId).toBe(ambientSpanContext.traceId);
-    expect(opSpan!.links[0].context.spanId).toBe(ambientSpanContext.spanId);
+    expect(opSpan!.links[0].context.traceId).toBe(
+      invocationSpan!.spanContext().traceId,
+    );
+    expect(opSpan!.links[0].context.spanId).toBe(
+      invocationSpan!.spanContext().spanId,
+    );
 
-    // Assertion 5: Attempt span has link to the ambient invocation span
+    // Assertion 5: Attempt span has link to the plugin-created Invocation_Span
     const attemptSpan = spans.find(
       (s) => s.attributes["durable.attempt.number"] === 1,
     );
     expect(attemptSpan).toBeDefined();
     expect(attemptSpan!.links.length).toBeGreaterThan(0);
     expect(attemptSpan!.links[0].context.traceId).toBe(
-      ambientSpanContext.traceId,
+      invocationSpan!.spanContext().traceId,
     );
     expect(attemptSpan!.links[0].context.spanId).toBe(
-      ambientSpanContext.spanId,
+      invocationSpan!.spanContext().spanId,
     );
 
     // Assertion 6: All child spans are parented under Workflow_Span or its descendants (not ambient)
@@ -343,13 +347,21 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     const secondOpSpan = spans.find((s) => s.name === "second-op");
     expect(secondOpSpan).toBeDefined();
 
-    // The link on second-op should point to ambientSpan2 (not ambientSpan1)
+    // Only the second invocation's Invocation span should be present (state cleared)
+    const secondInvocationSpan = spans.find((s) => s.name === "Invocation");
+    expect(secondInvocationSpan).toBeDefined();
+
+    // The link on second-op should point to the second invocation's plugin-created
+    // Invocation span (which is itself a child of ambientSpan2, not ambientSpan1)
     expect(secondOpSpan!.links.length).toBeGreaterThan(0);
     expect(secondOpSpan!.links[0].context.spanId).toBe(
+      secondInvocationSpan!.spanContext().spanId,
+    );
+    expect(secondInvocationSpan!.parentSpanContext?.spanId).toBe(
       ambientSpan2.spanContext().spanId,
     );
 
-    // No links to the first ambient span
+    // No leaked link to the first ambient span
     expect(secondOpSpan!.links[0].context.spanId).not.toBe(
       ambientSpan1.spanContext().spanId,
     );

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -175,11 +175,17 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
       ambientSpan.end();
 
-      // The operation span should have a link to the ambient invocation span
+      // The operation span should link to the plugin-created Invocation span,
+      // which is itself parented under the captured ambient invocation span.
       const opSpan = findSpan(exporter, "test-op");
+      const invocationSpan = findSpan(exporter, "Invocation");
       expect(opSpan).toBeDefined();
+      expect(invocationSpan).toBeDefined();
       expect(opSpan!.links.length).toBe(1);
       expect(opSpan!.links[0].context.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
+      expect(invocationSpan!.parentSpanContext?.spanId).toBe(
         ambientSpan.spanContext().spanId,
       );
     });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -291,7 +291,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
   });
 
   describe("Per-invocation state is cleared after onInvocationEnd", () => {
-    it("clears savedInvocationContext after onInvocationEnd", async () => {
+    it("does not leak invocation state across invocations (no ambient context on second)", async () => {
       const plugin = new ExecutionOtelPlugin({
         useDefaultTracerProvider: true,
       });
@@ -313,7 +313,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       exporter.reset();
 
       // Second invocation WITHOUT ambient context
-      // The savedInvocationContext from the first invocation should be cleared
+      // No state from the first invocation should leak into the second
       await plugin.onInvocationStart(
         makeInvocationInfo({ executionArn: "arn:second" }),
       );

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-span-links.test.ts
@@ -122,12 +122,13 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
     propagation.disable();
   });
 
-  describe("buildInvocationLinks() returns link to ambient span in default-provider mode", () => {
+  describe("buildInvocationLinks() returns link to the plugin-created Invocation_Span in default-provider mode", () => {
     /**
-     * When useDefaultTracerProvider=true, the plugin captures the ambient
-     * context and builds span links pointing to the ambient invocation span.
+     * When useDefaultTracerProvider=true, the plugin still creates its own
+     * Invocation_Span (as a child of the ambient context) and builds span
+     * links pointing to that plugin-created span.
      */
-    it("Operation_Span has a link to the ambient invocation span", async () => {
+    it("Operation_Span has a link to the plugin-created Invocation_Span", async () => {
       const plugin = new ExecutionOtelPlugin({
         tracerProvider: provider,
         useDefaultTracerProvider: true,
@@ -155,16 +156,20 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       ambientSpan.end();
 
       const opSpan = findSpan(exporter, "link-op");
+      const invocationSpan = findSpan(exporter, "Invocation");
       expect(opSpan).toBeDefined();
+      expect(invocationSpan).toBeDefined();
       expect(opSpan!.links.length).toBeGreaterThan(0);
 
-      // The link should point to the ambient span's context
+      // The link should point to the plugin-created Invocation_Span, not the ambient span
       const linkSpanContext = opSpan!.links[0].context;
-      expect(linkSpanContext.traceId).toBe(ambientSpan.spanContext().traceId);
-      expect(linkSpanContext.spanId).toBe(ambientSpan.spanContext().spanId);
+      expect(linkSpanContext.traceId).toBe(
+        invocationSpan!.spanContext().traceId,
+      );
+      expect(linkSpanContext.spanId).toBe(invocationSpan!.spanContext().spanId);
     });
 
-    it("Attempt_Span has a link to the ambient invocation span", async () => {
+    it("Attempt_Span has a link to the plugin-created Invocation_Span", async () => {
       const plugin = new ExecutionOtelPlugin({
         tracerProvider: provider,
         useDefaultTracerProvider: true,
@@ -204,12 +209,16 @@ describe("ExecutionOtelPlugin - Span Link Construction", () => {
       const attemptSpan = getExportedSpans(exporter).find(
         (s) => s.attributes["durable.attempt.number"] === 1,
       );
+      const invocationSpan = findSpan(exporter, "Invocation");
       expect(attemptSpan).toBeDefined();
+      expect(invocationSpan).toBeDefined();
       expect(attemptSpan!.links.length).toBeGreaterThan(0);
 
       const linkSpanContext = attemptSpan!.links[0].context;
-      expect(linkSpanContext.traceId).toBe(ambientSpan.spanContext().traceId);
-      expect(linkSpanContext.spanId).toBe(ambientSpan.spanContext().spanId);
+      expect(linkSpanContext.traceId).toBe(
+        invocationSpan!.spanContext().traceId,
+      );
+      expect(linkSpanContext.spanId).toBe(invocationSpan!.spanContext().spanId);
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -278,16 +278,10 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   /**
    * Builds span links to the invocation span for child spans.
    *
-   * In default-provider mode, links to the ambient invocation span captured
-   * from the active context. Otherwise, links to the explicit Invocation_Span.
+   * Always links to the plugin-created Invocation_Span (this.invocationSpan),
+   * which is created in both default-provider and non-default modes.
    */
   private buildInvocationLinks(): Link[] {
-    if (this.useDefaultTracerProvider && this.savedInvocationContext) {
-      const invocationSpan = trace.getSpan(this.savedInvocationContext);
-      if (invocationSpan) {
-        return [{ context: invocationSpan.spanContext() }];
-      }
-    }
     if (this.invocationSpan) {
       return [{ context: this.invocationSpan.spanContext() }];
     }

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -13,7 +13,6 @@ import type {
   TracerProvider,
   Tracer,
   Span,
-  Context,
   Link,
 } from "@opentelemetry/api";
 import {
@@ -66,7 +65,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
   // Default provider mode
   private readonly useDefaultTracerProvider: boolean;
-  private savedInvocationContext: Context | undefined;
 
   // Workflow span name (configurable)
   private readonly workflowSpanName: string;
@@ -122,11 +120,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
     // 5. Set it as the next span ID so the tracer uses it for the Workflow_Span
     this.idGenerator.setNextSpanId(workflowSpanId);
-
-    // Save ambient invocation context when using default provider
-    if (this.useDefaultTracerProvider) {
-      this.savedInvocationContext = context.active();
-    }
 
     // 6. Create the Workflow_Span with deterministic ID (always as root — no parent)
     this.workflowSpan = this.tracer.startSpan(
@@ -191,7 +184,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     } else {
       // Default provider mode: create invocation span as child of the ambient
       // Lambda invocation span (from the ADOT layer or other auto-instrumentation)
-      const parentContext = this.savedInvocationContext ?? context.active();
+      const parentContext = context.active();
 
       this.invocationSpan = this.tracer.startSpan(
         "Invocation",
@@ -271,7 +264,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.spanMap.clear();
     this.workflowSpan = undefined;
     this.invocationSpan = undefined;
-    this.savedInvocationContext = undefined;
     this.executionArn = "";
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Link to explicitly created invocation span when using defaultTracerProvider instead of the lambda environment span.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
