### PR TITLE
fix(otel): set explicit span status OK on successful operation and attempt spans

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -3,7 +3,13 @@ import {
   SimpleSpanProcessor,
   NodeTracerProvider,
 } from "@opentelemetry/sdk-trace-node";
-import { context, trace, propagation, ROOT_CONTEXT } from "@opentelemetry/api";
+import {
+  context,
+  trace,
+  propagation,
+  ROOT_CONTEXT,
+  SpanStatusCode,
+} from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 import type {
   InvocationInfo,
@@ -461,5 +467,81 @@ describe("ExecutionOtelPlugin - Parent-child workflow span ID collision preventi
     expect(validateSpan!.spanContext().spanId).not.toBe(
       enrichSpan!.spanContext().spanId,
     );
+  });
+
+  // Regression: onOperationEnd can be reached with a terminal FAILURE status
+  // (TIMED_OUT/STOPPED/FAILED/CANCELLED) and NO error object (callback-timeout
+  // and chained-invoke cross-invocation fast paths). Those must NOT be labelled
+  // OTel OK — the OK branch is gated on SUCCEEDED, so a no-error failure leaves
+  // the span status at the default UNSET (code 0).
+  it("onOperationEnd terminal path: TIMED_OUT status with NO error leaves the operation span NOT OK (UNSET)", async () => {
+    const plugin = new ExecutionOtelPlugin({
+      useDefaultTracerProvider: true,
+    });
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({ id: "op-timeout", name: "timeout-op" }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "op-timeout",
+        name: "timeout-op",
+        status: "TIMED_OUT" as any,
+        // no error object
+      }),
+    );
+    await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+    const opSpan = findSpan(exporter, "timeout-op");
+    expect(opSpan).toBeDefined();
+    expect(opSpan!.status.code).not.toBe(SpanStatusCode.OK);
+    expect(opSpan!.status.code).toBe(SpanStatusCode.UNSET);
+  });
+
+  it("onOperationEnd cross-invocation path: STOPPED status with NO error leaves the span NOT OK (UNSET)", async () => {
+    const plugin = new ExecutionOtelPlugin({
+      useDefaultTracerProvider: true,
+    });
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    // No prior onOperationStart -> spanMap miss -> cross-invocation span path.
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "op-cross-stopped",
+        name: "cross-stopped",
+        status: "STOPPED" as any,
+        // no error object
+      }),
+    );
+    await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+    const opSpan = findSpan(exporter, "cross-stopped");
+    expect(opSpan).toBeDefined();
+    expect(opSpan!.status.code).not.toBe(SpanStatusCode.OK);
+    expect(opSpan!.status.code).toBe(SpanStatusCode.UNSET);
+  });
+
+  it("onOperationEnd terminal path: SUCCEEDED status with NO error stamps OK", async () => {
+    const plugin = new ExecutionOtelPlugin({
+      useDefaultTracerProvider: true,
+    });
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({ id: "op-ok", name: "ok-op" }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "op-ok",
+        name: "ok-op",
+        status: "SUCCEEDED" as any,
+      }),
+    );
+    await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+    const opSpan = findSpan(exporter, "ok-op");
+    expect(opSpan).toBeDefined();
+    expect(opSpan!.status.code).toBe(SpanStatusCode.OK);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -1256,6 +1256,71 @@ describe("InvocationOtelPlugin", () => {
       );
       expect(exceptionEvent).toBeDefined();
     });
+
+    // Regression: onOperationEnd can be reached with a terminal FAILURE status
+    // (TIMED_OUT/STOPPED/FAILED/CANCELLED) and NO error object (callback-timeout
+    // and chained-invoke "already failed" cross-invocation fast paths). Those
+    // must NOT be labelled OTel OK — the OK branch is gated on SUCCEEDED, so a
+    // no-error failure leaves the span status at the default UNSET (code 0).
+    it("onOperationEnd terminal path: TIMED_OUT status with NO error leaves the operation span NOT OK (UNSET)", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-timeout", name: "timeout-op" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-timeout",
+          name: "timeout-op",
+          status: "TIMED_OUT" as any,
+          // no error object
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("timeout-op");
+      expect(opSpan).toBeDefined();
+      expect(opSpan!.status.code).not.toBe(SpanStatusCode.OK);
+      expect(opSpan!.status.code).toBe(SpanStatusCode.UNSET);
+    });
+
+    it("onOperationEnd continuation path: STOPPED status with NO error leaves the continuation span NOT OK (UNSET)", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // No prior onOperationStart -> spanMap miss -> cross-invocation
+      // continuation span path.
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-cross-stopped",
+          name: "cross-stopped",
+          status: "STOPPED" as any,
+          // no error object
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const continuationSpan = findSpan("cross-stopped");
+      expect(continuationSpan).toBeDefined();
+      expect(continuationSpan!.status.code).not.toBe(SpanStatusCode.OK);
+      expect(continuationSpan!.status.code).toBe(SpanStatusCode.UNSET);
+    });
+
+    it("onOperationEnd terminal path: SUCCEEDED status with NO error stamps OK", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "op-ok", name: "ok-op" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-ok",
+          name: "ok-op",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const opSpan = findSpan("ok-op");
+      expect(opSpan).toBeDefined();
+      expect(opSpan!.status.code).toBe(SpanStatusCode.OK);
+    });
   });
 
   describe("wrapInvocation", () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -374,7 +374,11 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
           message: info.error.message,
         });
         span.recordException(info.error);
