### PR TITLE
ci: Add issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,13 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  triage:
+    permissions:
+      issues: write
+    uses: aws/aws-durable-execution-ci/.github/workflows/issue-triage.yml@043a1a0ac3e0a7f51f92826431aea93c234ad7cd


### PR DESCRIPTION
*Issue #, if available:*
Followup on https://github.com/aws/aws-durable-execution-ci/pull/6

*Description of changes:*
Adds a GitHub Actions workflow that automatically triages newly opened issues by delegating to the shared reusable workflow in `aws/aws-durable-execution-ci`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
