### PR TITLE
feat(otel): workflow span status

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -564,6 +564,23 @@ Cross-invocation operations are correlated via span links to deterministic span 
 - **Operation_Span**: `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status`, `durable.attempt.number`
 - **Attempt_Span**: all operation attributes plus `durable.attempt.number`, `durable.attempt.outcome`
 
+### Span Status
+
+The **Workflow_Span** OTel status is derived from the terminal `PluginInvocationStatus`:
+
+| `PluginInvocationStatus` | Workflow_Span status |
+| ------------------------ | -------------------- |
+| `SUCCEEDED`              | `OK`                 |
+| `FAILED`                 | `ERROR` (with the execution error message) |
+| `PENDING`                | `UNSET` (span not ended/exported) |
+| `RETRYING`               | `UNSET` (span not ended/exported) |
+
+For non-terminal outcomes (`PENDING`/`RETRYING`) the Workflow_Span is intentionally left un-ended, so it is never exported and its status stays `UNSET`.
+
+> **Note:** the OTel plugin does **not** know whether a failed workflow was `TIMED_OUT` or `STOPPED`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`. `TIMED_OUT` and `STOPPED` are operation-level states (`PluginOperationStatus`) and are not surfaced at the invocation/workflow level, so any such outcome is reported as `FAILED` → span status `ERROR`.
+
+The **Invocation_Span** follows the same mapping (`FAILED` → `ERROR`, otherwise `UNSET`) and additionally records the raw value in the `durable.invocation.status` attribute.
+
 ---
 
 ## Additional npm Dependencies

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -579,7 +579,16 @@ For non-terminal outcomes (`PENDING`/`RETRYING`) the Workflow_Span is intentiona
 
 > **Note:** the OTel plugin does **not** know whether a failed workflow was `TIMED_OUT` or `STOPPED`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`. `TIMED_OUT` and `STOPPED` are operation-level states (`PluginOperationStatus`) and are not surfaced at the invocation/workflow level, so any such outcome is reported as `FAILED` → span status `ERROR`.
 
-The **Invocation_Span** follows the same mapping (`FAILED` → `ERROR`, otherwise `UNSET`) and additionally records the raw value in the `durable.invocation.status` attribute.
+The **Invocation_Span** uses a slightly different mapping, because a `PENDING` suspension is a normal outcome for an individual invocation and a `RETRYING` invocation means the handler threw:
+
+| `PluginInvocationStatus` | Invocation_Span status |
+| ------------------------ | ---------------------- |
+| `SUCCEEDED`              | `OK`                   |
+| `PENDING`                | `OK`                   |
+| `FAILED`                 | `ERROR` (with the execution error message) |
+| `RETRYING`               | `ERROR`                |
+
+Unlike the Workflow_Span, the Invocation_Span is **always** ended and exported (one per Lambda invocation), so `PENDING`/`RETRYING` invocations are exported with the mapping above. The raw value is also recorded in the `durable.invocation.status` attribute.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -579,16 +579,18 @@ For non-terminal outcomes (`PENDING`/`RETRYING`) the Workflow_Span is intentiona
 
 > **Note:** the OTel plugin does **not** know whether a failed workflow was `TIMED_OUT` or `STOPPED`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`. `TIMED_OUT` and `STOPPED` are operation-level states (`PluginOperationStatus`) and are not surfaced at the invocation/workflow level, so any such outcome is reported as `FAILED` → span status `ERROR`.
 
-The **Invocation_Span** uses a slightly different mapping, because a `PENDING` suspension is a normal outcome for an individual invocation and a `RETRYING` invocation means the handler threw:
+The **Invocation_Span** uses a slightly different mapping, because a `PENDING` suspension is a normal outcome for an individual invocation:
 
 | `PluginInvocationStatus` | Invocation_Span status |
 | ------------------------ | ---------------------- |
 | `SUCCEEDED`              | `OK`                   |
 | `PENDING`                | `OK`                   |
 | `FAILED`                 | `ERROR` (with the execution error message) |
-| `RETRYING`               | `ERROR`                |
+| `RETRYING`               | `UNSET`                |
 
 Unlike the Workflow_Span, the Invocation_Span is **always** ended and exported (one per Lambda invocation), so `PENDING`/`RETRYING` invocations are exported with the mapping above. The raw value is also recorded in the `durable.invocation.status` attribute.
+
+> **Note:** the OTel plugin does **not** know whether an invocation/workflow was `STOPPED` or `TIMED_OUT`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`; `STOPPED` and `TIMED_OUT` are operation-level states (`PluginOperationStatus`) that are not surfaced at the invocation/workflow level. This is also **why `RETRYING` maps to `UNSET`** rather than `ERROR`: the plugin cannot tell a genuine retry apart from a `STOPPED`/`TIMED_OUT` outcome, so it does not assert an error status for it.
 
 ---
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   propagation,
   ROOT_CONTEXT,
   SpanStatusCode,
