### PR TITLE
fix(otel): Workflow root span in all provider modes; invocation-rooted with Workflow links

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
@@ -95,10 +95,15 @@ createTests({
         expect(workflowSpan).toBeDefined();
         expect(workflowSpan!.attributes["durable.execution.arn"]).toBeDefined();
 
-        // Verify Invocation span exists and is child of Workflow
+        // The Invocation span is invocation-rooted: it is NOT a child of the
+        // Workflow span. With no active parent span (community-collector local
+        // mode) it is a trace root. Execution correlation to the Workflow span
+        // is expressed via links on the operation/attempt spans instead.
         const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
-        expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
+        expect(invocationSpan!.parentSpanId).toBeUndefined();
+        // The Invocation span itself carries no links.
+        expect(invocationSpan!.links).toHaveLength(0);
 
         // Filter to operation spans: have durable.operation.type but NOT durable.attempt.outcome
         const operationSpans = spans.filter(
@@ -106,6 +111,14 @@ createTests({
             s.attributes["durable.operation.type"] !== undefined &&
             s.attributes["durable.attempt.outcome"] === undefined,
         );
+
+        // Every operation span links to the Workflow span for execution-scoped
+        // correlation (invocation-rooted plugin expresses the join via links).
+        for (const opSpan of operationSpans) {
+          expect(
+            opSpan.links.some((l) => l.spanId === workflowSpan!.spanId),
+          ).toBe(true);
+        }
 
         // Verify operation spans exist with correct attributes by durable.operation.name
         const fetchDataSpan = operationSpans.find(

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
@@ -95,13 +95,14 @@ createTests({
         expect(workflowSpan).toBeDefined();
         expect(workflowSpan!.attributes["durable.execution.arn"]).toBeDefined();
 
-        // In community-collector (owned provider) mode the Invocation span is
-        // parented to the Workflow span we create (no ambient Lambda span to
-        // attach to). It carries no links itself; execution correlation is
-        // expressed via links on the operation/attempt spans.
+        // The Invocation span is invocation-rooted: it is NOT a child of the
+        // Workflow span. With no active parent span (community-collector local
+        // mode) it is a trace root. Execution correlation to the Workflow span
+        // is expressed via links on the operation/attempt spans instead.
         const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
-        expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
+        expect(invocationSpan!.parentSpanId).toBeUndefined();
+        // The Invocation span itself carries no links.
         expect(invocationSpan!.links).toHaveLength(0);
 
         // Filter to operation spans: have durable.operation.type but NOT durable.attempt.outcome

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts
@@ -95,14 +95,13 @@ createTests({
         expect(workflowSpan).toBeDefined();
         expect(workflowSpan!.attributes["durable.execution.arn"]).toBeDefined();
 
-        // The Invocation span is invocation-rooted: it is NOT a child of the
-        // Workflow span. With no active parent span (community-collector local
-        // mode) it is a trace root. Execution correlation to the Workflow span
-        // is expressed via links on the operation/attempt spans instead.
+        // In community-collector (owned provider) mode the Invocation span is
+        // parented to the Workflow span we create (no ambient Lambda span to
+        // attach to). It carries no links itself; execution correlation is
+        // expressed via links on the operation/attempt spans.
         const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
-        expect(invocationSpan!.parentSpanId).toBeUndefined();
-        // The Invocation span itself carries no links.
+        expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
         expect(invocationSpan!.links).toHaveLength(0);
 
         // Filter to operation spans: have durable.operation.type but NOT durable.attempt.outcome

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
@@ -135,10 +135,15 @@ describe("InvocationOtelPlugin - useDefaultTracerProvider mode", () => {
     expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
       "SUCCEEDED",
     );
-    // The Invocation span parents to the Workflow root
-    expect(invocationSpan!.parentSpanContext?.spanId).toBe(
-      workflowSpan!.spanContext().spanId,
-    );
+    // The Invocation span stays invocation-rooted: it is NOT a child of the
+    // Workflow span. With no active parent span in this test it is a root.
+    expect(invocationSpan!.parentSpanContext).toBeUndefined();
+    // Operation spans link to the Workflow span for execution correlation.
+    expect(
+      opSpan!.links.some(
+        (l) => l.context.spanId === workflowSpan!.spanContext().spanId,
+      ),
+    ).toBe(true);
   });
 
   it("creates its own internal provider when no config is provided", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
@@ -4,7 +4,8 @@
  * These tests mirror the execution-plugin-default-provider-integration tests
  * but verify InvocationOtelPlugin-specific behavior:
  * - Uses the globally registered TracerProvider by default
- * - Creates "Invocation" span (not "Workflow" + "Invocation" like ExecutionOtelPlugin)
+ * - Emits the "Workflow" root span plus the "Invocation" span in both provider
+ *   modes (matching ExecutionOtelPlugin)
  * - Custom instrumentationName support
  * - forceFlush error handling
  */
@@ -123,9 +124,21 @@ describe("InvocationOtelPlugin - useDefaultTracerProvider mode", () => {
     expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(
       "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123",
     );
-    // No workflow span in default provider mode
+    // The Workflow root span is now emitted in default provider mode too
+    // (matching ExecutionOtelPlugin and the Python/Java reference plugins).
     const workflowSpan = spans.find((s) => s.name === "Workflow");
-    expect(workflowSpan).toBeUndefined();
+    expect(workflowSpan).toBeDefined();
+    expect(workflowSpan!.parentSpanContext).toBeUndefined();
+    expect(workflowSpan!.attributes["durable.execution.arn"]).toBe(
+      "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123",
+    );
+    expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+      "SUCCEEDED",
+    );
+    // The Invocation span parents to the Workflow root
+    expect(invocationSpan!.parentSpanContext?.spanId).toBe(
+      workflowSpan!.spanContext().spanId,
+    );
   });
 
   it("creates its own internal provider when no config is provided", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -337,8 +337,13 @@ describe("InvocationOtelPlugin", () => {
       // When using internal provider with DeterministicIdGenerator, span ID is deterministic.
       // With external provider, we verify the durable.operation.id attribute is set correctly.
       expect(opSpan!.attributes["durable.operation.id"]).toBe("op-abc");
-      // Non-replay spans should NOT have links (unlike replay spans)
-      expect(opSpan!.links.length).toBe(0);
+      // Non-replay spans carry no self-link, but do link to the Workflow span
+      // for execution correlation.
+      const workflowSpan = findSpan("Workflow");
+      expect(opSpan!.links.length).toBe(1);
+      expect(opSpan!.links[0].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
     });
 
     it("replay operation uses random span ID with Link to deterministic", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -94,23 +94,31 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.idGenerator.setTraceId(derivedId);
     }
 
-    // 4. Create the Workflow span when using community collector (not default provider)
-    if (!this.useDefaultTracerProvider) {
-      const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
-      this.idGenerator.setNextSpanId(workflowSpanId);
+    // 4. Create the Workflow root span.
+    //
+    // The Workflow span is the parentless root of the execution-scoped trace and
+    // is emitted in BOTH provider modes (default/ADOT and owned/community
+    // collector), matching ExecutionOtelPlugin and the Python/Java reference
+    // plugins. It is keyed to a deterministic span ID derived from the execution
+    // ARN so every invocation of the same durable execution shares one root, and
+    // it is finalized (stamped with a terminal execution status and ended) only
+    // once, at the terminal invocation (see onInvocationEnd). Emitting it only in
+    // community-collector mode previously left the invocation view without a root
+    // Workflow span under ADOT/X-Ray.
+    const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
+    this.idGenerator.setNextSpanId(workflowSpanId);
 
-      this.workflowSpan = this.tracer.startSpan(
-        this.workflowSpanName,
-        {
-          kind: SpanKind.INTERNAL,
-          attributes: {
-            "durable.execution.arn": info.executionArn,
-          },
-          startTime: info.executionStartTimestamp ?? new Date(),
+    this.workflowSpan = this.tracer.startSpan(
+      this.workflowSpanName,
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+          "durable.execution.arn": info.executionArn,
         },
-        ROOT_CONTEXT,
-      );
-    }
+        startTime: info.executionStartTimestamp ?? new Date(),
+      },
+      ROOT_CONTEXT,
+    );
 
     // 5. Always create the invocation span (regardless of provider mode)
     const parentContext = this.workflowSpan
@@ -176,7 +184,9 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end();
     }
 
-    // 3. Handle Workflow span based on terminal status (community collector mode only)
+    // 3. Handle Workflow span based on terminal status. The Workflow span is
+    //    always created (both provider modes); it is finalized only on a
+    //    terminal invocation, and dropped un-exported while non-terminal.
     if (this.workflowSpan) {
       if (info.status === "SUCCEEDED" || info.status === "FAILED") {
         // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -120,15 +120,22 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       ROOT_CONTEXT,
     );
 
-    // 5. Create the invocation span, parented to the ACTIVE context. Under
-    //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
-    //    execution-environment span, so the invocation span nests beneath it.
-    //    The invocation span is intentionally NOT a child of the Workflow span:
-    //    this plugin stays invocation-rooted. Execution-scoped correlation to
-    //    the Workflow span is expressed via links on the operation/attempt
-    //    spans (see onOperationStart / onOperationAttemptStart), matching the
-    //    Java (aws/aws-durable-execution-sdk-java#572) and Python
-    //    (aws/aws-durable-execution-sdk-python#593) reference plugins.
+    // 5. Create the invocation span.
+    //    - Default tracer provider (ADOT/X-Ray): parent to the ACTIVE context,
+    //      which at onInvocationStart is the Lambda execution-environment span,
+    //      so the invocation span nests beneath it. It is NOT parented to the
+    //      Workflow span (the ambient Lambda span is the container).
+    //    - Owned / community-collector provider: there is no ambient Lambda
+    //      span, so parent the invocation span to the Workflow span we created
+    //      to give the trace a proper root.
+    //    In both modes, execution-scoped correlation is additionally expressed
+    //    via links on the operation/attempt spans (see onOperationStart /
+    //    onOperationAttemptStart).
+    const invocationParentContext =
+      !this.useDefaultTracerProvider && this.workflowSpan
+        ? trace.setSpan(context.active(), this.workflowSpan)
+        : context.active();
+
     this.invocationSpan = this.tracer.startSpan(
       "Invocation",
       {
@@ -138,7 +145,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           "durable.invocation.first": info.isFirstInvocation,
         },
       },
-      context.active(),
+      invocationParentContext,
     );
   }
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -9,7 +9,7 @@ import type {
   OperationChangeInfo,
 } from "@aws/durable-execution-sdk-js";
 import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
-import type { TracerProvider, Tracer, Span } from "@opentelemetry/api";
+import type { TracerProvider, Tracer, Span, SpanContext, Link } from "@opentelemetry/api";
 import {
   context,
   trace,
@@ -120,11 +120,15 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       ROOT_CONTEXT,
     );
 
-    // 5. Always create the invocation span (regardless of provider mode)
-    const parentContext = this.workflowSpan
-      ? trace.setSpan(context.active(), this.workflowSpan)
-      : context.active();
-
+    // 5. Create the invocation span, parented to the ACTIVE context. Under
+    //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
+    //    execution-environment span, so the invocation span nests beneath it.
+    //    The invocation span is intentionally NOT a child of the Workflow span:
+    //    this plugin stays invocation-rooted. Execution-scoped correlation to
+    //    the Workflow span is expressed via links on the operation/attempt
+    //    spans (see onOperationStart / onOperationAttemptStart), matching the
+    //    Java (aws/aws-durable-execution-sdk-java#572) and Python
+    //    (aws/aws-durable-execution-sdk-python#593) reference plugins.
     this.invocationSpan = this.tracer.startSpan(
       "Invocation",
       {
@@ -134,7 +138,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           "durable.invocation.first": info.isFirstInvocation,
         },
       },
-      parentContext,
+      context.active(),
     );
   }
 
@@ -267,6 +271,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         {
           attributes,
           startTime: info.startTimestamp,
+          links: this.workflowLinks(),
         },
         parentContext,
       );
@@ -280,10 +285,13 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         {
           attributes,
           startTime: info.startTimestamp,
+          // Self-link to the deterministic operation span first, then the
+          // Workflow link (order-significant per the conformance contract).
           links: [
             {
               context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
             },
+            ...this.workflowLinks(),
           ],
         },
         parentContext,
@@ -397,10 +405,13 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         {
           attributes,
           startTime: info.startTimestamp,
+          // Self-link to the deterministic operation span first, then the
+          // Workflow link (order-significant per the conformance contract).
           links: [
             {
               context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
             },
+            ...this.workflowLinks(),
           ],
         },
         parentContext,
@@ -458,6 +469,8 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       {
         attributes,
         startTime: info.startTimestamp,
+        // Self-link to the deterministic operation span first, then the
+        // Workflow link (order-significant per the conformance contract).
         links: [
           {
             context: {
@@ -466,6 +479,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
               traceFlags: 1,
             },
           },
+          ...this.workflowLinks(),
         ],
       },
       parentContext,
@@ -518,6 +532,19 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       spanId: spanContext.spanId,
       otelTraceSampled: (spanContext.traceFlags & 1) !== 0,
     };
+  }
+
+  /**
+   * Link(s) to the execution-scoped Workflow span. Operation and attempt spans
+   * carry this link so they correlate to the one Workflow span for the durable
+   * execution while remaining parented to the invocation/operation hierarchy.
+   * The invocation span itself does NOT carry this link. Returns an empty array
+   * if the Workflow span was not created.
+   */
+  private workflowLinks(): Link[] {
+    const workflowContext: SpanContext | undefined =
+      this.workflowSpan?.spanContext();
+    return workflowContext ? [{ context: workflowContext }] : [];
   }
 
   private attemptSpanKey(operationId: string, attempt: number): string {

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -120,22 +120,15 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       ROOT_CONTEXT,
     );
 
-    // 5. Create the invocation span.
-    //    - Default tracer provider (ADOT/X-Ray): parent to the ACTIVE context,
-    //      which at onInvocationStart is the Lambda execution-environment span,
-    //      so the invocation span nests beneath it. It is NOT parented to the
-    //      Workflow span (the ambient Lambda span is the container).
-    //    - Owned / community-collector provider: there is no ambient Lambda
-    //      span, so parent the invocation span to the Workflow span we created
-    //      to give the trace a proper root.
-    //    In both modes, execution-scoped correlation is additionally expressed
-    //    via links on the operation/attempt spans (see onOperationStart /
-    //    onOperationAttemptStart).
-    const invocationParentContext =
-      !this.useDefaultTracerProvider && this.workflowSpan
-        ? trace.setSpan(context.active(), this.workflowSpan)
-        : context.active();
-
+    // 5. Create the invocation span, parented to the ACTIVE context. Under
+    //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
+    //    execution-environment span, so the invocation span nests beneath it.
+    //    The invocation span is intentionally NOT a child of the Workflow span:
+    //    this plugin stays invocation-rooted. Execution-scoped correlation to
+    //    the Workflow span is expressed via links on the operation/attempt
+    //    spans (see onOperationStart / onOperationAttemptStart), matching the
+    //    Java (aws/aws-durable-execution-sdk-java#572) and Python
+    //    (aws/aws-durable-execution-sdk-python#593) reference plugins.
     this.invocationSpan = this.tracer.startSpan(
       "Invocation",
       {
@@ -145,7 +138,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           "durable.invocation.first": info.isFirstInvocation,
         },
       },
-      invocationParentContext,
+      context.active(),
     );
   }
 


