### PR TITLE
feat(otel): capitalize InvocationOtelPlugin invocation span name

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/basic-steps/otel-basic-steps.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/basic-steps/otel-basic-steps.test.ts
@@ -78,7 +78,7 @@ createTests({
         );
 
         // The invocation span should now be present in the exported spans
-        const invocationSpan = spans.find((s) => s.name === "invocation");
+        const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.spanId).toBe(invocationSpanId);
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
@@ -126,7 +126,7 @@ createTests({
         expect(afterCallbackAttempt).toBeDefined();
 
         // --- Invocation span ---
-        const invocationSpan = spans.find((s) => s.name === "invocation");
+        const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
 
         // --- Continuation spans with links ---

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
@@ -96,7 +96,7 @@ createTests({
         expect(workflowSpan!.attributes["durable.execution.arn"]).toBeDefined();
 
         // Verify Invocation span exists and is child of Workflow
-        const invocationSpan = spans.find((s) => s.name === "invocation");
+        const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/invoke/otel-invoke.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/invoke/otel-invoke.test.ts
@@ -76,8 +76,8 @@ createTests({
         const spans = getSerializedSpans();
         // With exporter reset at the test level (not inside the handler), we capture
         // all spans across all invocations:
-        // Invocation 1: "before-invoke" (operation + attempt), "invoke-target" (CHAINED_INVOKE), "invocation"
-        // Invocation 2: "invoke-target" (continuation), "after-invoke" (operation + attempt), "invocation"
+        // Invocation 1: "before-invoke" (operation + attempt), "invoke-target" (CHAINED_INVOKE), "Invocation"
+        // Invocation 2: "invoke-target" (continuation), "after-invoke" (operation + attempt), "Invocation"
         // + 1 Workflow span
         expect(spans).toHaveLength(8);
 
@@ -111,7 +111,7 @@ createTests({
         expect(invokeSpan).toBeDefined();
 
         // --- invocation span ---
-        const invocationSpan = spans.find((s) => s.name === "invocation");
+        const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
 
         // --- after-invoke step ---

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/retry-steps/otel-retry-steps.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/retry-steps/otel-retry-steps.test.ts
@@ -98,7 +98,7 @@ createTests({
         expect(sorted[2].attributes["durable.attempt.number"]).toBe(3);
 
         // --- Invocation spans ---
-        const invocationSpans = spans.filter((s) => s.name === "invocation");
+        const invocationSpans = spans.filter((s) => s.name === "Invocation");
         expect(invocationSpans).toHaveLength(3);
       }
 

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-and-resume/otel-wait-and-resume.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-and-resume/otel-wait-and-resume.test.ts
@@ -107,7 +107,7 @@ createTests({
         expect(afterWaitAttempt).toBeDefined();
 
         // --- Invocation span ---
-        const invocationSpan = spans.find((s) => s.name === "invocation");
+        const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
 
         // --- Continuation spans with links (cross-invocation correlation) ---

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition.test.ts
@@ -159,7 +159,7 @@ createTests({
           expect(attemptSpans[2].attributes["durable.attempt.number"]).toBe(3);
 
           // 3 invocation spans
-          const invocationSpans = spans.filter((s) => s.name === "invocation");
+          const invocationSpans = spans.filter((s) => s.name === "Invocation");
           expect(invocationSpans).toHaveLength(3);
 
           // Verify continuation spans with links exist (proves multi-invocation replay)

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -46,6 +46,7 @@
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/propagator-aws-xray": "^2.2.0",
     "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.29.0",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jest": "^29.0.1",
@@ -64,7 +65,8 @@
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/propagator-aws-xray": "^2.0.0",
     "@opentelemetry/resources": "^2.0.0",
-    "@opentelemetry/sdk-trace-node": "^2.6.1"
+    "@opentelemetry/sdk-trace-node": "^2.6.1",
+    "@opentelemetry/semantic-conventions": "^1.29.0"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -466,6 +466,22 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
   });
 
   describe("Invocation_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
+    it("honors custom workflowSpanName from config; invocation span name is fixed", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        useDefaultTracerProvider: true,
+        workflowSpanName: "my-workflow",
+      });
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      expect(findSpan(exporter, "my-workflow")).toBeDefined();
+      expect(findSpan(exporter, "Workflow")).toBeUndefined();
+      // Invocation span name is not configurable; always "Invocation"
+      expect(findSpan(exporter, "Invocation")).toBeDefined();
+    });
+
     it.each([
       ["SUCCEEDED", SpanStatusCode.OK],
       ["PENDING", SpanStatusCode.OK],

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
@@ -4,7 +4,7 @@
  * These tests mirror the execution-plugin-default-provider-integration tests
  * but verify InvocationOtelPlugin-specific behavior:
  * - Uses the globally registered TracerProvider by default
- * - Creates "invocation" span (not "Workflow" + "Invocation" like ExecutionOtelPlugin)
+ * - Creates "Invocation" span (not "Workflow" + "Invocation" like ExecutionOtelPlugin)
  * - Custom instrumentationName support
  * - forceFlush error handling
  */
@@ -118,7 +118,7 @@ describe("InvocationOtelPlugin - useDefaultTracerProvider mode", () => {
     const opSpan = spans.find((s) => s.name === "test-op");
     expect(opSpan).toBeDefined();
     // Invocation span is always created (with durable.execution.arn)
-    const invocationSpan = spans.find((s) => s.name === "invocation");
+    const invocationSpan = spans.find((s) => s.name === "Invocation");
     expect(invocationSpan).toBeDefined();
     expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
       "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123",
@@ -138,7 +138,7 @@ describe("InvocationOtelPlugin - useDefaultTracerProvider mode", () => {
 
     // The global exporter should NOT have any spans since the plugin uses its own provider
     const globalSpans = exporter.getFinishedSpans();
-    const invocationSpan = globalSpans.find((s) => s.name === "invocation");
+    const invocationSpan = globalSpans.find((s) => s.name === "Invocation");
     expect(invocationSpan).toBeUndefined();
   });
 
@@ -261,7 +261,7 @@ describe("InvocationOtelPlugin - custom instrumentationName", () => {
     await plugin.onInvocationEnd(makeInvocationEndInfo());
 
     const spans = exporter.getFinishedSpans();
-    const invSpan = spans.find((s) => s.name === "invocation");
+    const invSpan = spans.find((s) => s.name === "Invocation");
     expect(invSpan).toBeDefined();
     expect(invSpan!.instrumentationScope.name).toBe(
       "aws-durable-execution-sdk-js",
@@ -278,7 +278,7 @@ describe("InvocationOtelPlugin - custom instrumentationName", () => {
     await plugin.onInvocationEnd(makeInvocationEndInfo());
 
     const spans = exporter.getFinishedSpans();
-    const invSpan = spans.find((s) => s.name === "invocation");
+    const invSpan = spans.find((s) => s.name === "Invocation");
     expect(invSpan).toBeDefined();
     expect(invSpan!.instrumentationScope.name).toBe("my-custom-tracer");
   });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -145,20 +145,34 @@ describe("InvocationOtelPlugin", () => {
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
       const spans = getExportedSpans();
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
       expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
         TEST_ARN,
       );
     });
 
-    it('creates invocation span with correct name "invocation"', async () => {
+    it('creates invocation span with correct name "Invocation"', async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
-      expect(invocationSpan!.name).toBe("invocation");
+      expect(invocationSpan!.name).toBe("Invocation");
+    });
+
+    it("honors custom workflowSpanName from config; invocation span name is fixed", async () => {
+      const customPlugin = new InvocationOtelPlugin({
+        tracerProvider: provider,
+        workflowSpanName: "my-workflow",
+      });
+      await customPlugin.onInvocationStart(makeInvocationInfo());
+      await customPlugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(findSpan("my-workflow")).toBeDefined();
+      expect(findSpan("Workflow")).toBeUndefined();
+      // Invocation span name is not configurable; always "Invocation"
+      expect(findSpan("Invocation")).toBeDefined();
     });
   });
 
@@ -172,7 +186,7 @@ describe("InvocationOtelPlugin", () => {
         makeInvocationEndInfo({ status: status as any }),
       );
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
       expect(invocationSpan!.status.code).toBe(expected);
     });
@@ -183,7 +197,7 @@ describe("InvocationOtelPlugin", () => {
         makeInvocationEndInfo({ status: "RETRYING" as any }),
       );
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
       expect(invocationSpan!.status.code).toBe(SpanStatusCode.UNSET);
     });
@@ -197,7 +211,7 @@ describe("InvocationOtelPlugin", () => {
         }),
       );
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
       expect(invocationSpan!.status.code).toBe(SpanStatusCode.ERROR);
       expect(invocationSpan!.status.message).toBe("invocation boom");
@@ -271,7 +285,7 @@ describe("InvocationOtelPlugin", () => {
       const spans = getExportedSpans();
       // Should have: op-1, op-2, invocation, Workflow (all ended)
       expect(spans.length).toBe(4);
-      expect(findSpan("invocation")).toBeDefined();
+      expect(findSpan("Invocation")).toBeDefined();
       expect(findSpan("Workflow")).toBeDefined();
     });
 
@@ -300,7 +314,7 @@ describe("InvocationOtelPlugin", () => {
       );
 
       const spans = getExportedSpans();
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(invocationSpan).toBeDefined();
       expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
         "arn:second",
@@ -471,7 +485,7 @@ describe("InvocationOtelPlugin", () => {
       );
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       const orphanSpan = findSpan("orphan");
       expect(invocationSpan).toBeDefined();
       expect(orphanSpan).toBeDefined();
@@ -490,7 +504,7 @@ describe("InvocationOtelPlugin", () => {
       );
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       const rootOpSpan = findSpan("root-child");
       expect(invocationSpan).toBeDefined();
       expect(rootOpSpan).toBeDefined();
@@ -1018,7 +1032,7 @@ describe("InvocationOtelPlugin", () => {
       await plugin.wrapInvocation(makeInvocationInfo(), fn);
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const invocationSpan = findSpan("invocation");
+      const invocationSpan = findSpan("Invocation");
       expect(capturedSpanId).toBeDefined();
       expect(capturedSpanId).toBe(invocationSpan!.spanContext().spanId);
     });
@@ -1631,12 +1645,12 @@ describe("InvocationOtelPlugin", () => {
       // --- Verify correct parenting ---
       const parentInvocationSpan = allSpans.find(
         (s) =>
-          s.name === "invocation" &&
+          s.name === "Invocation" &&
           s.attributes["durable.execution.arn"] === PARENT_ARN,
       );
       const childInvocationSpan = allSpans.find(
         (s) =>
-          s.name === "invocation" &&
+          s.name === "Invocation" &&
           s.attributes["durable.execution.arn"] === CHILD_ARN,
       );
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -118,7 +118,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       : context.active();
 
     this.invocationSpan = this.tracer.startSpan(
-      "invocation",
+      "Invocation",
       {
         kind: SpanKind.INTERNAL,
         attributes: {

--- a/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
@@ -7,6 +7,7 @@ import {
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { AWSXRayPropagator } from "@opentelemetry/propagator-aws-xray";
 import { resourceFromAttributes } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import {
   AlwaysOnSampler,
   BatchSpanProcessor,
@@ -56,7 +57,7 @@ function buildLambdaResource() {
   }
 
   const attributes: Record<string, string> = {
-    "service.name": functionName,
+    [ATTR_SERVICE_NAME]: functionName,
     "faas.name": functionName,
     "cloud.provider": "aws",
     "cloud.platform": "aws_lambda",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-conformance-tests/issues/23

*Description of changes:* Standardizes InvocationOtelPlugin's invocation span name from lowercase "invocation" to "Invocation", matching ExecutionOtelPlugin and the capitalized "Workflow" root span name. Adds tests covering the configurable workflowSpanName and the fixed "Invocation" span name in both plugins.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