+  SpanKind,
 } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 import type {
@@ -510,6 +511,18 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
   });
 
   describe("Workflow_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it("creates the Workflow_Span with SpanKind.INTERNAL", async () => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      const workflowSpan = findSpan(exporter, "Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.kind).toBe(SpanKind.INTERNAL);
+    });
+
     it("maps SUCCEEDED -> span status OK", async () => {
       const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
       await plugin.onInvocationStart(makeInvocationInfo());

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -464,6 +464,51 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
   });
 
+  describe("Invocation_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it.each([
+      ["SUCCEEDED", SpanStatusCode.OK],
+      ["PENDING", SpanStatusCode.OK],
+    ])("maps %s -> Invocation_Span status OK", async (status, expected) => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: status as any }),
+      );
+
+      const invocationSpan = findSpan(exporter, "Invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(expected);
+    });
+
+    it("maps RETRYING -> Invocation_Span status ERROR", async () => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "RETRYING" as any }),
+      );
+
+      const invocationSpan = findSpan(exporter, "Invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+    });
+
+    it("maps FAILED -> Invocation_Span status ERROR with the execution error message", async () => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "FAILED" as any,
+          executionError: new Error("invocation boom"),
+        }),
+      );
+
+      const invocationSpan = findSpan(exporter, "Invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(invocationSpan!.status.message).toBe("invocation boom");
+    });
+  });
+
   describe("Workflow_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
     it("maps SUCCEEDED -> span status OK", async () => {
       const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -3,7 +3,13 @@ import {
   SimpleSpanProcessor,
   NodeTracerProvider,
 } from "@opentelemetry/sdk-trace-node";
-import { context, trace, propagation, ROOT_CONTEXT } from "@opentelemetry/api";
+import {
+  context,
+  trace,
+  propagation,
+  ROOT_CONTEXT,
+  SpanStatusCode,
+} from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 import type {
   InvocationInfo,
@@ -456,5 +462,58 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
         }),
       );
     });
+  });
+
+  describe("Workflow_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it("maps SUCCEEDED -> span status OK", async () => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      const workflowSpan = findSpan(exporter, "Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.status.code).toBe(SpanStatusCode.OK);
+      expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+        "SUCCEEDED",
+      );
+    });
+
+    it("maps FAILED -> span status ERROR with the execution error message", async () => {
+      const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "FAILED" as any,
+          executionError: new Error("boom"),
+        }),
+      );
+
+      const workflowSpan = findSpan(exporter, "Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(workflowSpan!.status.message).toBe("boom");
+      expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+        "FAILED",
+      );
+    });
+
+    it.each(["PENDING", "RETRYING"])(
+      "leaves the Workflow_Span un-ended (UNSET, never exported) for non-terminal status %s",
+      async (status) => {
+        const plugin = new ExecutionOtelPlugin({
+          useDefaultTracerProvider: true,
+        });
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: status as any }),
+        );
+
+        // Non-terminal: the Workflow_Span is intentionally never ended, so it is
+        // never exported and its status stays UNSET.
+        expect(findSpan(exporter, "Workflow")).toBeUndefined();
+      },
+    );
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -481,7 +481,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       expect(invocationSpan!.status.code).toBe(expected);
     });
 
-    it("maps RETRYING -> Invocation_Span status ERROR", async () => {
+    it("maps RETRYING -> Invocation_Span status UNSET (STOPPED/TIMED_OUT indistinguishable from RETRYING)", async () => {
       const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
@@ -490,7 +490,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
       const invocationSpan = findSpan(exporter, "Invocation");
       expect(invocationSpan).toBeDefined();
-      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.UNSET);
     });
 
     it("maps FAILED -> Invocation_Span status ERROR with the execution error message", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -161,6 +161,48 @@ describe("InvocationOtelPlugin", () => {
     });
   });
 
