### PR TITLE
refactor(otel): drop faas/cloud attributes from Invocation span

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
@@ -89,10 +89,9 @@ createTests({
           "durable.execution.status": "SUCCEEDED",
         });
 
-        // Verify Invocation span has Lambda semantic attributes
+        // Verify Invocation span has durable attributes
         assertSpanAttributes(trace, "Invocation", {
-          "cloud.provider": "aws",
-          "cloud.platform": "aws_lambda",
+          "durable.invocation.status": "SUCCEEDED",
         });
       } else {
         // Local mode: assert spans via InMemorySpanExporter
@@ -120,8 +119,10 @@ createTests({
         const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
-        expect(invocationSpan!.attributes["cloud.provider"]).toBe("aws");
-        expect(invocationSpan!.attributes["cloud.platform"]).toBe("aws_lambda");
+        expect(invocationSpan!.attributes["durable.execution.arn"]).toBeDefined();
+        expect(invocationSpan!.attributes["durable.invocation.status"]).toBe(
+          "SUCCEEDED",
+        );
 
         // Verify operation spans exist with correct attributes.
         // Filter out Context_Execution spans (which have "execution" in name)

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
@@ -88,11 +88,6 @@ createTests({
         assertSpanAttributes(trace, "Workflow", {
           "durable.execution.status": "SUCCEEDED",
         });
-
-        // Verify Invocation span has durable attributes
-        assertSpanAttributes(trace, "Invocation", {
-          "durable.invocation.status": "SUCCEEDED",
-        });
       } else {
         // Local mode: assert spans via InMemorySpanExporter
         const spans = getSerializedSpans();
@@ -120,9 +115,6 @@ createTests({
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
         expect(invocationSpan!.attributes["durable.execution.arn"]).toBeDefined();
-        expect(invocationSpan!.attributes["durable.invocation.status"]).toBe(
-          "SUCCEEDED",
-        );
 
         // Verify operation spans exist with correct attributes.
         // Filter out Context_Execution spans (which have "execution" in name)

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -69,9 +69,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   // Workflow span name (configurable)
   private readonly workflowSpanName: string;
 
-  // Cold start tracking
-  private isColdStart: boolean = true;
-
   constructor(config?: OtelPluginConfig) {
     const instrumentationName =
       config?.instrumentationName ?? DEFAULT_INSTRUMENTATION_NAME;
@@ -140,10 +137,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       const parentContext = trace.setSpan(context.active(), this.workflowSpan);
 
       const invocationAttributes: Record<string, string | number | boolean> = {
-        "faas.invocation_id": info.requestId,
-        "faas.coldstart": this.isColdStart,
-        "cloud.provider": "aws",
-        "cloud.platform": "aws_lambda",
         "durable.execution.arn": info.executionArn,
         "durable.invocation.first": info.isFirstInvocation,
       };
@@ -199,9 +192,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         parentContext,
       );
     }
-
-    // Mark cold start as false after the first invocation
-    this.isColdStart = false;
   }
 
   wrapInvocation(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removes faas.invocation_id, faas.coldstart, cloud.provider, and cloud.platform from the ExecutionOtelPlugin Invocation span. The now-unused isColdStart field and its assignment are removed. cloud.resource_id/faas.max_memory and durable.* attributes are retained. InvocationOtelPlugin never set these attributes. Updates the community-collector execution e2e example test assertions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