### PR DESCRIPTION
> **Stacked PR (gh-stack style).** Review/merge bottom-up. This stack fixes the JS OTel invocation-view parity gaps surfaced by aws/aws-durable-execution-conformance-tests#40.
>
> 1. #773 — Workflow root span in all provider modes; invocation-rooted + Workflow links _(base: `main`)_
> 2. #774 — `durable.operation.status` state machine _(base: #773)_
> 3. #775 — wall-clock timing so op/attempt spans nest in Invocation span _(base: #774)_

---

## Summary

Aligns `InvocationOtelPlugin` with the newer invocation-view OTel contract (asserted by aws/aws-durable-execution-conformance-tests#40) and with the Java (aws/aws-durable-execution-sdk-java#572) and Python (aws/aws-durable-execution-sdk-python#593) reference plugins.

Previously the root `Workflow` span was created only in community-collector mode (`!useDefaultTracerProvider`), so ADOT/X-Ray invocation-view traces had no `Workflow` root and every `otel-invocation` conformance case failed with `span_assertions[0] (Workflow) matched no spans`.

## Changes

1. **Emit the `Workflow` root span unconditionally** (both provider modes), matching `ExecutionOtelPlugin` and the reference plugins. It keeps its deterministic execution-ARN span id (one root per execution), is finalized with `durable.execution.status` + span status `OK`/`ERROR` only on a **terminal** invocation, and is dropped un-exported while non-terminal (preserves the interrupted-timeout case).

2. **Keep the plugin invocation-rooted.** The `Invocation` span is parented to the **active context** (the Lambda execution-environment span under ADOT/X-Ray), **not** the `Workflow` span.

3. **Link operations & attempts to the `Workflow` span.** Every operation, continuation, and attempt span carries a link to the `Workflow` span for execution-scoped correlation; the `Invocation` span does not. Resumed/replayed ops keep their deterministic self-link first, then the `Workflow` link (order-significant per the contract).

## Conformance impact

- Resolves `span_assertions[0] (Workflow) matched no spans` across otel-invocation cases 1-9, 11, 16, 18, 19.
- Restores the required `Workflow` link on operation/attempt spans (enforced by the community/collector backend; relaxed under X-Ray via the `SPAN_LINKS` disparity flag).

Remaining invocation-view parity gaps are tracked as follow-up PRs: `durable.operation.status`/`STARTED` semantics, the op-span timing envelope, and the callback-handler naming (conformance repo).

## Testing

- `npm test` (otel package) — 180/180 pass
- `tsc --noEmit` — clean