+  describe("Invocation span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it.each([
+      ["SUCCEEDED", SpanStatusCode.OK],
+      ["PENDING", SpanStatusCode.OK],
+    ])("maps %s -> invocation span status OK", async (status, expected) => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: status as any }),
+      );
+
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(expected);
+    });
+
+    it("maps RETRYING -> invocation span status ERROR", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "RETRYING" as any }),
+      );
+
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+    });
+
+    it("maps FAILED -> invocation span status ERROR with the execution error message", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "FAILED" as any,
+          executionError: new Error("invocation boom"),
+        }),
+      );
+
+      const invocationSpan = findSpan("invocation");
+      expect(invocationSpan).toBeDefined();
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(invocationSpan!.status.message).toBe("invocation boom");
+    });
+  });
+
   describe("Workflow span status mapping (PluginInvocationStatus -> OTel span status)", () => {
     it("maps SUCCEEDED -> Workflow span status OK", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -161,6 +161,52 @@ describe("InvocationOtelPlugin", () => {
     });
   });
 
+  describe("Workflow span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it("maps SUCCEEDED -> Workflow span status OK", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      const workflowSpan = findSpan("Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.status.code).toBe(SpanStatusCode.OK);
+      expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+        "SUCCEEDED",
+      );
+    });
+
+    it("maps FAILED -> Workflow span status ERROR with the execution error message", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "FAILED" as any,
+          executionError: new Error("kaboom"),
+        }),
+      );
+
+      const workflowSpan = findSpan("Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(workflowSpan!.status.message).toBe("kaboom");
+      expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+        "FAILED",
+      );
+    });
+
+    it.each(["PENDING", "RETRYING"])(
+      "leaves the Workflow span un-ended (UNSET, never exported) for non-terminal status %s",
+      async (status) => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: status as any }),
+        );
+
+        expect(findSpan("Workflow")).toBeUndefined();
+      },
+    );
+  });
+
   describe("onInvocationEnd", () => {
     it("ends all open operation spans and invocation span", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -7,6 +7,7 @@ import {
   context,
   trace,
   SpanStatusCode,
+  SpanKind,
   propagation,
 } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
@@ -204,6 +205,17 @@ describe("InvocationOtelPlugin", () => {
   });
 
   describe("Workflow span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it("creates the Workflow span with SpanKind.INTERNAL", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      const workflowSpan = findSpan("Workflow");
+      expect(workflowSpan).toBeDefined();
+      expect(workflowSpan!.kind).toBe(SpanKind.INTERNAL);
+    });
+
     it("maps SUCCEEDED -> Workflow span status OK", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -177,7 +177,7 @@ describe("InvocationOtelPlugin", () => {
       expect(invocationSpan!.status.code).toBe(expected);
     });
 
-    it("maps RETRYING -> invocation span status ERROR", async () => {
+    it("maps RETRYING -> invocation span status UNSET (STOPPED/TIMED_OUT indistinguishable from RETRYING)", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({ status: "RETRYING" as any }),
@@ -185,7 +185,7 @@ describe("InvocationOtelPlugin", () => {
 
       const invocationSpan = findSpan("invocation");
       expect(invocationSpan).toBeDefined();
-      expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
+      expect(invocationSpan!.status.code).toBe(SpanStatusCode.UNSET);
     });
 
     it("maps FAILED -> invocation span status ERROR with the execution error message", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -235,14 +235,26 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
     // 2. Handle Workflow_Span based on terminal status
     if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-      // Terminal: set status attribute, end (causes export)
+      // Terminal: set status attribute, map to span status, end (causes export).
+      // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
+      // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
+      // — those are collapsed into FAILED -> ERROR here.
       if (this.workflowSpan) {
         this.workflowSpan.setAttribute("durable.execution.status", info.status);
+        if (info.status === "FAILED") {
+          this.workflowSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: info.executionError?.message ?? "Execution failed",
+          });
+        } else {
+          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
+        }
         this.workflowSpan.end();
       }
     }
     // Non-terminal (PENDING/RETRYING): do NOT end workflowSpan — just drop the reference.
-    // Spans that are never .end()'d are never exported by the OTel SDK.
+    // Its status stays UNSET and the span is never exported (spans that are never
+    // .end()'d are never exported by the OTel SDK).
 
     // 3. Discard open Operation_Spans without ending (they won't be exported)
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -125,6 +125,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.workflowSpan = this.tracer.startSpan(
       this.workflowSpanName,
       {
+        kind: SpanKind.INTERNAL,
         attributes: {
           "durable.execution.arn": info.executionArn,
         },

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -221,14 +221,22 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         info.status,
       );
 
-      // Set span status ERROR when execution has failed
-      if (info.status === "FAILED") {
+      // Map PluginInvocationStatus to span status:
+      //   FAILED / RETRYING -> ERROR (the handler threw; RETRYING means Lambda will retry)
+      //   SUCCEEDED / PENDING -> OK (PENDING is a normal suspension, not an error)
+      if (info.status === "FAILED" || info.status === "RETRYING") {
         this.invocationSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: info.executionError?.message ?? "Execution failed",
+          message:
+            info.executionError?.message ??
+            (info.status === "RETRYING"
+              ? "Invocation retrying"
+              : "Execution failed"),
         });
+      } else {
+        // SUCCEEDED / PENDING
+        this.invocationSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      // Otherwise leave status as UNSET (default)
 
       this.invocationSpan.end();
     }

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -223,21 +223,20 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       );
 
       // Map PluginInvocationStatus to span status:
-      //   FAILED / RETRYING -> ERROR (the handler threw; RETRYING means Lambda will retry)
+      //   FAILED -> ERROR
       //   SUCCEEDED / PENDING -> OK (PENDING is a normal suspension, not an error)
-      if (info.status === "FAILED" || info.status === "RETRYING") {
+      //   RETRYING -> UNSET. The plugin interface cannot distinguish a STOPPED or
+      //   TIMED_OUT invocation from a RETRYING one at onInvocationEnd, so RETRYING
+      //   is intentionally left UNSET rather than reported as ERROR.
+      if (info.status === "FAILED") {
         this.invocationSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message:
-            info.executionError?.message ??
-            (info.status === "RETRYING"
-              ? "Invocation retrying"
-              : "Execution failed"),
+          message: info.executionError?.message ?? "Execution failed",
         });
-      } else {
-        // SUCCEEDED / PENDING
+      } else if (info.status === "SUCCEEDED" || info.status === "PENDING") {
         this.invocationSpan.setStatus({ code: SpanStatusCode.OK });
       }
+      // RETRYING: leave status UNSET (default)
 
       this.invocationSpan.end();
     }

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -156,14 +156,22 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         info.status,
       );
 
