### PR TITLE
fix(sdk): terminate execution for invalid maxConcurrency instead of throwing

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.history.json
@@ -1,0 +1,43 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "55aac3c8-4326-4bd4-bf6e-eb03f75c5323",
+    "EventTimestamp": "2026-07-28T01:47:38.492Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 2,
+    "EventTimestamp": "2026-07-28T01:47:38.496Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-07-28T01:47:38.492Z",
+      "EndTimestamp": "2026-07-28T01:47:38.496Z",
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Invalid maxConcurrency: 0. Must be a positive number or undefined for unlimited concurrency.",
+          "ErrorType": "Error"
+        }
+      },
+      "RequestId": "cea0807a-1cac-4827-a2c2-7db583d1c337"
+    }
+  },
+  {
+    "EventType": "ExecutionFailed",
+    "EventId": 3,
+    "Id": "55aac3c8-4326-4bd4-bf6e-eb03f75c5323",
+    "EventTimestamp": "2026-07-28T01:47:38.496Z",
+    "ExecutionFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Invalid maxConcurrency: 0. Must be a positive number or undefined for unlimited concurrency.",
+          "ErrorType": "Error"
+        }
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.test.ts
@@ -1,0 +1,18 @@
+import { handler } from "./parallel-invalid-max-concurrency";
+import { createTests } from "../../../utils/test-helper";
+import { ExecutionStatus } from "@aws/durable-execution-sdk-js-testing";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("fails the execution when maxConcurrency is invalid", async () => {
+      const result = await runner.run();
+
+      expect(result.getStatus()).toBe(ExecutionStatus.FAILED);
+      const error = result.getError();
+      expect(error?.errorMessage).toMatch(/maxConcurrency/);
+
+      assertEventSignatures(result);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/parallel/invalid-max-concurrency/parallel-invalid-max-concurrency.ts
@@ -1,0 +1,30 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Parallel Invalid Max Concurrency",
+  description:
+    "An invalid maxConcurrency (<= 0) is a non-retryable config error that " +
+    "fails the execution (rather than being silently ignored or leaving the " +
+    "invocation PENDING).",
+};
+
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    // Invalid: must be a positive number or undefined for unlimited
+    // concurrency. This terminates the execution with a
+    // CONFIG_VALIDATION_ERROR (FAILED) before any branch starts.
+    const results = await context.parallel(
+      "parallel",
+      [async (childContext) => childContext.step(async () => "unreachable")],
+      {
+        maxConcurrency: 0,
+      },
+    );
+
+    return results.getResults();
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -926,6 +926,31 @@ Resources:
           AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
     Metadata:
       SkipBuild: "True"
+  MapCustomSummaryGeneratorReplay:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: MapCustomSummaryGeneratorReplay-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: map-custom-summary-generator-replay.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+    Metadata:
+      SkipBuild: "True"
   MapEmpty:
     Type: AWS::Serverless::Function
     Properties:
@@ -1328,6 +1353,35 @@ Resources:
         - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
     Metadata:
       SkipBuild: "True"
+  OtelAdotInvocationXrayE2e:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: OTelADOTInvocationXRayE2E-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: otel-adot-invocation-xray-e2e.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 120
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+      Tracing: Active
+      Layers:
+        - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
+    Metadata:
+      SkipBuild: "True"
   OtelBasicSteps:
     Type: AWS::Serverless::Function
     Properties:
@@ -1413,6 +1467,35 @@ Resources:
       Tracing: Active
       Layers:
         - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
+    Metadata:
+      SkipBuild: "True"
+  OtelCommunityCollectorExecutionXrayE2e:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: OTelCommunityCollectorExecutionXRayE2E-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: otel-community-collector-execution-xray-e2e.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 120
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+      Tracing: Active
+      Layers:
+        - arn:aws:lambda:us-west-2:184161586896:layer:opentelemetry-collector-amd64-0_22_0:1
     Metadata:
       SkipBuild: "True"
   OtelCommunityCollectorInvocationXrayE2e:
@@ -1502,35 +1585,6 @@ Resources:
         - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
     Metadata:
       SkipBuild: "True"
-  OtelCommunityCollectorExecutionXrayE2e:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: OTelCommunityCollectorExecutionXRayE2E-22x-NodeJS-Local
-      CodeUri: ./dist
-      Handler: otel-community-collector-execution-xray-e2e.handler
-      Runtime: nodejs22.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 60
-      DurableConfig:
-        ExecutionTimeout: 120
-        RetentionPeriodInDays: 7
-      Role:
-        Fn::GetAtt:
-          - DurableFunctionRole
-          - Arn
-      Environment:
-        Variables:
-          DURABLE_VERBOSE_MODE: "false"
-          DURABLE_EXAMPLES_VERBOSE: "true"
-          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
-          OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
-      Tracing: Active
-      Layers:
-        - arn:aws:lambda:us-west-2:184161586896:layer:opentelemetry-collector-amd64-0_22_0:1
-    Metadata:
-      SkipBuild: "True"
   OtelWaitAndResume:
     Type: AWS::Serverless::Function
     Properties:
@@ -1573,35 +1627,6 @@ Resources:
       Timeout: 60
       DurableConfig:
         ExecutionTimeout: 60
-        RetentionPeriodInDays: 7
-      Role:
-        Fn::GetAtt:
-          - DurableFunctionRole
-          - Arn
-      Environment:
-        Variables:
-          DURABLE_VERBOSE_MODE: "false"
-          DURABLE_EXAMPLES_VERBOSE: "true"
-          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
-          AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
-      Tracing: Active
-      Layers:
-        - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
-    Metadata:
-      SkipBuild: "True"
-  OtelAdotInvocationXrayE2e:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: OTelADOTInvocationXRayE2E-22x-NodeJS-Local
-      CodeUri: ./dist
-      Handler: otel-adot-invocation-xray-e2e.handler
-      Runtime: nodejs22.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 60
-      DurableConfig:
-        ExecutionTimeout: 120
         RetentionPeriodInDays: 7
       Role:
         Fn::GetAtt:
@@ -1774,6 +1799,31 @@ Resources:
       FunctionName: ParallelHeterogeneous-22x-NodeJS-Local
       CodeUri: ./dist
       Handler: parallel-heterogeneous.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+    Metadata:
+      SkipBuild: "True"
+  ParallelInvalidMaxConcurrency:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: ParallelInvalidMaxConcurrency-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: parallel-invalid-max-concurrency.handler
       Runtime: nodejs22.x
       Architectures:
         - x86_64

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.test.ts
@@ -95,14 +95,32 @@ describe("Concurrent Execution Handler", () => {
       ).rejects.toThrow("Concurrent execution requires an executor function");
     });
 
