### PR TITLE
fix(examples): make the SDK coverage harness runnable

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/SDK_COVERAGE.md
+++ b/packages/aws-durable-execution-sdk-js-examples/SDK_COVERAGE.md
@@ -5,8 +5,30 @@ This package is configured to collect code coverage for the core SDK (`aws-durab
 ## How It Works
 
 1. **Pre-test Copy**: Before tests run, `scripts/copy-sdk-source.js` copies the SDK source files into `src/dur-sdk/`
-2. **Module Mapping**: Jest is configured to resolve `@aws/durable-execution-sdk-js` imports to the local `src/dur-sdk/index.ts`
-3. **Coverage Collection**: Jest collects coverage from both example files and SDK source files
+2. **Version Stub Substitution**: The copy script then overwrites the copied `utils/constants/version.ts` with its own `utils/constants/__mocks__/version.ts` stub (see below)
+3. **Module Mapping**: Jest is configured to resolve `@aws/durable-execution-sdk-js` imports to the local `src/dur-sdk/index.ts`
+4. **Coverage Collection**: Jest collects coverage from both example files and SDK source files
+
+### Why version.ts is substituted
+
+The real `utils/constants/version.ts` reads `import.meta.url` at the top level.
+`ts-jest` compiles with `module: commonjs`, where `import.meta` is a hard
+compile error (TS1343) — so _every_ suite that transitively imports the SDK
+fails to compile and the harness reports no coverage at all.
+
+The SDK's own unit tests already avoid this through the manual mock at
+`utils/constants/__mocks__/version.ts`, so the copy script reuses it. Only the
+UserAgent version string differs, and no example asserts on it.
+
+Two things to know if you touch this:
+
+- If `__mocks__/version.ts` is ever renamed or removed, the copy script prints a
+  warning (`⚠ Expected version mock ... was not found`) and the coverage run
+  will fail with TS1343. The warning is the thing to grep for.
+- The substitution means `src/dur-sdk/` is _not_ a byte-faithful copy of the
+  SDK. If new top-level `import.meta` usage is added anywhere else in the SDK,
+  TS1343 will return and will need the same treatment (or the coverage config
+  moved to an ESM-capable `module` target).
 
 ## Running Tests
 
@@ -47,3 +69,5 @@ This will:
 - The `src/dur-sdk/` folder is automatically created and should not be committed
 - Coverage includes both example code and SDK code executed by the examples
 - The SDK source is copied fresh before each test run to ensure it's up-to-date
+- The copied `utils/constants/version.ts` is a stub, not the real module (see
+  [Why version.ts is substituted](#why-versionts-is-substituted))

--- a/packages/aws-durable-execution-sdk-js-examples/scripts/copy-sdk-source.js
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/copy-sdk-source.js
@@ -13,4 +13,27 @@ if (fs.existsSync(targetPath)) {
 
 fs.cpSync(sdkSourcePath, targetPath, { recursive: true });
 
+// `utils/constants/version.ts` reads `import.meta.url` at top level. ts-jest
+// compiles with `module: commonjs`, where that is a hard error (TS1343), so
+// every suite that transitively imports the SDK fails to compile. The SDK's own
+// unit tests avoid this via the manual mock at
+// `utils/constants/__mocks__/version.ts`; do the same here by substituting the
+// stub for the real module in the copied tree. Only the UserAgent version
+// string differs, which no example asserts on.
+const versionMockPath = path.join(
+  targetPath,
+  "utils/constants/__mocks__/version.ts",
+);
+const versionPath = path.join(targetPath, "utils/constants/version.ts");
+
+if (fs.existsSync(versionMockPath)) {
+  fs.copyFileSync(versionMockPath, versionPath);
+  console.log("✓ Substituted version.ts with its ts-jest-safe stub");
+} else {
+  console.warn(
+    `⚠ Expected version mock at ${versionMockPath} was not found; ` +
+      "coverage run may fail with TS1343.",
+  );
+}
+
 console.log(`✓ Copied SDK source to ${targetPath}`);


### PR DESCRIPTION
`npm run test-with-sdk-coverage` could not run at all. Every suite that transitively imports the SDK failed to compile, so the harness reported nothing.

`scripts/copy-sdk-source.js` copies the SDK source into `src/dur-sdk/` so Jest can collect coverage against it. One of the copied modules, `utils/constants/version.ts`, reads `import.meta.url` at top level. ts-jest compiles with `module: commonjs`, where that is a hard error:

    src/dur-sdk/utils/constants/version.ts:38:19 - error TS1343: The
    'import.meta' meta-property is only allowed when the '--module' option is
    'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or
    'nodenext'.

The SDK's own unit tests already avoid this through the manual mock at `utils/constants/__mocks__/version.ts`. Reuse it: after copying, substitute that stub for the real module in the copied tree. Only the UserAgent version string differs, and no example asserts on it.

If the mock is ever renamed or removed the script warns rather than failing silently, since the symptom otherwise reappears as TS1343 in every suite.

Document it in SDK_COVERAGE.md, including the consequence that `src/dur-sdk/` is not a byte-faithful copy of the SDK: new top-level `import.meta` usage anywhere else in the SDK would reintroduce the same error and need the same treatment, or an ESM-capable `module` target for the coverage config.

With this, the harness runs and reports core SDK coverage (currently 85.23% statements for dur-sdk across 139 example suites).