-      } else {
+      } else if (info.status === "SUCCEEDED") {
+        // Stamp explicit OK ONLY on a SUCCEEDED terminal status. Terminal
+        // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
+        // NO error object (callback-timeout, chained-invoke fast paths); those
+        // must NOT be labelled OK, so they are left UNSET.
         span.setStatus({ code: SpanStatusCode.OK });
       }
 
@@ -433,7 +437,11 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
           message: info.error.message,
         });
         span.recordException(info.error);
-      } else {
+      } else if (info.status === "SUCCEEDED") {
+        // Stamp explicit OK ONLY on a SUCCEEDED terminal status. Terminal
+        // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
+        // NO error object on the cross-invocation fast paths; those must NOT be
+        // labelled OK, so they are left UNSET.
         span.setStatus({ code: SpanStatusCode.OK });
       }
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -374,6 +374,8 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
           message: info.error.message,
         });
         span.recordException(info.error);
+      } else {
+        span.setStatus({ code: SpanStatusCode.OK });
       }
 
       span.end(info.endTimestamp);
@@ -431,6 +433,8 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
           message: info.error.message,
         });
         span.recordException(info.error);
+      } else {
+        span.setStatus({ code: SpanStatusCode.OK });
       }
 
       span.end(info.endTimestamp);
@@ -502,6 +506,9 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         if (info.error) {
           attemptSpan.recordException(info.error);
         }
+      } else {
+        // Non-failed attempt: stamp explicit OK (matches Python OTel #604).
+        attemptSpan.setStatus({ code: SpanStatusCode.OK });
       }
       attemptSpan.end(info.endTimestamp);
       this.spanMap.delete(key);

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -375,13 +375,18 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         span.setAttribute("durable.attempt.number", info.attempt);
       }
 
-      // Record error if present
+      // Record error if present; otherwise stamp explicit OK on the terminal
+      // completion path (matches Python OTel plugin #604). Only reached for
+      // operations that terminate this invocation — suspended ops early-return
+      // above and keep their STARTED status UNSET.
       if (info.error) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: info.error.message,
         });
         span.recordException(info.error);
+      } else {
+        span.setStatus({ code: SpanStatusCode.OK });
       }
 
       // End the span
@@ -444,13 +449,17 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         parentContext,
       );
 
-      // Record error if present
+      // Record error if present; otherwise stamp explicit OK (matches Python
+      // OTel plugin #604). This is the terminal completion path for an
+      // operation started in a prior invocation.
       if (info.error) {
         continuationSpan.setStatus({
           code: SpanStatusCode.ERROR,
           message: info.error.message,
         });
         continuationSpan.recordException(info.error);
+      } else {
+        continuationSpan.setStatus({ code: SpanStatusCode.OK });
       }
 
       // Immediately end
@@ -540,6 +549,9 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         if (info.error) {
           attemptSpan.recordException(info.error);
         }
+      } else {
+        // Non-failed attempt: stamp explicit OK (matches Python OTel #604).
+        attemptSpan.setStatus({ code: SpanStatusCode.OK });
       }
       attemptSpan.end();
       this.spanMap.delete(key);

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -375,17 +375,20 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         span.setAttribute("durable.attempt.number", info.attempt);
       }
 
-      // Record error if present; otherwise stamp explicit OK on the terminal
-      // completion path (matches Python OTel plugin #604). Only reached for
-      // operations that terminate this invocation — suspended ops early-return
-      // above and keep their STARTED status UNSET.
+      // Record error if present; otherwise stamp explicit OK ONLY on a
+      // SUCCEEDED terminal status (matches Python OTel plugin #604). Only
+      // reached for operations that terminate this invocation — suspended ops
+      // early-return above and keep their STARTED status UNSET. Terminal
+      // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
+      // NO error object (callback-timeout, chained-invoke fast paths); those
+      // must NOT be labelled OK, so they are left UNSET.
       if (info.error) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: info.error.message,
         });
         span.recordException(info.error);
-      } else {
+      } else if (info.status === "SUCCEEDED") {
         span.setStatus({ code: SpanStatusCode.OK });
       }
 
@@ -449,16 +452,19 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         parentContext,
       );
 
-      // Record error if present; otherwise stamp explicit OK (matches Python
-      // OTel plugin #604). This is the terminal completion path for an
-      // operation started in a prior invocation.
+      // Record error if present; otherwise stamp explicit OK ONLY on a
+      // SUCCEEDED terminal status (matches Python OTel plugin #604). This is
+      // the terminal completion path for an operation started in a prior
+      // invocation. Terminal FAILURE statuses can arrive with NO error object
+      // (callback-timeout, chained-invoke 'already failed' cross-invocation
+      // fast paths); those must NOT be labelled OK, so they are left UNSET.
       if (info.error) {
         continuationSpan.setStatus({
           code: SpanStatusCode.ERROR,
           message: info.error.message,
         });
         continuationSpan.recordException(info.error);
-      } else {
+      } else if (info.status === "SUCCEEDED") {
         continuationSpan.setStatus({ code: SpanStatusCode.OK });
       }
 


### PR DESCRIPTION
## Summary

set explicit span status OK on successful operation and attempt spans

## Testing

- `npm run build -w packages/aws-durable-execution-sdk-js-otel` — clean
- `npm test -w packages/aws-durable-execution-sdk-js-otel` — 187/187 (9 suites)

## Coordination

Aligns JS with the operation-status/span-status model tracked by aws/aws-durable-execution-conformance-tests#52 and #53, matching Python #604 and the Java companion change.