### PR TITLE
docs: record the AI disclosure wording as Legal-approved

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/README.md
@@ -358,7 +358,7 @@ consent; you can review or withdraw it at any time (see below).
 | **Amazon Bedrock** | Amazon Bedrock in your configured AWS account/region; under your AWS agreement + Bedrock terms                           |
 | **GitHub Copilot** | GitHub Copilot via the VS Code Language Model API; under your Copilot subscription terms                                 |
 | **Local server**   | Only the OpenAI-compatible endpoint you run and control (e.g. Ollama on localhost) — no third-party cloud if self-hosted |
-| **On-device**      | Stays entirely on your machine; nothing leaves your computer (source builds only)                                        |
+| **On-device**      | Stays entirely on your machine; nothing leaves your computer                                                             |
 
 Data you send is subject to the terms and privacy policy of the provider you
 select — review them before sending sensitive data. AI-generated queries and

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/AiConsentModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/AiConsentModal.tsx
@@ -24,10 +24,12 @@ interface Props {
  * or the Visualize page). Consent is persisted (workflowInsight.aiDisclosureAcceptedVersion)
  * so it's asked once per disclosure version.
  *
- * LEGAL: This wording is a placeholder pending review/approval by the Legal
- * team (tracked separately). When the approved text lands, update the copy
- * below AND bump AI_DISCLOSURE_VERSION in types.ts so already-consented users
- * are re-prompted.
+ * LEGAL: the copy below is reviewed and approved. Treat it as approved text
+ * rather than ordinary prose to tidy up in passing — it is what users are
+ * consenting to. Changing which providers are named, or what is said about where
+ * data goes, needs Legal review again *and* a bump of AI_DISCLOSURE_VERSION in
+ * types.ts so already-consented users re-accept. That constant documents the test
+ * to apply to a given edit.
  */
 export function AiConsentModal({ visible, capabilities, onAccept, onDecline }: Props) {
   const [agreed, setAgreed] = useState(false);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/types.ts
@@ -249,7 +249,8 @@ export interface Settings {
  * Version of the AI-usage disclosure. Bump this whenever the *substance* of the
  * notice changes — the providers named, or where data can go — so
  * previously-consented users are re-prompted.
- * LEGAL: wording is pending review by the Legal team (see tracked ticket).
+ * LEGAL: the disclosure copy in AiConsentModal.tsx is reviewed and approved. A
+ * substantive edit needs Legal review again as well as a bump here.
  *
  * Currently "2": "1" was the initial gate (features + generic data notice);
  * "2" added the per-provider data-flow breakdown, so early adopters on "1"
@@ -265,6 +266,13 @@ export interface Settings {
  * re-prompting every consented user would be disproportionate. The other
  * host-dependent edits only *remove* bullets, and only on a host where that
  * provider is unreachable, which likewise cannot widen the disclosure.
+ *
+ * Also deliberately NOT bumped when the wording moved from "pending Legal
+ * review" to approved. Legal approved the text as it already stood, so not one
+ * character a user reads changed — only a code comment describing its status.
+ * There is nothing for a consented user to re-accept. (An earlier note here said
+ * to bump when the approved text landed; that anticipated Legal returning
+ * *different* copy, which is not what happened.)
  *
  * The test to apply when editing this text: could a user who already consented
  * be surprised about where their data goes? If yes, bump. If the change only


### PR DESCRIPTION
The AI-usage disclosure carried two markers saying its wording was a placeholder awaiting Legal review. Legal has now approved it, so the markers are stale and misleading — the next person to read them would reasonably assume the copy is provisional and safe to reword.

  AiConsentModal.tsx  "This wording is a placeholder pending review/approval by
                      the Legal team (tracked separately)."
  types.ts            "LEGAL: wording is pending review by the Legal team (see
                      tracked ticket)."

Both now say the copy is reviewed and approved, and keep the useful half of the old note: what a future edit requires. That guard is worth more once the text is approved than it was while it was provisional, so it is stated more precisely — changing which providers are named, or what is said about where data goes, needs Legal review again *and* a version bump.

AI_DISCLOSURE_VERSION deliberately stays at "2", and types.ts now says why. Legal approved the text as it already stood, so not one character a user reads changed — the AiConsentModal diff is comment-only, verified — and there is nothing for a consented user to re-accept. Bumping would re-prompt every existing user for an identical notice. Worth recording because the old comment did say to bump "when the approved text lands": that anticipated Legal returning *different* copy, which is not what happened, and following it literally would have been the wrong call.

Also corrects one factual claim in the same subject matter, in the README's AI data-handling table: the On-device row said "(source builds only)". That is wrong — .vscodeignore explicitly un-ignores node_modules/node-llama-cpp, so the packaged VSIX does ship it and the provider works there. The same stale caveat was removed from the in-app disclosure in #795, so leaving it in the README had the documentation contradicting the approved notice on where data goes. No other row changed.

No behavior change: comments plus one README cell.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
