### PR TITLE
Add hook-info field-shape conformance handlers

### DIFF
--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_info_shape.ts
@@ -1,4 +1,4 @@
-// 10-21: Attempt hook info field shape (interface-shape probe)
+// 10-21: Attempt hook info field shape (canonical dump)
 import {
   DurableContext,
   withDurableExecution,
@@ -16,14 +16,45 @@ function isStep(type?: string): boolean {
   return (type || "").toUpperCase() === "STEP";
 }
 
-// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
-// info parameter. When the SDK's info type does not expose a field, the
-// corresponding has_* flag is emitted false; that omission is the honest signal
-// of a missing API surface.
+function iso(d?: Date): string | undefined {
+  return d != null ? new Date(d).toISOString() : undefined;
+}
+
+function compact(rec: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+// CANONICAL DUMP of the CURRENT hook's own attempt info. Replay indicators
+// (isReplay / isReplayingChildren) are dumped when the info exposes them but
+// are not asserted here; attempt-end additionally carries outcome and error.
+function dumpAttempt(hook: string, info: AttemptInfo): Record<string, unknown> {
+  return {
+    plugin: PLUGIN,
+    hook,
+    id: info.id,
+    name: info.name,
+    type: info.type != null ? info.type.toUpperCase() : undefined,
+    subType: info.subType,
+    parentId: info.parentId,
+    attempt: info.attempt,
+    startTimestamp: iso(info.startTimestamp),
+    endTimestamp: iso(info.endTimestamp),
+    isReplay: info.isReplay,
+    isReplayingChildren: (info as AttemptInfo & { isReplayingChildren?: boolean })
+      .isReplayingChildren,
+  };
+}
+
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
   const emit = (rec: Record<string, unknown>): void =>
-    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+    process.stdout.write(
+      JSON.stringify({ ...compact(rec), durableExecutionArn: executionArn }) + "\n",
+    );
 
   return {
     async onInvocationStart(info: InvocationInfo): Promise<void> {
@@ -32,28 +63,15 @@ function makePlugin(): DurableInstrumentationPlugin {
     },
     async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
       if (!isStep(info.type)) return;
-      emit({
-        plugin: PLUGIN,
-        hook: "attempt-start",
-        op: info.id,
-        name: info.name,
-        type: (info.type || "").toUpperCase(),
-        attempt: info.attempt,
-        has_start_time: info.startTimestamp != null,
-      });
+      emit(dumpAttempt("attempt-start", info));
     },
     async onOperationAttemptEnd(info: AttemptEndInfo): Promise<void> {
       if (!isStep(info.type)) return;
       emit({
-        plugin: PLUGIN,
-        hook: "attempt-end",
-        op: info.id,
-        name: info.name,
-        type: (info.type || "").toUpperCase(),
-        attempt: info.attempt,
-        // The attempt outcome as reported by the info parameter (SUCCEEDED / FAILED).
+        ...dumpAttempt("attempt-end", info),
+        // The attempt outcome as reported by the info (SUCCEEDED / FAILED).
         outcome: info.outcome,
-        has_error: info.error != null,
+        error: info.error != null ? info.error.message : undefined,
       });
     },
   };

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_attempt_info_shape.ts
@@ -1,0 +1,84 @@
+// 10-21: Attempt hook info field shape (interface-shape probe)
+import {
+  DurableContext,
+  withDurableExecution,
+  createRetryStrategy,
+  JitterStrategy,
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  AttemptInfo,
+  AttemptEndInfo,
+} from "@aws/durable-execution-sdk-js";
+
+const PLUGIN = "CONFPLUGIN";
+
+function isStep(type?: string): boolean {
+  return (type || "").toUpperCase() === "STEP";
+}
+
+// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
+// info parameter. When the SDK's info type does not expose a field, the
+// corresponding has_* flag is emitted false; that omission is the honest signal
+// of a missing API surface.
+function makePlugin(): DurableInstrumentationPlugin {
+  let executionArn = "";
+  const emit = (rec: Record<string, unknown>): void =>
+    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+
+  return {
+    async onInvocationStart(info: InvocationInfo): Promise<void> {
+      // ARN captured only for durableExecutionArn stamping (unasserted).
+      executionArn = info.executionArn;
+    },
+    async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
+      if (!isStep(info.type)) return;
+      emit({
+        plugin: PLUGIN,
+        hook: "attempt-start",
+        op: info.id,
+        name: info.name,
+        type: (info.type || "").toUpperCase(),
+        attempt: info.attempt,
+        has_start_time: info.startTimestamp != null,
+      });
+    },
+    async onOperationAttemptEnd(info: AttemptEndInfo): Promise<void> {
+      if (!isStep(info.type)) return;
+      emit({
+        plugin: PLUGIN,
+        hook: "attempt-end",
+        op: info.id,
+        name: info.name,
+        type: (info.type || "").toUpperCase(),
+        attempt: info.attempt,
+        // The attempt outcome as reported by the info parameter (SUCCEEDED / FAILED).
+        outcome: info.outcome,
+        has_error: info.error != null,
+      });
+    },
+  };
+}
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    return await context.step(
+      "flaky",
+      async (stepContext) => {
+        // Real per-step attempt counter: fails attempt 1, succeeds attempt 2.
+        if (stepContext.attempt < 2) {
+          throw new Error(`Attempt ${stepContext.attempt} failed`);
+        }
+        return "ok";
+      },
+      {
+        // Real built-in retry strategy: up to 2 attempts, deterministic ~1s delay.
+        retryStrategy: createRetryStrategy({
+          maxAttempts: 2,
+          initialDelay: { seconds: 1 },
+          jitter: JitterStrategy.NONE,
+        }),
+      },
+    );
+  },
+  { plugins: [makePlugin()] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_context_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_context_info_shape.ts
@@ -1,0 +1,117 @@
+// 10-23: Context-typed hook info field shape (canonical dump)
+import {
+  DurableContext,
+  withDurableExecution,
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  OperationInfo,
+  AttemptInfo,
+} from "@aws/durable-execution-sdk-js";
+
+const PLUGIN = "CONFPLUGIN";
+
+// CONTEXT-typed ops only: context.parallel emits its parent and each branch as
+// OperationType.CONTEXT ("CONTEXT"), distinguished by subType ("Parallel" /
+// "ParallelBranch"). Filtering on the SDK's own type token, dumped honestly.
+function isContext(type?: string): boolean {
+  return (type || "").toUpperCase() === "CONTEXT";
+}
+
+function iso(d?: Date): string | undefined {
+  return d != null ? new Date(d).toISOString() : undefined;
+}
+
+// Drops undefined/null so an unexposed field is OMITTED (missing key -> failed
+// assertion -> parity signal).
+function compact(rec: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+// Runtime probe: only report the children-replay indicator if the hook info
+// object ACTUALLY exposes it as a boolean own field (like the 10-19 end-info
+// first probe). The JS AttemptInfo does not declare isReplayingChildren, so
+// this returns undefined and the key is omitted -- the intended red signal.
+function probeReplayingChildren(info: object): boolean | undefined {
+  const rec = info as Record<string, unknown>;
+  if ("isReplayingChildren" in rec && typeof rec.isReplayingChildren === "boolean") {
+    return rec.isReplayingChildren;
+  }
+  return undefined;
+}
+
+function makePlugin(): DurableInstrumentationPlugin {
+  let executionArn = "";
+  const emit = (rec: Record<string, unknown>): void =>
+    process.stdout.write(
+      JSON.stringify({ ...compact(rec), durableExecutionArn: executionArn }) + "\n",
+    );
+
+  return {
+    async onInvocationStart(info: InvocationInfo): Promise<void> {
+      // ARN captured only for durableExecutionArn stamping (unasserted).
+      executionArn = info.executionArn;
+    },
+    // CANONICAL DUMP of the operation-start hook's own info for CONTEXT ops
+    // (the parallel parent and each branch), type token dumped as reported.
+    async onOperationStart(info: OperationInfo): Promise<void> {
+      if (!isContext(info.type)) return;
+      emit({
+        plugin: PLUGIN,
+        hook: "operation-start",
+        id: info.id,
+        name: info.name,
+        type: info.type != null ? info.type.toUpperCase() : undefined,
+        subType: info.subType,
+        parentId: info.parentId,
+        status: info.status,
+        startTimestamp: iso(info.startTimestamp),
+        endTimestamp: iso(info.endTimestamp),
+        isReplay: info.isReplay,
+      });
+    },
+    // CANONICAL DUMP of the per-attempt / user-function start hook for the
+    // CONTEXT-type branch functions. isReplayingChildren is included ONLY when
+    // the info object actually exposes it (probed); omitted otherwise.
+    async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
+      if (!isContext(info.type)) return;
+      emit({
+        plugin: PLUGIN,
+        hook: "fn-start",
+        id: info.id,
+        name: info.name,
+        type: info.type != null ? info.type.toUpperCase() : undefined,
+        subType: info.subType,
+        parentId: info.parentId,
+        attempt: info.attempt,
+        startTimestamp: iso(info.startTimestamp),
+        isReplay: info.isReplay,
+        isReplayingChildren: probeReplayingChildren(info),
+      });
+    },
+  };
+}
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    // Real context.parallel with two branches, max-concurrency 1 so branch A
+    // suspends mid-run (on its 2s wait) and re-runs on replay before branch B.
+    const results = await context.parallel<string>(
+      "ctx",
+      [
+        async (ctx: DurableContext) => {
+          await ctx.step("inner", async () => "x");
+          await ctx.wait({ seconds: 2 });
+          return "a-done";
+        },
+        async (_ctx: DurableContext) => "b-done",
+      ],
+      { maxConcurrency: 1 },
+    );
+    return results.getResults();
+  },
+  { plugins: [makePlugin()] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_context_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_context_info_shape.ts
@@ -97,17 +97,24 @@ function makePlugin(): DurableInstrumentationPlugin {
 
 export const handler = withDurableExecution(
   async (_event: any, context: DurableContext) => {
-    // Real context.parallel with two branches, max-concurrency 1 so branch A
-    // suspends mid-run (on its 2s wait) and re-runs on replay before branch B.
+    // Real context.parallel with two NAMED branches (branch-a / branch-b),
+    // max-concurrency 1 so branch-a suspends mid-run (on its 2s wait) and
+    // re-runs on replay before branch-b.
     const results = await context.parallel<string>(
       "ctx",
       [
-        async (ctx: DurableContext) => {
-          await ctx.step("inner", async () => "x");
-          await ctx.wait({ seconds: 2 });
-          return "a-done";
+        {
+          name: "branch-a",
+          func: async (ctx: DurableContext) => {
+            await ctx.step("inner", async () => "x");
+            await ctx.wait({ seconds: 2 });
+            return "a-done";
+          },
         },
-        async (_ctx: DurableContext) => "b-done",
+        {
+          name: "branch-b",
+          func: async (_ctx: DurableContext) => "b-done",
+        },
       ],
       { maxConcurrency: 1 },
     );

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
@@ -1,0 +1,76 @@
+// 10-19: Invocation hook info field shape (interface-shape probe)
+import {
+  DurableContext,
+  withDurableExecution,
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  InvocationEndInfo,
+} from "@aws/durable-execution-sdk-js";
+
+const PLUGIN = "CONFPLUGIN";
+const TERMINAL = new Set(["SUCCEEDED", "FAILED"]);
+
+// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
+// info parameter. When the SDK's info type does not expose a field, the
+// corresponding has_* flag is emitted false (or the value field omitted); that
+// omission is the honest signal of a missing API surface — never reconstructed
+// from another hook or from plugin state.
+function makePlugin(): DurableInstrumentationPlugin {
+  // The execution ARN is the ONLY value captured at invocation-start and reused
+  // on later records — it is used solely for durableExecutionArn stamping so the
+  // runner's CloudWatch filter locates records; it is not asserted.
+  let executionArn = "";
+  const emit = (rec: Record<string, unknown>): void =>
+    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+
+  return {
+    async onInvocationStart(info: InvocationInfo): Promise<void> {
+      executionArn = info.executionArn;
+      emit({
+        plugin: PLUGIN,
+        hook: "invocation-start",
+        first: info.isFirstInvocation,
+        has_request_id: info.requestId != null && info.requestId !== "",
+        has_input: info.executionInput !== undefined,
+        // The execution input value exactly as exposed on the start info.
+        input: info.executionInput,
+        has_operations: info.operations != null,
+        // The info's externally-updated-operations collection is non-empty.
+        updated_nonempty: Object.keys(info.updatedOperations).length > 0,
+        has_start_time: info.executionStartTimestamp != null,
+      });
+    },
+    async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
+      const status = String(info.status);
+      const rec: Record<string, unknown> = {
+        plugin: PLUGIN,
+        hook: "invocation-end",
+        // terminal := reported status is SUCCEEDED or FAILED.
+        terminal: TERMINAL.has(status),
+        status,
+        has_result: info.executionResult !== undefined,
+        has_error: info.executionError != null,
+      };
+      // `first` MUST come from the END info itself — capturing it at
+      // invocation-start is forbidden here because the field's presence on the
+      // end info is exactly what is under test. The JS InvocationEndInfo does
+      // NOT expose isFirstInvocation, so this reads undefined and the key is
+      // omitted entirely: the resulting red assertion is the intended signal of
+      // the missing API surface.
+      const endFirst = (info as InvocationEndInfo & { isFirstInvocation?: boolean })
+        .isFirstInvocation;
+      if (endFirst !== undefined) {
+        rec.first = endFirst;
+      }
+      emit(rec);
+    },
+  };
+}
+
+export const handler = withDurableExecution(
+  async (event: any, context: DurableContext) => {
+    await context.wait({ seconds: 2 });
+    return `done-${event}`;
+  },
+  { plugins: [makePlugin()] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
@@ -1,4 +1,4 @@
-// 10-19: Invocation hook info field shape (interface-shape probe)
+// 10-19: Invocation hook info field shape (canonical dump)
 import {
   DurableContext,
   withDurableExecution,
@@ -10,18 +10,37 @@ import {
 const PLUGIN = "CONFPLUGIN";
 const TERMINAL = new Set(["SUCCEEDED", "FAILED"]);
 
-// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
-// info parameter. When the SDK's info type does not expose a field, the
-// corresponding has_* flag is emitted false (or the value field omitted); that
-// omission is the honest signal of a missing API surface — never reconstructed
-// from another hook or from plugin state.
+// ISO-8601 string for a timestamp value; undefined when the field is unset so
+// the key is omitted from the record.
+function iso(d?: Date): string | undefined {
+  return d != null ? new Date(d).toISOString() : undefined;
+}
+
+// Drops keys whose value is undefined OR null so a field the SDK's info type
+// does not expose is OMITTED from the record — a missing key fails its
+// assertion, which is the parity signal.
+function compact(rec: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+// CANONICAL DUMP: every logged field is read one-to-one from the CURRENT hook's
+// own info parameter and emitted under its canonical camelCase name. Map-typed
+// fields become <name>Count integers; timestamps become ISO-8601 strings.
+// Unexposed fields read undefined and are omitted (the honest missing-surface
+// signal). No cross-hook reconstruction — never captured from another hook.
 function makePlugin(): DurableInstrumentationPlugin {
   // The execution ARN is the ONLY value captured at invocation-start and reused
-  // on later records — it is used solely for durableExecutionArn stamping so the
-  // runner's CloudWatch filter locates records; it is not asserted.
+  // on later records — solely for durableExecutionArn stamping so the runner's
+  // CloudWatch filter locates records; it is not asserted.
   let executionArn = "";
   const emit = (rec: Record<string, unknown>): void =>
-    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+    process.stdout.write(
+      JSON.stringify({ ...compact(rec), durableExecutionArn: executionArn }) + "\n",
+    );
 
   return {
     async onInvocationStart(info: InvocationInfo): Promise<void> {
@@ -29,34 +48,17 @@ function makePlugin(): DurableInstrumentationPlugin {
       emit({
         plugin: PLUGIN,
         hook: "invocation-start",
-        first: info.isFirstInvocation,
-        has_request_id: info.requestId != null && info.requestId !== "",
-        has_input: info.executionInput !== undefined,
-        // The execution input value exactly as exposed on the start info.
-        input: info.executionInput,
-        has_operations: info.operations != null,
-        // The info's externally-updated-operations collection is non-empty.
-        updated_nonempty: Object.keys(info.updatedOperations).length > 0,
-        has_start_time: info.executionStartTimestamp != null,
+        isFirstInvocation: info.isFirstInvocation,
+        requestId: info.requestId,
+        executionInput: info.executionInput,
+        operationsCount: Object.keys(info.operations).length,
+        updatedOperationsCount: Object.keys(info.updatedOperations).length,
+        executionStartTimestamp: iso(info.executionStartTimestamp),
       });
     },
     async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
-      const status = String(info.status);
-      const rec: Record<string, unknown> = {
-        plugin: PLUGIN,
-        hook: "invocation-end",
-        // terminal := reported status is SUCCEEDED or FAILED.
-        terminal: TERMINAL.has(status),
-        status,
-        has_result: info.executionResult !== undefined,
-        has_error: info.executionError != null,
-      };
-      // The execution result value exactly as exposed on the end info
-      // (omitted when the API does not populate it).
-      if (info.executionResult !== undefined) {
-        rec.result = info.executionResult;
-      }
-      // `first` MUST come from the END info itself — capturing it at
+      const status = info.status != null ? String(info.status) : undefined;
+      // `isFirstInvocation` MUST come from the END info itself — capturing it at
       // invocation-start is forbidden here because the field's presence on the
       // end info is exactly what is under test. The JS InvocationEndInfo does
       // NOT expose isFirstInvocation, so this reads undefined and the key is
@@ -64,10 +66,21 @@ function makePlugin(): DurableInstrumentationPlugin {
       // the missing API surface.
       const endFirst = (info as InvocationEndInfo & { isFirstInvocation?: boolean })
         .isFirstInvocation;
-      if (endFirst !== undefined) {
-        rec.first = endFirst;
-      }
-      emit(rec);
+      emit({
+        plugin: PLUGIN,
+        hook: "invocation-end",
+        isFirstInvocation: endFirst,
+        requestId: info.requestId,
+        executionInput: info.executionInput,
+        operationsCount: Object.keys(info.operations).length,
+        executionStartTimestamp: iso(info.executionStartTimestamp),
+        status,
+        // Derived scalar: reported status is SUCCEEDED or FAILED.
+        terminal: status != null ? TERMINAL.has(status) : undefined,
+        // The execution result exactly as exposed on the end info, BY VALUE.
+        executionResult: info.executionResult,
+        executionError: info.executionError != null ? info.executionError.message : undefined,
+      });
     },
   };
 }

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_invocation_info_shape.ts
@@ -51,6 +51,11 @@ function makePlugin(): DurableInstrumentationPlugin {
         has_result: info.executionResult !== undefined,
         has_error: info.executionError != null,
       };
+      // The execution result value exactly as exposed on the end info
+      // (omitted when the API does not populate it).
+      if (info.executionResult !== undefined) {
+        rec.result = info.executionResult;
+      }
       // `first` MUST come from the END info itself — capturing it at
       // invocation-start is forbidden here because the field's presence on the
       // end info is exactly what is under test. The JS InvocationEndInfo does

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change_shape.ts
@@ -1,0 +1,66 @@
+// 10-22: Operation-change hook info field shape (interface-shape probe)
+import {
+  DurableContext,
+  withDurableExecution,
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  OperationChangeInfo,
+} from "@aws/durable-execution-sdk-js";
+
+const PLUGIN = "CONFPLUGIN";
+
+function isStep(type?: string): boolean {
+  return (type || "").toUpperCase() === "STEP";
+}
+
+// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
+// info parameter (the change info and the DELTA ITEM's own OperationInfo) —
+// never reconstructed from another hook or from plugin state. When the SDK's
+// info type does not expose a field, the corresponding has_* flag is emitted
+// false; that omission is the honest signal of a missing API surface. The
+// reference item shape is the full operation info (identity + status +
+// payloads), not a reduced change-item record.
+function makePlugin(): DurableInstrumentationPlugin {
+  let executionArn = "";
+  const emit = (rec: Record<string, unknown>): void =>
+    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+
+  return {
+    async onInvocationStart(info: InvocationInfo): Promise<void> {
+      // ARN captured only for durableExecutionArn stamping (unasserted).
+      executionArn = info.executionArn;
+    },
+    async onOperationChange(info: OperationChangeInfo): Promise<void> {
+      const fullMap = info.operations;
+      // `has_arn` probes whether the change info itself carries the ARN.
+      const hasArn = info.executionArn != null && info.executionArn !== "";
+      for (const [id, op] of Object.entries(info.updatedOperations)) {
+        if (!isStep(op.type)) continue;
+        emit({
+          plugin: PLUGIN,
+          hook: "operation-change",
+          op: id,
+          status: op.status,
+          // Whether the same op id also appears in the info's full operations map.
+          in_full_map: id in fullMap,
+          has_arn: hasArn,
+          // The DELTA ITEM's own field surface.
+          item_name: op.name,
+          item_type: (op.type || "").toUpperCase(),
+          item_has_result: op.result != null,
+          item_has_end_time: op.endTimestamp != null,
+          item_has_attempt: op.attempt != null,
+          // The item exposes a replay indicator (isReplay field is present).
+          item_has_replay: "isReplay" in op,
+        });
+      }
+    },
+  };
+}
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    return await context.step("greet", async () => "task-a");
+  },
+  { plugins: [makePlugin()] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change_shape.ts
@@ -1,10 +1,11 @@
-// 10-22: Operation-change hook info field shape (interface-shape probe)
+// 10-22: Operation-change hook info field shape (canonical dump)
 import {
   DurableContext,
   withDurableExecution,
   DurableInstrumentationPlugin,
   InvocationInfo,
   OperationChangeInfo,
+  OperationInfo,
 } from "@aws/durable-execution-sdk-js";
 
 const PLUGIN = "CONFPLUGIN";
@@ -13,17 +14,29 @@ function isStep(type?: string): boolean {
   return (type || "").toUpperCase() === "STEP";
 }
 
-// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
-// info parameter (the change info and the DELTA ITEM's own OperationInfo) —
-// never reconstructed from another hook or from plugin state. When the SDK's
-// info type does not expose a field, the corresponding has_* flag is emitted
-// false; that omission is the honest signal of a missing API surface. The
-// reference item shape is the full operation info (identity + status +
-// payloads), not a reduced change-item record.
+function iso(d?: Date): string | undefined {
+  return d != null ? new Date(d).toISOString() : undefined;
+}
+
+function compact(rec: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+// CANONICAL DUMP: one record per step-type DELTA ITEM. Each record dumps the
+// item's own full operation field surface at top level (canonical camelCase;
+// type upper-cased; timestamps ISO-8601; result raw serialized string; error
+// message), plus the hook-level fields (executionArn, map-size counts) and the
+// derived scalar inFullMap := the id also appears in the info's full map.
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
   const emit = (rec: Record<string, unknown>): void =>
-    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+    process.stdout.write(
+      JSON.stringify({ ...compact(rec), durableExecutionArn: executionArn }) + "\n",
+    );
 
   return {
     async onInvocationStart(info: InvocationInfo): Promise<void> {
@@ -31,27 +44,33 @@ function makePlugin(): DurableInstrumentationPlugin {
       executionArn = info.executionArn;
     },
     async onOperationChange(info: OperationChangeInfo): Promise<void> {
-      const fullMap = info.operations;
-      // `has_arn` probes whether the change info itself carries the ARN.
-      const hasArn = info.executionArn != null && info.executionArn !== "";
+      const updatedOperationsCount = Object.keys(info.updatedOperations).length;
+      const operationsCount = Object.keys(info.operations).length;
       for (const [id, op] of Object.entries(info.updatedOperations)) {
         if (!isStep(op.type)) continue;
+        const item = op as OperationInfo;
         emit({
           plugin: PLUGIN,
           hook: "operation-change",
-          op: id,
-          status: op.status,
-          // Whether the same op id also appears in the info's full operations map.
-          in_full_map: id in fullMap,
-          has_arn: hasArn,
-          // The DELTA ITEM's own field surface.
-          item_name: op.name,
-          item_type: (op.type || "").toUpperCase(),
-          item_has_result: op.result != null,
-          item_has_end_time: op.endTimestamp != null,
-          item_has_attempt: op.attempt != null,
-          // The item exposes a replay indicator (isReplay field is present).
-          item_has_replay: "isReplay" in op,
+          // Hook-level fields from the change info itself.
+          executionArn: info.executionArn,
+          updatedOperationsCount,
+          operationsCount,
+          // Derived: the same id also appears in the info's full operations map.
+          inFullMap: id in info.operations,
+          // The delta item's own operation field surface, dumped at top level.
+          id: item.id,
+          name: item.name,
+          type: item.type != null ? item.type.toUpperCase() : undefined,
+          subType: item.subType,
+          parentId: item.parentId,
+          status: item.status,
+          startTimestamp: iso(item.startTimestamp),
+          endTimestamp: iso(item.endTimestamp),
+          result: item.result,
+          error: item.error != null ? item.error.message : undefined,
+          attempt: item.attempt,
+          isReplay: item.isReplay,
         });
       }
     },

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_info_shape.ts
@@ -1,0 +1,77 @@
+// 10-20: Operation hook info field shape (interface-shape probe)
+import {
+  DurableContext,
+  withDurableExecution,
+  DurableInstrumentationPlugin,
+  InvocationInfo,
+  OperationInfo,
+  OperationEndInfo,
+} from "@aws/durable-execution-sdk-js";
+
+const PLUGIN = "CONFPLUGIN";
+
+function isStep(type?: string): boolean {
+  return (type || "").toUpperCase() === "STEP";
+}
+
+// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
+// info parameter. When the SDK's info type does not expose a field, the
+// corresponding has_* flag is emitted false (or the value field omitted); that
+// omission is the honest signal of a missing API surface.
+function makePlugin(): DurableInstrumentationPlugin {
+  let executionArn = "";
+  const emit = (rec: Record<string, unknown>): void =>
+    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+
+  return {
+    async onInvocationStart(info: InvocationInfo): Promise<void> {
+      // ARN captured only for durableExecutionArn stamping (unasserted).
+      executionArn = info.executionArn;
+    },
+    async onOperationStart(info: OperationInfo): Promise<void> {
+      if (!isStep(info.type)) return;
+      emit({
+        plugin: PLUGIN,
+        hook: "operation-start",
+        op: info.id,
+        name: info.name,
+        type: (info.type || "").toUpperCase(),
+        replay: info.isReplay,
+        has_start_time: info.startTimestamp != null,
+        // Emitted for observability; not asserted at start (status may not be
+        // checkpointed yet when the live first-start hook fires).
+        has_status: info.status != null,
+      });
+    },
+    async onOperationEnd(info: OperationEndInfo): Promise<void> {
+      if (!isStep(info.type)) return;
+      const rec: Record<string, unknown> = {
+        plugin: PLUGIN,
+        hook: "operation-end",
+        op: info.id,
+        name: info.name,
+        type: (info.type || "").toUpperCase(),
+        replay: info.isReplay,
+        status: info.status,
+        has_result: info.result != null,
+        has_error: info.error != null,
+        // The 1-based attempt number exactly as exposed on the end info.
+        attempt: info.attempt,
+        has_end_time: info.endTimestamp != null,
+      };
+      // The operation's checkpointed serialized result exactly as exposed on the
+      // info parameter (e.g. '"task-a"'); omitted when unavailable.
+      if (info.result != null) {
+        rec.result = info.result;
+      }
+      emit(rec);
+    },
+  };
+}
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    return await context.step("greet", async () => "task-a");
+  },
+  { plugins: [makePlugin()] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_info_shape.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_info_shape.ts
@@ -1,4 +1,4 @@
-// 10-20: Operation hook info field shape (interface-shape probe)
+// 10-20: Operation hook info field shape (canonical dump)
 import {
   DurableContext,
   withDurableExecution,
@@ -14,14 +14,48 @@ function isStep(type?: string): boolean {
   return (type || "").toUpperCase() === "STEP";
 }
 
-// INTERFACE-SHAPE probe: every logged field is read from the CURRENT hook's own
-// info parameter. When the SDK's info type does not expose a field, the
-// corresponding has_* flag is emitted false (or the value field omitted); that
-// omission is the honest signal of a missing API surface.
+function iso(d?: Date): string | undefined {
+  return d != null ? new Date(d).toISOString() : undefined;
+}
+
+// Drops undefined/null so an unexposed field is OMITTED (missing key -> failed
+// assertion -> parity signal).
+function compact(rec: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+// CANONICAL DUMP of the CURRENT hook's own operation info: every field mapped
+// one-to-one to its canonical camelCase name; type upper-cased; timestamps as
+// ISO-8601 strings; result as the raw serialized string; error as its message.
+function dumpOperation(hook: string, info: OperationInfo): Record<string, unknown> {
+  return {
+    plugin: PLUGIN,
+    hook,
+    id: info.id,
+    name: info.name,
+    type: info.type != null ? info.type.toUpperCase() : undefined,
+    subType: info.subType,
+    parentId: info.parentId,
+    status: info.status,
+    startTimestamp: iso(info.startTimestamp),
+    endTimestamp: iso(info.endTimestamp),
+    result: info.result,
+    error: info.error != null ? info.error.message : undefined,
+    attempt: info.attempt,
+    isReplay: info.isReplay,
+  };
+}
+
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
   const emit = (rec: Record<string, unknown>): void =>
-    process.stdout.write(JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n");
+    process.stdout.write(
+      JSON.stringify({ ...compact(rec), durableExecutionArn: executionArn }) + "\n",
+    );
 
   return {
     async onInvocationStart(info: InvocationInfo): Promise<void> {
@@ -30,41 +64,11 @@ function makePlugin(): DurableInstrumentationPlugin {
     },
     async onOperationStart(info: OperationInfo): Promise<void> {
       if (!isStep(info.type)) return;
-      emit({
-        plugin: PLUGIN,
-        hook: "operation-start",
-        op: info.id,
-        name: info.name,
-        type: (info.type || "").toUpperCase(),
-        replay: info.isReplay,
-        has_start_time: info.startTimestamp != null,
-        // Emitted for observability; not asserted at start (status may not be
-        // checkpointed yet when the live first-start hook fires).
-        has_status: info.status != null,
-      });
+      emit(dumpOperation("operation-start", info));
     },
     async onOperationEnd(info: OperationEndInfo): Promise<void> {
       if (!isStep(info.type)) return;
-      const rec: Record<string, unknown> = {
-        plugin: PLUGIN,
-        hook: "operation-end",
-        op: info.id,
-        name: info.name,
-        type: (info.type || "").toUpperCase(),
-        replay: info.isReplay,
-        status: info.status,
-        has_result: info.result != null,
-        has_error: info.error != null,
-        // The 1-based attempt number exactly as exposed on the end info.
-        attempt: info.attempt,
-        has_end_time: info.endTimestamp != null,
-      };
-      // The operation's checkpointed serialized result exactly as exposed on the
-      // info parameter (e.g. '"task-a"'); omitted when unavailable.
-      if (info.result != null) {
-        rec.result = info.result;
-      }
-      emit(rec);
+      emit(dumpOperation("operation-end", info));
     },
   };
 }

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
@@ -334,3 +334,71 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  PluginInvocationInfoShape:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-19"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_invocation_info_shape.handler
+      Description: Invocation-start and invocation-end hook info carries the full invocation field set
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginOperationInfoShape:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-20"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_operation_info_shape.handler
+      Description: Operation-start and operation-end hook info carries the full operation field set
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginAttemptInfoShape:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-21"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_attempt_info_shape.handler
+      Description: Attempt-start and attempt-end hook info carries the full attempt field set
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300
+  PluginOperationChangeShape:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-22"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_operation_change_shape.handler
+      Description: Operation-change hook info carries full operation items in the delta and full map
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_plugin.yaml
@@ -402,3 +402,20 @@ Resources:
       DurableConfig:
         RetentionPeriodInDays: 7
         ExecutionTimeout: 300
+  PluginContextInfoShape:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["10-23"]
+    Properties:
+      CodeUri: ./dist
+      Handler: plugin_context_info_shape.handler
+      Description: Context operations expose subType tokens and user-function hooks expose the children-replay indicator
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
## Summary
Adds 5 conformance handlers (`handlers/plugin/plugin_{invocation_info,operation_info,attempt_info,operation_change,context_info}_shape.ts`) + `template_plugin.yaml` entries implementing plugin hook-info FIELD-SHAPE requirements 10-19..10-23 from aws/aws-durable-execution-conformance-tests#72 (land that PR first).

Each handler logs ONE single-line JSON record per hook event via `process.stdout.write`: a CANONICAL camelCase DUMP of that hook's own info parameter (undefined/null fields OMITTED — a missing key fails its assertion). GA note: experimental payload fields (execution input/result, operation result) are dumped when exposed but not asserted. The 10-19/10-23 handlers probe fields from the info objects at runtime and omit absent keys — the resulting reds are the intended signals.

## Live validation (us-west-2): 20/23 — THREE DELIBERATE FAILURES (SDK parity gaps, tracked in #803)
- ❌ **10-19**: `InvocationEndInfo` does not expose `isFirstInvocation` (Python/Java both do).
- ❌ **10-21**: FAILED retryable attempt-end records lack `startTimestamp`/`endTimestamp` (`AttemptEndInfo` backfilled from the retry-pending operation, `step-handler.ts` ~457-465); the SUCCEEDED attempt-end passes.
- ❌ **10-23**: attempt/user-function info has no `isReplayingChildren` (Python/Java expose it; JS models context functions via `wrapChildContextFn`).
- ✅ 10-20, 10-22, and the entire 10-1..10-18 regression.