### PR TITLE
test(examples): add a linear retry strategy example

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy-exhausted.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy-exhausted.history.json
@@ -1,0 +1,202 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "69b9e4a2-394e-4e8e-9d4b-4f02deca9b32",
+    "EventTimestamp": "2026-08-07T22:29:51.526Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"succeedOnAttempt\":9,\"maxDelaySeconds\":3}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "EventTimestamp": "2026-08-07T22:29:51.529Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-07T22:29:51.529Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-08-07T22:29:52.529Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 4,
+    "EventTimestamp": "2026-08-07T22:29:51.551Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-07T22:29:51.526Z",
+      "EndTimestamp": "2026-08-07T22:29:51.551Z",
+      "Error": {},
+      "RequestId": "61eb0120-b1b8-4d79-9b04-32b8d1571ff5"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 5,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-07T22:29:52.531Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-07T22:29:52.533Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 2,
+      "ScheduledEndTimestamp": "2026-08-07T22:29:54.533Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2026-08-07T22:29:52.554Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-07T22:29:52.531Z",
+      "EndTimestamp": "2026-08-07T22:29:52.554Z",
+      "Error": {},
+      "RequestId": "0d81df42-6166-436e-841a-dd7379e3fe64"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 8,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-07T22:29:54.534Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 2
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 9,
+    "Id": "13cee27a2bd93915",
+    "EventTimestamp": "2026-08-07T22:29:54.541Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 3,
+      "ScheduledEndTimestamp": "2026-08-07T22:29:57.541Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-08-07T22:29:54.564Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-07T22:29:54.534Z",
+      "EndTimestamp": "2026-08-07T22:29:54.564Z",
+      "Error": {},
+      "RequestId": "8f0a5261-52a3-4043-abf6-62666d26e56a"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 11,
+    "Id": "13cee27a2bd93915",
+    "EventTimestamp": "2026-08-07T22:29:57.542Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 3
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 12,
+    "Id": "3a170a9fe4f47efa",
+    "EventTimestamp": "2026-08-07T22:29:57.551Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 3,
+      "ScheduledEndTimestamp": "2026-08-07T22:30:00.551Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 13,
+    "EventTimestamp": "2026-08-07T22:29:57.574Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-07T22:29:57.543Z",
+      "EndTimestamp": "2026-08-07T22:29:57.574Z",
+      "Error": {},
+      "RequestId": "ac6d0177-1e68-4ff5-ab52-39de6463f90c"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 14,
+    "Id": "3a170a9fe4f47efa",
+    "EventTimestamp": "2026-08-07T22:30:00.552Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 3
+    }
+  },
+  {
+    "EventType": "ContextFailed",
+    "SubType": "RunInChildContext",
+    "EventId": 15,
+    "Id": "c4ca4238a0b92382",
+    "EventTimestamp": "2026-08-07T22:30:00.555Z",
+    "ContextFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorMessage": "Upstream temporarily unavailable (attempt 5)",
+          "ErrorType": "Error"
+        }
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 16,
+    "EventTimestamp": "2026-08-07T22:30:00.555Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-07T22:30:00.553Z",
+      "EndTimestamp": "2026-08-07T22:30:00.555Z",
+      "Error": {
+        "Payload": {
+          "ErrorType": "ChildContextError",
+          "ErrorMessage": "Upstream temporarily unavailable (attempt 5)"
+        }
+      },
+      "RequestId": "0b217582-74ff-4ae0-83eb-49d37ba3db7e"
+    }
+  },
+  {
+    "EventType": "ExecutionFailed",
+    "EventId": 17,
+    "Id": "69b9e4a2-394e-4e8e-9d4b-4f02deca9b32",
+    "EventTimestamp": "2026-08-07T22:30:00.555Z",
+    "ExecutionFailedDetails": {
+      "Error": {
+        "Payload": {
+          "ErrorType": "ChildContextError",
+          "ErrorMessage": "Upstream temporarily unavailable (attempt 5)"
+        }
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.history.json
@@ -2,8 +2,8 @@
   {
     "EventType": "ExecutionStarted",
     "EventId": 1,
-    "Id": "276c4d22-aa75-434e-85b3-a2fc370196ef",
-    "EventTimestamp": "2026-08-06T22:12:37.057Z",
+    "Id": "3321b914-5275-44fe-a8fe-3063706328a6",
+    "EventTimestamp": "2026-08-07T22:29:45.394Z",
     "ExecutionStartedDetails": {
       "Input": {
         "Payload": "{\"succeedOnAttempt\":4}"
@@ -15,7 +15,7 @@
     "SubType": "RunInChildContext",
     "EventId": 2,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-08-06T22:12:37.064Z",
+    "EventTimestamp": "2026-08-07T22:29:45.401Z",
     "ContextStartedDetails": {}
   },
   {
@@ -23,22 +23,22 @@
     "SubType": "Wait",
     "EventId": 3,
     "Id": "ea66c06c1e1c05fa",
-    "EventTimestamp": "2026-08-06T22:12:37.066Z",
+    "EventTimestamp": "2026-08-07T22:29:45.403Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitStartedDetails": {
       "Duration": 1,
-      "ScheduledEndTimestamp": "2026-08-06T22:12:38.066Z"
+      "ScheduledEndTimestamp": "2026-08-07T22:29:46.403Z"
     }
   },
   {
     "EventType": "InvocationCompleted",
     "EventId": 4,
-    "EventTimestamp": "2026-08-06T22:12:37.088Z",
+    "EventTimestamp": "2026-08-07T22:29:45.425Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-08-06T22:12:37.057Z",
-      "EndTimestamp": "2026-08-06T22:12:37.088Z",
+      "StartTimestamp": "2026-08-07T22:29:45.394Z",
+      "EndTimestamp": "2026-08-07T22:29:45.424Z",
       "Error": {},
-      "RequestId": "ef745f36-2d87-46c8-b85d-e38fc29c6136"
+      "RequestId": "fb3908bd-a514-4a43-811c-56b9e482b2ec"
     }
   },
   {
@@ -46,7 +46,7 @@
     "SubType": "Wait",
     "EventId": 5,
     "Id": "ea66c06c1e1c05fa",
-    "EventTimestamp": "2026-08-06T22:12:38.069Z",
+    "EventTimestamp": "2026-08-07T22:29:46.403Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitSucceededDetails": {
       "Duration": 1
@@ -57,22 +57,22 @@
     "SubType": "Wait",
     "EventId": 6,
     "Id": "98c6f2c2287f4c73",
-    "EventTimestamp": "2026-08-06T22:12:38.074Z",
+    "EventTimestamp": "2026-08-07T22:29:46.409Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitStartedDetails": {
       "Duration": 2,
-      "ScheduledEndTimestamp": "2026-08-06T22:12:40.074Z"
+      "ScheduledEndTimestamp": "2026-08-07T22:29:48.409Z"
     }
   },
   {
     "EventType": "InvocationCompleted",
     "EventId": 7,
-    "EventTimestamp": "2026-08-06T22:12:38.097Z",
+    "EventTimestamp": "2026-08-07T22:29:46.431Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-08-06T22:12:38.070Z",
-      "EndTimestamp": "2026-08-06T22:12:38.097Z",
+      "StartTimestamp": "2026-08-07T22:29:46.405Z",
+      "EndTimestamp": "2026-08-07T22:29:46.431Z",
       "Error": {},
-      "RequestId": "8a0f5ad7-1b9d-4a11-a8b7-497b969dd100"
+      "RequestId": "0e7c92e9-ffdf-4df5-b169-af8c49bf8250"
     }
   },
   {
@@ -80,7 +80,7 @@
     "SubType": "Wait",
     "EventId": 8,
     "Id": "98c6f2c2287f4c73",
-    "EventTimestamp": "2026-08-06T22:12:40.075Z",
+    "EventTimestamp": "2026-08-07T22:29:48.409Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitSucceededDetails": {
       "Duration": 2
@@ -91,22 +91,22 @@
     "SubType": "Wait",
     "EventId": 9,
     "Id": "13cee27a2bd93915",
-    "EventTimestamp": "2026-08-06T22:12:40.078Z",
+    "EventTimestamp": "2026-08-07T22:29:48.414Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitStartedDetails": {
       "Duration": 3,
-      "ScheduledEndTimestamp": "2026-08-06T22:12:43.078Z"
+      "ScheduledEndTimestamp": "2026-08-07T22:29:51.414Z"
     }
   },
   {
     "EventType": "InvocationCompleted",
     "EventId": 10,
-    "EventTimestamp": "2026-08-06T22:12:40.099Z",
+    "EventTimestamp": "2026-08-07T22:29:48.436Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-08-06T22:12:40.075Z",
-      "EndTimestamp": "2026-08-06T22:12:40.099Z",
+      "StartTimestamp": "2026-08-07T22:29:48.410Z",
+      "EndTimestamp": "2026-08-07T22:29:48.436Z",
       "Error": {},
-      "RequestId": "488777a8-b46b-4175-a820-e79745db181b"
+      "RequestId": "1378bd9a-eccd-4c56-aa15-836afc7aa9dc"
     }
   },
   {
@@ -114,7 +114,7 @@
     "SubType": "Wait",
     "EventId": 11,
     "Id": "13cee27a2bd93915",
-    "EventTimestamp": "2026-08-06T22:12:43.079Z",
+    "EventTimestamp": "2026-08-07T22:29:51.414Z",
     "ParentId": "c4ca4238a0b92382",
     "WaitSucceededDetails": {
       "Duration": 3
@@ -125,29 +125,29 @@
     "SubType": "RunInChildContext",
     "EventId": 12,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-08-06T22:12:43.084Z",
+    "EventTimestamp": "2026-08-07T22:29:51.417Z",
     "ContextSucceededDetails": {
       "Result": {
-        "Payload": "\"request confirmed on attempt 4\""
+        "Payload": "{\"message\":\"request confirmed on attempt 4\",\"attempts\":4}"
       }
     }
   },
   {
     "EventType": "InvocationCompleted",
     "EventId": 13,
-    "EventTimestamp": "2026-08-06T22:12:43.085Z",
+    "EventTimestamp": "2026-08-07T22:29:51.417Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-08-06T22:12:43.079Z",
-      "EndTimestamp": "2026-08-06T22:12:43.085Z",
+      "StartTimestamp": "2026-08-07T22:29:51.414Z",
+      "EndTimestamp": "2026-08-07T22:29:51.417Z",
       "Error": {},
-      "RequestId": "953583fb-4d29-4a4a-a9a3-efb6a7fce8ad"
+      "RequestId": "86fe5f0b-df58-4bf2-bc40-9081463cee88"
     }
   },
   {
     "EventType": "ExecutionSucceeded",
     "EventId": 14,
-    "Id": "276c4d22-aa75-434e-85b3-a2fc370196ef",
-    "EventTimestamp": "2026-08-06T22:12:43.086Z",
+    "Id": "3321b914-5275-44fe-a8fe-3063706328a6",
+    "EventTimestamp": "2026-08-07T22:29:51.417Z",
     "ExecutionSucceededDetails": {
       "Result": {
         "Payload": "{\"message\":\"request confirmed on attempt 4\",\"attempts\":4}"

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.history.json
@@ -1,0 +1,157 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "276c4d22-aa75-434e-85b3-a2fc370196ef",
+    "EventTimestamp": "2026-08-06T22:12:37.057Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{\"succeedOnAttempt\":4}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "EventTimestamp": "2026-08-06T22:12:37.064Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 3,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-06T22:12:37.066Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 1,
+      "ScheduledEndTimestamp": "2026-08-06T22:12:38.066Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 4,
+    "EventTimestamp": "2026-08-06T22:12:37.088Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-06T22:12:37.057Z",
+      "EndTimestamp": "2026-08-06T22:12:37.088Z",
+      "Error": {},
+      "RequestId": "ef745f36-2d87-46c8-b85d-e38fc29c6136"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 5,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-06T22:12:38.069Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 1
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 6,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-06T22:12:38.074Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 2,
+      "ScheduledEndTimestamp": "2026-08-06T22:12:40.074Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 7,
+    "EventTimestamp": "2026-08-06T22:12:38.097Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-06T22:12:38.070Z",
+      "EndTimestamp": "2026-08-06T22:12:38.097Z",
+      "Error": {},
+      "RequestId": "8a0f5ad7-1b9d-4a11-a8b7-497b969dd100"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 8,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-06T22:12:40.075Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 2
+    }
+  },
+  {
+    "EventType": "WaitStarted",
+    "SubType": "Wait",
+    "EventId": 9,
+    "Id": "13cee27a2bd93915",
+    "EventTimestamp": "2026-08-06T22:12:40.078Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitStartedDetails": {
+      "Duration": 3,
+      "ScheduledEndTimestamp": "2026-08-06T22:12:43.078Z"
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-08-06T22:12:40.099Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-06T22:12:40.075Z",
+      "EndTimestamp": "2026-08-06T22:12:40.099Z",
+      "Error": {},
+      "RequestId": "488777a8-b46b-4175-a820-e79745db181b"
+    }
+  },
+  {
+    "EventType": "WaitSucceeded",
+    "SubType": "Wait",
+    "EventId": 11,
+    "Id": "13cee27a2bd93915",
+    "EventTimestamp": "2026-08-06T22:12:43.079Z",
+    "ParentId": "c4ca4238a0b92382",
+    "WaitSucceededDetails": {
+      "Duration": 3
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "RunInChildContext",
+    "EventId": 12,
+    "Id": "c4ca4238a0b92382",
+    "EventTimestamp": "2026-08-06T22:12:43.084Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"request confirmed on attempt 4\""
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 13,
+    "EventTimestamp": "2026-08-06T22:12:43.085Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-06T22:12:43.079Z",
+      "EndTimestamp": "2026-08-06T22:12:43.085Z",
+      "Error": {},
+      "RequestId": "953583fb-4d29-4a4a-a9a3-efb6a7fce8ad"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 14,
+    "Id": "276c4d22-aa75-434e-85b3-a2fc370196ef",
+    "EventTimestamp": "2026-08-06T22:12:43.086Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"message\":\"request confirmed on attempt 4\",\"attempts\":4}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.test.ts
@@ -1,0 +1,37 @@
+import { handler } from "./with-retry-linear-strategy";
+import { createTests } from "../../../utils/test-helper";
+
+createTests({
+  handler,
+  tests: (runner, { assertEventSignatures }) => {
+    it("should retry with linear backoff and succeed on the fourth attempt", async () => {
+      const execution = await runner.run({ payload: { succeedOnAttempt: 4 } });
+
+      // Attempts 1, 2 and 3 fail, attempt 4 succeeds.
+      expect(execution.getResult()).toEqual({
+        message: "request confirmed on attempt 4",
+        attempts: 4,
+      });
+
+      // The backoff DURATIONS are what make this strategy linear, and they are
+      // not covered by assertEventSignatures — the event signature is only
+      // {EventType, SubType, Name}, so an exponential strategy retrying would
+      // produce a byte-identical signature. Assert the actual delays:
+      // initialDelay 1s + increment 1s per attempt, with JitterStrategy.NONE
+      // keeping them exact.
+      //
+      // Three delays are needed, not two: exponential backoff from the same 1s
+      // initial delay also produces 1s then 2s, so [1, 2] would pass for either
+      // strategy. Only the third delay separates them (linear 3s vs
+      // exponential 4s).
+      const waitDurations = execution
+        .getHistoryEvents()
+        .filter((event) => event.EventType === "WaitStarted")
+        .map((event) => event.WaitStartedDetails?.Duration);
+
+      expect(waitDurations).toEqual([1, 2, 3]);
+
+      assertEventSignatures(execution);
+    });
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.test.ts
@@ -1,5 +1,29 @@
+import { EventType } from "@aws-sdk/client-lambda";
+import { ExecutionStatus } from "@aws/durable-execution-sdk-js-testing";
 import { handler } from "./with-retry-linear-strategy";
 import { createTests } from "../../../utils/test-helper";
+
+/**
+ * The recorded backoff delays, in seconds.
+ *
+ * This is the only example test that reaches for raw history events. It has to:
+ * the durations are not exposed on the operations API, and
+ * `assertEventSignatures` compares only {EventType, SubType, Name} and excludes
+ * Wait durations — so an exponential strategy retrying the same number of times
+ * produces a byte-identical signature. The durations are the only thing that
+ * identifies the strategy.
+ */
+function waitDurationsOf(execution: {
+  getHistoryEvents: () => {
+    EventType?: string;
+    WaitStartedDetails?: { Duration?: number };
+  }[];
+}): (number | undefined)[] {
+  return execution
+    .getHistoryEvents()
+    .filter((event) => event.EventType === EventType.WaitStarted)
+    .map((event) => event.WaitStartedDetails?.Duration);
+}
 
 createTests({
   handler,
@@ -7,31 +31,46 @@ createTests({
     it("should retry with linear backoff and succeed on the fourth attempt", async () => {
       const execution = await runner.run({ payload: { succeedOnAttempt: 4 } });
 
-      // Attempts 1, 2 and 3 fail, attempt 4 succeeds.
+      expect(execution.getStatus()).toBe(ExecutionStatus.SUCCEEDED);
+
+      // Attempts 1, 2 and 3 fail, attempt 4 succeeds. The count is returned from
+      // inside the retried function, so it survives replay.
       expect(execution.getResult()).toEqual({
         message: "request confirmed on attempt 4",
         attempts: 4,
       });
 
-      // The backoff DURATIONS are what make this strategy linear, and they are
-      // not covered by assertEventSignatures — the event signature is only
-      // {EventType, SubType, Name}, so an exponential strategy retrying would
-      // produce a byte-identical signature. Assert the actual delays:
-      // initialDelay 1s + increment 1s per attempt, with JitterStrategy.NONE
-      // keeping them exact.
-      //
       // Three delays are needed, not two: exponential backoff from the same 1s
       // initial delay also produces 1s then 2s, so [1, 2] would pass for either
-      // strategy. Only the third delay separates them (linear 3s vs
-      // exponential 4s).
-      const waitDurations = execution
-        .getHistoryEvents()
-        .filter((event) => event.EventType === "WaitStarted")
-        .map((event) => event.WaitStartedDetails?.Duration);
-
-      expect(waitDurations).toEqual([1, 2, 3]);
+      // strategy. Only the third delay separates them — linear 3s against
+      // exponential 4s.
+      expect(waitDurationsOf(execution)).toEqual([1, 2, 3]);
 
       assertEventSignatures(execution);
+    });
+
+    it("should exhaust its retries and propagate the last error", async () => {
+      // Above maxAttempts (5), so every attempt fails and the strategy stops
+      // retrying — the `attemptsMade >= maxAttempts` branch.
+      const execution = await runner.run({
+        payload: { succeedOnAttempt: 9, maxDelaySeconds: 3 },
+      });
+
+      expect(execution.getStatus()).toBe(ExecutionStatus.FAILED);
+
+      // The error from the LAST attempt propagates, not the first.
+      expect(execution.getError()?.errorMessage).toContain(
+        "Upstream temporarily unavailable (attempt 5)",
+      );
+
+      // Four delays for five attempts, with maxDelay lowered to 3s so the
+      // fourth is clamped: the linear formula would give 4s. The success case
+      // leaves maxDelay generous on purpose -- clamping there would collapse
+      // [1, 2, 3] onto exponential's [1, 2, 4 -> 3] and the assertion above
+      // would stop distinguishing the two strategies.
+      expect(waitDurationsOf(execution)).toEqual([1, 2, 3, 3]);
+
+      assertEventSignatures(execution, "exhausted");
     });
   },
 });

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.ts
@@ -12,8 +12,14 @@ export const config: ExampleConfig = {
   description:
     "Retries a flaky block of durable logic with a LINEAR backoff strategy " +
     "(createLinearRetryStrategy) using the anonymous withRetry helper. Delays " +
-    "grow linearly (1s, 2s, 3s, ...) rather than exponentially.",
+    "grow linearly (1s, 2s, 3s, ...) rather than exponentially, up to maxDelay. " +
+    "Retries can also be exhausted, in which case the last error propagates.",
 };
+
+interface RetryResult {
+  message: string;
+  attempts: number;
+}
 
 /**
  * Demonstrates {@link createLinearRetryStrategy}, the linear-backoff retry
@@ -24,54 +30,72 @@ export const config: ExampleConfig = {
  *
  *   delay = min(initialDelay + increment * (attempt - 1), maxDelay)
  *
- * Here the first retry waits 1s, the second 2s, the third 3s, and so on, capped
- * at 10s. That third delay is what distinguishes linear from exponential
- * backoff: an exponential strategy with the same 1s initial delay would wait
- * 1s, 2s, 4s. `JitterStrategy.NONE` keeps the delays deterministic so the
- * behavior is easy to reason about in an example; production code often prefers
- * FULL jitter to avoid a thundering herd.
+ * With the configuration below the delays are 1s, 2s, 3s, 4s. The third delay is
+ * what distinguishes linear from exponential backoff: an exponential strategy
+ * with the same 1s initial delay would wait 1s, 2s, 4s. `maxDelay` clamps them,
+ * which the exhaustion test exercises by lowering it. `JitterStrategy.NONE` keeps the delays deterministic so
+ * the behavior is easy to reason about in an example; production code often
+ * prefers FULL jitter to avoid a thundering herd.
  *
  * We use the *anonymous* `withRetry(context, func, config)` overload (no name),
  * so the backoff waits between attempts are anonymous. `withRetry` re-runs the
  * whole function body from the top on each failure — this is "retry this block
  * of logic", not "retry a single operation".
+ *
+ * The "flaky upstream" here is plain in-process code, which keeps the example
+ * about the strategy alone. A real upstream call belongs in a `context.step` so
+ * that a successful attempt is checkpointed and not re-issued on replay.
+ *
+ * Note that the attempt count is *returned from inside* the retried function
+ * rather than assigned to a variable in the enclosing scope. Closure mutations
+ * do not survive a replay (AGENTS.md, "Closure Mutations Are Lost on Replay"):
+ * the retry runs in a child context, so on resume the value is restored from its
+ * checkpoint without the body re-running, and an outer variable would read back
+ * as its initial value.
  */
 export const handler = withDurableExecution(
   async (
-    event: { succeedOnAttempt?: number },
+    event: { succeedOnAttempt?: number; maxDelaySeconds?: number },
     context: DurableContext,
-  ): Promise<{ message: string; attempts: number }> => {
+  ): Promise<RetryResult> => {
     // Succeed on the 4th attempt by default: attempts 1, 2 and 3 fail, so the
     // linear strategy is exercised three times (1s, 2s, then 3s backoff). Three
     // delays rather than two is deliberate — the first two are the same under
     // exponential backoff, so only the 3s delay proves the strategy is linear.
-    const succeedOnAttempt = event?.succeedOnAttempt ?? 4;
-    let attempts = 0;
+    //
+    // Pass a value above `maxAttempts` to exhaust the retries instead, in which
+    // case the last error propagates out of `withRetry`.
+    const succeedOnAttempt = event.succeedOnAttempt ?? 4;
 
-    const message = await withRetry<string>(
+    // Generous by default so the delays grow unclamped and stay recognisably
+    // linear. Lower it to watch `maxDelay` clamp them.
+    const maxDelaySeconds = event.maxDelaySeconds ?? 10;
+
+    return await withRetry<RetryResult>(
       context,
       async (_ctx, attempt) => {
-        attempts = attempt;
         // Simulate a flaky upstream that only becomes healthy after warming up.
         if (attempt < succeedOnAttempt) {
           throw new Error(
             `Upstream temporarily unavailable (attempt ${attempt})`,
           );
         }
-        return `request confirmed on attempt ${attempt}`;
+        return {
+          message: `request confirmed on attempt ${attempt}`,
+          attempts: attempt,
+        };
       },
       {
-        // Linear backoff: 1s, 2s, 3s, 4s (capped at maxDelay), up to 5 attempts.
+        // Linear backoff over at most 5 attempts, so at most 4 delays:
+        // 1s, 2s, 3s, 4s — each clamped to `maxDelay`.
         retryStrategy: createLinearRetryStrategy({
           maxAttempts: 5,
           initialDelay: { seconds: 1 },
           increment: { seconds: 1 },
-          maxDelay: { seconds: 10 },
+          maxDelay: { seconds: maxDelaySeconds },
           jitter: JitterStrategy.NONE,
         }),
       },
     );
-
-    return { message, attempts };
   },
 );

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/with-retry/linear-strategy/with-retry-linear-strategy.ts
@@ -1,0 +1,77 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  withRetry,
+  createLinearRetryStrategy,
+  JitterStrategy,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "With Retry - Linear Strategy",
+  description:
+    "Retries a flaky block of durable logic with a LINEAR backoff strategy " +
+    "(createLinearRetryStrategy) using the anonymous withRetry helper. Delays " +
+    "grow linearly (1s, 2s, 3s, ...) rather than exponentially.",
+};
+
+/**
+ * Demonstrates {@link createLinearRetryStrategy}, the linear-backoff retry
+ * strategy, driven through the anonymous form of {@link withRetry}.
+ *
+ * Unlike the default exponential preset, a linear strategy increases the delay
+ * by a fixed `increment` on every attempt:
+ *
+ *   delay = min(initialDelay + increment * (attempt - 1), maxDelay)
+ *
+ * Here the first retry waits 1s, the second 2s, the third 3s, and so on, capped
+ * at 10s. That third delay is what distinguishes linear from exponential
+ * backoff: an exponential strategy with the same 1s initial delay would wait
+ * 1s, 2s, 4s. `JitterStrategy.NONE` keeps the delays deterministic so the
+ * behavior is easy to reason about in an example; production code often prefers
+ * FULL jitter to avoid a thundering herd.
+ *
+ * We use the *anonymous* `withRetry(context, func, config)` overload (no name),
+ * so the backoff waits between attempts are anonymous. `withRetry` re-runs the
+ * whole function body from the top on each failure — this is "retry this block
+ * of logic", not "retry a single operation".
+ */
+export const handler = withDurableExecution(
+  async (
+    event: { succeedOnAttempt?: number },
+    context: DurableContext,
+  ): Promise<{ message: string; attempts: number }> => {
+    // Succeed on the 4th attempt by default: attempts 1, 2 and 3 fail, so the
+    // linear strategy is exercised three times (1s, 2s, then 3s backoff). Three
+    // delays rather than two is deliberate — the first two are the same under
+    // exponential backoff, so only the 3s delay proves the strategy is linear.
+    const succeedOnAttempt = event?.succeedOnAttempt ?? 4;
+    let attempts = 0;
+
+    const message = await withRetry<string>(
+      context,
+      async (_ctx, attempt) => {
+        attempts = attempt;
+        // Simulate a flaky upstream that only becomes healthy after warming up.
+        if (attempt < succeedOnAttempt) {
+          throw new Error(
+            `Upstream temporarily unavailable (attempt ${attempt})`,
+          );
+        }
+        return `request confirmed on attempt ${attempt}`;
+      },
+      {
+        // Linear backoff: 1s, 2s, 3s, 4s (capped at maxDelay), up to 5 attempts.
+        retryStrategy: createLinearRetryStrategy({
+          maxAttempts: 5,
+          initialDelay: { seconds: 1 },
+          increment: { seconds: 1 },
+          maxDelay: { seconds: 10 },
+          jitter: JitterStrategy.NONE,
+        }),
+      },
+    );
+
+    return { message, attempts };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -3596,3 +3596,28 @@ Resources:
           AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
     Metadata:
       SkipBuild: "True"
+  WithRetryLinearStrategy:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: WithRetry-LinearStrategy-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: with-retry-linear-strategy.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+    Metadata:
+      SkipBuild: "True"


### PR DESCRIPTION
`createLinearRetryStrategy` had no example. Coverage of `utils/retry/linear-retry-strategy` was 47.36% statements, 0% branches.

The example retries a flaky block through the anonymous `withRetry(context, func, config)` overload -- the form that takes no name, so the backoff waits are anonymous -- with a linear strategy: `initialDelay` 1s, `increment` 1s, `JitterStrategy.NONE` to keep the delays exact.

It succeeds on the fourth attempt, not the third, and that matters. The test asserts the recorded wait durations are [1, 2, 3], and three delays are the minimum that identify the strategy: exponential backoff from the same 1s initial delay also produces 1s then 2s, so [1, 2] would pass for either. Only the third delay separates them -- linear 3s against exponential 4s. Mutation `createLinearRetryStrategy` -> `createRetryStrategy({ backoffRate: 2 })` fails the suite.

Durations have to be asserted explicitly because `assertEventSignatures` compares only {EventType, SubType, Name} counts and excludes Wait durations, so an exponential strategy retrying the same number of times produces a byte-identical signature.

Coverage of `linear-retry-strategy.ts` goes from 47.36 / 0 / 50 / 44.44 to 89.47 / 40 / 100 / 88.88 (statements / branches / functions / lines). The remaining uncovered lines are the maxDelay cap and the jitter branches, which need delays long enough to clamp.

Regenerate template.yml: one new function.