-    it("should throw for invalid maxConcurrency", async () => {
-      await expect(
-        concurrentExecutionHandler([], jest.fn(), { maxConcurrency: 0 }),
-      ).rejects.toThrow("Invalid maxConcurrency: 0");
+    it("should terminate execution for invalid maxConcurrency", async () => {
+      const terminate = jest.fn();
+      (mockExecutionContext as any).terminationManager = { terminate };
 
-      await expect(
-        concurrentExecutionHandler([], jest.fn(), { maxConcurrency: -1 }),
-      ).rejects.toThrow("Invalid maxConcurrency: -1");
+      // The returned promise never resolves (execution is terminated), so we
+      // don't await it -- just assert the termination was requested.
+      void concurrentExecutionHandler([], jest.fn(), { maxConcurrency: 0 });
+      await Promise.resolve();
+
+      expect(terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "CONFIG_VALIDATION_ERROR",
+          message: expect.stringContaining("Invalid maxConcurrency: 0"),
+        }),
+      );
+
+      terminate.mockClear();
+      void concurrentExecutionHandler([], jest.fn(), { maxConcurrency: -1 });
+      await Promise.resolve();
+
+      expect(terminate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "CONFIG_VALIDATION_ERROR",
+          message: expect.stringContaining("Invalid maxConcurrency: -1"),
+        }),
+      );
     });
 
     it("should terminate execution when shouldComplete is combined with threshold fields", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -64,6 +64,34 @@ function validateCompletionConfig(
   return true;
 }
 
+/**
+ * Validates `maxConcurrency` is a positive number (or unset, for unlimited
+ * concurrency). An invalid value is a deterministic, non-retryable
+ * configuration error: terminates the execution rather than throwing, so a
+ * misconfigured call fails cleanly instead of being retried by Lambda only
+ * to fail identically again. Returns `true` when the config is valid, or
+ * `false` when it terminated the execution (the caller must then stop).
+ */
+function validateMaxConcurrency(
+  maxConcurrency: number | undefined | null,
+  terminationManager: TerminationManager,
+): boolean {
+  if (
+    maxConcurrency !== undefined &&
+    maxConcurrency !== null &&
+    maxConcurrency <= 0
+  ) {
+    const message = `Invalid maxConcurrency: ${maxConcurrency}. Must be a positive number or undefined for unlimited concurrency.`;
+    terminationManager.terminate({
+      reason: TerminationReason.CONFIG_VALIDATION_ERROR,
+      message,
+      error: new Error(message),
+    });
+    return false;
+  }
+  return true;
+}
+
 export class ConcurrencyController<Logger extends DurableLogger> {
   constructor(
     private readonly operationName: string,
@@ -655,14 +683,17 @@ export const createConcurrentExecutionHandler = <Logger extends DurableLogger>(
         throw new Error("Concurrent execution requires an executor function");
       }
 
+      // Invalid maxConcurrency is a deterministic, non-retryable
+      // configuration error: terminate the execution rather than throwing.
+      // If it terminated, stop here with a never-resolving promise so we
+      // don't proceed.
       if (
-        config?.maxConcurrency !== undefined &&
-        config.maxConcurrency !== null &&
-        config.maxConcurrency <= 0
+        !validateMaxConcurrency(
+          config?.maxConcurrency,
+          context.terminationManager,
+        )
       ) {
-        throw new Error(
-          `Invalid maxConcurrency: ${config.maxConcurrency}. Must be a positive number or undefined for unlimited concurrency.`,
-        );
+        return new Promise<BatchResult<TResult>>(() => {});
       }
 
       // Mutually-exclusive completion config is a non-retryable configuration

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -177,6 +177,35 @@ describe("withDurableExecution", () => {
     );
   });
 
+  it("should return FAILED response for CONFIG_VALIDATION_ERROR reason", async () => {
+    // Setup: a deterministic, non-retryable caller mistake (e.g. an invalid
+    // maxConcurrency) must surface as FAILED, not fall through to the
+    // generic PENDING handling used for genuine suspends/pauses.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    const configError = new Error("Invalid maxConcurrency: 0");
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CONFIG_VALIDATION_ERROR,
+      message: configError.message,
+      error: configError,
+    });
+
+    // Execute
+    const wrappedHandler = withDurableExecution(mockHandler);
+    const response = await wrappedHandler(mockEvent, mockContext);
+
+    // Verify
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorMessage: configError.message,
+      }),
+    });
+    expect(mockHandler).toHaveBeenCalledWith(
+      mockCustomerHandlerEvent,
+      mockDurableContext,
+    );
+  });
+
   it("should return PENDING response for non-checkpoint termination", async () => {
     // Setup
     const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -255,6 +255,34 @@ async function runHandler<
           return response;
         }
 
+        // If termination was due to a config validation error (e.g. an
+        // invalid maxConcurrency or a mutually-exclusive completionConfig),
+        // return FAILED. This is a deterministic, non-retryable caller
+        // mistake -- same category as CONTEXT_VALIDATION_ERROR above, not a
+        // suspend/pause, so it must not fall through to the generic
+        // termination handling below (which returns PENDING).
+        if (
+          resultType === "termination" &&
+          result.reason === TerminationReason.CONFIG_VALIDATION_ERROR
+        ) {
+          log("🛑", "Config validation error - returning FAILED status");
+          const response = {
+            Status: InvocationStatus.FAILED,
+            Error: createErrorObjectFromError(
+              result.error || new Error(result.message),
+            ),
+          };
+          await plugin.onInvocationEnd?.({
+            ...invocationBaseInfo,
+            status: PluginInvocationStatus.FAILED,
+            executionInput: customerHandlerEvent,
+            executionError: result.error || new Error(result.message),
+            executionResult: undefined,
+            operations: toOperationInfoMap(executionContext._stepData),
+          });
+          return response;
+        }
+
         if (resultType === "termination") {
           log("🛑", "Returning termination response");
 


### PR DESCRIPTION
An invalid maxConcurrency (<= 0) is a deterministic, non-retryable configuration error -- the exact category the adjacent completionConfig guard already handles via terminationManager.terminate() rather than a plain throw. The maxConcurrency check was left as a plain throw, inconsistent with its sibling one guard below it: a thrown error propagates through Lambda's normal retry path, so a misconfigured call gets retried only to fail identically again, instead of being reported as a non-retryable config error immediately.

- Extracted validateMaxConcurrency, mirroring validateCompletionConfig's exact shape (same doc-comment style, same terminate-and-return-false contract), and call it before the completion-config guard.
- Updated the one existing test asserting the old throw/reject behavior to assert termination via the same mock pattern used for the completionConfig guard's own test.

No public API or error message text changed -- only how the error is delivered (terminate vs. throw). Verified: tsc clean, eslint clean (0 new errors/warnings), prettier clean, full jest suite green (1059/1059, no regressions).