### PR TITLE
fix(sdk): bound polling by the invocation deadline instead of hard-coding

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/invoke-handler.ts
@@ -35,6 +35,17 @@ export class InvokeHandler {
       awsRequestId: randomUUID(),
       logGroupName: "MyLogGroupName",
       logStreamName: "MyLogStreamName",
+      // Constant rather than a countdown, and overridable through the constructor. The SDK
+      // now uses this to decide whether to schedule a wait timer and whether to keep
+      // polling, so the value has two consequences locally: scheduling behaves as it always
+      // did (900_000 is what the SDK's old fixed cap was), but because the deadline never
+      // elapses, the stop-polling condition cannot trigger and a poll loop is bounded only
+      // by the backoff ceiling for as long as an operation stays EXECUTING.
+      //
+      // Making it count down would model a real invocation more closely -- note that
+      // skipTime does not manipulate the clock, so elapsed time here is real -- but it would
+      // also let operations stall locally in runs that advance fake timers themselves,
+      // which is a deliberate behaviour change rather than a fix. Left as is for now.
       getRemainingTimeInMillis: function (): number {
         return 900_000;
       },

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.test.ts
@@ -13,6 +13,7 @@ describe("DurableContext executionContext property", () => {
       _stepData: {},
       terminationManager: {} as any,
       requestId: "test-request-id",
+      getRemainingTimeMs: (): number => Infinity,
       tenantId: undefined,
       pendingCompletions: new Set(),
       getStepData: jest.fn(),

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.test.ts
@@ -141,8 +141,26 @@ describe("initializeExecutionContext", () => {
         isOperationUpdatedBetweenInvocation: expect.any(Function),
         tenantId: mockLambdaContext.tenantId,
         requestId: mockLambdaContext.awsRequestId,
+        getRemainingTimeMs: expect.any(Function),
       },
     });
+  });
+
+  it("reports remaining time from the platform context on each call", async () => {
+    // This is the single point where the compute's deadline enters the SDK, so it has to
+    // delegate rather than capture: the value changes over the life of the invocation.
+    const remaining = jest
+      .fn()
+      .mockReturnValueOnce(120_000)
+      .mockReturnValueOnce(90_000);
+    const { executionContext } = await initializeExecutionContext(
+      mockEvent,
+      { ...mockLambdaContext, getRemainingTimeInMillis: remaining },
+      undefined,
+    );
+
+    expect(executionContext.getRemainingTimeMs()).toBe(120_000);
+    expect(executionContext.getRemainingTimeMs()).toBe(90_000);
   });
 
   it("should initialize execution context in verbose mode", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/execution-context/execution-context.ts
@@ -130,6 +130,10 @@ export const initializeExecutionContext = async (
       },
       tenantId: context.tenantId,
       requestId: context.awsRequestId,
+      // The one reduction here that is a function rather than a value, because the answer
+      // changes over the life of the invocation. Where no deadline is known, a caller
+      // supplies `() => Infinity`.
+      getRemainingTimeMs: () => context.getRemainingTimeInMillis(),
     },
     durableExecutionMode,
     checkpointToken,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