-      // Set span status ERROR when execution has failed
-      if (info.status === "FAILED") {
+      // Map PluginInvocationStatus to span status:
+      //   FAILED / RETRYING -> ERROR (the handler threw; RETRYING means Lambda will retry)
+      //   SUCCEEDED / PENDING -> OK (PENDING is a normal suspension, not an error)
+      if (info.status === "FAILED" || info.status === "RETRYING") {
         this.invocationSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message: info.executionError?.message ?? "Execution failed",
+          message:
+            info.executionError?.message ??
+            (info.status === "RETRYING"
+              ? "Invocation retrying"
+              : "Execution failed"),
         });
+      } else {
+        // SUCCEEDED / PENDING
+        this.invocationSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      // Otherwise leave status as UNSET (default)
 
       this.invocationSpan.end();
     }

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -102,6 +102,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.workflowSpan = this.tracer.startSpan(
         this.workflowSpanName,
         {
+          kind: SpanKind.INTERNAL,
           attributes: {
             "durable.execution.arn": info.executionArn,
           },

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -158,21 +158,20 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       );
 
       // Map PluginInvocationStatus to span status:
-      //   FAILED / RETRYING -> ERROR (the handler threw; RETRYING means Lambda will retry)
+      //   FAILED -> ERROR
       //   SUCCEEDED / PENDING -> OK (PENDING is a normal suspension, not an error)
-      if (info.status === "FAILED" || info.status === "RETRYING") {
+      //   RETRYING -> UNSET. The plugin interface cannot distinguish a STOPPED or
+      //   TIMED_OUT invocation from a RETRYING one at onInvocationEnd, so RETRYING
+      //   is intentionally left UNSET rather than reported as ERROR.
+      if (info.status === "FAILED") {
         this.invocationSpan.setStatus({
           code: SpanStatusCode.ERROR,
-          message:
-            info.executionError?.message ??
-            (info.status === "RETRYING"
-              ? "Invocation retrying"
-              : "Execution failed"),
+          message: info.executionError?.message ?? "Execution failed",
         });
-      } else {
-        // SUCCEEDED / PENDING
+      } else if (info.status === "SUCCEEDED" || info.status === "PENDING") {
         this.invocationSpan.setStatus({ code: SpanStatusCode.OK });
       }
+      // RETRYING: leave status UNSET (default)
 
       this.invocationSpan.end();
     }

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -171,10 +171,22 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     // 3. Handle Workflow span based on terminal status (community collector mode only)
     if (this.workflowSpan) {
       if (info.status === "SUCCEEDED" || info.status === "FAILED") {
+        // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
+        // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
+        // — those are collapsed into FAILED -> ERROR here.
         this.workflowSpan.setAttribute("durable.execution.status", info.status);
+        if (info.status === "FAILED") {
+          this.workflowSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: info.executionError?.message ?? "Execution failed",
+          });
+        } else {
+          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
+        }
         this.workflowSpan.end();
       }
-      // Non-terminal: do NOT end — span is dropped without export
+      // Non-terminal (PENDING/RETRYING): do NOT end — status stays UNSET and the
+      // span is dropped without export
     }
 
     // 4. Force flush the tracer provider


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-conformance-tests/issues/23

*Description of changes:*

In execution view, execution span status can use this mapping from PluginInvocationStatus:

FAILED -> ERROR
SUCCEEDED -> OK
RETRY/PENDING -> UNSET
which reflects the execution status.

The invocation span status can use the following mapping from PluginInvocationStatus:

SUCCEEDED/PENDING -> OK
RETRY/FAILED -> ERROR

Also setting span.kind=INTERNAL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
