### PR TITLE
fix(testing-sdk): stop duplicating ExecutionSucceeded

### DIFF
--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-execution-result.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/__tests__/checkpoint-manager-execution-result.test.ts
@@ -1,0 +1,175 @@
+import {
+  OperationAction,
+  OperationStatus,
+  OperationType,
+} from "@aws/durable-execution-sdk-js";
+import { EventType } from "@aws-sdk/client-lambda";
+import { CheckpointManager } from "../checkpoint-manager";
+import { createExecutionId } from "../../utils/tagged-strings";
+
+/**
+ * The SDK's oversized-result path checkpoints the return value as its own
+ * EXECUTION-typed SUCCEED update with a synthetic `execution-result-<timestamp>`
+ * id, then returns `{ Status: SUCCEEDED, Result: "" }` from the invocation.
+ *
+ * The real service applies any EXECUTION-typed update to the execution itself,
+ * ignoring that id, and then ignores the invocation response because the
+ * execution is already terminal. A real `GetDurableExecutionHistory` for such an
+ * execution contains exactly one `ExecutionSucceeded`, keyed by the execution id
+ * and carrying the oversized payload. These tests pin that behavior.
+ */
+describe("CheckpointManager oversized execution result", () => {
+  let storage: CheckpointManager;
+
+  beforeEach(() => {
+    storage = new CheckpointManager(createExecutionId("test-execution-id"));
+  });
+
+  afterEach(() => {
+    storage.cleanup();
+  });
+
+  it("applies an EXECUTION-typed checkpoint to the execution operation, not a new one", () => {
+    const initial = storage.initialize();
+    const executionId = initial.operation.Id;
+
+    storage.registerUpdate({
+      Id: "execution-result-1700000000000",
+      Type: OperationType.EXECUTION,
+      Action: OperationAction.SUCCEED,
+      Payload: '"oversized"',
+    });
+
+    // No separate operation was created for the synthetic id.
+    expect(storage.getOperationData("execution-result-1700000000000")).toBe(
+      undefined,
+    );
+
+    const execution = storage.getOperationData(executionId);
+    expect(execution?.operation.Status).toBe(OperationStatus.SUCCEEDED);
+
+    const succeeded = (execution?.events ?? []).filter(
+      (event) => event.EventType === EventType.ExecutionSucceeded,
+    );
+    expect(succeeded).toHaveLength(1);
+    expect(succeeded[0].Id).toBe(executionId);
+    expect(storage.isExecutionCompleted()).toBe(true);
+  });
+
+  it("ignores the invocation response once the execution is already terminal", () => {
+    const initial = storage.initialize();
+    const executionId = initial.operation.Id;
+
+    storage.registerUpdate({
+      Id: "execution-result-1700000000000",
+      Type: OperationType.EXECUTION,
+      Action: OperationAction.SUCCEED,
+      Payload: '"oversized"',
+    });
+
+    // This is what the orchestrator does when the invocation returns SUCCEEDED.
+    // The service would not record a second completion, and neither should we.
+    storage.updateOperation(
+      executionId,
+      { Status: OperationStatus.SUCCEEDED },
+      "",
+      undefined,
+    );
+
+    const succeeded = (
+      storage.getOperationData(executionId)?.events ?? []
+    ).filter((event) => event.EventType === EventType.ExecutionSucceeded);
+    expect(succeeded).toHaveLength(1);
+  });
+
+  it("publishes the ignored response without merging or adding events", async () => {
+    const initial = storage.initialize();
+    const executionId = initial.operation.Id;
+
+    storage.registerUpdate({
+      Id: "execution-result-1700000000000",
+      Type: OperationType.EXECUTION,
+      Action: OperationAction.SUCCEED,
+      Payload: '"oversized"',
+    });
+
+    // Drain the checkpoint's own update so anything left is attributable to the
+    // finalization below.
+    await storage.getPendingCheckpointUpdates();
+
+    storage.updateOperation(
+      executionId,
+      { Status: OperationStatus.SUCCEEDED },
+      "",
+      undefined,
+    );
+
+    // An update must still be published: the invocation only runs to completion
+    // once one is, and without it the run records no InvocationCompleted event
+    // and `getInvocations()` comes back empty.
+    const published = await storage.getPendingCheckpointUpdates();
+    expect(published).toHaveLength(1);
+
+    // But it carries no new history events, so the terminal event is not
+    // duplicated...
+    const succeeded = published[0].events.filter(
+      (event) => event.EventType === EventType.ExecutionSucceeded,
+    );
+    expect(succeeded).toHaveLength(1);
+
+    // ...and the payload is the checkpoint's, not the empty response body.
+    expect(succeeded[0].ExecutionSucceededDetails?.Result?.Payload).toBe(
+      '"oversized"',
+    );
+  });
+
+  it("does not let a late contradictory status overwrite the terminal state", () => {
+    const initial = storage.initialize();
+    const executionId = initial.operation.Id;
+
+    storage.registerUpdate({
+      Id: "execution-result-1700000000000",
+      Type: OperationType.EXECUTION,
+      Action: OperationAction.SUCCEED,
+      Payload: '"oversized"',
+    });
+
+    // The response contradicts the checkpoint. The stored operation must not
+    // drift away from the recorded history.
+    storage.updateOperation(
+      executionId,
+      { Status: OperationStatus.FAILED },
+      undefined,
+      { ErrorMessage: "late failure" },
+    );
+
+    const stored = storage.getOperationData(executionId);
+    expect(stored?.operation.Status).toBe(OperationStatus.SUCCEEDED);
+
+    const terminal = (stored?.events ?? []).filter(
+      (event) =>
+        event.EventType === EventType.ExecutionSucceeded ||
+        event.EventType === EventType.ExecutionFailed,
+    );
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0].EventType).toBe(EventType.ExecutionSucceeded);
+  });
+
+  it("still records the terminal event on the ordinary inline path", () => {
+    const initial = storage.initialize();
+    const executionId = initial.operation.Id;
+
+    storage.updateOperation(
+      executionId,
+      { Status: OperationStatus.SUCCEEDED },
+      '"small"',
+      undefined,
+    );
+
+    const succeeded = (
+      storage.getOperationData(executionId)?.events ?? []
+    ).filter((event) => event.EventType === EventType.ExecutionSucceeded);
+    expect(succeeded).toHaveLength(1);
+    expect(succeeded[0].Id).toBe(executionId);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/checkpoint-server/storage/checkpoint-manager.ts
@@ -38,6 +38,19 @@ export class CheckpointManager {
 
   private _isExecutionCompleted = false;
 
+  /**
+   * Id of the execution's own EXECUTION-typed operation, assigned in
+   * {@link initialize}.
+   *
+   * The service keys the execution's terminal event by this id. When the SDK
+   * checkpoints an oversized result it invents its own id
+   * (`execution-result-<timestamp>`), but the service treats any EXECUTION-typed
+   * update as an update to the execution itself and ignores that id — a real
+   * execution history contains exactly one ExecutionSucceeded, carrying this id.
+   * {@link registerUpdate} redirects such updates here to match.
+   */
+  private executionOperationId: string | undefined = undefined;
+
   constructor(executionId: ExecutionId) {
     this.callbackManager = new CallbackManager(executionId, this);
   }
@@ -171,6 +184,7 @@ export class CheckpointManager {
     } satisfies OperationEvents;
 
     this.operationDataMap.set(initialId, initialOperationEvents);
+    this.executionOperationId = initialId;
 
     return initialOperationEvents;
   }
@@ -344,6 +358,12 @@ export class CheckpointManager {
             copied.operation.ContextDetails?.ReplayChildren,
         };
         break;
+      case OperationType.EXECUTION:
+        // The execution reached a terminal state through a checkpoint (the
+        // oversized-result path). Further checkpoints must be rejected, and the
+        // invocation response must not add a second terminal event.
+        this._isExecutionCompleted = true;
+        break;
     }
 
     return copied;
@@ -400,6 +420,26 @@ export class CheckpointManager {
 
     if (!newOperation.Status) {
       throw new Error("Missing Status in operation");
+    }
+
+    // The execution may already have been completed by an EXECUTION-typed
+    // checkpoint (the oversized-result path). The service ignores the invocation
+    // response in that case — the execution is terminal and its result is
+    // already stored — so return before the response is merged.
+    //
+    // Ignore the response's *contents*, not its arrival. Merging would let a
+    // contradictory status overwrite the terminal state, leaving a stored FAILED
+    // against a recorded ExecutionSucceeded. But the update must still be
+    // published: the invocation only runs to completion once an update is
+    // published, and without it no InvocationCompleted event is recorded and
+    // `getInvocations()` comes back empty. Publishing the original operation is
+    // a no-op for history, since it carries no new events.
+    if (
+      operationData.operation.Type === OperationType.EXECUTION &&
+      this._isExecutionCompleted
+    ) {
+      this.addOperationUpdate({ ...operationData, update: undefined });
+      return operationData;
     }
 
     const newOperationData: OperationEvents = {
@@ -520,6 +560,20 @@ export class CheckpointManager {
    * @returns the operation update along with the operation itself
    */
   registerUpdate(update: OperationUpdate): OperationEvents {
+    // An EXECUTION-typed update always refers to the execution itself, whatever
+    // id the caller used. The SDK's oversized-result path checkpoints with a
+    // synthetic `execution-result-<timestamp>` id; the service applies it to the
+    // execution's own operation and records a single terminal event keyed by the
+    // execution id, so redirect it here rather than creating a second
+    // EXECUTION-typed operation.
+    if (
+      update.Type === OperationType.EXECUTION &&
+      this.executionOperationId !== undefined &&
+      update.Id !== this.executionOperationId
+    ) {
+      update = { ...update, Id: this.executionOperationId };
+    }
+
     if (!update.Id) {
       throw new Error("Missing Id in update");
     }
@@ -619,7 +673,6 @@ export class CheckpointManager {
 
     return updatedResult;
   }
-
   /**
    * Clears all callback timers and all operation data.
    */

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/oversized-execution-result.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/__tests__/integration/oversized-execution-result.integration.test.ts
@@ -1,0 +1,114 @@
+import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { EventType } from "@aws-sdk/client-lambda";
+import { LocalDurableTestRunner } from "../../local-durable-test-runner";
+
+beforeAll(() => LocalDurableTestRunner.setupTestEnvironment());
+afterAll(() => LocalDurableTestRunner.teardownTestEnvironment());
+
+/**
+ * The oversized-result path, end to end.
+ *
+ * When a handler's return value exceeds Lambda's response size limit the SDK
+ * checkpoints it as an EXECUTION-typed SUCCEED update under a synthetic
+ * `execution-result-<timestamp>` id, then returns `{ Status: SUCCEEDED,
+ * Result: "" }`. The service applies that update to the execution itself,
+ * ignoring the synthetic id, and ignores the invocation response because the
+ * execution is already terminal.
+ *
+ * The shape asserted here is the one a real `GetDurableExecutionHistory` returns
+ * for such an execution:
+ *
+ *     ExecutionStarted      Id: <executionId>
+ *     StepStarted           Id: <stepId>
+ *     StepSucceeded         Id: <stepId>
+ *     InvocationCompleted   Id: None
+ *     ExecutionSucceeded    Id: <executionId>
+ *
+ * Ordering is the one known remaining difference: the service emits
+ * `InvocationCompleted` before the terminal event, the local runner after. That
+ * is tracked with the event-ordering TODO in local-durable-test-runner.ts, so
+ * these assertions are on counts and ids rather than positions.
+ */
+describe("oversized execution result", () => {
+  const oversizedHandler = withDurableExecution(async (_, context) => {
+    // Small enough to checkpoint inline as usual.
+    await context.step("plan", () => Promise.resolve({ rows: 1 }));
+
+    // Comfortably past the SDK's 6MB response-size guard.
+    return "x".repeat(6 * 1024 * 1024 + 1000);
+  });
+
+  it("matches the history the service produces", async () => {
+    const runner = new LocalDurableTestRunner({
+      handlerFunction: oversizedHandler,
+    });
+
+    const execution = await runner.run({ payload: {} });
+    const events = execution.getHistoryEvents();
+
+    const executionId = events.find(
+      (event) => event.EventType === EventType.ExecutionStarted,
+    )?.Id;
+    expect(typeof executionId).toBe("string");
+
+    // One ExecutionStarted. Two would mean the history was assembled twice.
+    expect(
+      events.filter((event) => event.EventType === EventType.ExecutionStarted),
+    ).toHaveLength(1);
+
+    // One terminal event, keyed by the execution id rather than by the
+    // checkpoint's synthetic `execution-result-*` id.
+    const succeeded = events.filter(
+      (event) => event.EventType === EventType.ExecutionSucceeded,
+    );
+    expect(succeeded).toHaveLength(1);
+    expect(succeeded[0].Id).toBe(executionId);
+
+    // The terminal event carries the oversized payload, which is why it could
+    // not be returned inline.
+    const payload = succeeded[0].ExecutionSucceededDetails?.Result?.Payload;
+    expect(typeof payload).toBe("string");
+    expect(Buffer.byteLength(payload!, "utf8")).toBeGreaterThan(
+      6 * 1024 * 1024 - 50,
+    );
+
+    // The invocation still completes. Suppressing the ignored response entirely
+    // stalls it, leaving no InvocationCompleted event and no invocations.
+    expect(
+      events.filter(
+        (event) => event.EventType === EventType.InvocationCompleted,
+      ),
+    ).toHaveLength(1);
+    expect(execution.getInvocations()).toHaveLength(1);
+
+    // The caller still receives the whole result.
+    expect((execution.getResult() as string).length).toBe(
+      6 * 1024 * 1024 + 1000,
+    );
+  }, 60000);
+
+  it("keeps the ordinary inline path unchanged", async () => {
+    const runner = new LocalDurableTestRunner({
+      handlerFunction: withDurableExecution(async (_, context) => {
+        await context.step("plan", () => Promise.resolve({ rows: 1 }));
+        return "small";
+      }),
+    });
+
+    const execution = await runner.run({ payload: {} });
+    const events = execution.getHistoryEvents();
+
+    expect(
+      events.filter(
+        (event) => event.EventType === EventType.ExecutionSucceeded,
+      ),
+    ).toHaveLength(1);
+    expect(
+      events.filter(
+        (event) => event.EventType === EventType.InvocationCompleted,
+      ),
+    ).toHaveLength(1);
+    expect(execution.getInvocations()).toHaveLength(1);
+    expect(execution.getResult()).toBe("small");
+  }, 60000);
+});

--- a/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
+++ b/packages/aws-durable-execution-sdk-js-testing/src/test-runner/local/test-execution-orchestrator.ts
@@ -37,6 +37,15 @@ export interface SkipTimeProps {
  * Orchestrates test execution lifecycle, polling, and handler invocation for LocalDurableTestRunner.
  * Manages the coordination between checkpoint polling, operation processing, and handler execution.
  */
+// Statuses from which an execution cannot move on. Used to tell an expected
+// update-less notification for a finished execution apart from a real gap.
+const TERMINAL_EXECUTION_STATUSES: ReadonlySet<OperationStatus> = new Set([
+  OperationStatus.SUCCEEDED,
+  OperationStatus.FAILED,
+  OperationStatus.STOPPED,
+  OperationStatus.TIMED_OUT,
+]);
+
 export class TestExecutionOrchestrator {
   private executionState: TestExecutionState;
   private invokeHandlerInstance: InvokeHandler;
@@ -478,6 +487,23 @@ export class TestExecutionOrchestrator {
     operation: Operation,
   ): void {
     if (!update) {
+      // An already-terminal execution is re-published without an update when the
+      // checkpoint server ignores the invocation response. That happens on the
+      // oversized-result path, where a checkpoint completes the execution before
+      // the handler returns, so this notification carries nothing to resolve.
+      // Keep the error for the genuinely unexpected case: a missing update on an
+      // execution that has not reached a terminal state.
+      if (
+        operation.Status &&
+        TERMINAL_EXECUTION_STATUSES.has(operation.Status)
+      ) {
+        defaultLogger.debug(
+          "Ignoring update-less notification for a terminal execution",
+          { status: operation.Status },
+        );
+        return;
+      }
+
       throw new Error("Operation update is missing for execution update");
     }
 


### PR DESCRIPTION
The local test runner recorded two ExecutionSucceeded events, and two
  ExecutionStarted events, for an execution whose result was too large to
  return inline. The service records one of each.

  Split out of #797.

  The bug

  When a handler's return value exceeds Lambda's response size limit, the SDK
  checkpoints it as an EXECUTION-typed SUCCEED update under a synthetic
  execution-result-<timestamp> id, then returns { Status: SUCCEEDED, Result:
  "" } from the invocation.

  The runner treated those as two separate completions:

  - registerUpdate didn't recognise the synthetic id, so it created a second
   EXECUTION-typed operation and emitted ExecutionSucceeded under that id.
  - handleCompletedExecution then finalized the execution's own operation from
  the invocation response, emitting ExecutionSucceeded again under the
  execution id. Re-emitting that operation with an extra event also defeated
  IndexedOperations' history de-duplication, so the whole event list was
  appended a second time — which is why ExecutionStarted was duplicated too.

  What the service does

  From GetDurableExecutionHistory against real Lambda:

  ExecutionStarted      Id: 8a76ceda-dcf9-3eb4-b693-6b45c7aac4d2
  StepStarted           Id: c4ca4238a0b92382
  StepSucceeded         Id: c4ca4238a0b92382
  InvocationCompleted   Id: None
  ExecutionSucceeded    Id: 8a76ceda-dcf9-3eb4-b693-6b45c7aac4d2

  Exactly one terminal event, keyed by the execution id and carrying the
  payload. The result checkpoint does not surface as its own event, and the
  invocation response is ignored because the execution is already terminal.

  The result is genuinely stored rather than echoed back from the response —
  get-durable-execution returns Result of length 6291407 with Status:
  SUCCEEDED even though the SDK returned Result: "".

  The change

  checkpoint-server/storage/checkpoint-manager.ts:

  - registerUpdate redirects any EXECUTION-typed update onto the execution's
  own operation, ignoring the id the caller supplied. An EXECUTION-typed
  update always refers to the execution itself.
  - updateOperation returns before merging the invocation response into the
  stored operation, so a contradictory late status can't overwrite terminal
  state. Previously, following a checkpointed SUCCEED with
  updateOperation(..., FAILED) left the operation FAILED against a recorded
  ExecutionSucceeded.
  - It still publishes the original, unmerged operation. Ignore the response's
  contents, not its arrival: the invocation only runs to completion once an
  update is published. Suppressing it leaves the handler returning but the
  invocation unfinished — no InvocationCompleted event and an empty
  getInvocations(). The published update carries no new events, so the
  terminal event isn't duplicated.

  test-runner/local/test-execution-orchestrator.ts:

  - handleExecutionUpdate treats an update-less notification for an
  already-terminal execution as a no-op instead of throwing "Operation update
  is missing for execution update". That's precisely what the publish above
  is, and the throw was reached on every oversized run — invisible only
  because the execution promise had already resolved. The error is kept for
  the genuinely unexpected case: a missing update on a non-terminal execution.

  The checkpoint server already modelled this contract on the SDK-facing path,
  where registerUpdates rejects updates after completion with "Invalid
  checkpoint token". The internal finalization path bypassed it.

  Result

  Measured on the same oversized execution:

  ```
  ┌─────────────┬────────────┬──────────────┬──────────────┬────────────┐
  │             │ ExecutionS │ ExecutionSuc │ InvocationCo │ getInvocat │
  │             │ tarted     │ ceeded       │ mpleted      │ ions()     │
  ├─────────────┼────────────┼──────────────┼──────────────┼────────────┤
  │ real Lambda │ 1          │ 1            │ present      │ 1          │
  ├─────────────┼────────────┼──────────────┼──────────────┼────────────┤
  │ before      │ 2          │ 2            │ present      │ 1          │
  ├─────────────┼────────────┼──────────────┼──────────────┼────────────┤
  │ after       │ 1          │ 1            │ present      │ 1          │
  └─────────────┴────────────┴──────────────┴──────────────┴────────────┘
  ```

  Only executions with more than one EXECUTION-typed operation are affected,
  which today means only the oversized-result path.

  Why it matters beyond the event count

  LocalOperationStorage builds history from the local runner, whereas
  CloudDurableTestRunner reads the service's authoritative event log via
  HistoryPoller, and assertEventSignatures grants no tolerance on
  ExecutionStarted or terminal events. Any test asserting one committed
  snapshot in both modes could only ever pass locally, and would fail against
  real Lambda for reasons pointing at the snapshot rather than at the harness.

  Known remaining difference

  The service emits InvocationCompleted before the terminal event; the local
  runner emits it after. Closing that needs EventId assignment shared between
  the checkpoint server and the invocation tracker, which can shift history
  order for every execution and may require regenerating example snapshots —
  so it's left to the event-ordering TODO already in
  local-durable-test-runner.ts and tracked separately. The assertions here are
  on counts and ids rather than positions.

  Testing

  Unit coverage in checkpoint-manager-execution-result.test.ts:

  - an EXECUTION-typed checkpoint under a foreign id lands on the execution
  operation, creating no second operation
  - the ignored response is published without being merged and without adding
  a duplicate event
  - a late contradictory status doesn't overwrite terminal state
  - the ordinary inline path still records its terminal event

  Integration coverage in oversized-execution-result.integration.test.ts,
  asserting the assembled history end to end — the layer whose absence hid
  this, since the duplicate events only appear once history is assembled. It
  pins all four columns of the table above, and fails before this change
  (duplicate ExecutionStarted) and if either half of the fix is reverted.

  Suites: testing package 71 suites / 1174 tests. Examples package unaffected:
  133 suites / 187 tests. tsc, ESLint and Prettier clean.