@@ -95,6 +95,7 @@ describe("Run In Child Context Integration Tests", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
 
     mockParentContext = { awsRequestId: "mock-request-id" };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.composed.test.ts
@@ -114,6 +114,7 @@ describe("runInChildContext serdes round-trip", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
 
     mockParentContext = { awsRequestId: "mock-request-id" };

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-manager-checkpoint.test.ts
@@ -24,6 +24,7 @@ const createCheckpoint = (
     new Set<string>(),
     {},
     "",
+    () => Infinity,
   );
   const checkpoint = (stepId: string, data: any): Promise<any> =>
     manager.checkpoint(stepId, data);
@@ -54,6 +55,7 @@ describe("TerminationManager Checkpoint Integration", () => {
       _stepData: {},
       terminationManager,
       requestId: "",
+      getRemainingTimeMs: (): number => Infinity,
       tenantId: "",
       pendingCompletions: new Set(),
       getStepData: jest.fn(),

--- a/packages/aws-durable-execution-sdk-js/src/testing/create-test-checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/create-test-checkpoint-manager.ts
@@ -7,6 +7,7 @@ export const createTestCheckpointManager = (
   checkpointToken: string,
   emitter: EventEmitter,
   logger: DurableLogger,
+  getRemainingTimeMs: () => number = (): number => Infinity,
 ): CheckpointManager => {
   return new CheckpointManager(
     context.durableExecutionArn,
@@ -19,5 +20,6 @@ export const createTestCheckpointManager = (
     new Set<string>(),
     {},
     "",
+    getRemainingTimeMs,
   );
 };

--- a/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/create-test-durable-context.ts
@@ -81,6 +81,7 @@ export function createTestDurableContext(options?: {
       return false;
     },
     requestId: "mock-request-id",
+    getRemainingTimeMs: (): number => Infinity,
     tenantId: undefined,
   };
 

--- a/packages/aws-durable-execution-sdk-js/src/testing/mock-checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/testing/mock-checkpoint-manager.ts
@@ -14,7 +14,7 @@ export class MockCheckpointManager extends CheckpointManager {
   public forceCheckpointCalls: number = 0;
   public setTerminatingCalls: number = 0;
 
-  constructor() {
+  constructor(getRemainingTimeMs: () => number = (): number => Infinity) {
     // Create a minimal mock - pass empty/mock values for required constructor params
     super(
       "mock-arn",
@@ -27,6 +27,7 @@ export class MockCheckpointManager extends CheckpointManager {
       new Set<string>(),
       {} as DurableInstrumentationPlugin,
       "mock-request-id",
+      getRemainingTimeMs,
     );
   }
 

--- a/packages/aws-durable-execution-sdk-js/src/types/core.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/core.ts
@@ -339,6 +339,15 @@ export interface ExecutionContext {
 
   requestId: string;
   tenantId: string | undefined;
+
+  /**
+   * How much longer the current invocation may run, in milliseconds.
+   *
+   * Reduced from the invocation context alongside `requestId` and `tenantId`, so that nothing
+   * downstream needs that context to answer it. Where no deadline is known, `Infinity`.
+   */
+  getRemainingTimeMs: () => number;
+
   pendingCompletions: Set<string>; // Track stepIds with pending SUCCEED/FAIL
   getStepData(stepId: string): Operation | undefined;
 

--- a/packages/aws-durable-execution-sdk-js/src/types/operation-lifecycle.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/operation-lifecycle.ts
@@ -24,5 +24,4 @@ export interface OperationInfo {
   timer?: NodeJS.Timeout;
   resolver?: () => void;
   pollCount?: number;
-  pollStartTime?: number;
 }

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-central-termination.test.ts
@@ -14,6 +14,8 @@ describe("CheckpointManager - Centralized Termination", () => {
   let mockTerminationManager: jest.Mocked<TerminationManager>;
   let mockClient: any;
   let mockStepDataEmitter: EventEmitter;
+  // Default: no deadline reported. Individual tests narrow this.
+  let mockRemainingTimeMs: number;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,6 +30,7 @@ describe("CheckpointManager - Centralized Termination", () => {
     };
 
     mockStepDataEmitter = new EventEmitter();
+    mockRemainingTimeMs = Infinity;
 
     checkpointManager = new CheckpointManager(
       "test-arn",
@@ -40,6 +43,7 @@ describe("CheckpointManager - Centralized Termination", () => {
       new Set<string>(),
       {},
       "",
+      () => mockRemainingTimeMs,
     );
   });
 
@@ -250,7 +254,6 @@ describe("CheckpointManager - Centralized Termination", () => {
           expect(op?.timer).toBeUndefined();
           expect(op?.resolver).toBeUndefined();
           expect(op?.pollCount).toBeUndefined();
-          expect(op?.pollStartTime).toBeUndefined();
 
           // Verify no timers were scheduled
           expect(jest.getTimerCount()).toBe(0);
@@ -294,7 +297,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeUndefined();
         expect(op?.resolver).toBeUndefined();
         expect(op?.pollCount).toBeUndefined();
-        expect(op?.pollStartTime).toBeUndefined();
 
         // Verify no timers were scheduled
         expect(jest.getTimerCount()).toBe(0);
@@ -335,7 +337,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -375,7 +376,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -420,7 +420,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -529,7 +528,6 @@ describe("CheckpointManager - Centralized Termination", () => {
           expect(op?.timer).toBeUndefined();
           expect(op?.resolver).toBeUndefined();
           expect(op?.pollCount).toBeUndefined();
-          expect(op?.pollStartTime).toBeUndefined();
 
           // Verify no timers were scheduled
           expect(jest.getTimerCount()).toBe(0);
@@ -573,7 +571,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeUndefined();
         expect(op?.resolver).toBeUndefined();
         expect(op?.pollCount).toBeUndefined();
-        expect(op?.pollStartTime).toBeUndefined();
 
         // Verify no timers were scheduled
         expect(jest.getTimerCount()).toBe(0);
@@ -613,7 +610,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -652,7 +648,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -696,7 +691,6 @@ describe("CheckpointManager - Centralized Termination", () => {
         expect(op?.timer).toBeDefined();
         expect(op?.resolver).toBeDefined();
         expect(op?.pollCount).toBe(0);
-        expect(op?.pollStartTime).toBeDefined();
 
         // Verify timer was scheduled
         expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -940,7 +934,6 @@ describe("CheckpointManager - Centralized Termination", () => {
       const ops = checkpointManager.getAllOperations();
       const op = ops.get("step-1");
       expect(op?.pollCount).toBe(0);
-      expect(op?.pollStartTime).toBeDefined();
     });
 
     it("should use endTimestamp for initial delay calculation", () => {
@@ -1436,11 +1429,18 @@ describe("CheckpointManager - Centralized Termination", () => {
     });
   });
 
-  describe("startTimerWithPolling - setTimeout overflow protection", () => {
-    it("should skip setTimeout when delay exceeds MAX_POLL_DURATION_MS", () => {
-      const stepId = "long-wait-step";
-
-      // Create operation in IDLE_AWAITED state
+  describe("startTimerWithPolling - invocation deadline and timer limits", () => {
+    /**
+     * Registers an awaited wait and returns a spy scoped to the poll timer.
+     *
+     * The spy has to be installed after markOperationState: that call schedules the
+     * termination cooldown (CHECKPOINT_TERMINATION_COOLDOWN_MS), which would otherwise be
+     * indistinguishable from the poll timer these tests are about.
+     */
+    const spyOnPollTimerFor = (
+      stepId: string,
+      waitEndsInMs: number,
+    ): jest.SpyInstance => {
       checkpointManager.markOperationState(
         stepId,
         OperationLifecycleState.IDLE_AWAITED,
@@ -1450,28 +1450,90 @@ describe("CheckpointManager - Centralized Termination", () => {
             type: OperationType.WAIT,
             subType: OperationSubType.WAIT,
           },
-          // Set endTimestamp to 364 days in the future (exceeds MAX_POLL_DURATION_MS)
-          endTimestamp: new Date(Date.now() + 364 * 24 * 60 * 60 * 1000),
+          endTimestamp: new Date(Date.now() + waitEndsInMs),
         },
       );
 
-      // Spy on setTimeout to verify it's not called
-      const setTimeoutSpy = jest.spyOn(global, "setTimeout");
-
-      // Call waitForStatusChange which internally calls startTimerWithPolling
+      const spy = jest.spyOn(global, "setTimeout");
       checkpointManager.waitForStatusChange(stepId);
+      return spy;
+    };
 
-      // Verify setTimeout was NOT called
+    it("skips the timer when the wait outlasts the invocation", () => {
+      // The timer could not fire, so the execution should suspend and resume later
+      // instead. This is the case the removed hard-coded cap approximated.
+      mockRemainingTimeMs = 60_000;
+
+      const setTimeoutSpy = spyOnPollTimerFor(
+        "outlasts-invocation",
+        5 * 60 * 1000,
+      );
+
       expect(setTimeoutSpy).not.toHaveBeenCalled();
-
       setTimeoutSpy.mockRestore();
     });
 
-    it("should use setTimeout when delay is within MAX_POLL_DURATION_MS", () => {
-      const stepId = "short-wait-step";
-      const shortDelay = 5 * 60 * 1000; // 5 minutes
+    it("schedules a timer beyond the removed bound when the invocation allows it", () => {
+      // The point of the change: the ceiling is now the deadline the invocation reports, so
+      // this wait is awaited in-invocation when the reported time allows it. Under the
+      // removed hard-coded cap it was skipped regardless.
+      mockRemainingTimeMs = 60 * 60 * 1000;
+      const thirtyMinutes = 30 * 60 * 1000;
 
-      // Create operation in IDLE_AWAITED state
+      const setTimeoutSpy = spyOnPollTimerFor(
+        "within-long-invocation",
+        thirtyMinutes,
+      );
+
+      expect(setTimeoutSpy).toHaveBeenCalled();
+      const scheduledDelay = setTimeoutSpy.mock.calls[0][1] as number;
+      expect(scheduledDelay).toBeGreaterThan(15 * 60 * 1000);
+      expect(scheduledDelay).toBeLessThanOrEqual(thirtyMinutes);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it("skips the timer when the delay exceeds what setTimeout can represent", () => {
+      // A compute with no deadline reports Infinity, so the invocation is no longer what
+      // bounds this -- without the explicit clamp Node would set the duration to 1 and fire
+      // almost immediately, turning a 60-day wait into a poll loop.
+      mockRemainingTimeMs = Infinity;
+
+      const setTimeoutSpy = spyOnPollTimerFor(
+        "beyond-timer-range",
+        60 * 24 * 60 * 60 * 1000,
+      );
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      setTimeoutSpy.mockRestore();
+    });
+
+    // The poll loop itself: when a timer fires, whether another poll is worth starting is
+    // decided by the invocation's remaining time rather than a fixed budget measured from
+    // the first poll. The timer is scheduled with the default (no deadline) and the
+    // remaining time is set just before it fires, which models an invocation running down
+    // and keeps this independent of the scheduling guard above. forceCheckpoint is stubbed
+    // because a real one would bring in the checkpoint queue and the termination cooldown,
+    // neither of which these tests are about.
+    const runPollWithRemaining = async (
+      stepId: string,
+      remainingTimeMs: number,
+    ): Promise<jest.SpyInstance> => {
+      // Polling only matters while the invocation is alive for some other reason: a lone
+      // awaited wait makes shouldTerminate suspend after the cooldown, which clears the poll
+      // timer before it can fire. A concurrently EXECUTING operation blocks termination
+      // (Rule 4), which is the situation in which polling does the work.
+      checkpointManager.markOperationState(
+        `${stepId}-concurrent`,
+        OperationLifecycleState.EXECUTING,
+        {
+          metadata: {
+            stepId: `${stepId}-concurrent`,
+            type: OperationType.STEP,
+            subType: OperationSubType.STEP,
+          },
+        },
+      );
+
       checkpointManager.markOperationState(
         stepId,
         OperationLifecycleState.IDLE_AWAITED,
@@ -1481,28 +1543,290 @@ describe("CheckpointManager - Centralized Termination", () => {
             type: OperationType.WAIT,
             subType: OperationSubType.WAIT,
           },
-          // Set endTimestamp to 5 minutes in the future
-          endTimestamp: new Date(Date.now() + shortDelay),
+          endTimestamp: new Date(Date.now() + 1000),
         },
       );
 
-      // Spy on setTimeout to capture the delay value
-      const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+      const forceCheckpointSpy = jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockResolvedValue();
 
-      // Call waitForStatusChange which internally calls startTimerWithPolling
       checkpointManager.waitForStatusChange(stepId);
 
-      // Verify setTimeout was called with original delay (within tolerance)
-      expect(setTimeoutSpy).toHaveBeenCalledWith(
-        expect.any(Function),
-        expect.any(Number),
+      mockRemainingTimeMs = remainingTimeMs;
+      await jest.advanceTimersByTimeAsync(1000);
+
+      return forceCheckpointSpy;
+    };
+
+    it("polls while the invocation still has time left", async () => {
+      const forceCheckpointSpy = await runPollWithRemaining(
+        "time-remaining",
+        60_000,
       );
 
-      const actualDelay = setTimeoutSpy.mock.calls[0][1] as number;
-      expect(actualDelay).toBeLessThanOrEqual(shortDelay);
-      expect(actualDelay).toBeGreaterThan(shortDelay - 1000); // Allow 1s tolerance
+      expect(forceCheckpointSpy).toHaveBeenCalled();
+    });
 
+    it("keeps polling long after the removed bound would have stopped", async () => {
+      // The headline behaviour change, and the reason elapsed polling time is no longer
+      // tracked: the removed budget stopped a loop after a fixed elapsed duration regardless
+      // of how much invocation was left. Polling long enough to cross that duration is what
+      // distinguishes this from the test above.
+      mockRemainingTimeMs = 60 * 60 * 1000;
+      const stepId = "past-old-budget";
+
+      checkpointManager.markOperationState(
+        `${stepId}-concurrent`,
+        OperationLifecycleState.EXECUTING,
+        {
+          metadata: {
+            stepId: `${stepId}-concurrent`,
+            type: OperationType.STEP,
+            subType: OperationSubType.STEP,
+          },
+        },
+      );
+      checkpointManager.markOperationState(
+        stepId,
+        OperationLifecycleState.IDLE_AWAITED,
+        {
+          metadata: {
+            stepId,
+            type: OperationType.WAIT,
+            subType: OperationSubType.WAIT,
+          },
+          endTimestamp: new Date(Date.now() + 1000),
+        },
+      );
+
+      const forceCheckpointSpy = jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockResolvedValue();
+
+      checkpointManager.waitForStatusChange(stepId);
+
+      await jest.advanceTimersByTimeAsync(16 * 60 * 1000);
+      const pollsInFirst16Minutes = forceCheckpointSpy.mock.calls.length;
+
+      forceCheckpointSpy.mockClear();
+      await jest.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(pollsInFirst16Minutes).toBeGreaterThan(0);
+      expect(forceCheckpointSpy).toHaveBeenCalled();
+    });
+
+    it("resolves the waiting promise once the status changes", async () => {
+      // The success path polling exists for: a status change observed by a poll releases the
+      // handler. Previously uncovered.
+      mockRemainingTimeMs = 60_000;
+      const stepId = "status-changes";
+
+      checkpointManager.markOperationState(
+        `${stepId}-concurrent`,
+        OperationLifecycleState.EXECUTING,
+        {
+          metadata: {
+            stepId: `${stepId}-concurrent`,
+            type: OperationType.STEP,
+            subType: OperationSubType.STEP,
+          },
+        },
+      );
+      checkpointManager.markOperationState(
+        stepId,
+        OperationLifecycleState.IDLE_AWAITED,
+        {
+          metadata: {
+            stepId,
+            type: OperationType.WAIT,
+            subType: OperationSubType.WAIT,
+          },
+          endTimestamp: new Date(Date.now() + 1000),
+        },
+      );
+
+      // Stand in for the backend reporting completion on the next refresh.
+      jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockImplementation(async () => {
+          (checkpointManager as any).stepData[hashId(stepId)] = {
+            Status: "SUCCEEDED",
+          };
+        });
+
+      let resolved = false;
+      void checkpointManager.waitForStatusChange(stepId).then(() => {
+        resolved = true;
+      });
+
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(resolved).toBe(true);
+      const op = checkpointManager.getAllOperations().get(stepId);
+      expect(op?.timer).toBeUndefined();
+    });
+
+    it("stops polling once too little invocation time remains", async () => {
+      // Below MIN_REMAINING_TIME_TO_POLL_MS: not enough left to receive a result and act on
+      // it, so the timer is cleared and the promise is left unresolved for suspension.
+      const forceCheckpointSpy = await runPollWithRemaining(
+        "deadline-imminent",
+        500,
+      );
+
+      expect(forceCheckpointSpy).not.toHaveBeenCalled();
+      const op = checkpointManager.getAllOperations().get("deadline-imminent");
+      expect(op?.timer).toBeUndefined();
+    });
+
+    it("schedules a timer with no deadline when the delay is representable", () => {
+      mockRemainingTimeMs = Infinity;
+      const fiveMinutes = 5 * 60 * 1000;
+
+      const setTimeoutSpy = spyOnPollTimerFor(
+        "no-deadline-short-wait",
+        fiveMinutes,
+      );
+
+      expect(setTimeoutSpy).toHaveBeenCalled();
+      expect(setTimeoutSpy.mock.calls[0][1]).toBeLessThanOrEqual(fiveMinutes);
       setTimeoutSpy.mockRestore();
+    });
+  });
+
+  describe("dispose", () => {
+    const armPollTimerFor = (
+      stepId: string,
+      manager = checkpointManager,
+    ): void => {
+      manager.markOperationState(
+        `${stepId}-concurrent`,
+        OperationLifecycleState.EXECUTING,
+        {
+          metadata: {
+            stepId: `${stepId}-concurrent`,
+            type: OperationType.STEP,
+            subType: OperationSubType.STEP,
+          },
+        },
+      );
+      manager.markOperationState(stepId, OperationLifecycleState.IDLE_AWAITED, {
+        metadata: {
+          stepId,
+          type: OperationType.WAIT,
+          subType: OperationSubType.WAIT,
+        },
+        endTimestamp: new Date(Date.now() + 1000),
+      });
+      manager.waitForStatusChange(stepId);
+    };
+
+    it("clears armed timers so they cannot fire into a later invocation", async () => {
+      // The gap this closes: a handler completing normally never terminates, so nothing
+      // else clears its timers.
+      const forceCheckpointSpy = jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockResolvedValue();
+      armPollTimerFor("armed-then-disposed");
+
+      expect(
+        checkpointManager.getAllOperations().get("armed-then-disposed")?.timer,
+      ).toBeDefined();
+
+      checkpointManager.dispose();
+
+      expect(
+        checkpointManager.getAllOperations().get("armed-then-disposed")?.timer,
+      ).toBeUndefined();
+      await jest.advanceTimersByTimeAsync(60_000);
+      expect(forceCheckpointSpy).not.toHaveBeenCalled();
+    });
+
+    it("refuses to arm new timers once disposed", async () => {
+      const forceCheckpointSpy = jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockResolvedValue();
+
+      checkpointManager.dispose();
+      armPollTimerFor("armed-after-disposal");
+
+      expect(
+        checkpointManager.getAllOperations().get("armed-after-disposal")?.timer,
+      ).toBeUndefined();
+      await jest.advanceTimersByTimeAsync(60_000);
+      expect(forceCheckpointSpy).not.toHaveBeenCalled();
+    });
+
+    it("cancels a scheduled termination", async () => {
+      // A lone awaited wait schedules termination after the cooldown. If the invocation ends
+      // first, that timer would otherwise fire and terminate an invocation that is already
+      // over.
+      checkpointManager.markOperationState(
+        "lone-wait",
+        OperationLifecycleState.IDLE_AWAITED,
+        {
+          metadata: {
+            stepId: "lone-wait",
+            type: OperationType.WAIT,
+            subType: OperationSubType.WAIT,
+          },
+        },
+      );
+
+      checkpointManager.dispose();
+      await jest.advanceTimersByTimeAsync(
+        CHECKPOINT_TERMINATION_COOLDOWN_MS * 5,
+      );
+
+      expect(mockTerminationManager.terminate).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent", () => {
+      checkpointManager.dispose();
+      expect(() => checkpointManager.dispose()).not.toThrow();
+    });
+
+    it("keeps polling when a second execution starts in the same process", async () => {
+      // The reason this is per-manager state rather than a module-level "current
+      // invocation" marker. A process-wide marker identifies the newest invocation, so a
+      // second execution starting would make the first one's manager stale: it would stop
+      // polling and stop arming timers while its operation stayed awaited with an
+      // unresolved resolver -- a hang. Executions already run concurrently in one process:
+      // the local test runner's factory creates nested runners for exactly that. This is not
+      // reachable through a single deployed invocation, which is why it needs a test rather
+      // than review vigilance.
+      const firstForceCheckpoint = jest
+        .spyOn(checkpointManager, "forceCheckpoint")
+        .mockResolvedValue();
+      armPollTimerFor("first-execution");
+
+      // A second execution begins while the first is still live.
+      const secondManager = new CheckpointManager(
+        "second-arn",
+        {},
+        mockClient,
+        mockTerminationManager,
+        "second-token",
+        new EventEmitter(),
+        {} as never,
+        new Set<string>(),
+        {},
+        "",
+        () => mockRemainingTimeMs,
+      );
+      armPollTimerFor("second-execution", secondManager);
+
+      // The first execution must be unaffected, both by the second starting...
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(firstForceCheckpoint).toHaveBeenCalled();
+
+      // ...and by it finishing.
+      firstForceCheckpoint.mockClear();
+      secondManager.dispose();
+      armPollTimerFor("first-execution-again");
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(firstForceCheckpoint).toHaveBeenCalled();
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-composed.test.ts
@@ -58,6 +58,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint = (stepId: string, data: any): Promise<any> =>
       checkpointManager.checkpoint(stepId, data);
@@ -97,6 +98,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint = (stepId: string, data: any): Promise<any> =>
       checkpointManager.checkpoint(stepId, data);
@@ -185,6 +187,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint = (stepId: string, data: any): Promise<any> =>
       checkpointManager.checkpoint(stepId, data);
@@ -226,6 +229,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint = (stepId: string, data: any): Promise<any> =>
       checkpointManager.checkpoint(stepId, data);
@@ -280,6 +284,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint1 = (stepId: string, data: any): Promise<any> =>
       checkpointManager1.checkpoint(stepId, data);
@@ -295,6 +300,7 @@ describe("Checkpoint Integration Tests", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
     const checkpoint2 = (stepId: string, data: any): Promise<any> =>
       checkpointManager2.checkpoint(stepId, data);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -24,7 +24,12 @@ import { DurableLogger } from "../../types/durable-logger";
 import { Checkpoint } from "./checkpoint-helper";
 import {
   CHECKPOINT_TERMINATION_COOLDOWN_MS,
-  MAX_POLL_DURATION_MS,
+  MAX_TIMER_DELAY_MS,
+  MIN_REMAINING_TIME_TO_POLL_MS,
+  INITIAL_POLL_DELAY_MS,
+  POLL_INTERVAL_CEILING_MS,
+  EXTENDED_POLL_INTERVAL_CEILING_MS,
+  POLLS_BEFORE_EXTENDED_INTERVAL,
 } from "../constants/constants";
 import {
   OperationInfo,
@@ -70,6 +75,7 @@ export class CheckpointManager implements Checkpoint {
   private readonly MAX_PAYLOAD_SIZE = 750 * 1024; // 750KB in bytes
   private readonly MAX_ITEMS_IN_BATCH = 250;
   private isTerminating = false;
+  private disposed = false;
 
   // Operation lifecycle tracking
   private operations = new Map<string, OperationInfo>();
@@ -92,6 +98,14 @@ export class CheckpointManager implements Checkpoint {
     private finishedAncestors: Set<string>,
     private plugin: DurableInstrumentationPlugin,
     private requestId: string,
+    /**
+     * How much longer the current invocation may run, in milliseconds.
+     *
+     * Deliberately a plain function rather than an invocation context: the caller supplies
+     * `() => context.getRemainingTimeInMillis()`, and where no deadline is known,
+     * `() => Infinity`. Nothing below this constructor needs the platform type to answer it.
+     */
+    private getRemainingTimeMs: () => number,
   ) {
     this.currentTaskToken = initialTaskToken;
   }
@@ -99,6 +113,43 @@ export class CheckpointManager implements Checkpoint {
   setTerminating(): void {
     this.isTerminating = true;
     log("🛑", "Checkpoint manager marked as terminating");
+  }
+
+  /**
+   * Releases everything this manager armed, and refuses to arm anything further.
+   *
+   * Timers outlive the invocation that armed them. Nothing else clears them on the normal
+   * path: cleanupAllOperations is only reached through executeTermination, and
+   * setTerminating merely sets a flag, so a handler that completes without suspending
+   * returns with its poll timers still pending. In a reused execution environment those
+   * fire during a later invocation and checkpoint against a task token that has since been
+   * replaced. Bounding timers by the reported deadline narrows this but cannot close it: a
+   * timer armed for five minutes is legitimate right up until the handler returns after ten
+   * seconds, and where no deadline is reported a timer can be armed for as long as
+   * MAX_TIMER_DELAY_MS allows.
+   *
+   * Deliberately per-manager rather than a module-level "current invocation" marker. A
+   * process-wide marker identifies the newest invocation rather than a particular execution,
+   * and executions already run concurrently in one process -- the local test runner's factory
+   * creates nested runners for exactly that. Such a marker would make an earlier execution's
+   * manager stale, silently stopping its polling while leaving its operations awaited and
+   * unresolved. State on the manager cannot conflate two executions, because each invocation
+   * has its own.
+   *
+   * Idempotent.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    if (this.terminationTimer) {
+      clearTimeout(this.terminationTimer);
+      this.terminationTimer = null;
+      this.terminationReason = null;
+    }
+
+    this.cleanupAllOperations();
+    log("🧹", "Checkpoint manager disposed");
   }
 
   /**
@@ -852,6 +903,9 @@ export class CheckpointManager implements Checkpoint {
   }
 
   private startTimerWithPolling(stepId: string, endTimestamp?: Date): void {
+    // This manager's invocation is over; a timer armed now could only fire into a later one.
+    if (this.disposed) return;
+
     const op = this.operations.get(stepId);
     if (!op) return;
 
@@ -863,21 +917,33 @@ export class CheckpointManager implements Checkpoint {
         endTimestamp instanceof Date ? endTimestamp : new Date(endTimestamp);
       // Wait until endTimestamp
       delay = Math.max(0, timestamp.getTime() - Date.now());
-
-      // Skip setTimeout if delay exceeds MAX_POLL_DURATION_MS (Lambda will timeout before it fires)
-      if (delay > MAX_POLL_DURATION_MS) {
-        return;
-      }
     } else {
-      // No timestamp, start polling immediately (1 second delay)
-      delay = 1000;
+      // No known end time, so poll promptly instead of waiting for one.
+      delay = INITIAL_POLL_DELAY_MS;
     }
 
-    // Initialize poll count and start time for this operation
-    if (!op.pollCount) {
-      op.pollCount = 0;
-      op.pollStartTime = Date.now();
+    // Don't schedule a timer that cannot usefully fire, for either of two reasons: the
+    // invocation ends before the wait does, in which case the execution should suspend and
+    // resume later instead of holding this timer; or the delay is larger than setTimeout can
+    // represent, in which case Node would fire it almost immediately. Leaving the timer
+    // unscheduled leaves the operation's promise unresolved, which is what lets central
+    // termination suspend the execution.
+    //
+    // MIN_REMAINING_TIME_TO_POLL_MS is subtracted so this agrees with what the poll loop
+    // will accept: without it, a wait ending in the final moments of the invocation would
+    // get a timer that forceRefreshAndCheckStatus is guaranteed to refuse the instant it
+    // fires. The guard covers both branches above -- an operation with no end time used to
+    // be the one path that ignored the deadline entirely.
+    const schedulableDelayMs = Math.min(
+      this.getRemainingTimeMs() - MIN_REMAINING_TIME_TO_POLL_MS,
+      MAX_TIMER_DELAY_MS,
+    );
+    if (delay > schedulableDelayMs) {
+      return;
     }
+
+    // Initialize poll count for this operation (drives the backoff below)
+    op.pollCount ??= 0;
 
     op.timer = setTimeout(() => {
       this.forceRefreshAndCheckStatus(stepId);
@@ -885,21 +951,23 @@ export class CheckpointManager implements Checkpoint {
   }
 
   private async forceRefreshAndCheckStatus(stepId: string): Promise<void> {
+    // Belt and braces: dispose clears armed timers, so reaching here after disposal means a
+    // callback was already queued. Checkpointing now would use a replaced task token.
+    if (this.disposed) return;
+
     const op = this.operations.get(stepId);
     if (!op) return;
 
-    // Check if we've exceeded max polling duration (15 minutes)
-    if (
-      op.pollStartTime &&
-      Date.now() - op.pollStartTime > MAX_POLL_DURATION_MS
-    ) {
-      // Stop polling after 15 minutes to prevent indefinite resource consumption.
-      // We don't resolve or reject the promise because the handler cannot continue
-      // without a status change. The execution will remain suspended until the
-      // operation completes or the Lambda times out.
+    // Stop polling once the invocation has too little time left to act on a result. We
+    // don't resolve or reject the promise because the handler cannot continue without a
+    // status change; the execution stays suspended until the operation completes or the
+    // invocation ends. A compute with no deadline reports Infinity and so keeps polling at
+    // the backoff interval below, which is the only way it can observe completion.
+    const remainingTimeMs = this.getRemainingTimeMs();
+    if (remainingTimeMs < MIN_REMAINING_TIME_TO_POLL_MS) {
       log(
         "⏱️",
-        `Max polling duration (15 min) exceeded for ${stepId}, stopping poll`,
+        `Only ${remainingTimeMs}ms left in this invocation, stopping poll for ${stepId}`,
       );
       if (op.timer) {
         clearTimeout(op.timer);
@@ -933,7 +1001,15 @@ export class CheckpointManager implements Checkpoint {
       // Status not changed yet, poll again with incremental backoff
       // Start at 1s, increase by 1s each poll, max 10s
       op.pollCount = (op.pollCount || 0) + 1;
-      const nextDelay = Math.min(op.pollCount * 1000, 10000);
+      // Widen the interval once this loop has run long enough that the operation is
+      // evidently not about to complete. The removed budget doubled as a cap on checkpoint
+      // calls; bounding by the reported deadline removes it, and where no deadline is
+      // reported there is nothing to bound it at all.
+      const intervalCeilingMs =
+        op.pollCount > POLLS_BEFORE_EXTENDED_INTERVAL
+          ? EXTENDED_POLL_INTERVAL_CEILING_MS
+          : POLL_INTERVAL_CEILING_MS;
+      const nextDelay = Math.min(op.pollCount * 1000, intervalCeilingMs);
 
       op.timer = setTimeout(() => {
         this.forceRefreshAndCheckStatus(stepId);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-queue-completion.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-queue-completion.test.ts
@@ -32,6 +32,7 @@ describe("CheckpointManager Queue Completion", () => {
       new Set<string>(),
       {},
       "",
+      () => Infinity,
     );
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-stepdata-update.test.ts
@@ -48,6 +48,7 @@ describe("CheckpointManager - StepData Update", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     };
 
     mockLogger = createDefaultLogger(mockContext);

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-termination.test.ts
@@ -38,6 +38,7 @@ describe("CheckpointManager Termination Behavior", () => {
       getStepData: jest.fn(),
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
+      getRemainingTimeMs: (): number => Infinity,
       tenantId: "",
       pendingCompletions: new Set(),
     } satisfies ExecutionContext;

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint.test.ts
@@ -36,6 +36,7 @@ const createCheckpoint = (
     new Set<string>(),
     {},
     "",
+    () => Infinity,
   );
   const checkpoint = (stepId: string, data: any): Promise<any> =>
     manager.checkpoint(stepId, data);
@@ -86,6 +87,7 @@ describe("CheckpointManager", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
     mockLogger = createDefaultLogger(mockContext);
 
@@ -757,6 +759,7 @@ describe("deleteCheckpointHandler", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
 
     const stepData2 = {};
@@ -772,6 +775,7 @@ describe("deleteCheckpointHandler", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
 
     mockLogger1 = createDefaultLogger(mockContext1);
@@ -1039,6 +1043,7 @@ describe("createCheckpointHandler", () => {
       isOperationUpdatedBetweenInvocation: jest.fn().mockReturnValue(false),
       requestId: "mock-request-id",
       tenantId: undefined,
+      getRemainingTimeMs: (): number => Infinity,
     } satisfies ExecutionContext;
     mockLogger = createDefaultLogger(mockContext);
   });

--- a/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/constants/constants.ts
@@ -16,11 +16,52 @@ export const STORE_STACK_TRACES = false;
 export const CHECKPOINT_TERMINATION_COOLDOWN_MS = 20;
 
 /**
- * Maximum polling duration in milliseconds (15 minutes)
- * Used to cap setTimeout delays to prevent 32-bit signed integer overflow
- * and limit polling duration for long-running operations
+ * Largest delay `setTimeout` can represent, in milliseconds (~24.9 days).
+ *
+ * Node does not clamp a delay above this. It emits a TimeoutOverflowWarning and sets the
+ * duration to 1 instead, so an unclamped long wait would fire a poll almost immediately and
+ * then keep polling for the rest of the invocation. This is a Node limit rather than a
+ * property of the compute, so it applies no matter how long an invocation may run -- and it
+ * is reachable, since a compute with no deadline reports `Infinity` as its remaining time.
  */
-export const MAX_POLL_DURATION_MS = 15 * 60 * 1000;
+export const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+/**
+ * Remaining invocation time, in milliseconds, below which starting another poll is not
+ * worthwhile: a poll costs a checkpoint round trip, and there has to be enough time left to
+ * receive the result and act on it.
+ *
+ * This replaces a hard-coded polling budget measured from the first poll, which was unrelated
+ * to any particular function's configured timeout: it stopped polling while an invocation may
+ * still have had time to run, leaving the operation unobserved until suspension took over.
+ *
+ * The value is a floor, not a measurement: it is not derived from observed checkpoint
+ * latency, and it should be revisited against real p99 data. Anything larger simply stops
+ * polling earlier.
+ */
+export const MIN_REMAINING_TIME_TO_POLL_MS = 1000;
+
+/** Delay before the first poll of an operation with no known end time. */
+export const INITIAL_POLL_DELAY_MS = 1000;
+
+/**
+ * Ceiling on the polling backoff interval, in milliseconds, and the point at which that
+ * ceiling is raised.
+ *
+ * Polling is bounded in rate rather than in total duration. The hard-coded budget this
+ * replaced also acted, accidentally, as a cap on service calls: it ended any poll loop after
+ * roughly {@link POLLS_BEFORE_EXTENDED_INTERVAL} checkpoint calls regardless of the
+ * invocation. Bounding by the reported deadline removes that cap, and where no deadline is
+ * reported there is nothing to bound it at all.
+ *
+ * The interval therefore widens once a loop has run long enough that the operation is
+ * evidently not about to complete, at which point call volume matters more than observing it
+ * a few seconds sooner. Anything completing before that point is unaffected, since the
+ * interval below the escalation point is unchanged.
+ */
+export const POLL_INTERVAL_CEILING_MS = 10_000;
+export const EXTENDED_POLL_INTERVAL_CEILING_MS = 60_000;
+export const POLLS_BEFORE_EXTENDED_INTERVAL = 95;
 
 /**
  * Maximum checkpoint payload size in bytes (256KB).

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
   (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
     checkpoint: jest.fn().mockResolvedValue(undefined),
     setTerminating: jest.fn(),
+    dispose: jest.fn(),
     waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
   }));
   mockTerminationManager.getTerminationPromise.mockReturnValue(

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -80,6 +80,7 @@ describe("withDurableExecution", () => {
     (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
       checkpoint: jest.fn().mockResolvedValue(undefined),
       setTerminating: jest.fn(),
+      dispose: jest.fn(),
       waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
     }));
 
@@ -89,6 +90,47 @@ describe("withDurableExecution", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("disposes the checkpoint manager on the normal-completion path", async () => {
+    // The path that never terminates, and therefore never reached any cleanup before:
+    // without disposal the invocation returns with its poll timers still armed.
+    const dispose = jest.fn();
+    (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
+      checkpoint: jest.fn().mockResolvedValue(undefined),
+      setTerminating: jest.fn(),
+      dispose,
+      waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockTerminationManager.getTerminationPromise.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    await withDurableExecution(jest.fn().mockResolvedValue({ ok: true }))(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(dispose).toHaveBeenCalled();
+  });
+
+  it("disposes the checkpoint manager when the handler throws", async () => {
+    const dispose = jest.fn();
+    (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
+      checkpoint: jest.fn().mockResolvedValue(undefined),
+      setTerminating: jest.fn(),
+      dispose,
+      waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+    }));
+    mockTerminationManager.getTerminationPromise.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    await withDurableExecution(
+      jest.fn().mockRejectedValue(new Error("handler blew up")),
+    )(mockEvent, mockContext);
+
+    expect(dispose).toHaveBeenCalled();
   });
 
   it("should return successful response when handler completes normally", async () => {
@@ -408,6 +450,7 @@ describe("withDurableExecution", () => {
     (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
       checkpoint: jest.fn().mockRejectedValue(checkpointError),
       setTerminating: jest.fn(),
+      dispose: jest.fn(),
     }));
 
     mockTerminationManager.getTerminationPromise.mockReturnValue(

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -79,6 +79,7 @@ async function runHandler<
     new Set<string>(),
     plugin,
     executionContext.requestId,
+    executionContext.getRemainingTimeMs,
   );
 
   // Extract customerHandlerEvent early so it's available for plugins in onInvocationStart
@@ -447,10 +448,15 @@ async function runHandler<
       }
     };
 
-  return (
-    plugin.wrapInvocation?.(invocationInfo, executeInvocation) ??
-    executeInvocation()
-  );
+  try {
+    return await (plugin.wrapInvocation?.(invocationInfo, executeInvocation) ??
+      executeInvocation());
+  } finally {
+    // Every exit from the invocation funnels through here, including the normal-completion
+    // path that never terminates. Without this, poll timers stay armed after the handler
+    // returns and can fire during a later invocation in a reused execution environment.
+    checkpointManager.dispose();
+  }
 }
 
 /**


### PR DESCRIPTION
`MAX_POLL_DURATION_MS` was one hard-coded duration serving three unrelated purposes, and
  a fixed duration cannot be right for every function. It exceeded many configured timeouts,
  so it armed timers that could not fire and kept polling past the point where an invocation
  could still act on a result. The runtime already reports how much time an invocation has
  left, so that is used instead.

  Separating the three purposes turned up a latent trap and two gaps.

  ## The trap

  The old docblock mentioned 32-bit overflow, but the removed constant was what actually
  prevented it. `setTimeout` does not clamp a delay above `2**31 - 1` (~24.9 days) — Node
  emits `TimeoutOverflowWarning` and sets the duration to `1`, firing almost immediately.
  Measured directly: a delay of `2**31` fired after 3 ms.

  Once the bound is no longer a fixed duration, a long wait would silently become an
  immediate poll followed by a backoff loop for the rest of the invocation.
  `MAX_TIMER_DELAY_MS` is now an explicit guard, and it is a Node limit rather than anything
  platform-specific.

  ## Gap 1: the polling bound ignored the actual deadline

  Polling was bounded by elapsed time since the first poll, tracked in `op.pollStartTime`,
  which is unrelated to how much time the invocation actually has. It is now bounded by the
  reported remaining time. `pollStartTime` is removed, since it existed only to serve the old
  bound; `pollCount` stays, as it drives the backoff.

  ## Gap 2: the two thresholds disagreed

  Scheduling admitted any `delay <= remaining` while the poll loop refused to poll below
  `MIN_REMAINING_TIME_TO_POLL_MS`, so a wait ending in the final moments of an invocation got
  a timer that was guaranteed to be refused the instant it fired. Scheduling now subtracts
  the same threshold, and the guard covers the no-`endTimestamp` branch, previously the only
  path that ignored the deadline.

  ## Reading the deadline

  `ExecutionContext` gains `getRemainingTimeMs`, reduced from the invocation context in the
  same place as `requestId` and `tenantId`, so that context is read in one place.
  `CheckpointManager` receives the function and never sees the platform type. A test asserts
  it delegates on each call rather than capturing a value, since the number changes over the
  life of an invocation. Where no deadline is known, `Infinity` is supplied — the case the
  overflow guard above exists for.

  ## Poll rate is bounded deliberately

  The removed bound also acted as an accidental cap on service calls. Every poll is a real
  round trip — `processQueue` proceeds when `forceCheckpointPromises` is non-empty even with
  an empty batch — so it ended any poll loop after roughly 95 checkpoint calls. Bounding by
  the reported deadline removes that cap, and where no deadline is reported there is nothing
  to bound it at all.

  Polling is therefore bounded in **rate** rather than duration: the backoff ceiling widens
  from 10s to 60s once a loop passes ~95 polls, at which point the operation is evidently not
  about to complete and call volume matters more than observing it a few seconds sooner.
  Anything completing before that point is unaffected, since the interval below the escalation
  point is unchanged — deliberately, so this does not trade observation latency for call
  volume in the common case.

  A loop with no reported deadline remains unbounded in total. That is a trade-off rather than
  an oversight: an operation that is genuinely pending has to keep being observed, and
  stopping would restore Gap 1.

  ## Timers outliving their invocation

  Nothing cleared poll timers on the normal path. `cleanupAllOperations` is reachable only
  from `executeTermination`, and `setTerminating` merely sets a flag, so a handler completing
  without suspending returned with its timers still pending — four return paths, none of them
  clearing anything. In a reused execution environment those fire during a later invocation
  and checkpoint against a task token that has since been replaced.

  Bounding timers by the reported deadline narrows this but cannot close it: a five-minute
  timer is legitimate right up until the handler returns after ten seconds, and where no
  deadline is reported a timer can be armed for as long as `MAX_TIMER_DELAY_MS` allows.

  `CheckpointManager.dispose()` clears armed timers, cancels a scheduled termination, and
  refuses to arm anything further. It is called from a `finally` around `runHandler`'s single
  exit funnel, so it covers normal completion, suspension and thrown errors alike.

  **Per-manager state, not a module-level marker.** A process-wide marker for "the current
  invocation" identifies the newest one rather than a particular execution, and executions
  already run concurrently in one process — the local test runner's factory creates nested
  runners for exactly that. Such a marker would make an earlier execution's manager stale,
  silently stopping its polling while leaving its operations awaited with unresolved
  resolvers. Demonstrated rather than argued: the isolation test added here fails when the
  guard is reimplemented as a module-global counter and passes with per-manager state.

  ## Cost and blast radius

  Billed invocation duration is unaffected, which is worth stating because longer timers look
  like they should hold compute open. Suspension is governed by `shouldTerminate`, whose Rule
  4 blocks termination only while an operation is `EXECUTING`, on a 20 ms cooldown. A lone
  awaited wait suspends and the timer dies with the sandbox. Polling only matters while the
  invocation is alive for another reason, so a longer timer cannot extend an invocation that
  would otherwise have ended.

  **No public API change.** `MAX_POLL_DURATION_MS`, `pollStartTime`, `ExecutionContext` and
  `CheckpointManager` are all absent from the API reports, which are unchanged.

  ## Testing

  The two tests that pinned the old constant asserted one thing about one number. They are
  replaced by tests for:

  - each distinct reason a timer is refused — the wait outlasting the invocation, and the
    delay exceeding what `setTimeout` can represent
  - a wait scheduled beyond the removed bound when the reported deadline allows it
  - the removal of the elapsed-time bound, by polling long enough to cross it
  - the success path polling exists for: a status change releasing the handler
  - disposal, including that the wiring calls it on both the normal-completion and
    thrown-error paths

  Each was verified non-vacuous by restoring the old behaviour and confirming it fails.

  `checkpoint-manager.ts` coverage: **87.12% → 94.0%** statements, **86.5% → 93.02%**
  branches. The poll loop previously had none.

  Two details are recorded in the test file because they cost time: the `setTimeout` spy has
  to be installed after `markOperationState`, or the termination cooldown's own timer is
  indistinguishable from the poll timer; and driving the poll loop needs a concurrently
  `EXECUTING` operation, or termination suspends the execution and clears the timer before it
  fires — the same property that makes the cost argument above hold.

  Of the 23 files touched, 10 are source; most of the rest is one added constructor argument
  threaded through test call sites.

  ## Known gaps

  - `MIN_REMAINING_TIME_TO_POLL_MS` (1000) is a floor, not a measurement. It is not derived
    from observed checkpoint latency and should be revisited against real data.
  - The local test runner's fake context returns a constant, so the deadline never elapses
    there: scheduling behaves as before, but the stop-polling condition cannot trigger locally
    and a local poll loop is bounded only by the backoff ceiling. Documented in place. Making
    it count down would let operations stall in runs that advance fake timers themselves, so
    that is a deliberate behaviour change rather than a fix.
  - `CheckpointManager` now takes 12 positional constructor arguments. Converting it to an
    options object is worth doing separately.


Fixes: #794 