### PR TITLE
feat(otel): add enrichLogger config toggle to gate log context enrichment

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -1551,6 +1551,25 @@ describe("InvocationOtelPlugin", () => {
       const result = plugin.enrichLogContext();
       expect(result).toBeUndefined();
     });
+
+    it("returns undefined when enrichLogger is disabled, even with an active span", async () => {
+      const noEnrichPlugin = new InvocationOtelPlugin({
+        tracerProvider: provider,
+        enrichLogger: false,
+      });
+      await noEnrichPlugin.onInvocationStart(makeInvocationInfo());
+
+      let logContext: Record<string, string | number | boolean> | undefined;
+      const fn = async () => {
+        logContext = noEnrichPlugin.enrichLogContext();
+        return { output: "test" } as any;
+      };
+
+      await noEnrichPlugin.wrapInvocation(makeInvocationInfo(), fn);
+      await noEnrichPlugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(logContext).toBeUndefined();
+    });
   });
 
   describe("Span attributes", () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -69,6 +69,9 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   // Workflow span name (configurable)
   private readonly workflowSpanName: string;
 
+  // Whether enrichLogContext() contributes trace context to log records
+  private readonly enrichLogger: boolean;
+
   constructor(config?: OtelPluginConfig) {
     const instrumentationName =
       config?.instrumentationName ?? DEFAULT_INSTRUMENTATION_NAME;
@@ -77,6 +80,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.contextExtractor = config?.contextExtractor ?? xRayContextExtractor;
     this.useDefaultTracerProvider = config?.useDefaultTracerProvider ?? false;
     this.workflowSpanName = config?.workflowSpanName ?? "Workflow";
+    this.enrichLogger = config?.enrichLogger ?? true;
 
     // Create or accept TracerProvider via the provider factory
     const { tracerProvider, ownsProvider } = createTracerProvider(config);
@@ -528,6 +532,9 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   }
 
   enrichLogContext(): Record<string, string | number | boolean> | undefined {
+    if (!this.enrichLogger) {
+      return undefined;
+    }
     const span = trace.getSpan(context.active());
     if (!span) {
       return undefined;

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -45,6 +45,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private readonly contextExtractor: ContextExtractor;
   private readonly useDefaultTracerProvider: boolean;
   private readonly workflowSpanName: string;
+  private readonly enrichLogger: boolean;
 
   // Per-invocation state
   private spanMap: Map<string, Span> = new Map();
@@ -61,6 +62,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.contextExtractor = config?.contextExtractor ?? xRayContextExtractor;
     this.useDefaultTracerProvider = config?.useDefaultTracerProvider ?? false;
     this.workflowSpanName = config?.workflowSpanName ?? "Workflow";
+    this.enrichLogger = config?.enrichLogger ?? true;
 
     // Pass config directly to createTracerProvider — when neither tracerProvider
     // nor useDefaultTracerProvider is set, option 3 creates an internal provider
@@ -569,6 +571,9 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   }
 
   enrichLogContext(): Record<string, string | number | boolean> | undefined {
+    if (!this.enrichLogger) {
+      return undefined;
+    }
     const span = trace.getSpan(context.active());
     if (!span) {
       return undefined;

--- a/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-config.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-config.ts
@@ -82,6 +82,18 @@ export interface OtelPluginConfig {
    * Defaults to `"Workflow"`.
    */
   workflowSpanName?: string;
+
+  /**
+   * Whether `enrichLogContext()` contributes the active OTel trace context
+   * (`traceId`, `spanId`, `otelTraceSampled`) to each durable log record.
+   *
+   * When `true` (default), every log line emitted through the durable logger is
+   * stamped with the current span context for log/trace correlation. Set to
+   * `false` to disable the extra fields (e.g. to avoid duplicating context that
+   * a separate log-instrumentation layer already injects, or to keep log output
+   * minimal). Mirrors Python's `enrich_logger` and Java's `enableMdc`.
+   */
+  enrichLogger?: boolean;
 }
 
 /**


### PR DESCRIPTION
## issue

https://github.com/aws/aws-durable-execution-conformance-tests/issues/23#issuecomment-5184325293

## Summary

Both OTel plugins expose `enrichLogContext()`, which `DefaultLogger` invokes on **every** durable log line to stamp `traceId`/`spanId`/`otelTraceSampled` for log↔trace correlation. Previously this was unconditional with no way to opt out.

This PR adds `enrichLogger?: boolean` to the shared `OtelPluginConfig` and gates the body of `enrichLogContext()` in both `ExecutionOtelPlugin` and `InvocationOtelPlugin`.

- **Default `true`** — preserves current behavior.
- **Set `false`** — `enrichLogContext()` returns `undefined`, so no trace fields are added (e.g. to avoid duplicating context a separate log-instrumentation layer already injects, or to keep log output minimal).

## Cross-SDK motivation

Closes the log-correlation config gap identified in the cross-SDK OTel plugin reconciliation: **Python** already has `enrich_logger` and **Java** has `enableMdc`; JS had no equivalent toggle. This aligns the capability (same default: on).

## Tests

+1 test asserting `enrichLogContext()` returns `undefined` when `enrichLogger: false` even with an active span. Full otel suite: 194/194. Types build clean.