### PR TITLE
feat(insight): serve Workflow Insight from an MCP server host

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
         run: npm run build -w packages/aws-durable-execution-sdk-js-insight-vscode
       - name: Bundle the desktop app
         run: npm run build -w packages/aws-durable-execution-sdk-js-insight-desktop
+      - name: Bundle the MCP server
+        run: npm run build -w packages/durable-insight-mcp
 
   unit-tests:
     needs: build

--- a/.github/workflows/iterate-publish-npm.sh
+++ b/.github/workflows/iterate-publish-npm.sh
@@ -29,6 +29,7 @@ else
     "packages/aws-durable-execution-sdk-js-eslint-plugin"
     "packages/aws-durable-execution-sdk-js-otel"
     "packages/aws-durable-execution-sdk-js-insight"
+    "packages/durable-insight-mcp"
   )
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27739,7 +27739,6 @@
       "version": "0.1.0-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws/durable-insight-core": "0.1.0-alpha.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^4.4.3"
       },
@@ -27747,6 +27746,7 @@
         "durable-insight-mcp": "dist/server.js"
       },
       "devDependencies": {
+        "@aws/durable-insight-core": "0.1.0-alpha.0",
         "@types/jest": "^29.5.0",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,6 +1355,10 @@
       "resolved": "packages/durable-insight-core",
       "link": true
     },
+    "node_modules/@aws/durable-insight-mcp": {
+      "resolved": "packages/durable-insight-mcp",
+      "link": true
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
@@ -2886,6 +2890,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
@@ -3763,6 +3779,46 @@
         "ajv": "~8.18.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7364,6 +7420,44 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -7422,7 +7516,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -7454,7 +7547,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -8028,6 +8120,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -8275,7 +8404,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8283,6 +8411,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -8762,6 +8906,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -8769,12 +8935,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -9892,6 +10093,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -10038,7 +10248,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -10064,6 +10273,12 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -10275,6 +10490,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10338,7 +10562,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10348,7 +10571,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10365,7 +10587,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -10448,6 +10669,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -10959,11 +11186,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -11050,6 +11307,93 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -11131,7 +11475,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -11152,7 +11495,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11299,6 +11641,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -11371,12 +11734,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -11418,7 +11799,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11459,7 +11839,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -11494,7 +11873,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -11645,7 +12023,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11743,7 +12120,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11772,13 +12148,21 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -11827,6 +12211,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -11894,6 +12298,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -11994,7 +12414,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -12002,6 +12421,24 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/ipull": {
       "version": "3.9.5",
@@ -12234,6 +12671,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -13017,6 +13460,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13078,8 +13530,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13812,10 +14269,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -14052,6 +14533,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -14374,6 +14864,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -14402,11 +14913,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -14611,6 +15133,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -14671,6 +15202,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -14728,6 +15269,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -15088,6 +15638,19 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -15146,6 +15709,22 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15187,6 +15766,34 @@
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -15262,7 +15869,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15596,6 +16202,22 @@
         "rollup": "^4.0.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15635,6 +16257,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -15701,6 +16329,57 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -15732,6 +16411,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15759,6 +16463,78 @@
       "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -15942,6 +16718,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -16550,6 +17335,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -16777,6 +17571,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -16860,6 +17710,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unrs-resolver": {
@@ -17016,6 +17875,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -17360,7 +18228,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -17540,6 +18407,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/aws-durable-execution-sdk-js": {
@@ -26836,6 +27721,1646 @@
       }
     },
     "packages/durable-insight-core/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "packages/durable-insight-mcp": {
+      "name": "@aws/durable-insight-mcp",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws/durable-insight-core": "0.1.0-alpha.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "durable-insight-mcp": "dist/server.js"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "esbuild": "^0.24.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.0",
+        "typescript": "~5.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/durable-insight-mcp/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/durable-insight-mcp/node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/durable-insight-mcp/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/durable-insight-mcp/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/durable-insight-mcp/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && npm install --workspaces",
-    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-otel && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/aws-durable-execution-sdk-js-insight && npm run test -w packages/cjs-integration-test && npm run test -w packages/esm-integration-test && npm run test -w packages/cdk-bundling-integration-test && npm run test -w packages/lambda-runtime-detection-integration-test && npm run test -w packages/durable-insight-core && npm run test -w packages/aws-durable-execution-sdk-js-insight-vscode && npm run test -w packages/aws-durable-execution-sdk-js-insight-desktop",
+    "test": "npm run test -w packages/aws-durable-execution-sdk-js && npm run test -w packages/aws-durable-execution-sdk-js-testing && npm run test -w packages/aws-durable-execution-sdk-js-otel && npm run test -w packages/aws-durable-execution-sdk-js-examples && npm run test -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run test -w packages/aws-durable-execution-sdk-js-insight && npm run test -w packages/cjs-integration-test && npm run test -w packages/esm-integration-test && npm run test -w packages/cdk-bundling-integration-test && npm run test -w packages/lambda-runtime-detection-integration-test && npm run test -w packages/durable-insight-core && npm run test -w packages/aws-durable-execution-sdk-js-insight-vscode && npm run test -w packages/aws-durable-execution-sdk-js-insight-desktop && npm run test -w packages/durable-insight-mcp",
     "test:integration": "node .github/workflows/scripts/integration-test/integration-test.js",
-    "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-otel && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run build -w packages/aws-durable-execution-sdk-js-insight",
+    "build": "npm run build -w packages/aws-durable-execution-sdk-js && npm run build -w packages/aws-durable-execution-sdk-js-testing && npm run build -w packages/aws-durable-execution-sdk-js-otel && npm run build -w packages/aws-durable-execution-sdk-js-examples && npm run build -w packages/aws-durable-execution-sdk-js-eslint-plugin && npm run build -w packages/aws-durable-execution-sdk-js-insight && npm run build -w packages/durable-insight-mcp",
     "postpublish": "git restore .",
     "clean": "rm -rf node_modules && npm run clean --workspaces --if-present",
     "prepare": "husky install",
     "run-durable": "NODE_OPTIONS=\"--import tsx\" npx run-durable --",
     "lint": "eslint .",
-    "typecheck:hosts": "npm run typecheck -w packages/durable-insight-core && npm run typecheck -w packages/aws-durable-execution-sdk-js-insight-vscode && npm run typecheck -w packages/aws-durable-execution-sdk-js-insight-desktop"
+    "typecheck:hosts": "npm run typecheck -w packages/durable-insight-core && npm run typecheck -w packages/aws-durable-execution-sdk-js-insight-vscode && npm run typecheck -w packages/aws-durable-execution-sdk-js-insight-desktop && npm run typecheck -w packages/durable-insight-mcp"
   },
   "repository": {
     "type": "git",

--- a/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
@@ -815,6 +815,26 @@ Review of this change added five more, all of them the same shape as the two abo
   `hasMore`. Note the MCP host's own tests could not have caught a regression here --
   they mock the runner -- so the pinning test lives in core, against the SDK response.
 
+A second review round added two more, both of which passed every test for the same
+reason -- the default value made the bug invisible:
+
+- **Two bounds that can disagree.** On a log destination `since`/`until` become
+  `filter` stages inside the pipe query, while the `StartQuery` window is a separate
+  parameter that stayed at its 24-hour default. Asking for executions since last week
+  scanned one day, applied a filter everything in that day satisfied, and returned a
+  plausible partial answer with `truncated: false`. The window is now derived from the
+  bounds, deliberately as a superset, and reported as `searchedLookbackHours`. General
+  lesson: when a result is bounded in two places, assert on the bound the caller cannot
+  see, not on the query text -- the query text was correct throughout.
+- **A default that hid a missing qualification.** The Redshift target was the bare
+  table name while core qualifies it with `redshiftSchema` in four places. It passed
+  because the default schema is `public`, where an unqualified name resolves through
+  `search_path` to the same table; set the documented setting to anything else and the
+  same SQL reads a different table. An existing test asserted `FROM workflow_insight`
+  and so pinned the bug. Both the generated SQL and the target `describe_schema`
+  teaches now go through one helper, because a target the agent is taught that differs
+  from the one queried is its own failure.
+
 ## 14. Risks
 
 | Risk                                                         | Severity | Mitigation                                                                         |

--- a/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
@@ -1,0 +1,846 @@
+# Workflow Insight as an MCP Host — Design
+
+|              |                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------- |
+| **Status**   | Phases 0–5 complete. Phase 1 merged (#809); Phases 2–5 are **this** change                            |
+| **Scope**    | New package `@aws/durable-insight-mcp`, plus extraction of `durable-insight-core`                     |
+| **Baseline** | `main` @ `556bfd40`, i.e. after #795 (dual host), #804 (disclosure), #809 (core)                      |
+| **Legal**    | **Confirmed** — disclosure only, no consent gate. See [§8](#8-disclosure-readme-only-no-consent-gate) |
+
+> This document ships with the implementation it describes. Phase 1 (the shared core)
+> merged separately as #809; Phases 2–5 are the change you are reading. Phase 6 is
+> deliberately deferred — see §11.
+
+---
+
+## 1. Summary
+
+Customers have asked to use Workflow Insight from inside the AI agent they already
+work in — Claude Code, Kiro IDE, Kiro CLI — rather than through a VS Code
+extension or a desktop app.
+
+We propose serving that as a **third host** on the seam introduced by #795: an MCP
+server that exposes the existing query layer as tools, paired with a **skill** that
+carries the per-destination schema expertise we already generate for our own
+prompts.
+
+The work is meaningfully smaller than the Electron host was, because this host
+_deletes_ a subsystem rather than adding one: the agent is the model, so roughly
+1,700 lines of LLM plumbing do not come along.
+
+Phase 0 is complete: Legal confirmed the disclosure position (§8), design review
+ratified that the MCP host bypasses `ExplorerSession` (§6.3), and client config paths
+are verified (§6.4). Phase 1 — extracting `durable-insight-core` — is unblocked. The
+remaining open items (§15) are scoping calls, not blockers.
+
+---
+
+## 2. Motivation
+
+**Customer feedback.** The functionality is wanted, the delivery vehicle is not.
+Users investigating a failed workflow are already in an agent session; switching to
+a separate app to ask "why did this fail" and then switching back to act on the
+answer is the friction being reported.
+
+**The follow-up question is the real product.** Today a user asks one question, gets
+a table, and asks the next question from scratch. In an agent, "show me the input
+payloads for those three executions" is just the next turn — no new UI, no new query
+mode, no chart configuration. This is a capability the extension structurally cannot
+offer, not merely a packaging preference.
+
+**Competitive parity.** Our own competitive analysis records DBOS shipping an "MCP
+server for AI agents" (`workflow-observability-requirements-v2.md`, DBOS row). This
+is table stakes rather than differentiation.
+
+**Architectural validation.** #795 asserted that Explorer behavior is host-free. A
+third host with a radically different shape — no UI, no webview, no LLM — is the
+strongest available test of that claim, and the cheapest time to find out it is
+false.
+
+---
+
+## 3. Goals and non-goals
+
+### Goals
+
+- **G1** Query workflow execution data from any MCP-capable agent with no install
+  step beyond a config block.
+- **G2** Support the destinations the extension supports, with the same read-only
+  guarantees.
+- **G3** Give the agent enough schema knowledge to write correct queries against
+  whichever of the 8 destinations the customer uses.
+- **G4** Reuse the existing core rather than fork it; a third consumer must not
+  cause a third copy of anything.
+- **G5** Setup no harder than the extension's — ideally easier, since credentials
+  need no configuration.
+
+### Non-goals
+
+- **NG1** Charts and an interactive result grid. See §9.
+- **NG2** Replacing the VS Code or Electron hosts. This is additive; both keep
+  every feature they have today.
+- **NG3** Shipping our own LLM integration in this host. The agent supplies the
+  model, and we should not second-guess it.
+- **NG4** Write operations of any kind. Read-only is a product invariant, not a
+  phase-one limitation.
+- **NG5** Streaming/tail in v1. See §11 Phase 6.
+
+---
+
+## 4. Background: what #795 left us
+
+Measured on `main` @ `556bfd40`, in `packages/aws-durable-execution-sdk-js-insight-vscode/src`:
+
+| Category                | Files                                                                                                           | Lines     | Fate in MCP host                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- | --------- | ---------------------------------- |
+| **VS Code-bound**       | `extension.ts` (248), `config.ts` (31)                                                                          | **279**   | Not used                           |
+| Data access             | `athena` 436, `opensearch` 222, `logsInsights` 218, `redshift` 205, `aurora` 148, `dynamodb` 130, `sqs` 110     | **1,469** | **Reused as-is**                   |
+| Schema knowledge        | `schema.ts`                                                                                                     | **754**   | **Reused**; also becomes the skill |
+| Query safety            | `queryShape` 392, `verdict` 143, `queryValidator` 127, `sandbox` 101                                            | **763**   | Reused; safety promoted (§6.7)     |
+| Destination diagnostics | `destinationTest.ts`                                                                                            | **411**   | **Reused** as `test_destination`   |
+| Seam                    | `configCore` 220, `hostCapabilities` 105, `hostPort` 80                                                         | **405**   | Reused, adapted                    |
+| Session/dispatch        | `explorerSession.ts`                                                                                            | **1,639** | Partially reused (§6.3)            |
+| **LLM machinery**       | `llm` 851, `agentLoop` 528, `bedrockModels` 86, `localServerParse` 84, `bedrockConverse` 70, `copilotBridge` 58 | **1,677** | **Dropped**                        |
+| Charts                  | `chartSpec.ts`                                                                                                  | **238**   | Not used in v1 (§9)                |
+
+Only **279 of ~7,000 lines** are VS Code-bound. The Electron host already proved
+the remainder is portable, and `hostAgnostic.test.ts` mechanically enforces that no
+module reachable from a non-VS-Code host imports `vscode`.
+
+**Dropping 1,677 lines of LLM plumbing also drops its problems:** provider
+selection and coercion, model lists, `downloadModel`, the `node-llama-cpp` native
+addon, and the Electron binary/packaging friction that dominated #795's review.
+
+---
+
+## 5. Design overview
+
+```
+                       ┌──────────────────────────────────┐
+                       │ durable-insight-core (host-free) │
+                       │  data access · schema · safety   │
+                       │   configCore · destinationTest   │
+                       └──────────────────────────────────┘
+                                ▲        ▲       ▲
+                ┌───────────────┘        │       └────────────────┐
+     ┌──────────┴──────────┐  ┌──────────┴──────────┐  ┌──────────┴──────────┐
+     │  …-insight-vscode   │  │  …-insight-desktop  │  │ durable-insight-mcp │
+     │   (existing name)   │  │   (existing name)   │  │        (NEW)        │
+     │    extension.ts     │  │    main/host.ts     │  │      server.ts      │
+     │    + webview UI     │  │     + Electron      │  │    stdio, no UI     │
+     │      LLM: ours      │  │      LLM: ours      │  │   LLM: the agent    │
+     └─────────────────────┘  └─────────────────────┘  └─────────────────────┘
+```
+
+**Naming:** the two new packages take the `durable-insight-*` stem. The two existing
+hosts keep their current `aws-durable-execution-sdk-js-insight-*` names for now;
+renaming them (and the settings namespace and display name) is deferred to separate
+work — see §15 note on naming.
+
+Three deliberate choices:
+
+**5.1 The MCP server is a host, not a feature.** It sits where `extension.ts` and
+`main.ts` sit. It owns transport, config, and tool registration, and nothing else.
+
+**5.2 Capability and expertise are separate layers.** MCP gives the agent reach;
+the skill gives it competence. Shipping tools without schema guidance produces an
+agent that writes plausible-but-wrong queries against 8 subtly different backends
+and blames our tool. Both are required; see §6.6.
+
+**5.3 The agent is the model.** No provider config, no prompt engineering, no
+agentic loop of our own. `queryMode` (`query`/`ask`/`agent`) collapses: every MCP
+interaction is what the extension calls _agent_ mode, with the client's model
+driving.
+
+---
+
+## 6. Detailed design
+
+### 6.1 New package
+
+```
+packages/durable-insight-mcp/
+├── package.json          # @aws/durable-insight-mcp, bin: durable-insight-mcp
+├── src/
+│   ├── server.ts         # MCP server, transport, registration
+│   ├── tools/            # one module per tool
+│   ├── config.ts         # env → InsightConfig (via configCore)
+│   ├── envKeys.ts        # SETTING_KEYS ↔ env var mapping
+│   └── skill/SKILL.md    # published skill (§6.6)
+└── README.md
+```
+
+`workspaces: ["packages/*"]` picks it up with no root change.
+
+**Four names, deliberately distinct:**
+
+| Layer                         | Value                          |
+| ----------------------------- | ------------------------------ |
+| Directory                     | `packages/durable-insight-mcp` |
+| npm package                   | `@aws/durable-insight-mcp`     |
+| `bin`                         | `durable-insight-mcp`          |
+| Server key in customer config | `durable-insight`              |
+
+The server key is the customer's choice but the README should suggest
+`durable-insight`: prefixed tool names are capped at 64 characters, and
+`durable-insight/test_destination` is 32.
+
+**This host must be published, unlike its siblings.** The repo's convention splits
+on publishability, not on package kind:
+
+| Kind      | Convention                       | Examples                                                                 |
+| --------- | -------------------------------- | ------------------------------------------------------------------------ |
+| Published | `@aws/`-scoped, `private: false` | `@aws/durable-execution-sdk-js`, `@aws/durable-execution-sdk-js-insight` |
+| Hosts     | unscoped, `private: true`        | `-insight-vscode`, `-insight-desktop`                                    |
+
+Both existing hosts are private because they ship as a VSIX and an app. This one
+ships through npm — `npx -y @aws/durable-insight-mcp` cannot resolve anything
+else — so it is the first host needing `@aws/` scope and `private: false`. Version
+starts at `0.1.0-alpha.0` to match the insight family.
+
+### 6.2 Prerequisite: extract `durable-insight-core`
+
+The desktop host currently reaches the shared core by relative path with **no
+declared dependency**:
+
+```ts
+from "../../aws-durable-execution-sdk-js-insight-vscode/src/explorerSession"
+```
+
+Tolerable at two hosts. At three it becomes an MCP package importing across two
+sibling packages to reach code that lives, misleadingly, inside the _VS Code_
+package.
+
+Extract `packages/durable-insight-core` containing every host-free module in §4 (data access, schema, safety, `destinationTest`,
+`configCore`, `hostPort`, `hostCapabilities`, `settingsKeys`). Mostly `git mv` plus
+import rewrites, guarded by the existing test suites (222 in `-insight-vscode`,
+36 in `-insight-desktop`).
+
+Do this **before** the MCP work. Doing it after means rewriting three hosts'
+imports instead of two.
+
+> This is the only part of the project that touches VS Code and Electron code. It is
+> a no-behavior-change refactor, but it is not zero-risk, and it should be its own
+> reviewable PR.
+
+### 6.3 What happens to `explorerSession.ts`
+
+`ExplorerSession` (1,639 lines) is host-free but _shaped for a UI_: it dispatches
+`{type}` messages and pushes results back via `HostPort.post`. Its ~17 message
+types split cleanly:
+
+| Extension message                              | MCP fate                            |
+| ---------------------------------------------- | ----------------------------------- |
+| `fetchDetail`                                  | → `get_execution` tool              |
+| `testDestination`                              | → `test_destination` tool           |
+| `generate`                                     | dropped — the agent generates       |
+| `visualize`, `exportChart`                     | dropped — no charts (§9)            |
+| `listModels`, `downloadModel`                  | dropped — no model management       |
+| `setMode`, `newSession`, `ready`, `setConsent` | dropped — no UI session             |
+| `saveSettings`                                 | dropped — config is env-only (§6.4) |
+| `saveFavorite`, `deleteFavorite`               | dropped in v1 — no favorites        |
+| `exportData`                                   | dropped — the agent has the data    |
+| `startListening`, `stopListening`              | deferred (§11 Phase 6)              |
+
+**Decision: the MCP host does not use `ExplorerSession`.** Only 2 of 17 messages
+survive, and both are thin wrappers over functions the session itself calls. Tools
+should call the core directly (`fetchAthenaRecord`, `runAthenaQuery`,
+`destinationTest`). Routing request/response tools through a stateful,
+push-oriented session would be adapting to an interface neither side wants.
+
+`ExplorerSession` stays where it is, shared by the two UI hosts. This is a deliberate
+divergence from the #795 pattern, **ratified in design review** — the two hosts that
+render a UI keep the session; the one that answers an agent does not. AC-T4 guards the
+facts they must continue to share.
+
+### 6.4 Configuration
+
+Env vars only — no settings file, no mutable config. MCP passes `env` natively,
+which is why this host is easier to configure than either existing one.
+
+**Convention:** `DURABLE_INSIGHT_` + `SCREAMING_SNAKE(settingKey)`.
+`athenaDatabase` → `DURABLE_INSIGHT_ATHENA_DATABASE`. Mechanical, so it is
+testable (§11 AC-T3), and one settings table can document all three hosts.
+
+> **Known, accepted divergence.** The VS Code settings namespace stays
+> `workflowInsight.*` until the deferred rename lands, so this host's env prefix
+> (`DURABLE_INSIGHT_`) and the extension's setting prefix name the same product two
+> ways. Only the prefix differs — key derivation is identical, so one settings table
+> still documents all three hosts and AC-T3 is unaffected. Call it out in the README
+> rather than papering over it.
+
+The 8 LLM/consent keys are **not accepted** by this host: `llmProvider`,
+`bedrockModelId`, `localModel`, `localServerUrl`, `localServerModel`,
+`agenticMaxIterations`, `queryMode`, `aiDisclosureAcceptedVersion`.
+
+Existing defaults from `DEFAULT_SETTINGS` apply unchanged, so a typical customer
+sets **two to four** values:
+
+| Destination                          | Required                                                      |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `cloudwatch-logs-exporter` (default) | `logGroupName`                                                |
+| `dynamodb`                           | `dynamodbTableName`                                           |
+| `athena` / `s3`                      | `athenaDatabase` + workgroup or `athenaOutputLocation`        |
+| `opensearch`                         | `opensearchEndpoint`                                          |
+| `aurora`                             | `auroraResourceArn`, `auroraSecretArn`                        |
+| `redshift`                           | workgroup or cluster + `redshiftSecretArn` / `redshiftDbUser` |
+| `sqs`                                | `sqsQueueUrl`                                                 |
+
+Defaulted: `region: us-east-1`, `athenaTable: workflow_insight`,
+`auroraDatabase: postgres`, `opensearchIndex: workflow-insight`, and the rest.
+
+**Credentials need no configuration.** `resolveCredentials(profile?)` is four
+lines — `fromIni({profile})` or `fromNodeProviderChain()` — so env credentials,
+`~/.aws/credentials`, and SSO all work already.
+
+Customer-facing config, identical in shape across clients:
+
+```json
+{
+  "mcpServers": {
+    "durable-insight": {
+      "command": "npx",
+      "args": ["-y", "@aws/durable-insight-mcp"],
+      "env": {
+        "AWS_REGION": "us-east-1",
+        "AWS_PROFILE": "prod",
+        "DURABLE_INSIGHT_DESTINATION_TYPE": "dynamodb",
+        "DURABLE_INSIGHT_DYNAMODB_TABLE_NAME": "workflow-insight"
+      }
+    }
+  }
+}
+```
+
+All three target clients accept that same `mcpServers` shape; only the file location
+differs (verified against client documentation, T0.3):
+
+| Client          | Project / workspace scope | User / global scope         |
+| --------------- | ------------------------- | --------------------------- |
+| **Kiro**        | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` |
+| **Claude Code** | `.mcp.json` (repo root)   | `~/.claude.json`            |
+| **Cursor**      | `.cursor/mcp.json`        | `~/.cursor/mcp.json`        |
+
+Workspace scope takes precedence in each. The README should **lead with the CLI
+helpers** (`kiro-cli mcp add`, `claude mcp add`) and present the JSON as reference:
+paths move between client versions, the `mcpServers` shape does not.
+
+Note that every client's project scope is a committed file, so adding the server there
+shares it with the whole team. Cleared by Legal (§8), but worth one README line so the
+behavior is not a surprise.
+
+### 6.5 Tool surface
+
+Few, well-described tools plus schema discovery. Constraints observed from client
+documentation: tool names must match `^[a-zA-Z][a-zA-Z0-9_]*$` and stay under 64
+characters _including_ the server prefix; tool _descriptions_ over ~10,000
+characters degrade agent performance. So bulk schema content belongs in tool
+**results** and the skill, never in a description.
+
+| Tool               | Parameters                                               | Returns                                                | Backed by                         |
+| ------------------ | -------------------------------------------------------- | ------------------------------------------------------ | --------------------------------- |
+| `test_destination` | —                                                        | connectivity, record count, most recent record         | `destinationTest.ts` (411)        |
+| `describe_schema`  | —                                                        | destination type, record schema, query idioms, dialect | `schema.ts`                       |
+| `list_executions`  | `status?`, `since?`, `until?`, `functionName?`, `limit?` | execution summaries                                    | engine runners                    |
+| `get_execution`    | `executionId`                                            | full record incl. operations                           | `fetchAthenaRecord` + equivalents |
+| `query`            | `query`, `limit?`                                        | rows + column names                                    | engine runners + safety layer     |
+
+`list_executions` exists so the common case needs no SQL at all — cheaper in
+tokens and impossible to get wrong. `query` is the escape hatch for anything else.
+
+**Every tool result must be structured JSON**, not prose. The agent formats for
+the user; our job is facts.
+
+### 6.6 Skill delivery — three layers
+
+Increasing polish, decreasing portability. Ship all three.
+
+1. **`describe_schema` as a tool.** Works in every MCP client, zero extra setup.
+   The floor, and the only layer we can guarantee.
+2. **MCP prompts.** MCP servers can publish prompts; clients surface them (Kiro
+   lists them under `/prompts` and `@name`). Ships _inside_ the server, so the
+   customer installs nothing extra.
+3. **A published `SKILL.md`.** For clients with skill support. Kiro loads these via
+   `skill://.kiro/skills/**/SKILL.md` in an agent's `resources`, requiring YAML
+   frontmatter with `name` and `description`; metadata loads at startup and full
+   content only on demand — the best token economy for content this size.
+
+**Source of truth.** `schema.ts:buildSystemPrompt(destinationType, options)` (a
+~130-line builder over 8 destinations) already emits exactly this material for our
+own prompts. Measured in Phase 3: **3,414 characters for DynamoDB and 10,143 for
+Athena/s3** — the latter alone exceeds the 10,000-character description limit, which
+settles empirically that this content belongs in tool _results_ and the skill, never in
+a description. It covers: which destinations expose `operationsByName` as a dot-path-queryable
+map versus a stringified field, how to reach operations by name via a JSONB
+predicate on Aurora, PartiQL path syntax on DynamoDB. Layers 1–3 must all derive
+from it, not restate it (§10, AC-T4). Retargeting is editing, not authoring.
+
+### 6.7 Safety model
+
+`assertReadOnly(query, engine)` (`queryValidator.ts:93`) and
+`ensureLimit(query, max = 1000)` (`schema.ts:748`) currently guard SQL produced by
+_our own_ prompt. Here they guard SQL from a model we do not control, invoked in a
+loop, on behalf of a user who may approve without reading.
+
+They move from a safety net to **the** security boundary of the host, and become
+the highest-value test target in the package.
+
+> **Structural hazard, verified in Phase 3.** `assertReadOnly` and `ensureLimit` are
+> called _only_ inside `explorerSession.ts` — never inside the engine runners. Since
+> this host deliberately bypasses `ExplorerSession` (§6.3), `runAthenaQuery` and
+> `runDynamoDBQuery` are reachable with **no read-only enforcement at all**; nothing in
+> core would stop a `DELETE`. The mitigation is deliberately not a call at each site,
+> which is the pattern that let it be forgotten: `runReadOnlyQuery` is the single choke
+> point, and a test mechanically asserts no other non-test file in the package imports a
+> runner. **Follow-up worth considering for core:** push enforcement into the runners
+> themselves, default-on, with an explicit opt-out for the one legitimate DDL caller
+> (`ensureAthenaTable`, which executes `CREATE EXTERNAL TABLE` through
+> `runAthenaQuery`). That would protect every future consumer, but it touches the
+> extension's table-creation path and deserves its own PR.
+
+- Every engine path routes through `assertReadOnly` before execution — no
+  exceptions, enforced by test (§10, AC-T2).
+- Every result set is bounded by `ensureLimit`; unbounded queries are a token-cost
+  denial-of-service as much as a data risk.
+- **CloudWatch Logs Insights is a deliberate exception, verified in Phase 4.**
+  `assertReadOnly` must NOT be applied to it: Logs Insights is a pipe language
+  (`fields @timestamp | filter … | stats …`), so a `SELECT`/`WITH` prefix check would
+  reject _every valid query_. Read-only is guaranteed by the API surface instead — the
+  language has no write forms and `StartQuery` can only read — so its absence removes
+  no protection, and `explorerSession.ts` draws the same line. Because "add the guard
+  here too, for consistency" is a plausible future change, the test is **inverted**: it
+  asserts valid pipe queries are _accepted_. Adding `assertReadOnly` there fails 22
+  tests.
+  `ensureLimit` is correspondingly right here and wrong everywhere else, and the
+  **escaping differs**: Logs Insights literals are double-quoted, so core's
+  `escapeQuotedString` (backslashes first, then quotes) is required — the SQL
+  quote-doubling escaper would leave the trailing-backslash breakout CodeQL flags.
+- **Row bounding is per engine.** Athena stops paging at `maxRows`; DynamoDB issues one
+  non-paginating statement; Aurora, Redshift and OpenSearch do **not** cap at all
+  (Redshift pages every `NextToken`), so the MCP layer slices to `MAX_ROWS`.
+- **`sandbox.ts:runSandboxedJs` is NOT exposed as a tool in v1.** Arbitrary
+  agent-authored JS execution is a different risk class from a bounded read-only
+  query, and the agent already has its own code execution. Revisit only with an
+  explicit security review.
+
+---
+
+## 7. Customer experience
+
+Setup is §6.4's four lines. `npx -y` fetches on first run, so there is no install
+step. Then:
+
+**Verify:**
+
+> "Is my workflow insight connection working?"
+> → `test_destination` → _"Connected to DynamoDB table `workflow-insight` in
+> us-east-1. 1,284 records, most recent 4 minutes ago."_
+
+A better failure story than the extension's: when it breaks, the agent reads the
+error and suggests the fix.
+
+**Investigate:**
+
+> "Why did the order-processing workflow fail last night?"
+> → `describe_schema` → `query` →
+> _"Three executions failed between 02:14 and 02:31, all on the `charge-payment`
+> step with a Stripe timeout. The retry strategy gave up after 3 attempts."_
+
+**Then the part the extension cannot do:**
+
+> "Show me the input payloads for those three."
+> → `get_execution` ×3 — just the next turn.
+
+---
+
+## 8. Disclosure: README only, no consent gate
+
+**Settled: this host needs disclosure, not consent. Legal has confirmed the position
+in §8.3. Nothing here gates shipping; what remains is implementing §8.2 in the
+README.**
+
+### 8.1 Why no consent mechanism
+
+The extension's disclosure exists because the extension _itself_ routes user data
+to a provider _it_ selected — Bedrock, Copilot, a local server, on-device — and
+`aiDisclosureAcceptedVersion` records acceptance of that specific set.
+
+Neither half of that is true here.
+
+**We make no model calls.** Verified by inspection across every module this host
+would use — `athena`, `dynamodb`, `aurora`, `redshift`, `opensearch`,
+`logsInsights`, `sqs`, `destinationTest`, `schema`, `queryValidator`: not one
+Bedrock, Anthropic, OpenAI, or `vscode.lm` call among them. The 1,677 lines that
+did talk to providers (§4) are exactly the lines this host drops. The server is
+stdio in, JSON out, on the user's own machine.
+
+**We select no provider.** There is no provider choice to disclose, because there
+is none to make. Whatever reaches a model does so under the agent's terms, which
+the user accepted when they chose that agent and pointed it at their source code.
+We are not a party to that flow.
+
+**Installation is the opt-in.** Unlike an extension or an app, nobody encounters
+this host incidentally. Using it requires writing a config block that names our
+package into the agent you already chose — a more deliberate act than accepting a
+modal. There is no drive-by user to protect.
+
+### 8.2 What the README must say
+
+Disclosure still matters, and it should be specific rather than perfunctory,
+because of one fact that is easy to miss:
+
+**Execution records carry `input` and `output` payloads and we return them
+verbatim.** Our own schema guidance uses `customerName` and `claimType` as the
+example fields to extract (`schema.ts:474`). So "query my workflow data"
+concretely means production payloads — whatever the workflow processes — entering
+the agent's context and therefore its model.
+
+Someone reading a README about workflow observability will not necessarily connect
+those. The README section must therefore state:
+
+- Which tools return payload data, and that `input`/`output` are returned as
+  stored, not redacted or summarized.
+- That the data goes to the agent that asked, and from there wherever that agent's
+  configuration sends it — determined by the customer, not by us.
+- That this server makes no model calls of its own.
+- That `query` is read-only and cannot modify the customer's data (§6.7).
+
+No acceptance step, no env var, no version. G5 (§3) is preserved: setup stays two
+to four values.
+
+### 8.3 Legal confirmation (received)
+
+Legal confirmed the following position. Record the thread reference here for future
+readers:
+
+> This host makes no model provider calls and selects no provider. Installation
+> into a customer-chosen agent is the opt-in. We plan specific README disclosure —
+> including that execution input/output payloads are returned verbatim — and no
+> consent gate or version tracking. Confirm?
+
+Confirmed. §8.2 is therefore the whole of the obligation: specific README disclosure,
+no acceptance step, no version tracking. §8.4 records the rejected alternative in case
+the question is reopened.
+
+### 8.4 Rejected: an env-var consent gate
+
+For the record, since it is the obvious alternative. The server could refuse to
+serve until `DURABLE_INSIGHT_AI_DISCLOSURE_ACCEPTED=<version>` matched
+`AI_DISCLOSURE_VERSION` — affirmative, recorded, versioned, fails closed.
+
+Rejected because it protects against nothing here (§8.1), adds a required setup
+step against G5, and records the _operator's_ acceptance rather than each user's —
+so it would give the appearance of consent without the substance. A shared
+workspace config (Kiro reads `.kiro/settings/mcp.json`, which teams commit) would
+propagate one person's acceptance to everyone, which is true of any committed MCP
+server and is mitigated by client-side tool approval. Not a reason to build a gate.
+
+Also considered and unsuitable as notice channels: MCP's `instructions` field on
+`InitializeResult` is model-facing by specification ("a hint to the model") and
+inconsistently consumed by clients; tool descriptions likewise reach the model, not
+the user.
+
+---
+
+## 9. What we give up
+
+**Charts and the interactive result grid.** `chartSpec.ts` (238 lines) has no home
+in a text protocol, and there is no sortable, clickable grid.
+
+Smaller than it sounds: an agent can render a markdown table from `query` results,
+which Claude Code and Kiro both display. What is genuinely lost is
+_interactivity_ — sorting, paging, click-through.
+
+Charts are not strictly impossible: MCP tool results can carry image content, so a
+server-side render is conceivable. Not free — `chartSpec.ts` emits a spec, not an
+image, so a renderer would be needed, and client support varies. Out of scope for
+v1; revisit on demand.
+
+**This is the argument for adding a host rather than replacing one.** Customers who
+want charts keep the extension. Both hosts run against the same destination with
+the same handful of config values.
+
+---
+
+## 10. Alternatives considered
+
+| Alternative                                  | Why not                                                                                                                                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Skill only, no MCP**                       | A skill cannot reach Athena. It could teach the agent to shell out to `aws athena start-query-execution`, but then read-only enforcement, schema knowledge, and result shaping all live in prose the model may ignore. Capability needs code.          |
+| **MCP only, no skill**                       | The likely failure mode: the agent writes plausible-but-wrong queries across 8 subtly different schemas and the customer concludes the tool is broken. `schema.ts` exists precisely because a model needs this material. Skipping it wastes the asset. |
+| **Extend an existing AWS MCP server**        | Workflow Insight's value is the destination abstraction and record schema, which is ours, not generic AWS. A generic server would need all of `schema.ts` anyway. Revisit for distribution reach later.                                                |
+| **A CLI the agent shells out to**            | Works everywhere, no protocol. But loses typed tool schemas, structured results, and the client's approval UX; every agent re-learns argument parsing from `--help`. MCP exists for this.                                                              |
+| **"Copy for agent" export in the extension** | Cheap, and helps nobody who does not already run the extension — which is the actual complaint.                                                                                                                                                        |
+| **Reuse `ExplorerSession` for MCP**          | Only 2 of 17 messages survive; see §6.3. Adapting request/response tools to a push-oriented session serves neither.                                                                                                                                    |
+
+---
+
+## 11. Task breakdown
+
+Sizes are relative estimates (S ≈ under a day, M ≈ a few days, L ≈ a week or more)
+and should be re-estimated by whoever picks the work up.
+
+### Phase 0 — Unblock (no code)
+
+| ID       | Task                                                                 | Size | Depends |
+| -------- | -------------------------------------------------------------------- | ---- | ------- |
+| **T0.1** | ~~Send §8.3 to Legal~~ — **done, confirmed**                         | S    | —       |
+| **T0.2** | ~~Decide §6.3~~ — **done, ratified: MCP bypasses `ExplorerSession`** | S    | —       |
+| **T0.3** | ~~Confirm client MCP config paths~~ — **done, see §6.4 table**       | S    | —       |
+
+**AC:** All met. §8 confirmed by Legal; §6.3 ratified (MCP bypasses `ExplorerSession`);
+client config paths verified against documentation (§6.4). **Phase 0 complete — Phase 1
+is unblocked.**
+
+### Phase 1 — Extract the core (L) — **MERGED** (#809)
+
+| ID       | Task                                                                                                                                | Size | Depends |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| **T1.1** | Create `durable-insight-core`; move host-free modules (§4)                                                                          | M    | T0.2    |
+| **T1.2** | Repoint `-insight-vscode` and `-insight-desktop` imports; declare real dependencies                                                 | M    | T1.1    |
+| **T1.3** | Move the relevant tests of the 19 in `-insight-vscode/src`; extend `hostAgnostic.test.ts` to the new boundary                       | S    | T1.2    |
+| **T1.4** | Add `durable-insight-core` to root `test` and `typecheck:hosts` and the `insight-hosts` CI job (NOT `build` — it has no build step) | S    | T1.1    |
+
+**AC:**
+
+- **AC-1.1** All existing tests pass unchanged in count and name: **222**
+  (`-insight-vscode`) and **36** (`-insight-desktop`), redistributed but not
+  reduced.
+- **AC-1.2** No `../../aws-durable-execution-sdk-js-insight-*` relative import
+  remains in any package; every cross-package import resolves through a declared
+  dependency.
+- **AC-1.3** `hostAgnostic.test.ts` still fails if a `vscode` import is introduced
+  anywhere in the core — verified by deliberately adding one, not by observing
+  green.
+- **AC-1.4** Zero behavior change: both bundles build, and the VS Code extension
+  and desktop app launch and run a query.
+
+### Phase 2 — Server skeleton (M) — **DONE** (this change)
+
+| ID       | Task                                                                                       | Size | Depends |
+| -------- | ------------------------------------------------------------------------------------------ | ---- | ------- |
+| **T2.1** | Package scaffold, `bin`, stdio transport, MCP handshake                                    | S    | T1.4    |
+| **T2.2** | `envKeys.ts`: `SETTING_KEYS` ↔ env mapping; reject the 8 LLM/consent keys                  | S    | T2.1    |
+| **T2.3** | Config assembly through `configCore.normalizeConfig`; credentials via `resolveCredentials` | S    | T2.2    |
+| **T2.4** | `test_destination` tool over `destinationTest.ts`                                          | S    | T2.3    |
+
+**AC:**
+
+- **AC-2.1** Server starts under `npx`, completes an MCP handshake, and lists its
+  tools in at least one real client (Kiro or Claude Code).
+- **AC-2.2** `test_destination` reports success against a live destination and, on
+  misconfiguration, returns an error naming the missing env var.
+- **AC-2.3** ~~A missing required key fails at startup~~ **Revised during Phase 2.**
+  Missing config must NOT prevent startup: a server that refuses to start appears in
+  an MCP client as an unexplained failure, whereas one that starts can tell the agent
+  exactly what is wrong. Instead `test_destination` returns the precise unset
+  `DURABLE_INSIGHT_*` variable names with no network call, and no tool will query with
+  incomplete config — so the "silent default querying the wrong table" concern is still
+  covered.
+- **AC-T3** _(contract test)_ Every `SETTING_KEY` except the 8 excluded maps to
+  exactly one env var and round-trips; the 8 excluded are rejected if set.
+  Mirrors `settingsKeys.test.ts`.
+
+### Phase 3 — Query core, two destinations (M) — **DONE** (this change)
+
+| ID       | Task                                                                    | Size | Depends |
+| -------- | ----------------------------------------------------------------------- | ---- | ------- |
+| **T3.1** | `describe_schema` derived from `buildSystemPrompt`                      | M    | T2.4    |
+| **T3.2** | `query` for Athena + DynamoDB, through `assertReadOnly` + `ensureLimit` | M    | T2.4    |
+| **T3.3** | `get_execution` for both                                                | S    | T3.2    |
+| **T3.4** | `list_executions` (no SQL required)                                     | M    | T3.2    |
+
+**AC:**
+
+- **AC-3.1** An agent given only the tools answers "why did X fail last night?"
+  against a seeded dataset, and correctly follows up with the failing step's input.
+- **AC-3.2** Results are structured JSON; no tool returns prose.
+- **AC-3.3** No tool _description_ exceeds 10,000 characters.
+- **AC-T2** _(security test)_ Every mutating statement form — `INSERT`, `UPDATE`,
+  `DELETE`, `DROP`, `CREATE`, `ALTER`, `TRUNCATE`, `GRANT`, multi-statement,
+  comment-obfuscated — is rejected for **every** engine. Additionally: removing the
+  `assertReadOnly` call from any engine path must fail a test (mutation-verified,
+  not assumed).
+- **AC-T2b** Every result path bounds rows; an unbounded query cannot be issued.
+  **Mechanism corrected in Phase 3:** not `ensureLimit`, which emits `" | limit N"` —
+  CloudWatch Logs Insights syntax that is a syntax error appended to Trino or PartiQL.
+  The SQL bound is Athena's `maxRows` pagination cap (`GetQueryResults` otherwise pages
+  the entire result set into the process), with DynamoDB page-bounded by a single
+  `ExecuteStatement`.
+
+### Phase 4 — Remaining destinations (M) — **DONE** (this change)
+
+| ID       | Task                                                                                                                    | Size | Depends |
+| -------- | ----------------------------------------------------------------------------------------------------------------------- | ---- | ------- |
+| **T4.1** | Aurora, Redshift, OpenSearch, and the two CloudWatch Logs destinations (S3 landed in Phase 3; SQS is **not queryable**) | M    | T3.4    |
+
+**AC:** **AC-4.1** All 8 `DestinationType` values are handled — **7 queryable**, each
+with `describe_schema` output matching its real dialect, plus `sqs` explicitly refused.
+`assertReadOnly` coverage per AC-T2 holds for the **five SQL engines**; the two
+CloudWatch Logs destinations are the documented exception below.
+
+### Phase 5 — Skill delivery (M) — **DONE** (this change)
+
+| ID       | Task                                                                | Size | Depends |
+| -------- | ------------------------------------------------------------------- | ---- | ------- |
+| **T5.1** | Expose MCP prompts from the server                                  | S    | T3.1    |
+| **T5.2** | Author `SKILL.md` with YAML frontmatter, generated from `schema.ts` | M    | T3.1    |
+| **T5.3** | README: install per client, config table, destination matrix        | M    | T0.3    |
+
+**AC:**
+
+- **AC-5.1** Prompts appear in a real client's prompt list.
+- **AC-5.2** `SKILL.md` loads in Kiro via `skill://` and its frontmatter
+  `description` is specific enough to trigger on a relevant question.
+- **AC-T4** _(anti-drift test)_ **Strengthened in Phase 5.** Rather than deriving schema
+  facts and testing for drift, the skill and prompts contain **zero**
+  destination-specific schema facts and delegate to `describe_schema`, which makes drift
+  impossible rather than merely detectable — and avoids loading Athena's 10,143
+  characters for a DynamoDB user. `skillDrift.test.ts` asserts a list of schema-owned
+  tokens appears nowhere in the skill or prompts, **and first asserts each token really
+  occurs in some destination's `buildSystemPrompt` output** so the guard cannot pass
+  vacuously. That check immediately caught a candidate token (`executionarn`) that
+  appears in no prompt output at all.
+- **AC-5.3** A new user reaches a successful `test_destination` from the README
+  alone, unaided.
+
+### Phase 6 — Deferred
+
+| ID       | Task                      | Notes                                                                |
+| -------- | ------------------------- | -------------------------------------------------------------------- |
+| **T6.1** | `tail` / live following   | MCP is request/response; needs a polling-tool or notification design |
+| **T6.2** | Charts as rendered images | Requires a renderer; client support varies (§9)                      |
+| **T6.3** | Favorites / saved queries | Needs writable state, which §6.4 excludes by design                  |
+
+---
+
+## 12. Definition of done (v1)
+
+- **D1** `npx @aws/durable-insight-mcp` works in Kiro and Claude Code with only a
+  config block — no install, no build.
+- **D2** All 8 destinations queryable read-only, verified per AC-T2.
+- **D3** Agent answers a realistic multi-turn failure investigation end to end
+  (AC-3.1).
+- **D4** Zero regression in the VS Code and Electron hosts (AC-1.4).
+- **D5** No duplicated core logic — one copy, three consumers (AC-1.2, AC-T4).
+- **D6** README carries the §8.2 disclosure, including that `input`/`output`
+  payloads are returned verbatim. (Legal confirmation: received, §8.3.)
+- **D7** CI covers the new package: typecheck, tests, and the `hostAgnostic`
+  boundary.
+
+---
+
+## 13. Testing strategy
+
+Follows this repo's existing norms — `npm test` chains every workspace,
+`typecheck:hosts` gates the host packages, and the `insight-hosts` CI job bundles
+them.
+
+**Invariants worth a dedicated contract test**, in the style of the existing
+`settingsKeys.test.ts` and `hostCapabilitiesContract.test.ts`:
+
+| Test                              | Guards                                                    |
+| --------------------------------- | --------------------------------------------------------- |
+| `hostAgnostic.test.ts` (extended) | Core stays `vscode`-free with a third consumer            |
+| `envKeys.test.ts` (new)           | Env ↔ `SETTING_KEYS` parity, and the 8 exclusions (AC-T3) |
+| `readOnly.test.ts` (new)          | Every engine path enforces `assertReadOnly` (AC-T2)       |
+| `skillDrift.test.ts` (new)        | Skill/prompt schema facts derive from `schema.ts` (AC-T4) |
+
+**Mutation-verify each guard.** #795 produced two tests that passed for the wrong
+reason and could not fail; both were caught only by deliberately breaking the code
+they claimed to protect. Every AC above marked _mutation-verified_ means exactly
+that: break the thing, watch the test fail, restore. A green suite is not evidence
+that a test works.
+
+Phases 1–2 justified the rule twice over:
+
+- **stdout purity is not proven by a working session.** stdout is the MCP transport, so
+  a stray `console.log` corrupts it — yet adding one did **not** fail an end-to-end
+  session test. The SDK client catches per-line parse errors, reports them to an unset
+  handler, and continues, so the handshake completes and the bad line is skipped. Only
+  a direct assertion that the spawned binary emits nothing on stdout catches it. Any
+  future stdio server test must assert this explicitly.
+- **The plan's redshift requirements were wrong.** This document asserted
+  `redshiftSecretArn` was required; `destinationTest.ts` does not require it (IAM with
+  a db user is a valid alternative) and wants a workgroup _or_ a cluster identifier.
+  The code was right. `missingRequiredEnvVars` follows the code, not this document.
+
+Review of #809 added two more, both of which apply directly to the phases still
+unmerged:
+
+- **A gate that only runs pre-commit is not a gate.** The boundary rules existed as
+  eslint config but eslint ran only through lint-staged, which `--no-verify` bypasses,
+  and there was no lint job. `npm run lint` is now a step in the `insight-hosts` job.
+  When adding a rule, ask which CI job executes it.
+- **`workflow_dispatch`-only workflows are invisible to PR checks.** The extraction broke
+  the VSIX release workflow — it copies one package out of the workspace and runs
+  `npm install --no-workspaces`, which cannot resolve a private dependency — and every
+  check stayed green because no pull request runs that workflow. The same class then
+  turned out to affect the MCP package more severely: it is **published**, so a private
+  dependency would have failed `npx` for every customer. Both now have a
+  `packaging.test.ts` asserting the invariant offline, since the real path cannot run on
+  a PR. Any package this project publishes needs that check before it ships.
+
+---
+
+## 14. Risks
+
+| Risk                                                         | Severity | Mitigation                                                                         |
+| ------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------- |
+| ~~Legal requires a consent mechanism~~                       | —        | **Resolved** — §8 position confirmed (§8.3)                                        |
+| Core extraction destabilizes two shipping hosts              | Medium   | Own PR, AC-1.1/1.4, existing 258 tests as the net                                  |
+| Agent writes wrong queries despite the skill                 | Medium   | `list_executions` covers the common case without SQL; iterate on `describe_schema` |
+| Bypassing `ExplorerSession` (§6.3) diverges hosts and drifts | Low      | **Ratified** in review; AC-T4 guards shared facts                                  |
+| Token cost of large schema output                            | Low-Med  | Layer 3 skill loads on demand; keep descriptions small (AC-3.3)                    |
+| Client fragmentation (paths, prompt/skill support)           | Low      | T0.3 verifies; layer 1 works everywhere                                            |
+
+---
+
+## 15. Open questions
+
+- ~~**OQ1** Legal confirmation of §8.3.~~ **Resolved** — confirmed; see §8.3.
+- ~~**OQ2** Ratify §6.3 — MCP bypasses `ExplorerSession`.~~ **Resolved** — ratified;
+  Phase 1 unblocked.
+- ~~**OQ3** Publish `durable-insight-core`, or bundle it?~~ **Resolved — bundle.** Both
+  existing hosts already bundle with esbuild, so core stays `private: true` and remains
+  an internal boundary refactorable without semver obligations. Publishing it would be
+  _forced_ only if a public package depended on it directly.
+- **OQ4** Does `list_executions` need pagination in v1, or is `limit` + a
+  `since`/`until` window enough?
+- **OQ5** Should `describe_schema` be an MCP _resource_ rather than a tool? More
+  idiomatic; less uniformly supported.
+- **OQ6** Is one customer's feedback enough to fund Phases 1–5, or should a Phase
+  2–3 prototype gather more signal first?
+
+---
+
+### Note on naming (decided, deferred)
+
+New packages use `durable-insight-*`. Renaming the existing ones is **out of scope
+here** and tracked separately, because package names are only one of four layers and
+the other three have costs this project should not absorb:
+
+| Layer                | Current                                                 | Cost of renaming                                                        |
+| -------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Package + directory  | `aws-durable-execution-sdk-js-insight-{vscode,desktop}` | Mechanical                                                              |
+| VS Code extension ID | `aws.aws-durable-execution-sdk-js-insight-vscode`       | Cheap now (`private: true`, alpha); needs a reinstall once published    |
+| Settings namespace   | `workflowInsight.*` — 33 keys, 133 refs / 22 files      | User-visible; silent break for existing alpha users without a migration |
+| Display name         | "Workflow Insight" — 124 refs / 34 files                | Includes the Legal-approved disclosure header (`AiConsentModal.tsx`)    |
+
+Two things to carry into that work. The display name appears in Legal-approved
+disclosure copy, so a rename should ride along with an existing Legal thread rather
+than start a new one; by the `types.ts` test it should **not** need an
+`AI_DISCLOSURE_VERSION` bump, since a product name changes neither the providers
+named nor where data goes. And the published `@aws/durable-execution-sdk-js-insight`
+library would need a new name published plus the old deprecated — a different class
+of decision from renaming private packages.
+
+## 16. Recommended next step
+
+A prototype limited to `test_destination`, `describe_schema`, and `query` against a
+single destination — deliberately skipping the Phase 1 extraction by importing
+across packages the way `-insight-desktop` does today.
+
+That is throwaway code and should be labelled as such, but it answers OQ6 and gives
+the customer something to react to quickly. Nothing in Phases 1–5 depends on it, and
+with §8 settled nothing gates it.

--- a/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
+++ b/packages/aws-durable-execution-sdk-js-insight/docs/mcp-host-design.md
@@ -783,6 +783,38 @@ unmerged:
 
 ---
 
+Review of this change added five more, all of them the same shape as the two above
+-- a guard that could not fail, or a promise with no implementation:
+
+- **A declared parameter with no implementation.** `query` declared `limit`,
+  validated it, described it to the model as the row maximum, and never read it. The
+  schema and the handler are only comparable at the source level, so
+  `toolWiring.test.ts` now parses the TypeScript AST and asserts every declared
+  parameter is destructured, in both directions.
+- **Enumerating a rule by name prefix instead of by capability.** The choke-point
+  guard forbade the six `run*Query` runners. Core exports six MORE functions that
+  execute a query -- `fetchAthenaRecord`, `fetchDynamoDBRecord`,
+  `fetchAuroraRecord`, `fetchRedshiftRecord`, `tableExists`, and `ensureAthenaTable`,
+  which runs DDL -- so importing one executed SQL while mentioning no runner and the
+  guard stayed green. The list is now derived from core's AST and a meta-test fails
+  when a new core export falls outside it. This is the `electron` blind spot again:
+  the invariant was named too narrowly.
+- **A scanner that flagged its own documentation.** Widening that guard by matching
+  names as text immediately flagged `sqlSafe.ts` and `tools.ts`, which discuss
+  `fetchAthenaRecord` in doc comments while never importing it. Reading import
+  declarations from the AST fixes it. Third occurrence of this mistake in this
+  project; a name in prose is not a use.
+- **`private: false` is not "published".** `packaging.test.ts` asserted the manifest
+  flag and read as coverage for installability, but the release script publishes from
+  a hard-coded list this package was absent from -- so `npx` could not have worked
+  whatever the manifest said. The invariant is keyed on the `@aws/` scope, because
+  three packages here are non-private and correctly never published.
+- **Truncation reported from the wrong evidence.** `truncated` came from the row
+  count alone, but DynamoDB bounds a response at ~1 MB and signals more via
+  `NextToken`, so 400 rows of a matching 5,000 reported complete. Core now surfaces
+  `hasMore`. Note the MCP host's own tests could not have caught a regression here --
+  they mock the runner -- so the pinning test lives in core, against the SDK response.
+
 ## 14. Risks
 
 | Risk                                                         | Severity | Mitigation                                                                         |

--- a/packages/durable-insight-core/src/configCore.test.ts
+++ b/packages/durable-insight-core/src/configCore.test.ts
@@ -8,6 +8,11 @@ jest.mock("@aws-sdk/credential-providers", () => ({
   fromNodeProviderChain: jest.fn(),
 }));
 
+import {
+  DESTINATION_TYPES,
+  isDestinationType,
+  type DestinationType,
+} from "./schema";
 import { configFromWireSettings } from "./configCore";
 
 describe("configFromWireSettings", () => {
@@ -105,5 +110,56 @@ describe("configFromWireSettings", () => {
     expect(configFromWireSettings({ awsProfile: "dev" }).awsProfile).toBe(
       "dev",
     );
+  });
+});
+
+/**
+ * `DESTINATION_TYPES` is a runtime array that must stay identical to the
+ * `DestinationType` union it shadows. Nothing in the compiler enforces the
+ * direction that matters: `satisfies readonly DestinationType[]` catches an entry
+ * that is NOT a valid type, but adding a member to the union and forgetting the
+ * array still compiles -- and would make `isDestinationType` reject a destination
+ * the rest of the code supports.
+ *
+ * The exhaustive switch below is what closes that gap: a new union member makes
+ * `assertExhaustive` a compile error, so this file stops building until the array
+ * is updated too.
+ */
+describe("DESTINATION_TYPES matches the DestinationType union", () => {
+  it("contains every member of the union, checked exhaustively", () => {
+    const seen: DestinationType[] = [];
+    const visit = (t: DestinationType): void => {
+      switch (t) {
+        case "cloudwatch-logs-exporter":
+        case "lambda-log-exporter":
+        case "dynamodb":
+        case "aurora":
+        case "redshift":
+        case "opensearch":
+        case "sqs":
+        case "s3":
+          seen.push(t);
+          return;
+        default: {
+          // A new union member reaches here and fails to compile, which is the
+          // point: the array below cannot silently fall behind the type.
+          const assertExhaustive: never = t;
+          throw new Error(
+            `unhandled destination type: ${String(assertExhaustive)}`,
+          );
+        }
+      }
+    };
+    for (const t of DESTINATION_TYPES) visit(t);
+    expect(seen.sort()).toEqual([...DESTINATION_TYPES].sort());
+    // Non-vacuity: an empty array would satisfy the loop above trivially.
+    expect(DESTINATION_TYPES.length).toBe(8);
+  });
+
+  it("narrows only real destination types", () => {
+    for (const t of DESTINATION_TYPES) expect(isDestinationType(t)).toBe(true);
+    for (const bad of ["dynamo", "DynamoDB", "", " s3", "athena", "postgres"]) {
+      expect(isDestinationType(bad)).toBe(false);
+    }
   });
 });

--- a/packages/durable-insight-core/src/configCore.ts
+++ b/packages/durable-insight-core/src/configCore.ts
@@ -11,7 +11,7 @@
  */
 import { fromIni, fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
-import type { DestinationType } from "./schema";
+import { isDestinationType, type DestinationType } from "./schema";
 
 export interface InsightConfig {
   region: string;
@@ -93,23 +93,15 @@ export function normalizeConfig(src: ConfigSource): InsightConfig {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+  // An unrecognized value falls back to the default rather than throwing, which is
+  // what the extension needs: its setting comes from a dropdown, so a bad value is
+  // not a case a user can reach. A host whose configuration is environment-only
+  // CAN reach it, so `isDestinationType` is exported for callers that must warn --
+  // this function must not become the place that decides how to report it.
   const raw = (src.getString("destinationType") || "").trim();
-  const destinationType =
-    raw === "lambda-log-exporter"
-      ? ("lambda-log-exporter" as const)
-      : raw === "dynamodb"
-        ? ("dynamodb" as const)
-        : raw === "aurora"
-          ? ("aurora" as const)
-          : raw === "redshift"
-            ? ("redshift" as const)
-            : raw === "opensearch"
-              ? ("opensearch" as const)
-              : raw === "sqs"
-                ? ("sqs" as const)
-                : raw === "s3"
-                  ? ("s3" as const)
-                  : ("cloudwatch-logs-exporter" as const);
+  const destinationType: DestinationType = isDestinationType(raw)
+    ? raw
+    : "cloudwatch-logs-exporter";
   const dynamodbTableName = (src.getString("dynamodbTableName") || "").trim();
   const auroraResourceArn = (src.getString("auroraResourceArn") || "").trim();
   const auroraSecretArn = (src.getString("auroraSecretArn") || "").trim();

--- a/packages/durable-insight-core/src/dynamodb.test.ts
+++ b/packages/durable-insight-core/src/dynamodb.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `runDynamoDBQuery` must report whether the single page it fetched was the whole
+ * answer.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * This runner issues ONE `ExecuteStatement` and does not paginate. DynamoDB bounds a
+ * response at ~1 MB regardless of how many items match, and signals that more exist
+ * by returning a `NextToken`. That token was discarded and absent from
+ * `DynamoDBQueryResult`, so a caller had no way to tell a complete result of 400
+ * rows from the first 400 of 5,000 -- and the MCP host's `truncated` flag,
+ * necessarily derived from the row count alone, reported the second as the first.
+ *
+ * The MCP host's own tests cannot catch a regression here: they mock this runner, so
+ * a version that stops reading `NextToken` still satisfies them. This is the test
+ * that pins the behavior to the SDK response.
+ */
+const mockSend = jest.fn();
+
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn(() => ({ send: mockSend })),
+  ExecuteStatementCommand: jest.fn((i) => ({ __type: "execute", i })),
+}));
+
+import { runDynamoDBQuery } from "./dynamodb";
+
+const OPTS = {
+  region: "us-east-1",
+  credentials: (() => Promise.resolve({})) as never,
+  tableName: "T",
+  statement: "SELECT * FROM T",
+};
+
+/** One marshalled item, as ExecuteStatement returns them. */
+const item = (n: number) => ({ n: { N: String(n) } });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("runDynamoDBQuery reports response completeness", () => {
+  it("sets hasMore when the response carries a NextToken", async () => {
+    mockSend.mockResolvedValueOnce({
+      Items: [item(1), item(2)],
+      NextToken: "opaque-token",
+    });
+    const result = await runDynamoDBQuery(OPTS);
+    expect(result.hasMore).toBe(true);
+    // The rows it DID return are still returned in full.
+    expect(result.count).toBe(2);
+  });
+
+  it("leaves hasMore false when there is no NextToken", async () => {
+    // Acceptance matters as much: a runner that always reported hasMore would pass
+    // the case above while making every complete result look truncated.
+    mockSend.mockResolvedValueOnce({ Items: [item(1), item(2)] });
+    const result = await runDynamoDBQuery(OPTS);
+    expect(result.hasMore).toBe(false);
+    expect(result.count).toBe(2);
+  });
+
+  it("sets hasMore on an empty page that still has a NextToken", async () => {
+    // DynamoDB can return zero items with a token when a scan segment matched
+    // nothing; the early return for an empty page must not lose the signal, or
+    // "no results" would be indistinguishable from "none in the first megabyte".
+    mockSend.mockResolvedValueOnce({ Items: [], NextToken: "opaque-token" });
+    const result = await runDynamoDBQuery(OPTS);
+    expect(result.count).toBe(0);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it("leaves hasMore false on a genuinely empty result", async () => {
+    mockSend.mockResolvedValueOnce({ Items: [] });
+    const result = await runDynamoDBQuery(OPTS);
+    expect(result.count).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("issues exactly one ExecuteStatement, even when more results exist", async () => {
+    // Pins the non-paginating contract the `hasMore` flag exists to describe. If
+    // this runner ever starts paginating, `hasMore` changes meaning and every
+    // caller deriving truncation from it needs revisiting -- so that change should
+    // break a test rather than pass quietly.
+    mockSend.mockResolvedValueOnce({ Items: [item(1)], NextToken: "more" });
+    await runDynamoDBQuery(OPTS);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/durable-insight-core/src/dynamodb.ts
+++ b/packages/durable-insight-core/src/dynamodb.ts
@@ -11,6 +11,17 @@ export interface DynamoDBQueryResult {
   count: number;
   /** Per-column numeric flag (aligned with `columns`) — see AthenaQueryResult.numericColumns. */
   numericColumns: boolean[];
+  /**
+   * True when DynamoDB reported more results than this single page returned, i.e.
+   * `ExecuteStatement` came back with a `NextToken`.
+   *
+   * This runner issues ONE `ExecuteStatement` and does not paginate, and DynamoDB
+   * bounds a response at ~1 MB regardless of how many items match. So a caller that
+   * infers completeness from the row count is wrong whenever this is true: 400 rows
+   * of a matching 5,000 look exactly like a complete answer of 400. Callers that
+   * report truncation to a user MUST consult this rather than comparing counts.
+   */
+  hasMore: boolean;
 }
 
 /**
@@ -34,9 +45,12 @@ export async function runDynamoDBQuery(opts: {
   );
 
   const items = (result.Items ?? []).map((item) => unmarshall(item));
+  // Presence, not the value: this runner does not paginate, so the token is only
+  // ever a signal that what it returned is incomplete.
+  const hasMore = result.NextToken !== undefined;
 
   if (items.length === 0) {
-    return { columns: [], rows: [], count: 0, numericColumns: [] };
+    return { columns: [], rows: [], count: 0, numericColumns: [], hasMore };
   }
 
   // Collect all unique keys across all items as columns
@@ -85,7 +99,7 @@ export async function runDynamoDBQuery(opts: {
     return sawNumber;
   });
 
-  return { columns, rows, count: items.length, numericColumns };
+  return { columns, rows, count: items.length, numericColumns, hasMore };
 }
 
 /**

--- a/packages/durable-insight-core/src/schema.ts
+++ b/packages/durable-insight-core/src/schema.ts
@@ -33,6 +33,36 @@ export type DestinationType =
   | "sqs"
   | "s3";
 
+/**
+ * The same set as {@link DestinationType}, available at runtime.
+ *
+ * A union type vanishes at compile time, so a caller holding an arbitrary string
+ * -- an environment variable, a wire setting -- has no way to ask whether it names
+ * a real destination. `normalizeConfig` consumes this, and so does the MCP host,
+ * which needs to tell a user that `DURABLE_INSIGHT_DESTINATION_TYPE=dynamo` is a
+ * typo rather than silently treating it as the default.
+ *
+ * `satisfies readonly DestinationType[]` ties the two together: adding a member to
+ * the union without adding it here still compiles, but `isDestinationType` would
+ * then reject a valid type -- so `configCore.test.ts` asserts the two agree by
+ * exhaustively switching over the union.
+ */
+export const DESTINATION_TYPES = [
+  "cloudwatch-logs-exporter",
+  "lambda-log-exporter",
+  "dynamodb",
+  "aurora",
+  "redshift",
+  "opensearch",
+  "sqs",
+  "s3",
+] as const satisfies readonly DestinationType[];
+
+/** Narrow an arbitrary string to a {@link DestinationType}. */
+export function isDestinationType(value: string): value is DestinationType {
+  return (DESTINATION_TYPES as readonly string[]).includes(value);
+}
+
 // ─── DIRECT (CloudWatchLogsExporter) ─────────────────────────────────────────
 
 const RECORD_SCHEMA_DIRECT = `Each log event is a raw JSON WorkflowInsightRecord with fields at the top level:

--- a/packages/durable-insight-mcp/README.md
+++ b/packages/durable-insight-mcp/README.md
@@ -113,7 +113,11 @@ needs read access to whichever destination you point at.
 `DURABLE_INSIGHT_DESTINATION_TYPE` selects the backend. Seven destination types
 are **queryable**; each requires the variables below (anything not listed has a
 working default, shown in parentheses). If `DURABLE_INSIGHT_DESTINATION_TYPE` is
-unset it defaults to `cloudwatch-logs-exporter`.
+unset it defaults to `cloudwatch-logs-exporter`. A value that is **set but not
+recognized** (a typo such as `dynamo`, or wrong casing such as `DynamoDB`) also
+falls back to that default, so the server warns on startup and names the valid
+values — otherwise it would report a CloudWatch variable as missing to someone who
+had configured DynamoDB correctly.
 
 | `DURABLE_INSIGHT_DESTINATION_TYPE` | Required variables                                                                                                              | Notable defaults                                                                                                                                                                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -170,12 +174,20 @@ The server registers five tools. Call them roughly in this order.
 ### Result bounding
 
 - **Row cap.** Every result from every destination is capped at **1000 rows**
-  (`MAX_ROWS`). A `truncated: true` flag tells you the cap was hit — narrow your
-  filters rather than assuming you saw everything.
+  (`MAX_ROWS`). Pass a smaller `limit` when you only need a few rows: it is honored,
+  and rows you did not want still cost tokens to read. `limit` cannot raise the cap.
+- **`truncated` means "there may be more matching data than this."** It does not
+  mean the returned array was trimmed. Reaching the cap sets it; on DynamoDB a
+  response that hit the service's ~1 MB limit also sets it, which can happen far
+  below 1000 rows. Either way, narrow your filters rather than assuming you saw
+  everything.
 - **Log lookback window.** CloudWatch Logs Insights has no "all time"; a query
-  must carry an explicit `[start, end]` window. When you do not pass one, the
-  server uses the **last 24 hours** by default. This window is ignored by the SQL
-  destinations, which are not time-windowed.
+  must carry an explicit `[start, end]` window. When you do not pass one, `query`
+  uses the **last 24 hours** and `get_execution` the **last 7 days**. Both are
+  overridable with `lookbackHours`, and `get_execution` reports the window it
+  searched as `searchedLookbackHours` — so a `found: false` on a log destination
+  means "not in that window", not "does not exist". This window is ignored by the
+  SQL destinations, which are not time-windowed.
 
 ## Prompts
 

--- a/packages/durable-insight-mcp/README.md
+++ b/packages/durable-insight-mcp/README.md
@@ -159,7 +159,8 @@ The server registers five tools. Call them roughly in this order.
   of `status`, `functionName`, `since`, and `until`, with a bounded `limit` — no
   query language required. **Prefer this over a hand-written `query`:** it cannot
   be got wrong and costs fewer tokens. Reach for `query` only when a question
-  cannot be expressed through these filters.
+  cannot be expressed through these filters. On log destinations the scanned window
+  follows `since`, so filtering to last week scans last week.
 - **`get_execution`** — Fetch a single execution record by its execution ARN. A
   record that does not exist is a success with `found: false`, not an error. For
   the Athena/`s3` destination you may also pass `year`/`month`/`day` to prune to
@@ -181,13 +182,18 @@ The server registers five tools. Call them roughly in this order.
   response that hit the service's ~1 MB limit also sets it, which can happen far
   below 1000 rows. Either way, narrow your filters rather than assuming you saw
   everything.
-- **Log lookback window.** CloudWatch Logs Insights has no "all time"; a query
-  must carry an explicit `[start, end]` window. When you do not pass one, `query`
-  uses the **last 24 hours** and `get_execution` the **last 7 days**. Both are
-  overridable with `lookbackHours`, and `get_execution` reports the window it
-  searched as `searchedLookbackHours` — so a `found: false` on a log destination
-  means "not in that window", not "does not exist". This window is ignored by the
-  SQL destinations, which are not time-windowed.
+- **Log lookback window.** CloudWatch Logs Insights has no "all time"; a query must
+  carry an explicit `[start, end]` window, and that window is separate from any
+  filtering inside the query. All three tools report the window they scanned as
+  `searchedLookbackHours`, because a window narrower than your filters ask for returns
+  a partial answer that otherwise looks complete.
+  - `list_executions` **derives the window from `since`**, so filtering to last week
+    scans last week. Pass `lookbackHours` to widen a search that has no `since`.
+  - `query` defaults to the **last 24 hours**, `get_execution` to the **last 7 days**;
+    both accept `lookbackHours`.
+  - A `found: false` from `get_execution` therefore means "not in that window", not
+    "does not exist".
+  - This window is ignored by the SQL destinations, which are not time-windowed.
 
 ## Prompts
 

--- a/packages/durable-insight-mcp/README.md
+++ b/packages/durable-insight-mcp/README.md
@@ -1,0 +1,299 @@
+# Workflow Insight — MCP Server
+
+Query the execution history that AWS Lambda durable functions emit, from any MCP
+client, over stdio.
+
+This package is a **host adapter, not a second product**. It exposes the same
+read-only query capability the VS Code extension and desktop app provide —
+destination resolution, query engines, read-only enforcement — but through the
+[Model Context Protocol](https://modelcontextprotocol.io) instead of a UI. The
+engine runners, the `assertReadOnly` validator, and the per-destination schema
+guidance all come from `durable-insight-core`; nothing is forked here, so the
+hosts cannot drift.
+
+Concretely, this server is **stdio in, JSON out, on your machine**. It reads a
+query request from the agent driving it, runs it against the one destination it
+was configured for, and returns machine-readable JSON. It makes no model calls
+of its own (see [Data handling and AI disclosure](#data-handling-and-ai-disclosure)).
+
+## Install
+
+The package is published; you never clone or build it. Every client launches it
+the same way — `npx -y @aws/durable-insight-mcp` — and every client takes the
+same `mcpServers` JSON shape. Only the file the config lives in differs.
+
+**Lead with the CLI helper for your client.** The config-file paths below move
+between client versions; the server shape does not, so a helper that writes the
+file for you is the durable instruction.
+
+### Kiro
+
+```bash
+kiro-cli mcp add \
+  --name durable-insight \
+  --command npx \
+  --args "-y,@aws/durable-insight-mcp" \
+  --env DURABLE_INSIGHT_DESTINATION_TYPE=dynamodb \
+  --env DURABLE_INSIGHT_DYNAMODB_TABLE_NAME=my-workflow-table \
+  --env DURABLE_INSIGHT_REGION=us-east-1 \
+  --scope workspace
+```
+
+`--scope workspace` writes `.kiro/settings/mcp.json`; omit it (or use
+`--scope global`) to write `~/.kiro/settings/mcp.json`. Workspace scope wins when
+both are present.
+
+### Claude Code
+
+```bash
+claude mcp add durable-insight \
+  --scope project \
+  --env DURABLE_INSIGHT_DESTINATION_TYPE=dynamodb \
+  --env DURABLE_INSIGHT_DYNAMODB_TABLE_NAME=my-workflow-table \
+  --env DURABLE_INSIGHT_REGION=us-east-1 \
+  -- npx -y @aws/durable-insight-mcp
+```
+
+`--scope project` writes `.mcp.json` at the repo root; the default (user) scope
+writes `~/.claude.json`. Project scope wins when both are present.
+
+### JSON reference (all clients)
+
+If you prefer to edit the file directly, or your client has no helper, add this
+block. The shape is identical everywhere:
+
+```json
+{
+  "mcpServers": {
+    "durable-insight": {
+      "command": "npx",
+      "args": ["-y", "@aws/durable-insight-mcp"],
+      "env": {
+        "DURABLE_INSIGHT_DESTINATION_TYPE": "dynamodb",
+        "DURABLE_INSIGHT_DYNAMODB_TABLE_NAME": "my-workflow-table",
+        "DURABLE_INSIGHT_REGION": "us-east-1"
+      }
+    }
+  }
+}
+```
+
+Where that block lives, per client:
+
+| Client      | Project scope (wins)      | User scope                  |
+| ----------- | ------------------------- | --------------------------- |
+| Kiro        | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` |
+| Claude Code | `.mcp.json` (repo root)   | `~/.claude.json`            |
+| Cursor      | `.cursor/mcp.json`        | `~/.cursor/mcp.json`        |
+
+> **Project scope is a committed file.** Adding the server at project scope
+> (`.kiro/settings/mcp.json`, `.mcp.json`, `.cursor/mcp.json`) shares it — and
+> the destination it points at — with everyone who checks out the repo. Use user
+> scope if the destination is yours alone.
+
+## Configuration
+
+Configuration is **environment-only** — there is no settings file and no mutable
+state. Every knob is an environment variable named `DURABLE_INSIGHT_` + the
+SCREAMING_SNAKE form of its setting key (`athenaDatabase` →
+`DURABLE_INSIGHT_ATHENA_DATABASE`). Set them in the `env` block above.
+
+Two standard AWS variables are honored as fallbacks when their prefixed form is
+unset: `AWS_REGION` fills in `DURABLE_INSIGHT_REGION`, and `AWS_PROFILE` fills in
+`DURABLE_INSIGHT_AWS_PROFILE`. The prefixed form wins when both are set. Region
+falls back further to `AWS_DEFAULT_REGION`, then defaults to `us-east-1`.
+
+**Credentials need no configuration.** They come from the standard AWS SDK
+provider chain — environment variables, `~/.aws/credentials`, SSO — honoring
+`DURABLE_INSIGHT_AWS_PROFILE` (or `AWS_PROFILE`) when set. The identity you use
+needs read access to whichever destination you point at.
+
+### Destinations and their required variables
+
+`DURABLE_INSIGHT_DESTINATION_TYPE` selects the backend. Seven destination types
+are **queryable**; each requires the variables below (anything not listed has a
+working default, shown in parentheses). If `DURABLE_INSIGHT_DESTINATION_TYPE` is
+unset it defaults to `cloudwatch-logs-exporter`.
+
+| `DURABLE_INSIGHT_DESTINATION_TYPE` | Required variables                                                                                                              | Notable defaults                                                                                                                                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dynamodb`                         | `DURABLE_INSIGHT_DYNAMODB_TABLE_NAME`                                                                                           | —                                                                                                                                                                                                                                     |
+| `s3` (Athena)                      | `DURABLE_INSIGHT_ATHENA_DATABASE`, **and** one of `DURABLE_INSIGHT_ATHENA_WORKGROUP` / `DURABLE_INSIGHT_ATHENA_OUTPUT_LOCATION` | `DURABLE_INSIGHT_ATHENA_TABLE` (`workflow_insight`)                                                                                                                                                                                   |
+| `aurora`                           | `DURABLE_INSIGHT_AURORA_RESOURCE_ARN`, `DURABLE_INSIGHT_AURORA_SECRET_ARN`                                                      | `DURABLE_INSIGHT_AURORA_DATABASE` (`postgres`), `DURABLE_INSIGHT_AURORA_TABLE` (`workflow_insight`)                                                                                                                                   |
+| `redshift`                         | one of `DURABLE_INSIGHT_REDSHIFT_WORKGROUP_NAME` / `DURABLE_INSIGHT_REDSHIFT_CLUSTER_IDENTIFIER`                                | `DURABLE_INSIGHT_REDSHIFT_DATABASE` (`dev`), `DURABLE_INSIGHT_REDSHIFT_TABLE` (`workflow_insight`), `DURABLE_INSIGHT_REDSHIFT_SCHEMA` (`public`); `DURABLE_INSIGHT_REDSHIFT_SECRET_ARN` / `DURABLE_INSIGHT_REDSHIFT_DB_USER` optional |
+| `opensearch`                       | `DURABLE_INSIGHT_OPENSEARCH_ENDPOINT`                                                                                           | `DURABLE_INSIGHT_OPENSEARCH_INDEX` (`workflow-insight`)                                                                                                                                                                               |
+| `cloudwatch-logs-exporter`         | `DURABLE_INSIGHT_LOG_GROUP_NAME` (comma-separated for multiple)                                                                 | —                                                                                                                                                                                                                                     |
+| `lambda-log-exporter`              | `DURABLE_INSIGHT_LOG_GROUP_NAME` (comma-separated for multiple)                                                                 | —                                                                                                                                                                                                                                     |
+
+For Athena, note that `DURABLE_INSIGHT_ATHENA_S3_LOCATION` is **not** required:
+that is the source-data location used only to create the table, which this server
+never does. What it needs is somewhere to write query _results_ — a workgroup
+with an output location configured, or an explicit
+`DURABLE_INSIGHT_ATHENA_OUTPUT_LOCATION`.
+
+`sqs` is **not queryable.** It is a tail-only destination — a message queue this
+server can only long-poll, with no query engine behind it — so `query`,
+`get_execution`, and `list_executions` refuse it with an explanatory error rather
+than pretend. Do not configure `sqs` for use with this server.
+
+## The tools
+
+The server registers five tools. Call them roughly in this order.
+
+- **`test_destination`** — Run first. Read-only connectivity and completeness
+  checks against the configured destination. If required variables are unset it
+  names them and returns _without any AWS call_. Stop and fix if it reports a
+  problem.
+- **`describe_schema`** — **Call this before writing a `query`.** Returns the
+  configured destination's record schema, query engine/dialect, the table or log
+  group in play, and the row cap — sourced from the SDK for whatever destination
+  is actually configured. It makes no AWS call, so it is safe even before setup
+  is complete. Writing a query without it is guessing: field names, column
+  casing, and quoting genuinely differ across DynamoDB (PartiQL), Athena, Aurora,
+  Redshift, OpenSearch, and CloudWatch Logs.
+- **`list_executions`** — The common case. List execution records filtered by any
+  of `status`, `functionName`, `since`, and `until`, with a bounded `limit` — no
+  query language required. **Prefer this over a hand-written `query`:** it cannot
+  be got wrong and costs fewer tokens. Reach for `query` only when a question
+  cannot be expressed through these filters.
+- **`get_execution`** — Fetch a single execution record by its execution ARN. A
+  record that does not exist is a success with `found: false`, not an error. For
+  the Athena/`s3` destination you may also pass `year`/`month`/`day` to prune to
+  one partition instead of scanning the whole table.
+- **`query`** — The escape hatch. Execute a single read-only query against the
+  destination. For the SQL destinations (`dynamodb`, `s3`, `aurora`, `redshift`,
+  `opensearch`) only `SELECT`/`WITH` is accepted; any data-modifying or DDL
+  statement is refused before any AWS call. For the CloudWatch Logs destinations
+  (`cloudwatch-logs-exporter`, `lambda-log-exporter`) pass a CloudWatch Logs
+  Insights pipe query, not SQL, and use `lookbackHours` to set the time window.
+
+### Result bounding
+
+- **Row cap.** Every result from every destination is capped at **1000 rows**
+  (`MAX_ROWS`). A `truncated: true` flag tells you the cap was hit — narrow your
+  filters rather than assuming you saw everything.
+- **Log lookback window.** CloudWatch Logs Insights has no "all time"; a query
+  must carry an explicit `[start, end]` window. When you do not pass one, the
+  server uses the **last 24 hours** by default. This window is ignored by the SQL
+  destinations, which are not time-windowed.
+
+## Prompts
+
+The server ships two MCP prompts, so no separate install is needed — a client
+such as Kiro surfaces them under `/prompts` and `@name`, Claude Code as slash
+commands. Each encodes the correct _order of operations_ (verify, describe
+schema, narrow, drill in) and defers all schema facts to `describe_schema` at
+runtime.
+
+- **`investigate_workflow_failure`** — Guided, correct-order investigation of a
+  durable function failure. Accepts optional `functionName` and `lookbackHours`
+  to scope the search.
+- **`explore_recent_executions`** — Guided overview of recent executions. Accepts
+  an optional `status` filter.
+
+## Skill
+
+`SKILL.md` (shipped in the package under `src/skill/`) is a progressively-loaded
+skill that teaches an agent the one rule that keeps its queries correct: ask the
+server for the schema with `describe_schema` before writing a `query`. It
+contains zero destination-specific schema facts on purpose, so it can never drift
+from the server.
+
+For a client that supports skills, install it by placing the file where the
+client looks for skills and referencing it from an agent. In Kiro, drop it under
+`.kiro/skills/` and let an agent load it via a `skill://` entry in that agent's
+`resources`, for example:
+
+```json
+{
+  "resources": ["skill://.kiro/skills/**/SKILL.md"]
+}
+```
+
+Custom Kiro agents inherit workspace skills by default, so a file under
+`.kiro/skills/` is typically picked up without any config change.
+
+## Settings this host does not accept
+
+This host takes its model from the **agent** that drives it — the agent already
+has an LLM — so eight provider/model/agent-loop settings that the VS Code
+extension and desktop app accept are deliberately ignored here. There is no
+provider to choose, no local model to run, no agent loop of its own, and no
+AI-usage consent for it to record (that relationship belongs to the agent's own
+host):
+
+- `llmProvider`
+- `bedrockModelId`
+- `localModel`
+- `localServerUrl`
+- `localServerModel`
+- `agenticMaxIterations`
+- `queryMode`
+- `aiDisclosureAcceptedVersion`
+
+If you set the corresponding environment variable anyway (for instance, copied
+from VS Code settings), the server does not fail — it starts and emits a warning
+that the variable is ignored.
+
+## Data handling and AI disclosure
+
+Read this before pointing the server at production data.
+
+- **Execution records carry `input` and `output` payloads, and this server
+  returns them verbatim** — not redacted, not summarized, not filtered. The
+  `get_execution`, `list_executions`, and `query` tools all return record data,
+  and `get_execution` and `query` can surface the full `input` and `output`
+  payloads of an execution. In plain terms: asking your agent to "query my
+  workflow data" means the production payloads your workflows process — whatever
+  that data is — enter the agent's context, and therefore the model behind it.
+- **Where the data goes is determined by the customer, not by this server.** Data
+  flows to the agent that requested it, and from there wherever that agent's own
+  configuration sends it (its model provider, its logs, its storage). This server
+  chooses none of that and cannot see past its own stdout.
+- **This server makes no model calls of its own.** It selects no model provider
+  and contacts none. It is stdio in, JSON out, running on your machine; the only
+  outbound calls it makes are the read-only AWS API calls needed to run your
+  query.
+- **Every query is read-only; the server cannot modify your data.** On the SQL
+  destinations any statement that is not `SELECT`/`WITH` is refused before a
+  single AWS call is made. On the CloudWatch Logs destinations the Logs Insights
+  query language has no write or DDL forms at all, and the only API used can only
+  read. There is no code path through this server that mutates the customer's
+  data.
+
+Installing this server into an agent you chose is itself the opt-in; there is no
+separate consent gate, acceptance flag, or version to accept.
+
+## Troubleshooting
+
+- **`test_destination` reports missing configuration.** When required variables
+  are unset, `test_destination` returns a successful result with `ok: false` and
+  a `missingEnvVars` array **naming the exact `DURABLE_INSIGHT_*` variables** that
+  are unset — it does not guess and does not call AWS. Set the named variables in
+  your client's `env` block and re-run it.
+- **The server starts even when misconfigured — on purpose.** Missing destination
+  configuration is not a startup error. A server that refused to launch would
+  surface in an MCP client as an unexplained failure; one that starts can tell
+  the agent, through `test_destination`, exactly what is wrong. So if tools are
+  listed but queries report incomplete config, run `test_destination` first — it
+  is the diagnostic.
+- **A query is refused as not read-only.** That is the security boundary working:
+  only `SELECT`/`WITH` reaches an AWS call on the SQL destinations. Rephrase as a
+  read.
+- **`query` against `sqs` errors out.** Expected — `sqs` is tail-only and has no
+  query engine. Point the server at a queryable destination.
+
+## From zero to a confirmed connection
+
+A complete path for a new user, using DynamoDB as the example:
+
+1. Have AWS credentials available to the standard SDK chain (an exported
+   `AWS_PROFILE`, `~/.aws/credentials`, or SSO) with read access to the table.
+2. Add the server to your client with the destination variables set — use the
+   [Kiro](#kiro) or [Claude Code](#claude-code) helper above, substituting your
+   real table name and region. Nothing to install: `npx -y` fetches the package.
+3. Restart / reload your client so it launches the server.
+4. Ask the agent to run **`test_destination`**. A result with `ok: true` confirms
+   the connection. If it returns `missingEnvVars`, set those exact variables and
+   repeat step 4.
+5. Then run **`describe_schema`**, and start querying with **`list_executions`**.

--- a/packages/durable-insight-mcp/esbuild.mjs
+++ b/packages/durable-insight-mcp/esbuild.mjs
@@ -1,0 +1,77 @@
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import esbuild from "esbuild";
+
+const watch = process.argv.includes("--watch");
+
+// Single source of truth for the version: this package's own package.json,
+// injected as a compile-time constant so server.ts never hard-codes a copy.
+const { version } = JSON.parse(readFileSync("./package.json", "utf8"));
+
+/** @type {import("esbuild").BuildOptions} */
+const common = {
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  sourcemap: true,
+  logLevel: "info",
+  minify: !watch,
+  define: {
+    DURABLE_INSIGHT_MCP_VERSION: JSON.stringify(version),
+  },
+  // Output is ESM, but bundled CJS dependencies (the AWS SDK / smithy stack)
+  // call `require("node:https")` etc. at runtime. In an ESM bundle esbuild would
+  // otherwise emit a shim that throws "Dynamic require ... is not supported".
+  // Recreating a real `require` from import.meta.url makes those calls work.
+  // esbuild keeps the entry's shebang on line 1 and places this banner after it.
+  banner: {
+    js: [
+      "import { createRequire as __createRequire } from 'node:module';",
+      "const require = __createRequire(import.meta.url);",
+    ].join("\n"),
+  },
+  // node-llama-cpp is a native, optional dependency of core that is only ever
+  // reached through a dynamic `await import(...)` (the "local" LLM provider).
+  // This server never uses it, but core references it, so keep it external
+  // rather than bundling a native module.
+  external: ["node-llama-cpp", "@node-llama-cpp/*"],
+};
+
+const outfile = "dist/server.js";
+
+// The entry file (src/server.ts) begins with `#!/usr/bin/env node`; esbuild
+// preserves that shebang at the top of the bundle, so no banner is needed.
+const build = {
+  entryPoints: ["src/server.ts"],
+  outfile,
+};
+
+/**
+ * The package root has no `"type": "module"`, so Node would load dist/server.js
+ * as CommonJS by default — which breaks the ESM output (import.meta, imports).
+ * Dropping a minimal `package.json` scoped to dist/ marks that folder as ESM
+ * without changing how the rest of the package (jest, ts-jest) resolves.
+ */
+function markDistAsEsm() {
+  writeFileSync(
+    "dist/package.json",
+    `${JSON.stringify({ type: "module" }, null, 2)}\n`,
+  );
+}
+
+/** stdio MCP servers run as executables via `npx`; make the bin runnable. */
+function makeExecutable() {
+  chmodSync(outfile, 0o755);
+}
+
+if (watch) {
+  const ctx = await esbuild.context({ ...common, ...build });
+  await ctx.watch();
+  markDistAsEsm();
+  console.error("esbuild: watching...");
+} else {
+  await esbuild.build({ ...common, ...build });
+  markDistAsEsm();
+  makeExecutable();
+  console.error("durable-insight-mcp: built dist/server.js");
+}

--- a/packages/durable-insight-mcp/package.json
+++ b/packages/durable-insight-mcp/package.json
@@ -24,8 +24,8 @@
     "build": "node esbuild.mjs"
   },
   "dependencies": {
+    "@aws/durable-insight-core": "0.1.0-alpha.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "durable-insight-core": "*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/durable-insight-mcp/package.json
+++ b/packages/durable-insight-mcp/package.json
@@ -14,6 +14,10 @@
   "bin": {
     "durable-insight-mcp": "dist/server.js"
   },
+  "files": [
+    "dist",
+    "src/skill/SKILL.md"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "npm run build && jest",

--- a/packages/durable-insight-mcp/package.json
+++ b/packages/durable-insight-mcp/package.json
@@ -24,11 +24,11 @@
     "build": "node esbuild.mjs"
   },
   "dependencies": {
-    "@aws/durable-insight-core": "0.1.0-alpha.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@aws/durable-insight-core": "0.1.0-alpha.0",
     "@types/jest": "^29.5.0",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",

--- a/packages/durable-insight-mcp/package.json
+++ b/packages/durable-insight-mcp/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@aws/durable-insight-mcp",
+  "version": "0.1.0-alpha.0",
+  "license": "Apache-2.0",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",
+    "directory": "packages/durable-insight-mcp"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "durable-insight-mcp": "dist/server.js"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && jest",
+    "build": "node esbuild.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "durable-insight-core": "*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "esbuild": "^0.24.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.0",
+    "typescript": "~5.8.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/src/**/*.test.ts"
+    ],
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.test.json"
+        }
+      ]
+    }
+  }
+}

--- a/packages/durable-insight-mcp/src/config.ts
+++ b/packages/durable-insight-mcp/src/config.ts
@@ -1,0 +1,131 @@
+/**
+ * Reads this host's configuration from the environment.
+ *
+ * The MCP host is configured entirely by `DURABLE_INSIGHT_`-prefixed
+ * environment variables (see envKeys.ts). This module gathers the set ones into
+ * the same all-string map shape the VS Code Settings webview produces, then
+ * hands it to core's {@link configFromWireSettings} so defaults, coercion, and
+ * normalization are applied in exactly one place — this host never reimplements
+ * them.
+ */
+import {
+  configFromWireSettings,
+  type InsightConfig,
+} from "durable-insight-core";
+import {
+  envVarFor,
+  MCP_SETTING_KEYS,
+  MCP_EXCLUDED_SETTING_KEYS,
+} from "./envKeys";
+
+export interface ReadConfigResult {
+  config: InsightConfig;
+  warnings: string[];
+}
+
+/**
+ * Builds an {@link InsightConfig} from `env`.
+ *
+ * - Reads every {@link MCP_SETTING_KEYS} key from its `DURABLE_INSIGHT_*`
+ *   variable and passes the set ones to core's normalizer.
+ * - Applies the standard AWS fallbacks: `AWS_REGION` for region and
+ *   `AWS_PROFILE` for the profile, so customers who already export the standard
+ *   variables don't have to duplicate them. The prefixed form wins when both
+ *   are set.
+ * - Never throws. A stray excluded variable (e.g. copied from VS Code settings)
+ *   produces a warning, not a failure — the model comes from the agent, so
+ *   there is nothing to apply. Missing destination config is likewise NOT an
+ *   error here: diagnosing it belongs to the `test_destination` tool, because a
+ *   server that refuses to start surfaces in an MCP client as an unexplained
+ *   failure, whereas one that starts can tell the agent exactly what is wrong.
+ */
+export function readConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ReadConfigResult {
+  const warnings: string[] = [];
+  const wire: Record<string, string> = {};
+
+  for (const key of MCP_SETTING_KEYS) {
+    const value = env[envVarFor(key)];
+    if (value !== undefined) {
+      wire[key] = value;
+    }
+  }
+
+  // Standard AWS fallbacks. The prefixed form already collected above wins;
+  // only fill in from the standard variable when the prefixed one is unset.
+  if (wire["region"] === undefined && env.AWS_REGION !== undefined) {
+    wire["region"] = env.AWS_REGION;
+  }
+  if (wire["awsProfile"] === undefined && env.AWS_PROFILE !== undefined) {
+    wire["awsProfile"] = env.AWS_PROFILE;
+  }
+
+  // Warn (don't apply, don't throw) for any excluded variable that is present:
+  // this host takes its model from the agent, so there is nothing to configure.
+  for (const key of MCP_EXCLUDED_SETTING_KEYS) {
+    const varName = envVarFor(key);
+    if (env[varName] !== undefined) {
+      warnings.push(
+        `${varName} is set but ignored: this host takes its model from the agent, ` +
+          `so provider/model settings do not apply.`,
+      );
+    }
+  }
+
+  return { config: configFromWireSettings(wire), warnings };
+}
+
+/**
+ * Given a normalized config, the `DURABLE_INSIGHT_*` variable NAMES a query
+ * against `cfg.destinationType` needs but which are absent.
+ *
+ * The notion of "required" is taken from core's destinationTest.ts (its
+ * `missing.push` checks) so this host and the UI agree on what a destination
+ * needs. Note two consequences of trusting that source:
+ *   - Fields core defaults to a non-empty value (auroraDatabase="postgres",
+ *     redshiftDatabase="dev") can never be blank in a normalized config, so
+ *     they are never reported.
+ *   - Redshift requires a workgroup OR cluster but does NOT require a secret ARN
+ *     (destinationTest.ts runs its SELECT 1 with secretArn optional). This
+ *     differs from an earlier spec that listed redshiftSecretArn as required;
+ *     we follow destinationTest.ts.
+ */
+export function missingRequiredEnvVars(cfg: InsightConfig): string[] {
+  const missing: string[] = [];
+  const need = (key: string) => missing.push(envVarFor(key));
+
+  switch (cfg.destinationType) {
+    case "cloudwatch-logs-exporter":
+    case "lambda-log-exporter":
+      if (cfg.logGroupNames.length === 0) need("logGroupName");
+      break;
+    case "dynamodb":
+      if (!cfg.dynamodbTableName) need("dynamodbTableName");
+      break;
+    case "s3":
+      if (!cfg.athenaDatabase) need("athenaDatabase");
+      if (!cfg.athenaS3Location) need("athenaS3Location");
+      break;
+    case "aurora":
+      if (!cfg.auroraResourceArn) need("auroraResourceArn");
+      if (!cfg.auroraSecretArn) need("auroraSecretArn");
+      break;
+    case "redshift":
+      // Serverless (workgroup) or provisioned (cluster) — need exactly one.
+      // Report both names when neither is set.
+      if (!cfg.redshiftWorkgroupName && !cfg.redshiftClusterIdentifier) {
+        need("redshiftWorkgroupName");
+        need("redshiftClusterIdentifier");
+      }
+      break;
+    case "opensearch":
+      if (!cfg.opensearchEndpoint) need("opensearchEndpoint");
+      break;
+    case "sqs":
+      if (!cfg.sqsQueueUrl) need("sqsQueueUrl");
+      break;
+  }
+
+  return missing;
+}

--- a/packages/durable-insight-mcp/src/config.ts
+++ b/packages/durable-insight-mcp/src/config.ts
@@ -11,6 +11,8 @@
 import {
   configFromWireSettings,
   type InsightConfig,
+  DESTINATION_TYPES,
+  isDestinationType,
 } from "@aws/durable-insight-core";
 import {
   envVarFor,
@@ -54,8 +56,13 @@ export function readConfigFromEnv(
 
   // Standard AWS fallbacks. The prefixed form already collected above wins;
   // only fill in from the standard variable when the prefixed one is unset.
-  if (wire["region"] === undefined && env.AWS_REGION !== undefined) {
-    wire["region"] = env.AWS_REGION;
+  if (wire["region"] === undefined) {
+    // Both, and in this order — `normalizeConfig` honors AWS_DEFAULT_REGION too, so
+    // reading only AWS_REGION here made this the narrower of two overlapping
+    // fallbacks: a user with only AWS_DEFAULT_REGION set got core's default region
+    // in the config this function returns, while core would have resolved it.
+    const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION;
+    if (region !== undefined) wire["region"] = region;
   }
   if (wire["awsProfile"] === undefined && env.AWS_PROFILE !== undefined) {
     wire["awsProfile"] = env.AWS_PROFILE;
@@ -71,6 +78,30 @@ export function readConfigFromEnv(
           `so provider/model settings do not apply.`,
       );
     }
+  }
+
+  // An unrecognized DESTINATION_TYPE is the expected failure mode for a host
+  // configured only by environment variables, and it is silent: `normalizeConfig`
+  // falls back to "cloudwatch-logs-exporter", so `DESTINATION_TYPE=dynamo` yields a
+  // server that reports DURABLE_INSIGHT_LOG_GROUP_NAME as missing to a user who set
+  // every DynamoDB variable correctly. The default is right for the extension, where
+  // the value comes from a dropdown and cannot be misspelled; it is a trap here.
+  //
+  // A warning rather than a throw, for the same reason missing destination config is
+  // a warning: a server that refuses to start appears in an MCP client as an
+  // unexplained failure, while one that starts can say what is wrong.
+  const rawDestination = wire["destinationType"];
+  if (
+    rawDestination !== undefined &&
+    !isDestinationType(rawDestination.trim())
+  ) {
+    warnings.push(
+      `${envVarFor("destinationType")}="${rawDestination}" is not a recognized ` +
+        `destination type, so it was ignored and the default ` +
+        `"cloudwatch-logs-exporter" is in use — which is why a required variable ` +
+        `for that destination may be reported as missing. Valid values: ` +
+        `${DESTINATION_TYPES.join(", ")}.`,
+    );
   }
 
   return { config: configFromWireSettings(wire), warnings };

--- a/packages/durable-insight-mcp/src/config.ts
+++ b/packages/durable-insight-mcp/src/config.ts
@@ -11,7 +11,7 @@
 import {
   configFromWireSettings,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import {
   envVarFor,
   MCP_SETTING_KEYS,

--- a/packages/durable-insight-mcp/src/config.ts
+++ b/packages/durable-insight-mcp/src/config.ts
@@ -105,7 +105,19 @@ export function missingRequiredEnvVars(cfg: InsightConfig): string[] {
       break;
     case "s3":
       if (!cfg.athenaDatabase) need("athenaDatabase");
-      if (!cfg.athenaS3Location) need("athenaS3Location");
+      // Querying Athena needs somewhere to put RESULTS: either a workgroup that
+      // has an output location configured, or an explicit one. This mirrors
+      // destinationTest.ts, which treats "no workgroup and no output location"
+      // as the incomplete case.
+      //
+      // Note this is deliberately NOT athenaS3Location. That is the SOURCE data
+      // location, required only to CREATE the table -- something this host never
+      // does. Requiring it here would demand a variable the customer does not
+      // need, while leaving the one they do need unreported.
+      if (!cfg.athenaWorkgroup && !cfg.athenaOutputLocation) {
+        need("athenaWorkgroup");
+        need("athenaOutputLocation");
+      }
       break;
     case "aurora":
       if (!cfg.auroraResourceArn) need("auroraResourceArn");

--- a/packages/durable-insight-mcp/src/describeSchema.test.ts
+++ b/packages/durable-insight-mcp/src/describeSchema.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `describe_schema` returns guidance produced by a function SHARED with the VS
+ * Code extension (`buildSystemPrompt`). That function closes by instructing the
+ * model to call `emit_query` -- a tool that exists in the extension's own LLM
+ * loop and does NOT exist in this MCP host. An agent that followed it would call
+ * an unknown tool and stall.
+ *
+ * This was found by running `describe_schema` against a real Aurora destination,
+ * not by a unit test: the existing tests asserted the guidance was long and
+ * self-consistent, which it was. They could not know that its closing sentence
+ * addressed a different host. Hence these tests, which assert the guidance names
+ * only tools that exist here.
+ */
+import { buildDescribeSchemaResult } from "./tools";
+import { TOOL_DESCRIPTIONS } from "./tools";
+import type { InsightConfig } from "durable-insight-core";
+import { configFromWireSettings } from "durable-insight-core";
+
+/** Every destination `describe_schema` supports. */
+const SUPPORTED = [
+  "s3",
+  "dynamodb",
+  "aurora",
+  "redshift",
+  "opensearch",
+  "cloudwatch-logs-exporter",
+  "lambda-log-exporter",
+] as const;
+
+function cfgFor(destinationType: string): InsightConfig {
+  return configFromWireSettings({
+    destinationType,
+    region: "us-east-1",
+    athenaDatabase: "insights",
+    athenaTable: "workflow_insight",
+    athenaWorkgroup: "primary",
+    dynamodbTableName: "records",
+    auroraResourceArn: "arn:aws:rds:us-east-1:1:cluster:c",
+    auroraSecretArn: "arn:aws:secretsmanager:us-east-1:1:secret:s",
+    auroraTable: "workflow_insight",
+    redshiftWorkgroupName: "wg",
+    redshiftTable: "workflow_insight",
+    opensearchEndpoint: "https://example.us-east-1.es.amazonaws.com",
+    opensearchIndex: "workflow-insight",
+    logGroupName: "/aws/lambda/fn",
+  });
+}
+
+/**
+ * Tool names that belong to the extension's LLM loop, not to this server. If
+ * `describe_schema` mentions one, an agent will try to call it.
+ */
+const FOREIGN_TOOLS = ["emit_query", "emit_chart", "run_query_tool"];
+
+describe("describe_schema names only tools that exist in this host", () => {
+  it.each(SUPPORTED)(
+    "%s: guidance mentions no foreign tool",
+    (destinationType) => {
+      const { guidance } = buildDescribeSchemaResult(cfgFor(destinationType));
+      for (const foreign of FOREIGN_TOOLS) {
+        expect(guidance).not.toContain(foreign);
+      }
+    },
+  );
+
+  it.each(SUPPORTED)("%s: guidance is still substantial", (destinationType) => {
+    // Guard against "fixing" the above by returning an empty string: stripping
+    // the closing instruction must not gut the schema knowledge, which is the
+    // whole value of this tool.
+    const { guidance, guidanceLength } = buildDescribeSchemaResult(
+      cfgFor(destinationType),
+    );
+    expect(guidance.length).toBeGreaterThan(1500);
+    expect(guidanceLength).toBe(guidance.length);
+  });
+
+  it.each(SUPPORTED)(
+    "%s: howToRun points at real tools and states the cap",
+    (destinationType) => {
+      const { howToRun, maxRows } = buildDescribeSchemaResult(
+        cfgFor(destinationType),
+      );
+      const real = TOOL_DESCRIPTIONS.map((t) => t.name);
+      expect(howToRun).toContain("query");
+      // Every tool howToRun names must actually be registered.
+      for (const word of howToRun.match(/"([a-z_]+)"/g) ?? []) {
+        const name = word.replace(/"/g, "");
+        expect(real).toContain(name);
+      }
+      expect(howToRun).toContain(String(maxRows));
+    },
+  );
+
+  it("keeps the schema content that precedes the stripped instruction", () => {
+    // The Aurora guidance's distinctive content must survive stripping -- this is
+    // the real-world case that exposed the bug.
+    const { guidance } = buildDescribeSchemaResult(cfgFor("aurora"));
+    expect(guidance).toContain("record_json");
+    expect(guidance).toContain("workflow_insight");
+    expect(guidance).not.toContain("emit_query");
+  });
+});

--- a/packages/durable-insight-mcp/src/describeSchema.test.ts
+++ b/packages/durable-insight-mcp/src/describeSchema.test.ts
@@ -13,8 +13,8 @@
  */
 import { buildDescribeSchemaResult } from "./tools";
 import { TOOL_DESCRIPTIONS } from "./tools";
-import type { InsightConfig } from "durable-insight-core";
-import { configFromWireSettings } from "durable-insight-core";
+import type { InsightConfig } from "@aws/durable-insight-core";
+import { configFromWireSettings } from "@aws/durable-insight-core";
 
 /** Every destination `describe_schema` supports. */
 const SUPPORTED = [

--- a/packages/durable-insight-mcp/src/envKeys.test.ts
+++ b/packages/durable-insight-mcp/src/envKeys.test.ts
@@ -20,6 +20,7 @@ import {
   MCP_EXCLUDED_SETTING_KEYS,
 } from "./envKeys";
 import { readConfigFromEnv, missingRequiredEnvVars } from "./config";
+import { DESTINATION_TYPES } from "@aws/durable-insight-core";
 
 describe("envVarFor", () => {
   it("1. every MCP setting key round-trips to a valid DURABLE_INSIGHT_ variable", () => {
@@ -281,5 +282,90 @@ describe("missingRequiredEnvVars — every DestinationType", () => {
   it("covers all eight DestinationType values", () => {
     const covered = new Set(CASES.map((c) => c.type));
     expect(covered.size).toBe(8);
+  });
+});
+/**
+ * An unrecognized DESTINATION_TYPE must be reported, not absorbed.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * `normalizeConfig` ends its destination-type resolution in a fallback to
+ * "cloudwatch-logs-exporter". In the extension that is correct -- the value comes
+ * from a dropdown, so an invalid one is unreachable. Here configuration is
+ * environment-only, so a typo is the expected failure mode, and it was silent:
+ * DESTINATION_TYPE=dynamo produced a server that reported
+ * DURABLE_INSIGHT_LOG_GROUP_NAME as the missing variable to a user who had set
+ * every DynamoDB variable correctly. `missingRequiredEnvVars` can never name the
+ * real problem, because by the time it runs the typo is gone.
+ */
+describe("unrecognized destination type is surfaced", () => {
+  const findWarning = (warnings: string[]) =>
+    warnings.find((w) => w.includes("not a recognized destination type"));
+
+  it.each(["dynamo", "DynamoDB", "athena", "postgres", " s3 x"])(
+    "warns for %s",
+    (value) => {
+      const { warnings } = readConfigFromEnv({
+        DURABLE_INSIGHT_DESTINATION_TYPE: value,
+      } as NodeJS.ProcessEnv);
+      const warning = findWarning(warnings);
+      expect(warning).toBeDefined();
+      // The value must appear, or the user cannot see their own typo.
+      expect(warning).toContain(value);
+      // And the valid set, or they cannot fix it without reading the source.
+      expect(warning).toContain("dynamodb");
+    },
+  );
+
+  it.each(DESTINATION_TYPES)("stays silent for the valid type %s", (value) => {
+    // Acceptance matters as much as rejection: a check that warned for everything
+    // would pass the cases above while making every correct config noisy.
+    const { warnings, config } = readConfigFromEnv({
+      DURABLE_INSIGHT_DESTINATION_TYPE: value,
+    } as NodeJS.ProcessEnv);
+    expect(findWarning(warnings)).toBeUndefined();
+    expect(config.destinationType).toBe(value);
+  });
+
+  it("stays silent when the variable is unset", () => {
+    // Unset is not a typo -- it is the documented default, and warning about it
+    // would train users to ignore warnings.
+    const { warnings } = readConfigFromEnv({} as NodeJS.ProcessEnv);
+    expect(findWarning(warnings)).toBeUndefined();
+  });
+
+  it("tolerates surrounding whitespace, as normalizeConfig does", () => {
+    const { warnings, config } = readConfigFromEnv({
+      DURABLE_INSIGHT_DESTINATION_TYPE: "  dynamodb  ",
+    } as NodeJS.ProcessEnv);
+    expect(findWarning(warnings)).toBeUndefined();
+    expect(config.destinationType).toBe("dynamodb");
+  });
+});
+
+describe("region falls back to both standard AWS variables", () => {
+  it("uses AWS_DEFAULT_REGION when AWS_REGION is unset", () => {
+    // This function shadows normalizeConfig's own fallback, which reads both. The
+    // local copy read only AWS_REGION, making it the narrower of the two.
+    const { config } = readConfigFromEnv({
+      AWS_DEFAULT_REGION: "eu-west-2",
+    } as NodeJS.ProcessEnv);
+    expect(config.region).toBe("eu-west-2");
+  });
+
+  it("prefers AWS_REGION over AWS_DEFAULT_REGION", () => {
+    const { config } = readConfigFromEnv({
+      AWS_REGION: "us-west-2",
+      AWS_DEFAULT_REGION: "eu-west-2",
+    } as NodeJS.ProcessEnv);
+    expect(config.region).toBe("us-west-2");
+  });
+
+  it("prefers the prefixed variable over both", () => {
+    const { config } = readConfigFromEnv({
+      DURABLE_INSIGHT_REGION: "ap-south-1",
+      AWS_REGION: "us-west-2",
+      AWS_DEFAULT_REGION: "eu-west-2",
+    } as NodeJS.ProcessEnv);
+    expect(config.region).toBe("ap-south-1");
   });
 });

--- a/packages/durable-insight-mcp/src/envKeys.test.ts
+++ b/packages/durable-insight-mcp/src/envKeys.test.ts
@@ -209,13 +209,20 @@ describe("missingRequiredEnvVars — every DestinationType", () => {
     },
     {
       type: "s3",
+      // Querying Athena needs a RESULTS destination: a workgroup (which
+      // carries its own output location) or an explicit output location.
+      // athenaS3Location is the SOURCE data bucket, required only to CREATE
+      // the table -- something this host never does -- so it is deliberately
+      // not required here. Confusing the two would write query result files
+      // into the data being queried.
       complete: {
         athenaDatabase: "insights",
-        athenaS3Location: "s3://bucket/prefix/",
+        athenaWorkgroup: "primary",
       },
       expectedMissing: [
         envVarFor("athenaDatabase"),
-        envVarFor("athenaS3Location"),
+        envVarFor("athenaWorkgroup"),
+        envVarFor("athenaOutputLocation"),
       ],
     },
     {

--- a/packages/durable-insight-mcp/src/envKeys.test.ts
+++ b/packages/durable-insight-mcp/src/envKeys.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Contract test (acceptance criterion AC-T3) for the MCP host's environment
+ * layer. These assertions are what keep the env-var scheme, the accept/exclude
+ * split, and the per-destination required-config notion from silently drifting
+ * away from core's shared constants and destinationTest.ts.
+ *
+ * Tests pass a fake env object into readConfigFromEnv — process.env is never
+ * mutated.
+ */
+import {
+  SETTING_KEYS,
+  isSettingKey,
+  configFromWireSettings,
+  type InsightConfig,
+  type DestinationType,
+} from "durable-insight-core";
+import {
+  envVarFor,
+  MCP_SETTING_KEYS,
+  MCP_EXCLUDED_SETTING_KEYS,
+} from "./envKeys";
+import { readConfigFromEnv, missingRequiredEnvVars } from "./config";
+
+describe("envVarFor", () => {
+  it("1. every MCP setting key round-trips to a valid DURABLE_INSIGHT_ variable", () => {
+    for (const key of MCP_SETTING_KEYS) {
+      const v = envVarFor(key);
+      expect(v.length).toBeGreaterThan(0);
+      expect(v.startsWith("DURABLE_INSIGHT_")).toBe(true);
+      expect(v).toMatch(/^[A-Z0-9_]+$/);
+    }
+  });
+
+  it("2. is injective over all SETTING_KEYS (no two keys share a variable)", () => {
+    const seen = new Map<string, string>();
+    for (const key of SETTING_KEYS) {
+      const v = envVarFor(key);
+      const prior = seen.get(v);
+      expect(prior).toBeUndefined(); // a collision would hide a setting
+      seen.set(v, key);
+    }
+    expect(seen.size).toBe(SETTING_KEYS.length);
+  });
+
+  it("5. spot-checks exact spellings (guards the conversion rule)", () => {
+    expect(envVarFor("athenaDatabase")).toBe("DURABLE_INSIGHT_ATHENA_DATABASE");
+    expect(envVarFor("athenaS3Location")).toBe(
+      "DURABLE_INSIGHT_ATHENA_S3_LOCATION",
+    );
+    expect(envVarFor("dynamodbTableName")).toBe(
+      "DURABLE_INSIGHT_DYNAMODB_TABLE_NAME",
+    );
+  });
+});
+
+describe("MCP_SETTING_KEYS / MCP_EXCLUDED_SETTING_KEYS partition", () => {
+  it("3. exactly partitions SETTING_KEYS (union equal, intersection empty, all real keys)", () => {
+    const included = new Set(MCP_SETTING_KEYS);
+    const excluded = new Set(MCP_EXCLUDED_SETTING_KEYS);
+    const all = new Set<string>(SETTING_KEYS);
+
+    // No key is in both lists.
+    for (const k of included) expect(excluded.has(k)).toBe(false);
+
+    // Union equals SETTING_KEYS (same size + every all-key present in one list).
+    expect(included.size + excluded.size).toBe(all.size);
+    for (const k of all) {
+      expect(included.has(k) || excluded.has(k)).toBe(true);
+    }
+
+    // No invented keys: everything in either list is a real setting key.
+    for (const k of [...included, ...excluded]) {
+      expect(isSettingKey(k)).toBe(true);
+    }
+
+    // Sanity: the exclusion list is exactly the documented eight.
+    expect(excluded.size).toBe(8);
+  });
+});
+
+describe("readConfigFromEnv — excluded keys", () => {
+  // Each excluded key mapped to the config field it would have set and that
+  // field's normalized default, so we can prove the env value was NOT applied.
+  const EXCLUDED_CASES: Array<{
+    key: string;
+    envValue: string;
+    field: keyof InsightConfig;
+    expectedDefault: unknown;
+  }> = [
+    {
+      key: "llmProvider",
+      envValue: "copilot",
+      field: "llmProvider",
+      expectedDefault: "bedrock",
+    },
+    {
+      key: "bedrockModelId",
+      envValue: "some-other-model",
+      field: "bedrockModelId",
+      expectedDefault: "us.anthropic.claude-sonnet-5",
+    },
+    {
+      key: "localModel",
+      envValue: "phi-3.5-mini",
+      field: "localModel",
+      expectedDefault: "llama-3-groq-8b-tool-use",
+    },
+    {
+      key: "localServerUrl",
+      envValue: "http://example.com/v1",
+      field: "localServerUrl",
+      expectedDefault: "http://localhost:11434/v1",
+    },
+    {
+      key: "localServerModel",
+      envValue: "some-model",
+      field: "localServerModel",
+      expectedDefault: "llama3.1",
+    },
+    {
+      key: "agenticMaxIterations",
+      envValue: "3",
+      field: "agenticMaxIterations",
+      expectedDefault: 8,
+    },
+    {
+      key: "queryMode",
+      envValue: "query",
+      field: "queryMode",
+      expectedDefault: "agent",
+    },
+    {
+      key: "aiDisclosureAcceptedVersion",
+      envValue: "v99",
+      field: "aiDisclosureAcceptedVersion",
+      expectedDefault: "",
+    },
+  ];
+
+  it("4. each excluded key is ignored (default kept) and produces a warning naming its variable", () => {
+    for (const c of EXCLUDED_CASES) {
+      const varName = envVarFor(c.key);
+      const { config, warnings } = readConfigFromEnv({ [varName]: c.envValue });
+
+      // Not applied: the field keeps its normalized default.
+      expect(config[c.field]).toBe(c.expectedDefault);
+
+      // Warned: at least one warning names the variable.
+      expect(warnings.some((w) => w.includes(varName))).toBe(true);
+    }
+  });
+
+  it("does not warn when no excluded variable is present", () => {
+    const { warnings } = readConfigFromEnv({
+      DURABLE_INSIGHT_REGION: "us-east-1",
+    });
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("readConfigFromEnv — AWS fallbacks", () => {
+  it("6. AWS_REGION alone sets region; DURABLE_INSIGHT_REGION wins when both set", () => {
+    expect(readConfigFromEnv({ AWS_REGION: "eu-west-1" }).config.region).toBe(
+      "eu-west-1",
+    );
+    expect(
+      readConfigFromEnv({
+        AWS_REGION: "eu-west-1",
+        DURABLE_INSIGHT_REGION: "us-east-2",
+      }).config.region,
+    ).toBe("us-east-2");
+  });
+
+  it("6. AWS_PROFILE alone sets profile; DURABLE_INSIGHT_AWS_PROFILE wins when both set", () => {
+    expect(readConfigFromEnv({ AWS_PROFILE: "team-a" }).config.awsProfile).toBe(
+      "team-a",
+    );
+    expect(
+      readConfigFromEnv({
+        AWS_PROFILE: "team-a",
+        DURABLE_INSIGHT_AWS_PROFILE: "team-b",
+      }).config.awsProfile,
+    ).toBe("team-b");
+  });
+});
+
+describe("missingRequiredEnvVars — every DestinationType", () => {
+  // For each destination: the wire settings that make it COMPLETE, and the
+  // env-var names expected to be reported when only destinationType is set.
+  const CASES: Array<{
+    type: DestinationType;
+    complete: Record<string, string>;
+    expectedMissing: string[];
+  }> = [
+    {
+      type: "cloudwatch-logs-exporter",
+      complete: { logGroupName: "/aws/lambda/fn" },
+      expectedMissing: [envVarFor("logGroupName")],
+    },
+    {
+      type: "lambda-log-exporter",
+      complete: { logGroupName: "/aws/lambda/fn" },
+      expectedMissing: [envVarFor("logGroupName")],
+    },
+    {
+      type: "dynamodb",
+      complete: { dynamodbTableName: "records" },
+      expectedMissing: [envVarFor("dynamodbTableName")],
+    },
+    {
+      type: "s3",
+      complete: {
+        athenaDatabase: "insights",
+        athenaS3Location: "s3://bucket/prefix/",
+      },
+      expectedMissing: [
+        envVarFor("athenaDatabase"),
+        envVarFor("athenaS3Location"),
+      ],
+    },
+    {
+      type: "aurora",
+      complete: {
+        auroraResourceArn: "arn:aws:rds:...:cluster/c",
+        auroraSecretArn: "arn:aws:secretsmanager:...:secret/s",
+      },
+      expectedMissing: [
+        envVarFor("auroraResourceArn"),
+        envVarFor("auroraSecretArn"),
+      ],
+    },
+    {
+      type: "redshift",
+      complete: { redshiftWorkgroupName: "wg" },
+      expectedMissing: [
+        envVarFor("redshiftWorkgroupName"),
+        envVarFor("redshiftClusterIdentifier"),
+      ],
+    },
+    {
+      type: "opensearch",
+      complete: { opensearchEndpoint: "https://d.us-east-1.es.amazonaws.com" },
+      expectedMissing: [envVarFor("opensearchEndpoint")],
+    },
+    {
+      type: "sqs",
+      complete: {
+        sqsQueueUrl: "https://sqs.us-east-1.amazonaws.com/1/q",
+      },
+      expectedMissing: [envVarFor("sqsQueueUrl")],
+    },
+  ];
+
+  it("7. reports DURABLE_INSIGHT_ names when required config is absent, and none when complete", () => {
+    for (const c of CASES) {
+      const incomplete = configFromWireSettings({ destinationType: c.type });
+      const reported = missingRequiredEnvVars(incomplete);
+
+      // Every reported item is a DURABLE_INSIGHT_ variable name.
+      for (const name of reported) {
+        expect(name.startsWith("DURABLE_INSIGHT_")).toBe(true);
+      }
+      expect(new Set(reported)).toEqual(new Set(c.expectedMissing));
+
+      // A complete config for the same destination reports nothing missing.
+      const complete = configFromWireSettings({
+        destinationType: c.type,
+        ...c.complete,
+      });
+      expect(missingRequiredEnvVars(complete)).toEqual([]);
+    }
+  });
+
+  it("covers all eight DestinationType values", () => {
+    const covered = new Set(CASES.map((c) => c.type));
+    expect(covered.size).toBe(8);
+  });
+});

--- a/packages/durable-insight-mcp/src/envKeys.test.ts
+++ b/packages/durable-insight-mcp/src/envKeys.test.ts
@@ -13,7 +13,7 @@ import {
   configFromWireSettings,
   type InsightConfig,
   type DestinationType,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import {
   envVarFor,
   MCP_SETTING_KEYS,

--- a/packages/durable-insight-mcp/src/envKeys.ts
+++ b/packages/durable-insight-mcp/src/envKeys.ts
@@ -9,7 +9,7 @@
  * below cannot drift from the extension's manifest (envKeys.test.ts enforces
  * this as a contract).
  */
-import { SETTING_KEYS } from "durable-insight-core";
+import { SETTING_KEYS } from "@aws/durable-insight-core";
 
 /**
  * The environment variable name for a setting key.

--- a/packages/durable-insight-mcp/src/envKeys.ts
+++ b/packages/durable-insight-mcp/src/envKeys.ts
@@ -1,0 +1,60 @@
+/**
+ * The environment-variable naming scheme for the MCP host, and the split
+ * between the setting keys this host accepts and the ones it deliberately does
+ * not.
+ *
+ * This host is configured by environment variables only — no settings file, no
+ * mutable config. Every knob is a `DURABLE_INSIGHT_`-prefixed variable derived
+ * mechanically from the shared {@link SETTING_KEYS} constant, so the two lists
+ * below cannot drift from the extension's manifest (envKeys.test.ts enforces
+ * this as a contract).
+ */
+import { SETTING_KEYS } from "durable-insight-core";
+
+/**
+ * The environment variable name for a setting key.
+ *
+ * Convention: `DURABLE_INSIGHT_` + SCREAMING_SNAKE of the key. The key is
+ * lower-camelCase, so we insert `_` before each uppercase letter and uppercase
+ * the whole string. Examples:
+ *   athenaDatabase   -> DURABLE_INSIGHT_ATHENA_DATABASE
+ *   athenaS3Location -> DURABLE_INSIGHT_ATHENA_S3_LOCATION
+ *   sqsQueueUrl      -> DURABLE_INSIGHT_SQS_QUEUE_URL
+ */
+export function envVarFor(settingKey: string): string {
+  const screamingSnake = settingKey.replace(/([A-Z])/g, "_$1").toUpperCase();
+  return `DURABLE_INSIGHT_${screamingSnake}`;
+}
+
+/**
+ * Setting keys this host does NOT accept.
+ *
+ * The MCP host takes its model from the AGENT that drives it: the agent already
+ * has an LLM, so there is no provider for this host to configure, no local
+ * model to run, no agent-loop iteration budget of its own, no query-mode
+ * default, and no AI-usage consent to record (the agent's host owns that
+ * relationship with the user). Listing these explicitly — rather than deriving
+ * them — makes the exclusion intentional and reviewable; the partition test
+ * guarantees they are all real setting keys and that nothing else leaks in.
+ */
+export const MCP_EXCLUDED_SETTING_KEYS: readonly string[] = [
+  "llmProvider", // agent supplies the model — no provider to choose
+  "bedrockModelId", // "
+  "localModel", // no on-device model run by this host
+  "localServerUrl", // no local-server provider configured here
+  "localServerModel", // "
+  "agenticMaxIterations", // the agent owns its own loop/iteration budget
+  "queryMode", // the agent decides how to query; no persisted default
+  "aiDisclosureAcceptedVersion", // consent belongs to the agent's host
+];
+
+const EXCLUDED_SET: ReadonlySet<string> = new Set(MCP_EXCLUDED_SETTING_KEYS);
+
+/**
+ * The setting keys this host accepts: {@link SETTING_KEYS} minus the excluded
+ * eight. Computed from the real constant so it can never drift from the
+ * extension's manifest.
+ */
+export const MCP_SETTING_KEYS: readonly string[] = SETTING_KEYS.filter(
+  (k) => !EXCLUDED_SET.has(k),
+);

--- a/packages/durable-insight-mcp/src/hostAgnostic.test.ts
+++ b/packages/durable-insight-mcp/src/hostAgnostic.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Guards that the MCP server package imports only ITS OWN host API.
+ *
+ * This host is plain Node. It speaks the MCP protocol, so `@modelcontextprotocol/sdk`
+ * is legitimate here — but it has neither the VS Code extension API nor Electron, so
+ * importing either would break it at runtime. Like the desktop guard, this is "this
+ * host and no other" rather than "host-free", which is why the permitted module is
+ * named explicitly instead of banning the whole list.
+ *
+ * WHY THIS FILE EXISTS AT ALL:
+ * Review found that a host-specific import in shared code was invisible to every
+ * mechanism — eslint, typecheck, bundles and tests all passed with an Electron import
+ * sitting in a core module that no test happened to cover. Core and the desktop
+ * package each gained a guard; this package is the third host and needs the same one,
+ * or it inherits exactly the gap that was just closed elsewhere.
+ *
+ * The detector comes from `@aws/durable-insight-core`, where it is self-tested against
+ * every module in every import form including subpaths. It is deliberately not
+ * re-implemented: two divergent copies of a correctness-critical regex is the
+ * duplication this whole stack exists to remove.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { HOST_MODULES, findHostModules } from "@aws/durable-insight-core";
+
+const SRC = __dirname;
+
+/** The only host API this package may import. */
+const PERMITTED = HOST_MODULES.mcpSdk;
+
+/** The other hosts' APIs, which do not exist in this process. */
+const FORBIDDEN = [HOST_MODULES.vscode, HOST_MODULES.electron];
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const names = collectSourceFiles(SRC)
+  .map((f) => relative(SRC, f))
+  .sort();
+
+describe("MCP host imports only its own host API", () => {
+  // Guards against the guard passing by finding nothing.
+  it("finds its own sources, including known members", () => {
+    expect(names.length).toBeGreaterThan(3);
+    for (const expected of ["server.ts", "tools.ts", "readOnlyQuery.ts"]) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  it.each(names)("%s imports no other host's API", (name) => {
+    const found = findHostModules(
+      readFileSync(join(SRC, name), "utf-8"),
+      FORBIDDEN,
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("does import the MCP SDK somewhere, so the check above is not vacuous", () => {
+    const usesSdk = names.some(
+      (n) =>
+        findHostModules(readFileSync(join(SRC, n), "utf-8"), [PERMITTED])
+          .length > 0,
+    );
+    expect(usesSdk).toBe(true);
+  });
+});

--- a/packages/durable-insight-mcp/src/hostAgnostic.test.ts
+++ b/packages/durable-insight-mcp/src/hostAgnostic.test.ts
@@ -21,9 +21,15 @@
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
-import { HOST_MODULES, findHostModules } from "@aws/durable-insight-core";
+import {
+  HOST_MODULES,
+  findEscapingImports,
+  findHostModules,
+} from "@aws/durable-insight-core";
 
 const SRC = __dirname;
+/** The package root, i.e. the directory holding package.json. */
+const PACKAGE_ROOT = join(__dirname, "..");
 
 /** The only host API this package may import. */
 const PERMITTED = HOST_MODULES.mcpSdk;
@@ -55,6 +61,18 @@ describe("MCP host imports only its own host API", () => {
     for (const expected of ["server.ts", "tools.ts", "readOnlyQuery.ts"]) {
       expect(names).toContain(expected);
     }
+  });
+
+  // Per-file host scans cannot see a host API reached THROUGH a sibling package, and
+  // reaching sideways is itself the defect the core extraction existed to fix.
+  it.each(names)("%s does not reach into a sibling package", (name) => {
+    const file = join(SRC, name);
+    const escaping = findEscapingImports(
+      file,
+      readFileSync(file, "utf-8"),
+      PACKAGE_ROOT,
+    );
+    expect(escaping).toEqual([]);
   });
 
   it.each(names)("%s imports no other host's API", (name) => {

--- a/packages/durable-insight-mcp/src/injection.test.ts
+++ b/packages/durable-insight-mcp/src/injection.test.ts
@@ -27,6 +27,7 @@ import {
   type InsightConfig,
 } from "@aws/durable-insight-core";
 import { runGetExecution, runListExecutions } from "./tools";
+import { escapeSqlString } from "./sqlSafe";
 
 jest.mock("@aws/durable-insight-core", () => {
   const actual = jest.requireActual<typeof import("@aws/durable-insight-core")>(
@@ -68,7 +69,15 @@ const EMPTY_ATHENA = {
   numericColumns: [],
   truncated: false,
 };
-const EMPTY_PLAIN = { columns: [], rows: [], count: 0, numericColumns: [] };
+const EMPTY_PLAIN = {
+  columns: [],
+  rows: [],
+  count: 0,
+  numericColumns: [],
+  // `hasMore` is DynamoDB-only; false keeps these fixtures complete-by-default so a
+  // test that cares about incompleteness has to say so.
+  hasMore: false,
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -340,5 +349,54 @@ describe("list_executions — validated filters build the expected per-dialect S
     expect(sql).toContain("functionName = 'my-fn'");
     // startTime is a DATE field, so ORDER BY on it is allowed by the SQL plugin.
     expect(sql).toMatch(/ORDER BY startTime DESC LIMIT 100$/);
+  });
+});
+
+/**
+ * A trailing backslash must be rejected rather than escaped.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * `escapeSqlString` doubled single quotes only. On Redshift that is incomplete:
+ * backslash is an escape character in its string literals (its own `QUOTE_LITERAL`
+ * doubles backslashes as well as quotes), so a value ending in `\` produces `'foo\'`
+ * where the doubled closing quote is itself escaped and the literal runs on into the
+ * surrounding SQL. The log path already had this closed via core's
+ * `escapeQuotedString`; the SQL path did not.
+ *
+ * WHY REJECTION AND NOT ESCAPING:
+ * Doubling backslashes would be correct for Redshift and WRONG for Athena/Trino,
+ * where a backslash is an ordinary character -- there, doubling turns a search for
+ * `foo\` into a search for `foo\\`. No single escaping is right for all six engines.
+ * Rejection sidesteps it and loses nothing real: only execution ARNs and Lambda
+ * function names reach this code, and neither can contain a backslash.
+ */
+describe("backslashes are rejected on the SQL path", () => {
+  it.each([
+    ["trailing backslash", "fn\\"],
+    ["backslash before a quote", "fn\\'"],
+    ["interior backslash", "a\\b"],
+    ["double backslash", "fn\\\\"],
+  ])("rejects a %s", (_label, value) => {
+    expect(() => escapeSqlString(value)).toThrow(/backslash/i);
+  });
+
+  it("still escapes quotes in values without a backslash", () => {
+    // Acceptance: a check that threw for everything would satisfy the cases above
+    // while breaking every legitimate value.
+    expect(escapeSqlString("O'Brien")).toBe("O''Brien");
+    expect(escapeSqlString("plain-name")).toBe("plain-name");
+    expect(escapeSqlString("")).toBe("");
+  });
+
+  it("names the offending value so a caller can see what was wrong", () => {
+    expect(() => escapeSqlString("bad\\name")).toThrow(/bad\\\\name/);
+  });
+
+  it("rejects at the tool boundary, before any query is built", async () => {
+    // The unit above proves the helper throws; this proves the throw reaches the
+    // caller instead of being swallowed into a malformed query.
+    await expect(
+      runListExecutions(cfgFor("redshift"), { functionName: "fn\\" }),
+    ).rejects.toThrow(/backslash/i);
   });
 });

--- a/packages/durable-insight-mcp/src/injection.test.ts
+++ b/packages/durable-insight-mcp/src/injection.test.ts
@@ -1,0 +1,245 @@
+/**
+ * SQL-injection tests for the structured tools (`get_execution`,
+ * `list_executions`).
+ *
+ * These prove the mitigation on the ACTUAL generated SQL, not merely that no
+ * error was thrown. The core runners are mocked so the exact query string built
+ * by this package is captured and asserted on:
+ *   - Athena  -> `runAthenaQuery`'s   `query`
+ *   - DynamoDB -> `runDynamoDBQuery`'s `statement`
+ *
+ * `assertReadOnly` is deliberately NOT mocked (it runs for real inside
+ * `runReadOnlyQuery`) — but it is the BACKSTOP, not the sanitizer: an injected
+ * `' OR '1'='1` is a valid SELECT it allows. The point of these tests is that a
+ * tautology is never BUILT in the first place, which is this package's job.
+ */
+import {
+  configFromWireSettings,
+  runAthenaQuery,
+  runDynamoDBQuery,
+  resolveCredentials,
+  type InsightConfig,
+} from "durable-insight-core";
+import { runGetExecution, runListExecutions } from "./tools";
+
+jest.mock("durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("durable-insight-core")>(
+    "durable-insight-core",
+  );
+  return {
+    ...actual,
+    // Real: assertReadOnly, configFromWireSettings, buildSystemPrompt, ...
+    // Stubbed: the runners (capture SQL, never hit the network) + credentials.
+    runAthenaQuery: jest.fn(),
+    runDynamoDBQuery: jest.fn(),
+    resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
+  };
+});
+
+const runAthenaMock = runAthenaQuery as jest.MockedFunction<
+  typeof runAthenaQuery
+>;
+const runDynamoDBMock = runDynamoDBQuery as jest.MockedFunction<
+  typeof runDynamoDBQuery
+>;
+
+const EMPTY_ATHENA = {
+  columns: [],
+  rows: [],
+  count: 0,
+  numericColumns: [],
+  truncated: false,
+};
+const EMPTY_DYNAMODB = { columns: [], rows: [], count: 0, numericColumns: [] };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  runAthenaMock.mockResolvedValue(EMPTY_ATHENA);
+  runDynamoDBMock.mockResolvedValue(EMPTY_DYNAMODB);
+});
+
+function cfgFor(destinationType: string): InsightConfig {
+  return configFromWireSettings({
+    destinationType,
+    region: "us-east-1",
+    dynamodbTableName: "workflow_insight",
+    athenaDatabase: "insight_db",
+    athenaOutputLocation: "s3://results-bucket/athena/",
+  });
+}
+
+/** The SQL string the runner was handed (Athena `query` / DynamoDB `statement`). */
+function athenaSql(): string {
+  expect(runAthenaMock).toHaveBeenCalledTimes(1);
+  return runAthenaMock.mock.calls[0][0].query;
+}
+function dynamoSql(): string {
+  expect(runDynamoDBMock).toHaveBeenCalledTimes(1);
+  return runDynamoDBMock.mock.calls[0][0].statement;
+}
+
+/**
+ * Blank the CONTENTS of single-quoted string literals (treating `''` as an
+ * escaped quote), leaving the surrounding SQL. Used to prove a keyword/`;` that
+ * appears in the query survives ONLY inside a literal, never as executable SQL.
+ */
+function outsideLiterals(sql: string): string {
+  let out = "";
+  let inStr = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    if (inStr) {
+      if (ch === "'") {
+        if (sql[i + 1] === "'") {
+          i++; // escaped quote — stay in string
+          continue;
+        }
+        inStr = false;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inStr = true;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+const TAUTOLOGY = "x' OR '1'='1";
+const DROP = "x'; DROP TABLE t; --";
+
+// ── get_execution ────────────────────────────────────────────────────────────
+
+describe("get_execution — id injection", () => {
+  describe.each(["s3", "dynamodb"] as const)("%s", (dest) => {
+    const sqlOf = dest === "s3" ? athenaSql : dynamoSql;
+    const idCol = dest === "s3" ? "executionarn" : "pk";
+
+    it("escapes a tautology id to a single equality against the literal", async () => {
+      await runGetExecution(cfgFor(dest), { executionArn: TAUTOLOGY });
+      const sql = sqlOf();
+      // The value survives ONLY as an escaped literal — quotes doubled.
+      expect(sql).toContain(`${idCol} = 'x'' OR ''1''=''1'`);
+      // ...and NOT as a boolean tautology. If escaping were removed the SQL
+      // would contain `'1'='1'` and this assertion (and the one above) fail.
+      expect(sql).not.toMatch(/'1'\s*=\s*'1'/);
+      // Exactly one equality predicate against the id column — no injected OR.
+      expect(outsideLiterals(sql)).not.toMatch(/\bOR\b/i);
+    });
+
+    it("keeps a DROP-carrying id a single SELECT with no surviving DROP statement", async () => {
+      await runGetExecution(cfgFor(dest), { executionArn: DROP });
+      const sql = sqlOf();
+      // Whole payload contained in one escaped literal.
+      expect(sql).toContain(`${idCol} = 'x''; DROP TABLE t; --'`);
+      const code = outsideLiterals(sql);
+      expect(code).not.toMatch(/\bDROP\b/i); // no DROP outside the literal
+      expect(code).not.toContain(";"); // no second statement
+      expect(code.trimStart()).toMatch(/^SELECT\b/i); // still one SELECT
+    });
+  });
+});
+
+describe("get_execution — Athena partition-value injection", () => {
+  it("rejects a non-numeric year and never reaches the runner", async () => {
+    await expect(
+      runGetExecution(cfgFor("s3"), { executionArn: "arn", year: TAUTOLOGY }),
+    ).rejects.toThrow(/year/i);
+    expect(runAthenaMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a DROP-carrying month and never reaches the runner", async () => {
+    await expect(
+      runGetExecution(cfgFor("s3"), { executionArn: "arn", month: DROP }),
+    ).rejects.toThrow(/month/i);
+    expect(runAthenaMock).not.toHaveBeenCalled();
+  });
+
+  it("interpolates validated numeric partitions as a pruning predicate", async () => {
+    await runGetExecution(cfgFor("s3"), {
+      executionArn: "arn",
+      year: "2024",
+      month: "01",
+      day: "31",
+    });
+    const sql = athenaSql();
+    expect(sql).toContain("year = '2024' AND month = '01' AND day = '31' AND");
+    expect(sql).toContain("executionarn = 'arn' LIMIT 1");
+  });
+});
+
+// ── list_executions ──────────────────────────────────────────────────────────
+
+describe("list_executions — filter injection", () => {
+  describe.each([
+    ["s3", athenaSql, "functionname"] as const,
+    ["dynamodb", dynamoSql, "functionName"] as const,
+  ])("%s", (dest, sqlOf, fnCol) => {
+    it("rejects an injected status (closed enum) before any runner call", async () => {
+      await expect(
+        runListExecutions(cfgFor(dest), { status: TAUTOLOGY }),
+      ).rejects.toThrow(/status/i);
+      expect(runAthenaMock).not.toHaveBeenCalled();
+      expect(runDynamoDBMock).not.toHaveBeenCalled();
+    });
+
+    it("escapes an injected functionName to a single equality, not a tautology", async () => {
+      await runListExecutions(cfgFor(dest), { functionName: TAUTOLOGY });
+      const sql = sqlOf();
+      expect(sql).toContain(`${fnCol} = 'x'' OR ''1''=''1'`);
+      expect(sql).not.toMatch(/'1'\s*=\s*'1'/);
+      // The only OR-free, single-statement SELECT is what we want.
+      const code = outsideLiterals(sql);
+      expect(code).not.toMatch(/\bOR\b/i);
+      expect(code.trimStart()).toMatch(/^SELECT\b/i);
+    });
+
+    it("keeps a DROP-carrying functionName a single SELECT with no surviving DROP", async () => {
+      await runListExecutions(cfgFor(dest), { functionName: DROP });
+      const sql = sqlOf();
+      expect(sql).toContain(`${fnCol} = 'x''; DROP TABLE t; --'`);
+      const code = outsideLiterals(sql);
+      expect(code).not.toMatch(/\bDROP\b/i);
+      expect(code).not.toContain(";");
+      expect(code.trimStart()).toMatch(/^SELECT\b/i);
+    });
+
+    it("rejects a malformed since timestamp before any runner call", async () => {
+      await expect(
+        runListExecutions(cfgFor(dest), { since: TAUTOLOGY }),
+      ).rejects.toThrow(/since/i);
+      expect(runAthenaMock).not.toHaveBeenCalled();
+      expect(runDynamoDBMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("list_executions — validated filters build the expected SQL", () => {
+  it("s3: interpolates a validated status and ISO bounds as literals", async () => {
+    await runListExecutions(cfgFor("s3"), {
+      status: "FAILED",
+      since: "2024-01-01",
+      until: "2024-02-01T00:00:00Z",
+      functionName: "my-fn",
+    });
+    const sql = athenaSql();
+    expect(sql).toContain("recordtype = 'WorkflowInsight'");
+    expect(sql).toContain("status = 'FAILED'");
+    expect(sql).toContain("functionname = 'my-fn'");
+    expect(sql).toContain("starttime >= '2024-01-01'");
+    expect(sql).toContain("starttime <= '2024-02-01T00:00:00Z'");
+    expect(sql).toMatch(/ORDER BY starttime DESC LIMIT 100$/);
+  });
+
+  it("dynamodb: builds a PartiQL SELECT with no ORDER BY / LIMIT", async () => {
+    await runListExecutions(cfgFor("dynamodb"), { status: "SUCCEEDED" });
+    const sql = dynamoSql();
+    expect(sql).toContain('FROM "workflow_insight"');
+    expect(sql).toContain("recordType = 'WorkflowInsight'");
+    expect(sql).toContain("status = 'SUCCEEDED'");
+    expect(sql).not.toMatch(/\bLIMIT\b/i);
+    expect(sql).not.toMatch(/\bORDER BY\b/i);
+  });
+});

--- a/packages/durable-insight-mcp/src/injection.test.ts
+++ b/packages/durable-insight-mcp/src/injection.test.ts
@@ -5,8 +5,11 @@
  * These prove the mitigation on the ACTUAL generated SQL, not merely that no
  * error was thrown. The core runners are mocked so the exact query string built
  * by this package is captured and asserted on:
- *   - Athena  -> `runAthenaQuery`'s   `query`
- *   - DynamoDB -> `runDynamoDBQuery`'s `statement`
+ *   - Athena     -> `runAthenaQuery`'s     `query`
+ *   - DynamoDB   -> `runDynamoDBQuery`'s   `statement`
+ *   - Aurora     -> `runAuroraQuery`'s     `sql`
+ *   - Redshift   -> `runRedshiftQuery`'s   `sql`
+ *   - OpenSearch -> `runOpenSearchQuery`'s `sql`
  *
  * `assertReadOnly` is deliberately NOT mocked (it runs for real inside
  * `runReadOnlyQuery`) — but it is the BACKSTOP, not the sanitizer: an injected
@@ -16,7 +19,10 @@
 import {
   configFromWireSettings,
   runAthenaQuery,
+  runAuroraQuery,
   runDynamoDBQuery,
+  runOpenSearchQuery,
+  runRedshiftQuery,
   resolveCredentials,
   type InsightConfig,
 } from "durable-insight-core";
@@ -32,6 +38,9 @@ jest.mock("durable-insight-core", () => {
     // Stubbed: the runners (capture SQL, never hit the network) + credentials.
     runAthenaQuery: jest.fn(),
     runDynamoDBQuery: jest.fn(),
+    runAuroraQuery: jest.fn(),
+    runRedshiftQuery: jest.fn(),
+    runOpenSearchQuery: jest.fn(),
     resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
   };
 });
@@ -42,6 +51,15 @@ const runAthenaMock = runAthenaQuery as jest.MockedFunction<
 const runDynamoDBMock = runDynamoDBQuery as jest.MockedFunction<
   typeof runDynamoDBQuery
 >;
+const runAuroraMock = runAuroraQuery as jest.MockedFunction<
+  typeof runAuroraQuery
+>;
+const runRedshiftMock = runRedshiftQuery as jest.MockedFunction<
+  typeof runRedshiftQuery
+>;
+const runOpenSearchMock = runOpenSearchQuery as jest.MockedFunction<
+  typeof runOpenSearchQuery
+>;
 
 const EMPTY_ATHENA = {
   columns: [],
@@ -50,12 +68,15 @@ const EMPTY_ATHENA = {
   numericColumns: [],
   truncated: false,
 };
-const EMPTY_DYNAMODB = { columns: [], rows: [], count: 0, numericColumns: [] };
+const EMPTY_PLAIN = { columns: [], rows: [], count: 0, numericColumns: [] };
 
 beforeEach(() => {
   jest.clearAllMocks();
   runAthenaMock.mockResolvedValue(EMPTY_ATHENA);
-  runDynamoDBMock.mockResolvedValue(EMPTY_DYNAMODB);
+  runDynamoDBMock.mockResolvedValue(EMPTY_PLAIN);
+  runAuroraMock.mockResolvedValue(EMPTY_PLAIN);
+  runRedshiftMock.mockResolvedValue(EMPTY_PLAIN);
+  runOpenSearchMock.mockResolvedValue(EMPTY_PLAIN);
 });
 
 function cfgFor(destinationType: string): InsightConfig {
@@ -65,10 +86,14 @@ function cfgFor(destinationType: string): InsightConfig {
     dynamodbTableName: "workflow_insight",
     athenaDatabase: "insight_db",
     athenaOutputLocation: "s3://results-bucket/athena/",
+    auroraResourceArn: "arn:aws:rds:us-east-1:111:cluster:c1",
+    auroraSecretArn: "arn:aws:secretsmanager:us-east-1:111:secret:s1",
+    redshiftWorkgroupName: "wg1",
+    opensearchEndpoint: "https://os.example.com",
   });
 }
 
-/** The SQL string the runner was handed (Athena `query` / DynamoDB `statement`). */
+/** The SQL string the runner was handed, per engine. */
 function athenaSql(): string {
   expect(runAthenaMock).toHaveBeenCalledTimes(1);
   return runAthenaMock.mock.calls[0][0].query;
@@ -76,6 +101,27 @@ function athenaSql(): string {
 function dynamoSql(): string {
   expect(runDynamoDBMock).toHaveBeenCalledTimes(1);
   return runDynamoDBMock.mock.calls[0][0].statement;
+}
+function auroraSql(): string {
+  expect(runAuroraMock).toHaveBeenCalledTimes(1);
+  return runAuroraMock.mock.calls[0][0].sql;
+}
+function redshiftSql(): string {
+  expect(runRedshiftMock).toHaveBeenCalledTimes(1);
+  return runRedshiftMock.mock.calls[0][0].sql;
+}
+function openSearchSql(): string {
+  expect(runOpenSearchMock).toHaveBeenCalledTimes(1);
+  return runOpenSearchMock.mock.calls[0][0].sql;
+}
+
+/** Assert NONE of the five runners were invoked. */
+function expectNoRunnerCalled(): void {
+  expect(runAthenaMock).not.toHaveBeenCalled();
+  expect(runDynamoDBMock).not.toHaveBeenCalled();
+  expect(runAuroraMock).not.toHaveBeenCalled();
+  expect(runRedshiftMock).not.toHaveBeenCalled();
+  expect(runOpenSearchMock).not.toHaveBeenCalled();
 }
 
 /**
@@ -110,13 +156,23 @@ function outsideLiterals(sql: string): string {
 const TAUTOLOGY = "x' OR '1'='1";
 const DROP = "x'; DROP TABLE t; --";
 
+/**
+ * Per-engine facts the injection assertions parametrize over: the SQL getter,
+ * the execution-id column (get_execution), and the functionName column
+ * (list_executions). These differ per dialect and are sourced from schema.ts.
+ */
+const ENGINES = [
+  ["s3", athenaSql, "executionarn", "functionname"],
+  ["dynamodb", dynamoSql, "pk", "functionName"],
+  ["aurora", auroraSql, "execution_arn", "function_name"],
+  ["redshift", redshiftSql, "execution_arn", "function_name"],
+  ["opensearch", openSearchSql, "executionArn", "functionName"],
+] as const;
+
 // ── get_execution ────────────────────────────────────────────────────────────
 
 describe("get_execution — id injection", () => {
-  describe.each(["s3", "dynamodb"] as const)("%s", (dest) => {
-    const sqlOf = dest === "s3" ? athenaSql : dynamoSql;
-    const idCol = dest === "s3" ? "executionarn" : "pk";
-
+  describe.each(ENGINES)("%s", (dest, sqlOf, idCol) => {
     it("escapes a tautology id to a single equality against the literal", async () => {
       await runGetExecution(cfgFor(dest), { executionArn: TAUTOLOGY });
       const sql = sqlOf();
@@ -173,16 +229,12 @@ describe("get_execution — Athena partition-value injection", () => {
 // ── list_executions ──────────────────────────────────────────────────────────
 
 describe("list_executions — filter injection", () => {
-  describe.each([
-    ["s3", athenaSql, "functionname"] as const,
-    ["dynamodb", dynamoSql, "functionName"] as const,
-  ])("%s", (dest, sqlOf, fnCol) => {
+  describe.each(ENGINES)("%s", (dest, sqlOf, _idCol, fnCol) => {
     it("rejects an injected status (closed enum) before any runner call", async () => {
       await expect(
         runListExecutions(cfgFor(dest), { status: TAUTOLOGY }),
       ).rejects.toThrow(/status/i);
-      expect(runAthenaMock).not.toHaveBeenCalled();
-      expect(runDynamoDBMock).not.toHaveBeenCalled();
+      expectNoRunnerCalled();
     });
 
     it("escapes an injected functionName to a single equality, not a tautology", async () => {
@@ -210,14 +262,13 @@ describe("list_executions — filter injection", () => {
       await expect(
         runListExecutions(cfgFor(dest), { since: TAUTOLOGY }),
       ).rejects.toThrow(/since/i);
-      expect(runAthenaMock).not.toHaveBeenCalled();
-      expect(runDynamoDBMock).not.toHaveBeenCalled();
+      expectNoRunnerCalled();
     });
   });
 });
 
-describe("list_executions — validated filters build the expected SQL", () => {
-  it("s3: interpolates a validated status and ISO bounds as literals", async () => {
+describe("list_executions — validated filters build the expected per-dialect SQL", () => {
+  it("s3: lowercase columns, recordtype guard, ORDER BY + LIMIT", async () => {
     await runListExecutions(cfgFor("s3"), {
       status: "FAILED",
       since: "2024-01-01",
@@ -233,7 +284,7 @@ describe("list_executions — validated filters build the expected SQL", () => {
     expect(sql).toMatch(/ORDER BY starttime DESC LIMIT 100$/);
   });
 
-  it("dynamodb: builds a PartiQL SELECT with no ORDER BY / LIMIT", async () => {
+  it("dynamodb: camelCase columns, recordType guard, no ORDER BY / LIMIT", async () => {
     await runListExecutions(cfgFor("dynamodb"), { status: "SUCCEEDED" });
     const sql = dynamoSql();
     expect(sql).toContain('FROM "workflow_insight"');
@@ -241,5 +292,53 @@ describe("list_executions — validated filters build the expected SQL", () => {
     expect(sql).toContain("status = 'SUCCEEDED'");
     expect(sql).not.toMatch(/\bLIMIT\b/i);
     expect(sql).not.toMatch(/\bORDER BY\b/i);
+  });
+
+  it("aurora: snake_case columns, NO recordType guard, ORDER BY + LIMIT", async () => {
+    await runListExecutions(cfgFor("aurora"), {
+      status: "FAILED",
+      functionName: "my-fn",
+      since: "2024-01-01",
+    });
+    const sql = auroraSql();
+    // Aurora's dedicated table has no recordType column — the guard MUST be
+    // absent, else it would be a "column does not exist" error.
+    expect(sql).not.toMatch(/recordtype/i);
+    expect(sql).toContain("FROM workflow_insight");
+    expect(sql).toContain("status = 'FAILED'");
+    expect(sql).toContain("function_name = 'my-fn'");
+    expect(sql).toContain("start_time >= '2024-01-01'");
+    expect(sql).toMatch(/ORDER BY start_time DESC LIMIT 100$/);
+  });
+
+  it("aurora: no filters yields a bare SELECT with no WHERE clause", async () => {
+    await runListExecutions(cfgFor("aurora"), {});
+    const sql = auroraSql();
+    expect(sql).not.toMatch(/\bWHERE\b/i);
+    expect(sql).toMatch(/ORDER BY start_time DESC LIMIT 100$/);
+  });
+
+  it("redshift: snake_case columns, NO recordType guard, ORDER BY + LIMIT", async () => {
+    await runListExecutions(cfgFor("redshift"), { status: "RUNNING" });
+    const sql = redshiftSql();
+    expect(sql).not.toMatch(/recordtype/i);
+    expect(sql).toContain("FROM workflow_insight");
+    expect(sql).toContain("status = 'RUNNING'");
+    expect(sql).toMatch(/ORDER BY start_time DESC LIMIT 100$/);
+  });
+
+  it("opensearch: camelCase columns, backtick-quoted index, recordType guard, ORDER BY startTime", async () => {
+    await runListExecutions(cfgFor("opensearch"), {
+      status: "SUCCEEDED",
+      functionName: "my-fn",
+    });
+    const sql = openSearchSql();
+    // Index name has a hyphen -> MUST be backtick-quoted.
+    expect(sql).toContain("FROM `workflow-insight`");
+    expect(sql).toContain("recordType = 'WorkflowInsight'");
+    expect(sql).toContain("status = 'SUCCEEDED'");
+    expect(sql).toContain("functionName = 'my-fn'");
+    // startTime is a DATE field, so ORDER BY on it is allowed by the SQL plugin.
+    expect(sql).toMatch(/ORDER BY startTime DESC LIMIT 100$/);
   });
 });

--- a/packages/durable-insight-mcp/src/injection.test.ts
+++ b/packages/durable-insight-mcp/src/injection.test.ts
@@ -331,7 +331,13 @@ describe("list_executions — validated filters build the expected per-dialect S
     await runListExecutions(cfgFor("redshift"), { status: "RUNNING" });
     const sql = redshiftSql();
     expect(sql).not.toMatch(/recordtype/i);
-    expect(sql).toContain("FROM workflow_insight");
+    // Schema-qualified. This assertion previously pinned the BUG: it read
+    // `FROM workflow_insight`, which passed only because the default schema is
+    // `public` and an unqualified name resolves through `search_path` to the
+    // same table. Core qualifies Redshift wherever it builds SQL; so does this
+    // package now. Aurora above stays unqualified on purpose -- it has no
+    // schema setting, and core does not qualify it either.
+    expect(sql).toContain("FROM public.workflow_insight");
     expect(sql).toContain("status = 'RUNNING'");
     expect(sql).toMatch(/ORDER BY start_time DESC LIMIT 100$/);
   });

--- a/packages/durable-insight-mcp/src/injection.test.ts
+++ b/packages/durable-insight-mcp/src/injection.test.ts
@@ -25,12 +25,12 @@ import {
   runRedshiftQuery,
   resolveCredentials,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import { runGetExecution, runListExecutions } from "./tools";
 
-jest.mock("durable-insight-core", () => {
-  const actual = jest.requireActual<typeof import("durable-insight-core")>(
-    "durable-insight-core",
+jest.mock("@aws/durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("@aws/durable-insight-core")>(
+    "@aws/durable-insight-core",
   );
   return {
     ...actual,

--- a/packages/durable-insight-mcp/src/logsInsights.test.ts
+++ b/packages/durable-insight-mcp/src/logsInsights.test.ts
@@ -27,7 +27,7 @@ import {
   resolveCredentials,
   type InsightConfig,
   type QueryResultTable,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import {
   DEFAULT_LOG_TIME_RANGE_MS,
   LOGS_INSIGHTS_ENGINE,
@@ -41,9 +41,9 @@ import {
   runListExecutions,
 } from "./tools";
 
-jest.mock("durable-insight-core", () => {
-  const actual = jest.requireActual<typeof import("durable-insight-core")>(
-    "durable-insight-core",
+jest.mock("@aws/durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("@aws/durable-insight-core")>(
+    "@aws/durable-insight-core",
   );
   return {
     ...actual,

--- a/packages/durable-insight-mcp/src/logsInsights.test.ts
+++ b/packages/durable-insight-mcp/src/logsInsights.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for the CloudWatch Logs Insights query path (Phase 4).
+ *
+ * WHY THIS SUITE IS SHAPED DIFFERENTLY FROM readOnlyQuery.test.ts:
+ *   The five SQL engines are guarded by `assertReadOnly`, so their suite proves
+ *   that BAD input (writes) is rejected. The Logs Insights path is the exact
+ *   inverse: `assertReadOnly` MUST NOT run here (it requires SELECT/WITH and
+ *   would reject every valid pipe query), so the critical property to prove is
+ *   that VALID Logs Insights queries are ACCEPTED and reach the runner. The
+ *   plausible future regression is someone adding `assertReadOnly` "for
+ *   consistency" and silently breaking every log query — the accept tests below
+ *   are the guard against exactly that.
+ *
+ * `assertReadOnly` and `ensureLimit` are the REAL implementations from core
+ * (not mocked): the accept tests only pass because the log path never calls
+ * `assertReadOnly`, and the bounding tests only pass because it does call
+ * `ensureLimit`. Only the async boundaries are stubbed:
+ *   - `runLogsInsightsQuery`   — capture the query string + window, no network.
+ *   - `fetchLogsInsightsRecord`— capture the get_execution lookup, no network.
+ *   - `resolveCredentials`     — no provider chain constructed.
+ */
+import {
+  configFromWireSettings,
+  escapeQuotedString,
+  fetchLogsInsightsRecord,
+  runLogsInsightsQuery,
+  resolveCredentials,
+  type InsightConfig,
+  type QueryResultTable,
+} from "durable-insight-core";
+import {
+  DEFAULT_LOG_TIME_RANGE_MS,
+  LOGS_INSIGHTS_ENGINE,
+  MAX_ROWS,
+  runReadOnlyQuery,
+} from "./readOnlyQuery";
+import {
+  buildDescribeSchemaResult,
+  buildListExecutionsLogsQuery,
+  runGetExecution,
+  runListExecutions,
+} from "./tools";
+
+jest.mock("durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("durable-insight-core")>(
+    "durable-insight-core",
+  );
+  return {
+    ...actual,
+    // Real: assertReadOnly, ensureLimit, escapeQuotedString, buildSystemPrompt,
+    //       configFromWireSettings, normalizeConfig, ...
+    // Stubbed: the two async log boundaries + credential resolution.
+    runLogsInsightsQuery: jest.fn(),
+    fetchLogsInsightsRecord: jest.fn(),
+    resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
+  };
+});
+
+const runLogsMock = runLogsInsightsQuery as jest.MockedFunction<
+  typeof runLogsInsightsQuery
+>;
+const fetchRecordMock = fetchLogsInsightsRecord as jest.MockedFunction<
+  typeof fetchLogsInsightsRecord
+>;
+
+const EMPTY_TABLE: QueryResultTable = {
+  columns: [],
+  rows: [],
+  recordsMatched: 0,
+  recordsScanned: 0,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  runLogsMock.mockResolvedValue(EMPTY_TABLE);
+  fetchRecordMock.mockResolvedValue(undefined);
+});
+
+/** Both CloudWatch Logs Insights destination types. */
+const LOG_TYPES = ["cloudwatch-logs-exporter", "lambda-log-exporter"] as const;
+
+function cfgFor(
+  destinationType: string,
+  logGroupName = "/aws/lambda/fn",
+): InsightConfig {
+  return configFromWireSettings({
+    destinationType,
+    region: "us-east-1",
+    logGroupName,
+  });
+}
+
+/** The queryString handed to the (mocked) Logs Insights runner on call N. */
+function queryStringAt(n = 0): string {
+  expect(runLogsMock.mock.calls.length).toBeGreaterThan(n);
+  return runLogsMock.mock.calls[n][0].queryString;
+}
+
+// ── The inverted guard: VALID Logs Insights queries are ACCEPTED ─────────────
+
+const VALID_QUERIES: Array<[string, string]> = [
+  [
+    "fields + filter + sort",
+    'fields @timestamp, @message | filter recordType = "WorkflowInsight" | sort @timestamp desc',
+  ],
+  ["stats aggregation", "fields @timestamp | stats count() by status"],
+  ["filter then fields", 'filter status = "FAILED" | fields executionArn'],
+];
+
+describe.each(LOG_TYPES)(
+  "runReadOnlyQuery on %s ACCEPTS valid Logs Insights queries (never assertReadOnly)",
+  (destinationType) => {
+    it.each(VALID_QUERIES)("accepts and runs: %s", async (_label, query) => {
+      // The whole point: this resolves (is NOT rejected). If someone adds
+      // assertReadOnly to the log path, the real validator rejects a query that
+      // does not start with SELECT/WITH and this line throws.
+      const result = await runReadOnlyQuery(cfgFor(destinationType), query);
+      expect(runLogsMock).toHaveBeenCalledTimes(1);
+      expect(result.engine).toBe(LOGS_INSIGHTS_ENGINE);
+    });
+  },
+);
+
+// ── ensureLimit is applied on the log path (and only where appropriate) ──────
+
+describe.each(LOG_TYPES)("ensureLimit bounding on %s", (destinationType) => {
+  it("appends `| limit MAX_ROWS` to a non-aggregating query without a limit", async () => {
+    await runReadOnlyQuery(
+      cfgFor(destinationType),
+      'filter status = "FAILED" | fields executionArn',
+    );
+    expect(queryStringAt()).toBe(
+      `filter status = "FAILED" | fields executionArn | limit ${MAX_ROWS}`,
+    );
+  });
+
+  it("leaves a query that already contains `limit` unchanged", async () => {
+    await runReadOnlyQuery(
+      cfgFor(destinationType),
+      'filter status = "FAILED" | fields executionArn | limit 5',
+    );
+    const q = queryStringAt();
+    expect(q).toBe('filter status = "FAILED" | fields executionArn | limit 5');
+    // No second limit was appended.
+    expect(q.match(/\blimit\b/gi)?.length).toBe(1);
+  });
+
+  it("leaves a `stats` aggregation alone (no limit appended)", async () => {
+    await runReadOnlyQuery(
+      cfgFor(destinationType),
+      "fields @timestamp | stats count() by status",
+    );
+    const q = queryStringAt();
+    expect(q).toBe("fields @timestamp | stats count() by status");
+    expect(q).not.toMatch(/\blimit\b/i);
+  });
+});
+
+// ── Explicit time window is ALWAYS supplied ──────────────────────────────────
+
+describe.each(LOG_TYPES)("time window on %s", (destinationType) => {
+  it("always passes numeric startTimeMs/endTimeMs with endTimeMs >= startTimeMs", async () => {
+    await runReadOnlyQuery(cfgFor(destinationType), "fields @timestamp");
+    const opts = runLogsMock.mock.calls[0][0];
+    expect(typeof opts.startTimeMs).toBe("number");
+    expect(typeof opts.endTimeMs).toBe("number");
+    expect(opts.endTimeMs).toBeGreaterThanOrEqual(opts.startTimeMs);
+  });
+
+  it("uses the 24h default window when no time range is given", async () => {
+    await runReadOnlyQuery(cfgFor(destinationType), "fields @timestamp");
+    const opts = runLogsMock.mock.calls[0][0];
+    expect(opts.endTimeMs - opts.startTimeMs).toBe(DEFAULT_LOG_TIME_RANGE_MS);
+  });
+
+  it("honors an explicit timeRangeMs option", async () => {
+    const oneHour = 60 * 60 * 1000;
+    await runReadOnlyQuery(cfgFor(destinationType), "fields @timestamp", {
+      timeRangeMs: oneHour,
+    });
+    const opts = runLogsMock.mock.calls[0][0];
+    expect(opts.endTimeMs - opts.startTimeMs).toBe(oneHour);
+  });
+});
+
+// ── logGroupNames is passed through as the array from config ─────────────────
+
+describe.each(LOG_TYPES)("log groups on %s", (destinationType) => {
+  it("passes cfg.logGroupNames (the array) straight through", async () => {
+    const cfg = cfgFor(destinationType, "/aws/lambda/a,/aws/lambda/b");
+    await runReadOnlyQuery(cfg, "fields @timestamp");
+    const opts = runLogsMock.mock.calls[0][0];
+    expect(opts.logGroupNames).toEqual(["/aws/lambda/a", "/aws/lambda/b"]);
+    // Confirm it really is the multi-element array from config, not a string.
+    expect(Array.isArray(opts.logGroupNames)).toBe(true);
+    expect(cfg.logGroupNames).toEqual(["/aws/lambda/a", "/aws/lambda/b"]);
+  });
+});
+
+// ── Escaping — proven on the ACTUAL generated query string ───────────────────
+//
+// list_executions is where THIS package interpolates an agent-supplied value
+// into a Logs Insights literal, so it is where the escaping must be proven.
+// The correct escaper is core's escapeQuotedString (backslashes first, then
+// double quotes). Swapping it for the SQL single-quote doubler (escapeSqlString)
+// leaves a trailing backslash unescaped and lets the value break out of the
+// double-quoted literal — the trailing-backslash test below is what catches it.
+
+describe.each(LOG_TYPES)(
+  "list_executions escapes an injected functionName on %s",
+  (destinationType) => {
+    it("a value carrying a closing quote + pipe cannot break out of the literal", async () => {
+      const q = buildListExecutionsLogsQuery(cfgFor(destinationType), {
+        functionName: 'x" | fields @message',
+      });
+      // The `"` is escaped to `\"`, so the pipe stays INSIDE the literal.
+      expect(q).toContain('functionName = "x\\" | fields @message"');
+      // The un-escaped breakout form (quote-x-quote) must NOT appear.
+      expect(q).not.toContain('functionName = "x" |');
+    });
+
+    it("a value ending in a backslash is escaped so the closing quote survives", async () => {
+      // Input is the two-char string  x\  — a lone trailing backslash.
+      const q = buildListExecutionsLogsQuery(cfgFor(destinationType), {
+        functionName: "x\\",
+      });
+      // Correct (escapeQuotedString): the backslash is doubled -> `x\\`, so the
+      // closing quote is a real terminator: functionName = "x\\"
+      expect(q).toContain('functionName = "x\\\\"');
+      // Cross-check against the real escaper (diverges the moment production
+      // swaps in escapeSqlString, which would leave a single backslash).
+      expect(q).toContain(`functionName = "${escapeQuotedString("x\\")}"`);
+    });
+  },
+);
+
+// get_execution routes through core's fetchLogsInsightsRecord, which escapes the
+// executionArn with escapeQuotedString internally (covered by core's
+// logsInsights.test.ts, incl. the trailing-backslash case). Here we prove the
+// MCP layer forwards the raw arn + the log-group ARRAY to that helper.
+describe.each(LOG_TYPES)("get_execution on %s", (destinationType) => {
+  it("forwards executionArn and the logGroupNames array to fetchLogsInsightsRecord", async () => {
+    const cfg = cfgFor(destinationType, "/aws/lambda/a,/aws/lambda/b");
+    await runGetExecution(cfg, { executionArn: "arn:aws:lambda:exec/1" });
+    expect(fetchRecordMock).toHaveBeenCalledTimes(1);
+    const opts = fetchRecordMock.mock.calls[0][0];
+    expect(opts.executionArn).toBe("arn:aws:lambda:exec/1");
+    expect(opts.logGroupNames).toEqual(["/aws/lambda/a", "/aws/lambda/b"]);
+  });
+
+  it("maps a missing record to found=false (not an error)", async () => {
+    fetchRecordMock.mockResolvedValueOnce(undefined);
+    const res = await runGetExecution(cfgFor(destinationType), {
+      executionArn: "arn:missing",
+    });
+    expect(res.found).toBe(false);
+    expect(res.engine).toBe(LOGS_INSIGHTS_ENGINE);
+    expect(res.record).toBeUndefined();
+  });
+
+  it("maps a present record to found=true with the record", async () => {
+    fetchRecordMock.mockResolvedValueOnce({
+      executionArn: "arn:x",
+      status: "SUCCEEDED",
+    });
+    const res = await runGetExecution(cfgFor(destinationType), {
+      executionArn: "arn:x",
+    });
+    expect(res.found).toBe(true);
+    expect(res.record).toEqual({ executionArn: "arn:x", status: "SUCCEEDED" });
+  });
+});
+
+// ── list_executions runs through the choke point and is bounded ──────────────
+
+describe.each(LOG_TYPES)(
+  "list_executions dispatch on %s",
+  (destinationType) => {
+    it("validates status against the closed enum (rejects before any runner call)", async () => {
+      await expect(
+        runListExecutions(cfgFor(destinationType), { status: "x' OR '1'='1" }),
+      ).rejects.toThrow(/status/i);
+      expect(runLogsMock).not.toHaveBeenCalled();
+    });
+
+    it("builds a pipe query (NOT SQL), runs it, and reports the logs engine", async () => {
+      const res = await runListExecutions(cfgFor(destinationType), {
+        status: "FAILED",
+      });
+      expect(res.engine).toBe(LOGS_INSIGHTS_ENGINE);
+      const q = queryStringAt();
+      // A pipe query, never SQL.
+      expect(q).not.toMatch(/^\s*SELECT\b/i);
+      expect(q).toContain("filter ");
+      // Bounded: the builder appends its own limit, so ensureLimit leaves it be.
+      expect(q).toMatch(/\| limit \d+$/);
+    });
+  },
+);
+
+// ── describe_schema covers both log types (guidance in the RESULT) ───────────
+
+describe.each(LOG_TYPES)("describe_schema on %s", (destinationType) => {
+  it("reports the logs engine, the log groups as the table, and non-empty guidance", () => {
+    const cfg = cfgFor(destinationType, "/aws/lambda/a,/aws/lambda/b");
+    const res = buildDescribeSchemaResult(cfg);
+    expect(res.engine).toBe(LOGS_INSIGHTS_ENGINE);
+    expect(res.table).toBe("/aws/lambda/a, /aws/lambda/b");
+    expect(res.guidance.length).toBeGreaterThan(0);
+    expect(res.guidanceLength).toBe(res.guidance.length);
+  });
+});

--- a/packages/durable-insight-mcp/src/packaging.test.ts
+++ b/packages/durable-insight-mcp/src/packaging.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Guards that a customer can actually install this package.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * This package is published (`"private": false`) and customers run it with
+ * `npx -y @aws/durable-insight-mcp`. So every entry in `dependencies` must be
+ * resolvable from the public registry. It briefly was not: `@aws/durable-insight-core`
+ * is a `"private": true` workspace package that is never published, and listing it as
+ * a runtime dependency made `npm install` fail with E404 for every user — reproduced
+ * by packing this package and installing it outside the workspace.
+ *
+ * The same class of bug had just been found in the VS Code extension's isolated VSIX
+ * packaging path, which is what prompted checking here.
+ *
+ * WHY IT IS A DEV DEPENDENCY:
+ * esbuild inlines core into `dist/server.js`, so nothing resolves it at runtime — the
+ * bundle carries core's code directly. That makes it a build input, not a runtime
+ * dependency, and `devDependencies` is where build inputs belong. Anything genuinely
+ * needed at runtime (a module marked `external` in the bundle) must stay in
+ * `dependencies` instead.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGES_DIR = join(__dirname, "..", "..");
+
+interface Manifest {
+  name?: string;
+  private?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+function read(path: string): Manifest | undefined {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Manifest;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Every workspace package by npm name. */
+const workspacePackages = new Map<string, Manifest>();
+for (const dir of readdirSync(PACKAGES_DIR)) {
+  const m = read(join(PACKAGES_DIR, dir, "package.json"));
+  if (m?.name) workspacePackages.set(m.name, m);
+}
+
+const self = read(join(__dirname, "..", "package.json")) as Manifest;
+
+describe("published package is installable by a customer", () => {
+  it("finds the workspace and this manifest", () => {
+    // Guards against passing because it read nothing.
+    expect(workspacePackages.size).toBeGreaterThan(5);
+    expect(self.name).toBe("@aws/durable-insight-mcp");
+  });
+
+  it("is published, which is what makes the rule below apply", () => {
+    expect(self.private ?? false).toBe(false);
+  });
+
+  it("declares no private workspace package as a runtime dependency", () => {
+    const offenders = Object.keys(self.dependencies ?? {}).filter(
+      (name) => workspacePackages.get(name)?.private === true,
+    );
+    // A private workspace package is never published, so npm cannot resolve it for a
+    // customer: `npx` fails with E404 before the server ever starts.
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the bundled core as a dev dependency", () => {
+    // Not merely absent from `dependencies` -- present where a build input belongs, so
+    // the build cannot silently lose it either.
+    expect(Object.keys(self.devDependencies ?? {})).toContain(
+      "@aws/durable-insight-core",
+    );
+  });
+});

--- a/packages/durable-insight-mcp/src/packaging.test.ts
+++ b/packages/durable-insight-mcp/src/packaging.test.ts
@@ -76,3 +76,59 @@ describe("published package is installable by a customer", () => {
     );
   });
 });
+
+/**
+ * `"private": false` is a manifest flag. It permits publishing; it does not cause it.
+ * The release script decides that, from a hard-coded list, and this package was missing
+ * from it -- so `npx -y @aws/durable-insight-mcp` could not have worked no matter what
+ * the manifest said. Every test above passed throughout, because none of them knew the
+ * release pipeline existed.
+ *
+ * The invariant is deliberately keyed on the `@aws/` SCOPE rather than on
+ * `private !== true`. Three packages in this workspace are non-private and are
+ * correctly never published -- `cdk-bundling-integration-test`, `esm-integration-test`,
+ * `lambda-runtime-detection-integration-test` -- so the broader rule would fail on
+ * pre-existing, correct state. A scoped name is the actual signal of intent to publish:
+ * nothing else can claim `@aws/`.
+ */
+describe("release pipeline actually publishes what claims to be published", () => {
+  const PUBLISH_SCRIPT = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    ".github",
+    "workflows",
+    "iterate-publish-npm.sh",
+  );
+  const script = readFileSync(PUBLISH_SCRIPT, "utf-8");
+
+  /** Directory names listed in the script's PACKAGES array. */
+  const listedDirs = new Set(
+    [...script.matchAll(/^\s*"packages\/([^"]+)"\s*$/gm)].map((m) => m[1]),
+  );
+
+  it("finds the publish list", () => {
+    // Non-vacuity: a renamed script or a restructured array must fail loudly here
+    // rather than silently making every assertion below trivially true.
+    expect(listedDirs.size).toBeGreaterThan(3);
+    expect(listedDirs).toContain("aws-durable-execution-sdk-js");
+  });
+
+  it("lists every publishable @aws/-scoped workspace package", () => {
+    const missing: string[] = [];
+    for (const dir of readdirSync(PACKAGES_DIR)) {
+      const m = read(join(PACKAGES_DIR, dir, "package.json"));
+      if (!m?.name || m.private === true) continue;
+      if (!m.name.startsWith("@aws/")) continue;
+      if (!listedDirs.has(dir)) missing.push(`${m.name} (packages/${dir})`);
+    }
+    // A package here is one a customer is told to install and cannot.
+    expect(missing).toEqual([]);
+  });
+
+  it("lists this package specifically", () => {
+    // Stated separately so the failure names this package rather than a set.
+    expect(listedDirs).toContain("durable-insight-mcp");
+  });
+});

--- a/packages/durable-insight-mcp/src/prompts.ts
+++ b/packages/durable-insight-mcp/src/prompts.ts
@@ -1,0 +1,191 @@
+/**
+ * MCP prompts surfaced by this server (via `registerPrompt`, the non-deprecated
+ * API). A client such as Kiro lists these under `/prompts` and `@name`, so they
+ * ship *inside* the server and need no separate install by the customer.
+ *
+ * ZERO destination-specific schema knowledge lives here — on purpose. Every
+ * fact about a destination's record fields, column casing, table quoting, and
+ * dialect idioms is owned by core's `buildSystemPrompt` and returned, for
+ * whatever destination is actually configured, by the `describe_schema` tool.
+ * A prompt therefore encodes only the *order of operations* an agent should
+ * follow — knowledge it will not otherwise infer — and defers all schema facts
+ * to `describe_schema` at runtime. `skillDrift.test.ts` enforces this
+ * mechanically: no schema-owned token may appear in any prompt's text.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MAX_ROWS } from "./readOnlyQuery";
+
+/**
+ * A prompt this server registers. `render` produces the message body from the
+ * (all-string, all-optional) arguments a client supplies; `skillDrift.test.ts`
+ * scans `title`, `description`, and `render({})` for schema-owned tokens.
+ */
+export interface PromptSpec {
+  name: string;
+  title: string;
+  description: string;
+  /** MCP prompt arguments are always strings; keep the shape simple. */
+  argsSchema: Record<string, z.ZodType<string | undefined>>;
+  render: (args: Record<string, string | undefined>) => string;
+}
+
+/** Shared preamble: the ordering every investigation should follow. */
+function orderingSteps(): string[] {
+  return [
+    "1. Call `test_destination` first to confirm the configured destination is " +
+      "reachable and fully configured. If it reports missing environment " +
+      "variables, stop and report them — do not guess.",
+    "2. Call `describe_schema` next, and read it, BEFORE writing any query. The " +
+      "record fields and query idioms differ per destination, and only the " +
+      "running server knows which destination is configured — so ask it rather " +
+      "than assuming.",
+    "3. Narrow the set with `list_executions` (filter by status, function name, " +
+      "or a time window). Prefer this over hand-written SQL: it cannot be got " +
+      "wrong and costs fewer tokens.",
+    "4. Drill into specific records with `get_execution` by their execution ARN " +
+      "to inspect step-level detail.",
+    "5. Fall back to `query` only when the structured tools cannot express the " +
+      "question — and only after `describe_schema`, so the query uses the right " +
+      "field names and syntax for the configured destination.",
+  ];
+}
+
+/** Closing note shared by both prompts. */
+function closingNote(): string {
+  return (
+    "All access is READ-ONLY (writes are refused before any AWS call), and " +
+    `results are capped at ${MAX_ROWS} rows. For CloudWatch Logs destinations, ` +
+    "set a lookback window — those queries require an explicit time range."
+  );
+}
+
+function renderInvestigate(args: Record<string, string | undefined>): string {
+  const focus: string[] = [];
+  if (args.functionName) {
+    focus.push(`Focus on the Lambda function "${args.functionName}".`);
+  }
+  if (args.lookbackHours) {
+    focus.push(
+      `Limit the investigation to roughly the last ${args.lookbackHours} ` +
+        "hours (pass this as the lookback window on log destinations, or as a " +
+        "since/until bound on list_executions).",
+    );
+  }
+  return [
+    "You are investigating failures in AWS Lambda durable function executions " +
+      "using the durable-insight MCP server. Work through the tools in this " +
+      "order — the ordering matters more than any single query:",
+    "",
+    ...orderingSteps(),
+    "",
+    "When narrowing in step 3, prefer filtering to FAILED executions first, " +
+      "then widen if you find nothing.",
+    ...(focus.length > 0 ? ["", ...focus] : []),
+    "",
+    closingNote(),
+  ].join("\n");
+}
+
+function renderExplore(args: Record<string, string | undefined>): string {
+  const filter = args.status
+    ? `Filter to executions with status "${args.status}".`
+    : "List across all statuses unless the user asks to narrow.";
+  return [
+    "You are getting an overview of recent AWS Lambda durable function " +
+      "executions using the durable-insight MCP server. Follow this order:",
+    "",
+    "1. Call `test_destination` to confirm the destination is configured and " +
+      "reachable.",
+    "2. Call `describe_schema` to learn the configured destination's fields and " +
+      "query idioms before running anything.",
+    "3. Use `list_executions` to page through recent executions. " + filter,
+    "4. Use `get_execution` to inspect any single execution by its execution " +
+      "ARN, and `query` only for questions the structured tools cannot express " +
+      "(after `describe_schema`).",
+    "",
+    closingNote(),
+  ].join("\n");
+}
+
+/** The single source of truth for every prompt this server registers. */
+export const PROMPTS: readonly PromptSpec[] = [
+  {
+    name: "investigate_workflow_failure",
+    title: "Investigate a durable function failure",
+    description:
+      "Guided, correct-order investigation of AWS Lambda durable function " +
+      "execution failures: verify the destination, learn its schema via " +
+      "describe_schema, narrow with list_executions, then drill into records " +
+      "with get_execution, using query only as a last resort. Accepts an " +
+      "optional functionName and lookbackHours to scope the search.",
+    argsSchema: {
+      functionName: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Lambda function name to focus the investigation on.",
+        ),
+      lookbackHours: z
+        .string()
+        .optional()
+        .describe(
+          'Optional lookback window in hours to scope the search (e.g. "24").',
+        ),
+    },
+    render: renderInvestigate,
+  },
+  {
+    name: "explore_recent_executions",
+    title: "Explore recent durable function executions",
+    description:
+      "Guided overview of recent AWS Lambda durable function executions: " +
+      "verify the destination, learn its schema via describe_schema, then use " +
+      "list_executions to survey activity, preferring the structured tools over " +
+      "hand-written SQL. Accepts an optional status filter.",
+    argsSchema: {
+      status: z
+        .string()
+        .optional()
+        .describe("Optional status filter: RUNNING, SUCCEEDED, or FAILED."),
+    },
+    render: renderExplore,
+  },
+];
+
+/**
+ * Register every prompt in {@link PROMPTS} on the server via `registerPrompt`.
+ * The handler wraps `render` output in a single user message — the shape
+ * `prompts/get` returns to a client.
+ */
+export function registerPrompts(server: McpServer): void {
+  for (const prompt of PROMPTS) {
+    server.registerPrompt(
+      prompt.name,
+      {
+        title: prompt.title,
+        description: prompt.description,
+        argsSchema: prompt.argsSchema,
+      },
+      (args: Record<string, string | undefined>) => ({
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text: prompt.render(args) },
+          },
+        ],
+      }),
+    );
+  }
+}
+
+/**
+ * All text every prompt contributes to a client's surface — name, title,
+ * description, and the rendered message body with no arguments. Used by
+ * `skillDrift.test.ts` to assert no schema-owned token leaks into a prompt.
+ */
+export function allPromptText(): string {
+  return PROMPTS.map((p) =>
+    [p.name, p.title, p.description, p.render({})].join("\n"),
+  ).join("\n\n");
+}

--- a/packages/durable-insight-mcp/src/queryChokePoint.test.ts
+++ b/packages/durable-insight-mcp/src/queryChokePoint.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Structural guard: enforces that `runReadOnlyQuery` is the ONE choke point
+ * through which every query in this package flows.
+ *
+ * WHY THIS IS A TEST AND NOT A REVIEW CONVENTION:
+ *   A procedural rule ("please route all queries through readOnlyQuery.ts")
+ *   that nobody enforces will rot the moment someone adds a second call site.
+ *   Core's engine runners (`runAthenaQuery`, `runDynamoDBQuery`, ...) carry NO
+ *   read-only enforcement of their own — `assertReadOnly` lives only in
+ *   `explorerSession.ts`, which this host does not use — so a stray import of a
+ *   runner anywhere else in this package would be an unguarded path to executing
+ *   arbitrary, model-supplied SQL, including writes. This test makes "one choke
+ *   point" a mechanically checked property of the code rather than a claim in a
+ *   commit message.
+ *
+ * Modeled on `durable-insight-core/src/hostAgnostic.test.ts`: enumerate the
+ * real source files and assert a property over each, plus a non-emptiness /
+ * known-member check so the enumeration can never pass vacuously.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SRC = __dirname;
+
+/** The single file permitted to import a runner. */
+const CHOKE_POINT = "readOnlyQuery.ts";
+
+/**
+ * Every core engine runner. Importing ANY of these is executing a query with no
+ * read-only enforcement, which is exactly what the choke point exists to
+ * prevent. Includes the Phase 4 runners (aurora/redshift/opensearch/logs) too:
+ * the guard must forbid them the moment someone wires one up outside the choke
+ * point, not only the two supported today.
+ */
+const RUNNER_NAMES = [
+  "runAthenaQuery",
+  "runDynamoDBQuery",
+  "runAuroraQuery",
+  "runRedshiftQuery",
+  "runOpenSearchQuery",
+  "runLogsInsightsQuery",
+] as const;
+
+/** Every non-test `.ts` file under this package's src, recursively. */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** True if `src` references any runner name as a whole word. */
+function importsAnyRunner(src: string): boolean {
+  return RUNNER_NAMES.some((name) => new RegExp(`\\b${name}\\b`).test(src));
+}
+
+const sourceFiles = collectSourceFiles(SRC).sort();
+const relNames = sourceFiles.map((f) => relative(SRC, f));
+
+describe("query choke point", () => {
+  it("enumerates the package sources and includes server.ts", () => {
+    // A scan that silently found zero files would make every per-file case
+    // below vacuous. Pin non-emptiness AND a known member so the guard cannot
+    // pass by finding nothing.
+    expect(relNames.length).toBeGreaterThan(0);
+    expect(relNames).toContain("server.ts");
+    expect(relNames).toContain(CHOKE_POINT);
+  });
+
+  it.each(sourceFiles.map((f) => [relative(SRC, f), f] as const))(
+    "%s imports a core runner only if it is the choke point",
+    (name, file) => {
+      const uses = importsAnyRunner(readFileSync(file, "utf-8"));
+      if (name === CHOKE_POINT) {
+        // The choke point is expected to import runners — that is its job.
+        expect(uses).toBe(true);
+      } else {
+        // Nothing else may. This is the invariant.
+        expect(uses).toBe(false);
+      }
+    },
+  );
+
+  it("the choke point actually calls assertReadOnly", () => {
+    const chokePointSrc = readFileSync(join(SRC, CHOKE_POINT), "utf-8");
+    expect(/\bassertReadOnly\s*\(/.test(chokePointSrc)).toBe(true);
+  });
+});

--- a/packages/durable-insight-mcp/src/queryChokePoint.test.ts
+++ b/packages/durable-insight-mcp/src/queryChokePoint.test.ts
@@ -1,94 +1,298 @@
 /**
- * Structural guard: enforces that `runReadOnlyQuery` is the ONE choke point
- * through which every query in this package flows.
+ * Structural guard: enforces that `runReadOnlyQuery` is the one place this package
+ * executes a query.
  *
  * WHY THIS IS A TEST AND NOT A REVIEW CONVENTION:
- *   A procedural rule ("please route all queries through readOnlyQuery.ts")
- *   that nobody enforces will rot the moment someone adds a second call site.
- *   Core's engine runners (`runAthenaQuery`, `runDynamoDBQuery`, ...) carry NO
- *   read-only enforcement of their own — `assertReadOnly` lives only in
- *   `explorerSession.ts`, which this host does not use — so a stray import of a
- *   runner anywhere else in this package would be an unguarded path to executing
- *   arbitrary, model-supplied SQL, including writes. This test makes "one choke
- *   point" a mechanically checked property of the code rather than a claim in a
- *   commit message.
+ * A procedural rule ("route all queries through readOnlyQuery.ts") rots the moment
+ * someone adds a second call site. `assertReadOnly` lives in this package, not in
+ * core's runners -- core's own guard is inside `explorerSession.ts`, which this host
+ * deliberately bypasses -- so any other path from here into core's query surface is
+ * an unguarded route to executing model-supplied SQL, writes included.
  *
- * Modeled on `durable-insight-core/src/hostAgnostic.test.ts`: enumerate the
- * real source files and assert a property over each, plus a non-emptiness /
- * known-member check so the enumeration can never pass vacuously.
+ * WHAT AN EARLIER VERSION GOT WRONG, TWICE:
+ *
+ *   1. It forbade only the six `run*Query` runners. Core exports SEVEN more
+ *      functions that execute a query, most of them by calling a runner
+ *      internally: `fetchAthenaRecord`, `fetchDynamoDBRecord`, `fetchAuroraRecord`,
+ *      `fetchRedshiftRecord`, `tableExists`, and `ensureAthenaTable` (which runs
+ *      DDL). A file importing `fetchAthenaRecord` executes SQL while mentioning no
+ *      runner at all, so the guard stayed green over exactly the hole it claims to
+ *      close. Enumerating by capability rather than by name prefix is the fix.
+ *
+ *   2. It matched names as whole words anywhere in the file, including comments.
+ *      `sqlSafe.ts` and `tools.ts` both DISCUSS `fetchAthenaRecord` in their doc
+ *      comments -- correctly, since they explain how core escapes values -- so a
+ *      text scan flags the documentation and forces the explanation to be deleted
+ *      to make the guard pass. This version reads import declarations from the
+ *      TypeScript AST, so a name is only "used" if it is actually imported.
+ *
+ * The same two mistakes, in the same shapes, as the host-module scan in core:
+ * an invariant named too narrowly, and a scanner that flagged its own prose.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
+import * as ts from "typescript";
 
 const SRC = __dirname;
+const CORE_SRC = join(SRC, "..", "..", "durable-insight-core", "src");
+const CORE_MODULE = "@aws/durable-insight-core";
 
-/** The single file permitted to import a runner. */
+/** The single file permitted to import core's query surface. */
 const CHOKE_POINT = "readOnlyQuery.ts";
 
 /**
- * Every core engine runner. Importing ANY of these is executing a query with no
- * read-only enforcement, which is exactly what the choke point exists to
- * prevent. Includes the Phase 4 runners (aurora/redshift/opensearch/logs) too:
- * the guard must forbid them the moment someone wires one up outside the choke
- * point, not only the two supported today.
+ * Core exports that execute a query, and which therefore carry NO read-only
+ * enforcement of their own.
+ *
+ * Kept complete by `core's query surface is fully enumerated` below, which derives
+ * the same set from core's AST and fails if this list falls behind.
  */
-const RUNNER_NAMES = [
+const QUERY_EXECUTING_EXPORTS = [
+  // The six engine runners.
   "runAthenaQuery",
   "runDynamoDBQuery",
   "runAuroraQuery",
   "runRedshiftQuery",
   "runOpenSearchQuery",
   "runLogsInsightsQuery",
+  // Single-record fetches that build and execute their own SQL.
+  "fetchAthenaRecord",
+  "fetchDynamoDBRecord",
+  "fetchAuroraRecord",
+  "fetchRedshiftRecord",
+  // Metadata and DDL.
+  "tableExists",
+  "ensureAthenaTable",
 ] as const;
+
+/**
+ * Deliberate exceptions, each with a reason it is safe.
+ *
+ * These execute a query outside the choke point ON PURPOSE. Listing them here is
+ * what makes them decisions rather than oversights: adding to this list requires
+ * writing down why, and the test below asserts each entry is genuinely used, so a
+ * stale exception cannot sit here widening the hole after its caller is gone.
+ */
+const PERMITTED_OUTSIDE_CHOKE_POINT: Record<
+  string,
+  { file: string; reason: string }
+> = {
+  fetchLogsInsightsRecord: {
+    file: "tools.ts",
+    reason:
+      "get_execution on a log destination. The Logs Insights query language has no " +
+      "write forms, so there is nothing for assertReadOnly to catch -- the same " +
+      "reason the choke point omits it on that path.",
+  },
+  testDestination: {
+    file: "server.ts",
+    reason:
+      "the test_destination tool. Core's own connectivity probe; it issues fixed " +
+      "read-only statements that no caller can influence.",
+  },
+};
 
 /** Every non-test `.ts` file under this package's src, recursively. */
 function collectSourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...collectSourceFiles(full));
-    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+    if (entry.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
       out.push(full);
     }
   }
   return out;
 }
 
-/** True if `src` references any runner name as a whole word. */
-function importsAnyRunner(src: string): boolean {
-  return RUNNER_NAMES.some((name) => new RegExp(`\\b${name}\\b`).test(src));
+/**
+ * Names a file imports from core. Reads import declarations only, so a name
+ * appearing in a comment or a string is not a use.
+ */
+function importedFromCore(file: string): string[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, "utf-8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const names: string[] = [];
+  for (const statement of source.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== CORE_MODULE
+    ) {
+      continue;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        // `propertyName` is the original name in `import { a as b }`.
+        names.push((element.propertyName ?? element.name).text);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Derive core's query-executing exports from its AST: an exported function whose
+ * body either calls one of the engine runners or sends an AWS SDK command.
+ */
+function deriveCoreQuerySurface(): string[] {
+  const RUNNERS = new Set([
+    "runAthenaQuery",
+    "runDynamoDBQuery",
+    "runAuroraQuery",
+    "runRedshiftQuery",
+    "runOpenSearchQuery",
+    "runLogsInsightsQuery",
+  ]);
+  const found: string[] = [];
+
+  for (const entry of readdirSync(CORE_SRC)) {
+    if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+    const file = join(CORE_SRC, entry);
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, "utf-8"),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+
+    for (const statement of source.statements) {
+      if (
+        !ts.isFunctionDeclaration(statement) ||
+        !statement.name ||
+        !statement.modifiers?.some(
+          (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+        ) ||
+        !statement.body
+      ) {
+        continue;
+      }
+      const name = statement.name.text;
+      if (RUNNERS.has(name)) {
+        found.push(name);
+        continue;
+      }
+
+      let executes = false;
+      const walk = (node: ts.Node): void => {
+        if (executes) return;
+        if (ts.isCallExpression(node)) {
+          const callee = node.expression;
+          // `runXQuery(...)`
+          if (ts.isIdentifier(callee) && RUNNERS.has(callee.text)) {
+            executes = true;
+          }
+          // `client.send(...)` -- a direct AWS call.
+          if (
+            ts.isPropertyAccessExpression(callee) &&
+            callee.name.text === "send"
+          ) {
+            executes = true;
+          }
+        }
+        ts.forEachChild(node, walk);
+      };
+      walk(statement.body);
+      if (executes) found.push(name);
+    }
+  }
+  return [...new Set(found)].sort();
 }
 
 const sourceFiles = collectSourceFiles(SRC).sort();
 const relNames = sourceFiles.map((f) => relative(SRC, f));
 
 describe("query choke point", () => {
-  it("enumerates the package sources and includes server.ts", () => {
-    // A scan that silently found zero files would make every per-file case
-    // below vacuous. Pin non-emptiness AND a known member so the guard cannot
-    // pass by finding nothing.
+  it("enumerates the package sources and includes known members", () => {
+    // A scan that found nothing would make every per-file case below vacuous.
     expect(relNames.length).toBeGreaterThan(0);
     expect(relNames).toContain("server.ts");
     expect(relNames).toContain(CHOKE_POINT);
   });
 
+  it("reads imports rather than text, so prose about core is not a use", () => {
+    // Aimed at the parser: these files DISCUSS core's record fetches in their doc
+    // comments. If this ever fails, the scan has regressed to matching text and
+    // will start demanding that documentation be deleted.
+    for (const file of ["sqlSafe.ts", "tools.ts"]) {
+      const src = readFileSync(join(SRC, file), "utf-8");
+      expect(src).toContain("fetchAthenaRecord");
+      expect(importedFromCore(join(SRC, file))).not.toContain(
+        "fetchAthenaRecord",
+      );
+    }
+  });
+
   it.each(sourceFiles.map((f) => [relative(SRC, f), f] as const))(
-    "%s imports a core runner only if it is the choke point",
+    "%s imports core's query surface only if permitted",
     (name, file) => {
-      const uses = importsAnyRunner(readFileSync(file, "utf-8"));
-      if (name === CHOKE_POINT) {
-        // The choke point is expected to import runners — that is its job.
-        expect(uses).toBe(true);
-      } else {
-        // Nothing else may. This is the invariant.
-        expect(uses).toBe(false);
+      const imported = importedFromCore(file);
+      const offenders = imported.filter(
+        (n) =>
+          (QUERY_EXECUTING_EXPORTS as readonly string[]).includes(n) &&
+          name !== CHOKE_POINT,
+      );
+      expect(offenders).toEqual([]);
+
+      // A permitted exception may only appear in the file it was granted for.
+      for (const n of imported) {
+        const exception = PERMITTED_OUTSIDE_CHOKE_POINT[n];
+        if (exception) expect(name).toBe(exception.file);
       }
     },
   );
 
-  it("the choke point actually calls assertReadOnly", () => {
-    const chokePointSrc = readFileSync(join(SRC, CHOKE_POINT), "utf-8");
-    expect(/\bassertReadOnly\s*\(/.test(chokePointSrc)).toBe(true);
+  it("the choke point imports runners and calls assertReadOnly", () => {
+    const imported = importedFromCore(join(SRC, CHOKE_POINT));
+    // Its job, so absence means the choke point stopped being one.
+    expect(imported).toContain("runAthenaQuery");
+    const src = readFileSync(join(SRC, CHOKE_POINT), "utf-8");
+    expect(/\bassertReadOnly\s*\(/.test(src)).toBe(true);
+  });
+
+  it("every permitted exception is actually used, and where it says", () => {
+    // Stops a stale exception from sitting here widening the rule after the
+    // caller it was written for is gone.
+    for (const [name, { file }] of Object.entries(
+      PERMITTED_OUTSIDE_CHOKE_POINT,
+    )) {
+      expect(importedFromCore(join(SRC, file))).toContain(name);
+    }
+  });
+
+  it("core's query surface is fully enumerated", () => {
+    // THE META-GUARD. Derives the set from core's AST, so a new core export that
+    // executes a query fails here instead of quietly falling outside the rule --
+    // which is how `fetchAthenaRecord` and friends escaped the first version.
+    const derived = deriveCoreQuerySurface();
+    // Non-vacuity: an empty derivation would make the assertion below trivial.
+    expect(derived.length).toBeGreaterThan(6);
+    expect(derived).toContain("runAthenaQuery");
+
+    const known = new Set<string>([
+      ...QUERY_EXECUTING_EXPORTS,
+      ...Object.keys(PERMITTED_OUTSIDE_CHOKE_POINT),
+      // Reaches a remote service but not a query engine: no SQL, so nothing for
+      // `assertReadOnly` to inspect.
+      //
+      // The derivation above treats ANY `.send(` as executing something, which
+      // over-matches on purpose: `verifyResult` calls `model.send(...)` on an LLM
+      // judge, and `sendConverse` talks to Bedrock. Narrowing the heuristic to
+      // `client.send(new SomeCommand(...))` would drop these, but it would also
+      // drop a future runner that dispatches differently. A false positive costs
+      // one line here; a false negative is an unguarded query path, which is the
+      // whole thing this file exists to prevent.
+      "sendConverse",
+      "listBedrockModels",
+      "listenToQueue",
+      "verifyResult",
+    ]);
+    const unclassified = derived.filter((n) => !known.has(n));
+    expect(unclassified).toEqual([]);
   });
 });

--- a/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
@@ -26,12 +26,12 @@ import {
   runRedshiftQuery,
   resolveCredentials,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
 
-jest.mock("durable-insight-core", () => {
-  const actual = jest.requireActual<typeof import("durable-insight-core")>(
-    "durable-insight-core",
+jest.mock("@aws/durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("@aws/durable-insight-core")>(
+    "@aws/durable-insight-core",
   );
   return {
     ...actual,

--- a/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
@@ -77,6 +77,7 @@ const PLAIN_OK = {
   rows: [["1"]],
   count: 1,
   numericColumns: [true],
+  hasMore: false,
 };
 
 beforeEach(() => {
@@ -304,6 +305,7 @@ describe("row bounding — DynamoDB single page sliced at the cap", () => {
       rows: Array.from({ length: MAX_ROWS + 5 }, (_, i) => [String(i)]),
       count: MAX_ROWS + 5,
       numericColumns: [true],
+      hasMore: false,
     });
     const result = await runReadOnlyQuery(
       cfgFor("dynamodb"),
@@ -321,6 +323,153 @@ describe("row bounding — DynamoDB single page sliced at the cap", () => {
     );
     expect(result.truncated).toBe(false);
   });
+
+  /**
+   * DynamoDB has a SECOND, independent reason a result can be incomplete, and it is
+   * invisible in the row count.
+   *
+   * THE FAILURE THIS PREVENTS:
+   * `runDynamoDBQuery` issues one non-paginating `ExecuteStatement`, and DynamoDB
+   * bounds a response at ~1 MB however many items match. Truncation used to be
+   * derived from `count >= cap` alone, so a query matching 5,000 items that returned
+   * 400 reported `truncated: false` -- a complete answer as far as the agent could
+   * tell, which it would then state as one. Silently wrong beats loudly wrong for
+   * getting through review, which is why this needed a test rather than a comment.
+   */
+  it("reports truncated=true when DynamoDB signals more results, even far below the cap", async () => {
+    runDynamoDBMock.mockResolvedValueOnce({
+      columns: ["n"],
+      rows: ROWS_DDB(400),
+      count: 400,
+      numericColumns: [true],
+      hasMore: true,
+    });
+    const result = await runReadOnlyQuery(
+      cfgFor("dynamodb"),
+      "SELECT * FROM t",
+    );
+    // 400 is nowhere near MAX_ROWS, so a count-based check cannot catch this.
+    expect(result.count).toBe(400);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("keeps every row when DynamoDB signals more but the cap was not reached", async () => {
+    // Incomplete is not the same as over-long: flagging truncation must not also
+    // start discarding rows the caller did receive.
+    runDynamoDBMock.mockResolvedValueOnce({
+      columns: ["n"],
+      rows: ROWS_DDB(400),
+      count: 400,
+      numericColumns: [true],
+      hasMore: true,
+    });
+    const result = await runReadOnlyQuery(
+      cfgFor("dynamodb"),
+      "SELECT * FROM t",
+    );
+    expect(result.rows.length).toBe(400);
+  });
+});
+
+/** Rows for DynamoDB fixtures. */
+const ROWS_DDB = (n: number) =>
+  Array.from({ length: n }, (_, i) => [String(i)]);
+
+/**
+ * A per-call `maxRows` must actually bound the result on EVERY engine.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * `query` declared a `limit` parameter, described it as the maximum number of rows
+ * to return, and then never read it -- the handler destructured only `{ sql,
+ * lookbackHours }`. An agent asking for 10 rows received up to MAX_ROWS, which is
+ * precisely the token cost the structured tools exist to avoid. Nothing failed,
+ * because no test passed the parameter.
+ *
+ * Each engine is asserted separately because each bounds differently: Athena is
+ * told the cap, DynamoDB is sliced afterwards, and the three unbounded runners go
+ * through `capUnbounded`. A single shared assertion would pass while one engine
+ * ignored the cap entirely.
+ */
+describe("per-call maxRows bounds every engine", () => {
+  const ROWS = (n: number) => Array.from({ length: n }, (_, i) => [String(i)]);
+
+  it("is handed to Athena as its own maxRows, not applied afterwards", async () => {
+    runAthenaMock.mockResolvedValueOnce({ ...ATHENA_OK });
+    await runReadOnlyQuery(cfgFor("s3"), "SELECT * FROM t", { maxRows: 10 });
+    // Athena pages server-side, so the cap has to reach the runner: slicing after
+    // the fact would still have transferred every row.
+    expect(runAthenaMock.mock.calls[0][0].maxRows).toBe(10);
+  });
+
+  it("slices the DynamoDB page to the per-call cap", async () => {
+    runDynamoDBMock.mockResolvedValueOnce({
+      columns: ["n"],
+      rows: ROWS(50),
+      count: 50,
+      numericColumns: [true],
+      hasMore: false,
+    });
+    const result = await runReadOnlyQuery(
+      cfgFor("dynamodb"),
+      "SELECT * FROM t",
+      {
+        maxRows: 10,
+      },
+    );
+    expect(result.rows.length).toBe(10);
+    expect(result.count).toBe(10);
+    expect(result.truncated).toBe(true);
+  });
+
+  it.each([
+    ["aurora", () => runAuroraMock],
+    ["redshift", () => runRedshiftMock],
+    ["opensearch", () => runOpenSearchMock],
+  ] as const)(
+    "slices the unbounded %s runner to the per-call cap",
+    async (destination, mock) => {
+      mock().mockResolvedValueOnce({
+        columns: ["n"],
+        rows: ROWS(50),
+        count: 50,
+        numericColumns: [true],
+      });
+      const result = await runReadOnlyQuery(
+        cfgFor(destination),
+        "SELECT * FROM t",
+        { maxRows: 10 },
+      );
+      expect(result.rows.length).toBe(10);
+      expect(result.truncated).toBe(true);
+    },
+  );
+
+  it("cannot raise the hard cap", async () => {
+    runAthenaMock.mockResolvedValueOnce({ ...ATHENA_OK });
+    await runReadOnlyQuery(cfgFor("s3"), "SELECT * FROM t", {
+      maxRows: MAX_ROWS * 10,
+    });
+    expect(runAthenaMock.mock.calls[0][0].maxRows).toBe(MAX_ROWS);
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["zero", 0],
+    ["negative", -5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])(
+    "falls back to the hard cap when the hint is %s",
+    async (_label, value) => {
+      runAthenaMock.mockResolvedValueOnce({ ...ATHENA_OK });
+      await runReadOnlyQuery(cfgFor("s3"), "SELECT * FROM t", {
+        maxRows: value,
+      });
+      // Falling back to zero rows would read as "no data" to an agent rather than
+      // as a bad parameter, which is a worse failure than ignoring the hint.
+      expect(runAthenaMock.mock.calls[0][0].maxRows).toBe(MAX_ROWS);
+    },
+  );
 });
 
 // ── Non-queryable and unsupported destinations ───────────────────────────────

--- a/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Security tests for the query choke point (AC-T2).
+ *
+ * The real assertion in every rejection case is NOT merely that an error was
+ * thrown — it is that the underlying AWS runner was NEVER invoked. A rejection
+ * that still hit the network would be worthless: the write would already have
+ * reached the data store. So we mock core's runners and assert the mock was not
+ * called. Conversely, the ACCEPT cases assert the runner WAS called and the SQL
+ * forwarded — otherwise a function that rejects everything unconditionally would
+ * pass a rejection-only suite.
+ *
+ * `assertReadOnly` itself is deliberately NOT mocked: this suite exercises the
+ * real validator from `durable-insight-core`. Only the runners and credential
+ * resolution are stubbed.
+ */
+import {
+  configFromWireSettings,
+  runAthenaQuery,
+  runDynamoDBQuery,
+  resolveCredentials,
+  type InsightConfig,
+} from "durable-insight-core";
+import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
+
+jest.mock("durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("durable-insight-core")>(
+    "durable-insight-core",
+  );
+  return {
+    ...actual,
+    // Real: assertReadOnly, configFromWireSettings, normalizeConfig, ...
+    // Stubbed: the runners (so a rejection cannot reach the network) and the
+    // credential resolver (so no provider chain is constructed).
+    runAthenaQuery: jest.fn(),
+    runDynamoDBQuery: jest.fn(),
+    resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
+  };
+});
+
+const runAthenaMock = runAthenaQuery as jest.MockedFunction<
+  typeof runAthenaQuery
+>;
+const runDynamoDBMock = runDynamoDBQuery as jest.MockedFunction<
+  typeof runDynamoDBQuery
+>;
+
+const ATHENA_OK = {
+  columns: ["n"],
+  rows: [["1"]],
+  count: 1,
+  numericColumns: [true],
+  truncated: false,
+};
+const DYNAMODB_OK = {
+  columns: ["n"],
+  rows: [["1"]],
+  count: 1,
+  numericColumns: [true],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  runAthenaMock.mockResolvedValue(ATHENA_OK);
+  runDynamoDBMock.mockResolvedValue(DYNAMODB_OK);
+});
+
+function cfgFor(
+  destinationType: string,
+  extra: Record<string, string> = {},
+): InsightConfig {
+  return configFromWireSettings({
+    destinationType,
+    region: "us-east-1",
+    dynamodbTableName: "workflow_insight",
+    athenaDatabase: "insight_db",
+    athenaS3Location: "s3://bucket/prefix/",
+    ...extra,
+  });
+}
+
+/** Statements that MUST be rejected before any AWS call. */
+const REJECTED: Array<[string, string]> = [
+  ["INSERT", "INSERT INTO t (a) VALUES (1)"],
+  ["UPDATE", "UPDATE t SET a = 1"],
+  ["DELETE", "DELETE FROM t"],
+  ["DROP", "DROP TABLE t"],
+  ["ALTER", "ALTER TABLE t ADD COLUMN a integer"],
+  ["CREATE", "CREATE TABLE t (a integer)"],
+  ["TRUNCATE", "TRUNCATE TABLE t"],
+  ["MERGE", "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE"],
+  ["GRANT", "GRANT SELECT ON t TO someone"],
+  ["REVOKE", "REVOKE SELECT ON t FROM someone"],
+  ["EXECUTE", "EXECUTE some_prepared_statement"],
+  ["CALL", "CALL some_procedure()"],
+  ["COPY", "COPY t FROM 's3://bucket/key'"],
+  ["UNLOAD", "UNLOAD ('SELECT * FROM t') TO 's3://bucket/key'"],
+  ["multi-statement", "SELECT 1; DELETE FROM t"],
+  ["line-comment obfuscation", "SELECT 1 -- \nDELETE FROM t"],
+  ["block-comment obfuscation", "SELECT 1 /* keep reading */\nDELETE FROM t"],
+  [
+    "data-modifying CTE (write after CTE)",
+    "WITH x AS (SELECT 1) DELETE FROM t",
+  ],
+  [
+    "data-modifying CTE (write inside CTE)",
+    "WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d",
+  ],
+  ["empty", ""],
+  ["whitespace-only", "   \n\t  "],
+];
+
+/** Statements that MUST be accepted and forwarded to the runner. */
+const ACCEPTED: Array<[string, string]> = [
+  ["plain SELECT", "SELECT id, status FROM t WHERE status = 'RUNNING'"],
+  ["read-only CTE", "WITH x AS (SELECT 1 AS n) SELECT * FROM x"],
+  [
+    "keyword inside a string literal",
+    "SELECT * FROM t WHERE status = 'DELETED'",
+  ],
+  [
+    "dangerous keyword as scalar function",
+    "SELECT REPLACE(name, 'a', 'b') FROM t",
+  ],
+];
+
+describe.each([
+  ["s3", () => runAthenaMock, "Trino/Presto SQL"],
+  ["dynamodb", () => runDynamoDBMock, "PartiQL"],
+] as const)("runReadOnlyQuery on %s", (destinationType, getMock, engine) => {
+  const cfg = () => cfgFor(destinationType);
+
+  describe("rejects writes without issuing any AWS call", () => {
+    it.each(REJECTED)("rejects %s", async (_label, sql) => {
+      await expect(runReadOnlyQuery(cfg(), sql)).rejects.toThrow();
+      // THE assertion: the runner was never reached, so nothing hit the network.
+      expect(getMock()).not.toHaveBeenCalled();
+      expect(resolveCredentials).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("accepts and forwards read-only queries", () => {
+    it.each(ACCEPTED)("accepts %s", async (_label, sql) => {
+      const result = await runReadOnlyQuery(cfg(), sql);
+      expect(getMock()).toHaveBeenCalledTimes(1);
+      expect(result.engine).toBe(engine);
+    });
+  });
+});
+
+describe("Athena dispatch is always bounded", () => {
+  it.each(ACCEPTED)(
+    "passes maxRows=MAX_ROWS (never undefined) for %s",
+    async (_label, sql) => {
+      await runReadOnlyQuery(cfgFor("s3"), sql);
+      expect(runAthenaMock).toHaveBeenCalledTimes(1);
+      const opts = runAthenaMock.mock.calls[0][0];
+      expect(opts.maxRows).toBe(MAX_ROWS);
+      expect(opts.maxRows).not.toBeUndefined();
+    },
+  );
+});
+
+describe("Athena results go to the output location, not the data bucket", () => {
+  // Regression guard for a real bug caught in review. athenaOutputLocation and
+  // athenaS3Location are DIFFERENT buckets:
+  //   athenaOutputLocation -> where Athena writes query RESULTS
+  //   athenaS3Location     -> the SOURCE data location, used for table DDL
+  // An earlier draft passed athenaS3Location as `outputLocation`, which would
+  // write result files into the data being queried. Every other call site in the
+  // repo passes athenaOutputLocation, and athena.ts's own error text names it.
+  it("passes athenaOutputLocation, never athenaS3Location", async () => {
+    const cfg = {
+      ...cfgFor("s3"),
+      athenaOutputLocation: "s3://results-bucket/athena/",
+      athenaS3Location: "s3://SOURCE-DATA-bucket/records/",
+    };
+    await runReadOnlyQuery(cfg, "SELECT 1");
+    const opts = runAthenaMock.mock.calls[0][0];
+    expect(opts.outputLocation).toBe("s3://results-bucket/athena/");
+    expect(opts.outputLocation).not.toBe("s3://SOURCE-DATA-bucket/records/");
+  });
+
+  it("leaves outputLocation undefined when only a workgroup is set", async () => {
+    const cfg = {
+      ...cfgFor("s3"),
+      athenaWorkgroup: "primary",
+      athenaOutputLocation: "",
+      athenaS3Location: "s3://SOURCE-DATA-bucket/records/",
+    };
+    await runReadOnlyQuery(cfg, "SELECT 1");
+    const opts = runAthenaMock.mock.calls[0][0];
+    expect(opts.outputLocation).toBeUndefined();
+    expect(opts.workgroup).toBe("primary");
+  });
+});
+
+describe("DynamoDB truncation", () => {
+  it("reports truncated=true when the row count reaches the cap", async () => {
+    const capped = {
+      columns: ["n"],
+      rows: Array.from({ length: MAX_ROWS }, (_, i) => [String(i)]),
+      count: MAX_ROWS,
+      numericColumns: [true],
+    };
+    runDynamoDBMock.mockResolvedValueOnce(capped);
+    const result = await runReadOnlyQuery(
+      cfgFor("dynamodb"),
+      "SELECT * FROM t",
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.count).toBe(MAX_ROWS);
+  });
+
+  it("reports truncated=false for a small result", async () => {
+    const result = await runReadOnlyQuery(
+      cfgFor("dynamodb"),
+      "SELECT * FROM t",
+    );
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe("unsupported destination", () => {
+  it("throws naming the type, without any AWS call", async () => {
+    await expect(
+      runReadOnlyQuery(cfgFor("aurora"), "SELECT 1"),
+    ).rejects.toThrow(/aurora/);
+    expect(runAthenaMock).not.toHaveBeenCalled();
+    expect(runDynamoDBMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.test.ts
@@ -12,11 +12,18 @@
  * `assertReadOnly` itself is deliberately NOT mocked: this suite exercises the
  * real validator from `durable-insight-core`. Only the runners and credential
  * resolution are stubbed.
+ *
+ * As of Phase 4 T4.1 the matrix runs across ALL FIVE SQL destinations
+ * (s3/Athena, DynamoDB, Aurora, Redshift, OpenSearch), not just the original
+ * two — the read-only guard and the row cap must hold for every one.
  */
 import {
   configFromWireSettings,
   runAthenaQuery,
+  runAuroraQuery,
   runDynamoDBQuery,
+  runOpenSearchQuery,
+  runRedshiftQuery,
   resolveCredentials,
   type InsightConfig,
 } from "durable-insight-core";
@@ -29,10 +36,13 @@ jest.mock("durable-insight-core", () => {
   return {
     ...actual,
     // Real: assertReadOnly, configFromWireSettings, normalizeConfig, ...
-    // Stubbed: the runners (so a rejection cannot reach the network) and the
-    // credential resolver (so no provider chain is constructed).
+    // Stubbed: every engine runner (so a rejection cannot reach the network)
+    // and the credential resolver (so no provider chain is constructed).
     runAthenaQuery: jest.fn(),
     runDynamoDBQuery: jest.fn(),
+    runAuroraQuery: jest.fn(),
+    runRedshiftQuery: jest.fn(),
+    runOpenSearchQuery: jest.fn(),
     resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
   };
 });
@@ -43,7 +53,17 @@ const runAthenaMock = runAthenaQuery as jest.MockedFunction<
 const runDynamoDBMock = runDynamoDBQuery as jest.MockedFunction<
   typeof runDynamoDBQuery
 >;
+const runAuroraMock = runAuroraQuery as jest.MockedFunction<
+  typeof runAuroraQuery
+>;
+const runRedshiftMock = runRedshiftQuery as jest.MockedFunction<
+  typeof runRedshiftQuery
+>;
+const runOpenSearchMock = runOpenSearchQuery as jest.MockedFunction<
+  typeof runOpenSearchQuery
+>;
 
+/** A one-row Athena result (Athena's shape carries `truncated`). */
 const ATHENA_OK = {
   columns: ["n"],
   rows: [["1"]],
@@ -51,7 +71,8 @@ const ATHENA_OK = {
   numericColumns: [true],
   truncated: false,
 };
-const DYNAMODB_OK = {
+/** A one-row result for the runners that DON'T carry `truncated`. */
+const PLAIN_OK = {
   columns: ["n"],
   rows: [["1"]],
   count: 1,
@@ -61,7 +82,10 @@ const DYNAMODB_OK = {
 beforeEach(() => {
   jest.clearAllMocks();
   runAthenaMock.mockResolvedValue(ATHENA_OK);
-  runDynamoDBMock.mockResolvedValue(DYNAMODB_OK);
+  runDynamoDBMock.mockResolvedValue(PLAIN_OK);
+  runAuroraMock.mockResolvedValue(PLAIN_OK);
+  runRedshiftMock.mockResolvedValue(PLAIN_OK);
+  runOpenSearchMock.mockResolvedValue(PLAIN_OK);
 });
 
 function cfgFor(
@@ -74,6 +98,10 @@ function cfgFor(
     dynamodbTableName: "workflow_insight",
     athenaDatabase: "insight_db",
     athenaS3Location: "s3://bucket/prefix/",
+    auroraResourceArn: "arn:aws:rds:us-east-1:111:cluster:c1",
+    auroraSecretArn: "arn:aws:secretsmanager:us-east-1:111:secret:s1",
+    redshiftWorkgroupName: "wg1",
+    opensearchEndpoint: "https://os.example.com",
     ...extra,
   });
 }
@@ -123,29 +151,49 @@ const ACCEPTED: Array<[string, string]> = [
   ],
 ];
 
-describe.each([
+/** Every supported SQL destination, its runner mock getter, and engine label. */
+const ENGINES = [
   ["s3", () => runAthenaMock, "Trino/Presto SQL"],
   ["dynamodb", () => runDynamoDBMock, "PartiQL"],
-] as const)("runReadOnlyQuery on %s", (destinationType, getMock, engine) => {
-  const cfg = () => cfgFor(destinationType);
+  ["aurora", () => runAuroraMock, "PostgreSQL"],
+  ["redshift", () => runRedshiftMock, "Redshift SQL"],
+  ["opensearch", () => runOpenSearchMock, "OpenSearch SQL"],
+] as const;
 
-  describe("rejects writes without issuing any AWS call", () => {
-    it.each(REJECTED)("rejects %s", async (_label, sql) => {
-      await expect(runReadOnlyQuery(cfg(), sql)).rejects.toThrow();
-      // THE assertion: the runner was never reached, so nothing hit the network.
-      expect(getMock()).not.toHaveBeenCalled();
-      expect(resolveCredentials).not.toHaveBeenCalled();
-    });
-  });
+/** Assert NONE of the five runners were invoked (a rejection reached no AWS). */
+function expectNoRunnerCalled(): void {
+  expect(runAthenaMock).not.toHaveBeenCalled();
+  expect(runDynamoDBMock).not.toHaveBeenCalled();
+  expect(runAuroraMock).not.toHaveBeenCalled();
+  expect(runRedshiftMock).not.toHaveBeenCalled();
+  expect(runOpenSearchMock).not.toHaveBeenCalled();
+}
 
-  describe("accepts and forwards read-only queries", () => {
-    it.each(ACCEPTED)("accepts %s", async (_label, sql) => {
-      const result = await runReadOnlyQuery(cfg(), sql);
-      expect(getMock()).toHaveBeenCalledTimes(1);
-      expect(result.engine).toBe(engine);
+describe.each(ENGINES)(
+  "runReadOnlyQuery on %s",
+  (destinationType, getMock, engine) => {
+    const cfg = () => cfgFor(destinationType);
+
+    describe("rejects writes without issuing any AWS call", () => {
+      it.each(REJECTED)("rejects %s", async (_label, sql) => {
+        await expect(runReadOnlyQuery(cfg(), sql)).rejects.toThrow();
+        // THE assertion: no runner was reached, so nothing hit the network.
+        expectNoRunnerCalled();
+        expect(resolveCredentials).not.toHaveBeenCalled();
+      });
     });
-  });
-});
+
+    describe("accepts and forwards read-only queries", () => {
+      it.each(ACCEPTED)("accepts %s", async (_label, sql) => {
+        const result = await runReadOnlyQuery(cfg(), sql);
+        expect(getMock()).toHaveBeenCalledTimes(1);
+        expect(result.engine).toBe(engine);
+        // Accept path is also bounded: a one-row result is under the cap.
+        expect(result.rows.length).toBeLessThanOrEqual(MAX_ROWS);
+      });
+    });
+  },
+);
 
 describe("Athena dispatch is always bounded", () => {
   it.each(ACCEPTED)(
@@ -194,21 +242,76 @@ describe("Athena results go to the output location, not the data bucket", () => 
   });
 });
 
-describe("DynamoDB truncation", () => {
-  it("reports truncated=true when the row count reaches the cap", async () => {
-    const capped = {
+// ── Per-engine row bounding ──────────────────────────────────────────────────
+//
+// Every destination must come back bounded by MAX_ROWS — but the MECHANISM
+// differs, and these tests assert the correct one per engine so a regression in
+// any single engine's bound is caught in isolation:
+//   - Athena self-bounds (maxRows passed to the runner); the MCP layer must NOT
+//     double-slice — it forwards the runner's rows/truncated as-is.
+//   - DynamoDB returns a single page; the MCP layer slices at the cap.
+//   - Aurora/Redshift/OpenSearch runners apply NO cap, so the MCP layer slices
+//     to MAX_ROWS and sets truncated when the runner returned more.
+
+describe("row bounding — runners that do NOT cap (MCP layer slices)", () => {
+  const oversized = () => ({
+    columns: ["n"],
+    rows: Array.from({ length: MAX_ROWS + 5 }, (_, i) => [String(i)]),
+    count: MAX_ROWS + 5,
+    numericColumns: [true],
+  });
+
+  describe.each([
+    ["aurora", () => runAuroraMock],
+    ["redshift", () => runRedshiftMock],
+    ["opensearch", () => runOpenSearchMock],
+  ] as const)("%s", (dest, getMock) => {
+    it("slices to MAX_ROWS and sets truncated when the runner returns more", async () => {
+      getMock().mockResolvedValueOnce(oversized());
+      const result = await runReadOnlyQuery(cfgFor(dest), "SELECT * FROM t");
+      expect(result.rows.length).toBe(MAX_ROWS);
+      expect(result.count).toBe(MAX_ROWS);
+      expect(result.truncated).toBe(true);
+    });
+
+    it("does not truncate a result at or under the cap", async () => {
+      const result = await runReadOnlyQuery(cfgFor(dest), "SELECT * FROM t");
+      expect(result.truncated).toBe(false);
+      expect(result.rows.length).toBeLessThanOrEqual(MAX_ROWS);
+    });
+  });
+});
+
+describe("row bounding — Athena self-bounds via maxRows", () => {
+  it("passes maxRows and surfaces the runner's truncated flag without re-slicing", async () => {
+    runAthenaMock.mockResolvedValueOnce({
       columns: ["n"],
-      rows: Array.from({ length: MAX_ROWS }, (_, i) => [String(i)]),
-      count: MAX_ROWS,
+      rows: [["1"]],
+      count: 1,
       numericColumns: [true],
-    };
-    runDynamoDBMock.mockResolvedValueOnce(capped);
+      truncated: true,
+    });
+    const result = await runReadOnlyQuery(cfgFor("s3"), "SELECT * FROM t");
+    expect(runAthenaMock.mock.calls[0][0].maxRows).toBe(MAX_ROWS);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe("row bounding — DynamoDB single page sliced at the cap", () => {
+  it("reports truncated=true and slices when the row count reaches the cap", async () => {
+    runDynamoDBMock.mockResolvedValueOnce({
+      columns: ["n"],
+      rows: Array.from({ length: MAX_ROWS + 5 }, (_, i) => [String(i)]),
+      count: MAX_ROWS + 5,
+      numericColumns: [true],
+    });
     const result = await runReadOnlyQuery(
       cfgFor("dynamodb"),
       "SELECT * FROM t",
     );
-    expect(result.truncated).toBe(true);
+    expect(result.rows.length).toBe(MAX_ROWS);
     expect(result.count).toBe(MAX_ROWS);
+    expect(result.truncated).toBe(true);
   });
 
   it("reports truncated=false for a small result", async () => {
@@ -220,12 +323,26 @@ describe("DynamoDB truncation", () => {
   });
 });
 
-describe("unsupported destination", () => {
-  it("throws naming the type, without any AWS call", async () => {
-    await expect(
-      runReadOnlyQuery(cfgFor("aurora"), "SELECT 1"),
-    ).rejects.toThrow(/aurora/);
-    expect(runAthenaMock).not.toHaveBeenCalled();
-    expect(runDynamoDBMock).not.toHaveBeenCalled();
+// ── Non-queryable and unsupported destinations ───────────────────────────────
+
+describe("sqs is explicitly rejected as non-queryable", () => {
+  it("throws an error explaining SQS is tailed, not queried, without any AWS call", async () => {
+    await expect(runReadOnlyQuery(cfgFor("sqs"), "SELECT 1")).rejects.toThrow(
+      /tail|message queue/i,
+    );
+    // The rejection must name SQS as non-queryable specifically — not the
+    // generic "unsupported destination" text (which would pass a bare toThrow).
+    await expect(runReadOnlyQuery(cfgFor("sqs"), "SELECT 1")).rejects.toThrow(
+      /sqs/i,
+    );
+    expectNoRunnerCalled();
+    expect(resolveCredentials).not.toHaveBeenCalled();
   });
 });
+
+// NOTE: CloudWatch Logs destinations (cloudwatch-logs-exporter,
+// lambda-log-exporter) were previously rejected here as "unsupported". As of
+// Phase 4 they ARE supported, on a deliberately separate (non-SQL) code path
+// that does NOT apply assertReadOnly. That path mocks a different core runner
+// (runLogsInsightsQuery), so its coverage lives in its own suite —
+// logsInsights.test.ts — rather than in this SQL-runner harness.

--- a/packages/durable-insight-mcp/src/readOnlyQuery.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.ts
@@ -1,0 +1,147 @@
+/**
+ * The one and only place in this package permitted to execute a query.
+ *
+ * WHY THIS FILE EXISTS — read before adding a second query path:
+ *   In the VS Code and Electron hosts, `assertReadOnly` guards SQL that our own
+ *   prompt produced, and it is invoked from `explorerSession.ts`. This MCP host
+ *   deliberately does NOT use `ExplorerSession`: here the SQL comes from a model
+ *   we do not control, invoked in a loop, on behalf of a user who may approve
+ *   without reading. This is THE security boundary of this host.
+ *
+ *   There is a verified structural hazard in core: `assertReadOnly` and
+ *   `ensureLimit` are called ONLY inside `explorerSession.ts`, never inside the
+ *   engine runners (`runAthenaQuery`, `runDynamoDBQuery`, ...). Those runners are
+ *   therefore reachable with NO read-only enforcement whatsoever — nothing in
+ *   core stops you executing a DELETE through them. The mitigation is NOT to
+ *   sprinkle `assertReadOnly` at each call site (that is exactly the pattern that
+ *   let it be forgotten); it is to have ONE choke point. `runReadOnlyQuery` is
+ *   that choke point, and `queryChokePoint.test.ts` mechanically enforces that no
+ *   other non-test file in this package imports a runner.
+ */
+import {
+  assertReadOnly,
+  resolveCredentials,
+  runAthenaQuery,
+  runDynamoDBQuery,
+  type InsightConfig,
+} from "durable-insight-core";
+
+/**
+ * Hard cap on rows pulled into this process from any single query.
+ *
+ * This is the SQL bound. It is deliberately a single exported constant so the
+ * cap lives in exactly one place, is testable, and is passed to Athena's
+ * `maxRows` on every dispatch. We do NOT use core's `ensureLimit` to bound the
+ * result: it emits `" | limit N"`, which is CloudWatch Logs Insights syntax, not
+ * SQL — appending it to a Trino or PartiQL statement produces a syntax error
+ * (verified against `schema.ts`'s `ensureLimit`). The row bound is this cap,
+ * enforced by the runner (`maxRows` for Athena; a page-bounded single
+ * `ExecuteStatement` plus a post-hoc slice for DynamoDB).
+ */
+export const MAX_ROWS = 1000;
+
+/** The normalized, engine-independent shape every query returns. */
+export interface ReadOnlyQueryResult {
+  columns: string[];
+  rows: string[][];
+  count: number;
+  truncated: boolean;
+  /**
+   * The query-language engine the SQL was validated and run against — the same
+   * label `assertReadOnly` was given, so error text is consistent with the other
+   * hosts (`"PartiQL"` for DynamoDB, `"Trino/Presto SQL"` for S3/Athena).
+   */
+  engine: string;
+}
+
+/**
+ * Execute `sql` against the configured destination, read-only.
+ *
+ * Order is load-bearing:
+ *   1. Resolve the engine label for the destination. An unsupported destination
+ *      is rejected HERE, before any validation or credential work — there is no
+ *      engine to validate against and nothing to run.
+ *   2. `assertReadOnly(sql, engine)` — core's validator, called BEFORE resolving
+ *      credentials or issuing any AWS call. A non-read-only statement throws here
+ *      and never reaches a runner. We call core's; we never reimplement it.
+ *   3. Resolve credentials.
+ *   4. Dispatch to the runner, always bounding the result to {@link MAX_ROWS}.
+ */
+export async function runReadOnlyQuery(
+  cfg: InsightConfig,
+  sql: string,
+): Promise<ReadOnlyQueryResult> {
+  // 1. Engine label per destination. Unsupported types are rejected up front.
+  let engine: string;
+  switch (cfg.destinationType) {
+    case "dynamodb":
+      engine = "PartiQL";
+      break;
+    case "s3":
+      engine = "Trino/Presto SQL";
+      break;
+    default:
+      throw new Error(
+        `Query is not supported for destination type "${cfg.destinationType}" ` +
+          `in this version. Supported destinations: "dynamodb", "s3". Aurora, ` +
+          `Redshift, OpenSearch, SQS and CloudWatch Logs are planned for Phase 4.`,
+      );
+  }
+
+  // 2. THE security boundary. Reject any non-read-only SQL before touching
+  //    credentials or the network. Do not move anything above this line.
+  assertReadOnly(sql, engine);
+
+  // 3. Credentials (lazy providers; no network until a runner uses them).
+  const credentials = resolveCredentials(cfg.awsProfile);
+
+  // 4. Dispatch, always bounding the result set.
+  if (cfg.destinationType === "s3") {
+    // Athena's GetQueryResults pages through the ENTIRE result set; without
+    // maxRows a query whose LIMIT the model omitted would pull every matching
+    // row into this process. Always pass the cap and surface the runner's
+    // `truncated` flag.
+    const result = await runAthenaQuery({
+      region: cfg.region,
+      credentials,
+      database: cfg.athenaDatabase,
+      workgroup: cfg.athenaWorkgroup || undefined,
+      // `athenaOutputLocation`, NOT `athenaS3Location`. These are different
+      // buckets and confusing them is quietly destructive: `athenaOutputLocation`
+      // is where Athena writes query RESULTS, while `athenaS3Location` is the
+      // SOURCE data location used for the table's DDL. Passing the source bucket
+      // here would write result files into the data being queried. Every other
+      // call site in the repo passes athenaOutputLocation, and athena.ts's own
+      // error text names it.
+      outputLocation: cfg.athenaOutputLocation || undefined,
+      query: sql,
+      maxRows: MAX_ROWS,
+    });
+    return {
+      columns: result.columns,
+      rows: result.rows,
+      count: result.count,
+      truncated: result.truncated,
+      engine,
+    };
+  }
+
+  // dynamodb: a single ExecuteStatementCommand with no pagination loop, so it is
+  // page-bounded already. There is no `truncated` flag from the runner, so if the
+  // returned row count reaches the cap we report truncation and slice to the cap.
+  const result = await runDynamoDBQuery({
+    region: cfg.region,
+    credentials,
+    tableName: cfg.dynamodbTableName,
+    statement: sql,
+  });
+  const truncated = result.count >= MAX_ROWS;
+  const rows = truncated ? result.rows.slice(0, MAX_ROWS) : result.rows;
+  return {
+    columns: result.columns,
+    rows,
+    count: rows.length,
+    truncated,
+    engine,
+  };
+}

--- a/packages/durable-insight-mcp/src/readOnlyQuery.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.ts
@@ -20,9 +20,14 @@
  */
 import {
   assertReadOnly,
+  ensureLimit,
   resolveCredentials,
   runAthenaQuery,
+  runAuroraQuery,
   runDynamoDBQuery,
+  runLogsInsightsQuery,
+  runOpenSearchQuery,
+  runRedshiftQuery,
   type InsightConfig,
 } from "durable-insight-core";
 
@@ -31,14 +36,62 @@ import {
  *
  * This is the SQL bound. It is deliberately a single exported constant so the
  * cap lives in exactly one place, is testable, and is passed to Athena's
- * `maxRows` on every dispatch. We do NOT use core's `ensureLimit` to bound the
- * result: it emits `" | limit N"`, which is CloudWatch Logs Insights syntax, not
- * SQL — appending it to a Trino or PartiQL statement produces a syntax error
- * (verified against `schema.ts`'s `ensureLimit`). The row bound is this cap,
- * enforced by the runner (`maxRows` for Athena; a page-bounded single
- * `ExecuteStatement` plus a post-hoc slice for DynamoDB).
+ * `maxRows` on every dispatch. On the SQL paths we do NOT use core's
+ * `ensureLimit` to bound the result: it emits `" | limit N"`, which is
+ * CloudWatch Logs Insights syntax, not SQL — appending it to a Trino or PartiQL
+ * statement produces a syntax error (verified against `schema.ts`'s
+ * `ensureLimit`). The CloudWatch Logs path is the exact opposite: `ensureLimit`
+ * IS the right bound there (see `runLogsInsightsReadOnly`), because `" | limit
+ * N"` is native Logs Insights syntax. The SQL row bound is this cap, enforced
+ * per engine according to what the runner does itself:
+ *   - Athena: passed as `maxRows`; the runner stops paging at the cap.
+ *   - DynamoDB: a single non-paginating `ExecuteStatement`, then a post-hoc
+ *     slice if the returned count reaches the cap.
+ *   - Aurora / Redshift / OpenSearch: their runners do NOT cap (Redshift even
+ *     pages through EVERY `NextToken` page), so this package slices the result
+ *     to the cap after dispatch and sets `truncated` when it did.
  */
 export const MAX_ROWS = 1000;
+
+/**
+ * The engine label for the two CloudWatch Logs Insights destinations
+ * (`cloudwatch-logs-exporter`, `lambda-log-exporter`). Unlike the five SQL
+ * labels this is NOT a SQL dialect — Logs Insights is a pipe language — and it
+ * is never handed to `assertReadOnly` (see the log path below for why).
+ */
+export const LOGS_INSIGHTS_ENGINE = "CloudWatch Logs Insights";
+
+/**
+ * Default lookback window for CloudWatch Logs Insights queries when the caller
+ * does not specify one: the last 24 hours. Logs Insights REQUIRES an explicit
+ * `[startTime, endTime]` window — there is no "all time" — so a default must
+ * exist. 24h matches `explorerSession.ts`'s default (`lookbackHours ?? 24`) so
+ * every host agrees on the same window.
+ */
+export const DEFAULT_LOG_TIME_RANGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Per-call options for {@link runReadOnlyQuery}. Everything here applies ONLY to
+ * the CloudWatch Logs Insights destinations; the five SQL engines are not
+ * time-windowed and ignore it.
+ */
+export interface RunReadOnlyQueryOptions {
+  /**
+   * Size of the Logs Insights lookback window, in milliseconds. The window is
+   * `[Date.now() - timeRangeMs, Date.now()]`. Defaults to
+   * {@link DEFAULT_LOG_TIME_RANGE_MS} when absent or non-positive. Ignored for
+   * SQL destinations.
+   */
+  timeRangeMs?: number;
+}
+
+/** True for the two CloudWatch Logs Insights destinations. */
+function isLogDestination(cfg: InsightConfig): boolean {
+  return (
+    cfg.destinationType === "cloudwatch-logs-exporter" ||
+    cfg.destinationType === "lambda-log-exporter"
+  );
+}
 
 /** The normalized, engine-independent shape every query returns. */
 export interface ReadOnlyQueryResult {
@@ -70,7 +123,40 @@ export interface ReadOnlyQueryResult {
 export async function runReadOnlyQuery(
   cfg: InsightConfig,
   sql: string,
+  opts: RunReadOnlyQueryOptions = {},
 ): Promise<ReadOnlyQueryResult> {
+  // ── CloudWatch Logs Insights path — DELIBERATELY NOT SQL ──────────────────
+  //
+  // This path is fundamentally different from the five SQL engines below and is
+  // handled BEFORE any of the SQL machinery, for three load-bearing reasons:
+  //
+  //   1. `assertReadOnly` is NOT called here, ON PURPOSE. It requires a query to
+  //      begin with SELECT or WITH; a Logs Insights query begins with `fields`,
+  //      `filter`, `stats`, ... so running it through `assertReadOnly` would
+  //      reject EVERY valid Logs Insights query. This is not an oversight to
+  //      "fix for consistency" — doing so silently breaks all log queries.
+  //      Read-only is instead guaranteed by the API surface: the Logs Insights
+  //      query language has NO write/DDL constructs at all, and the only API we
+  //      call (`StartQuery`/`GetQueryResults`) can only read. There is nothing a
+  //      caller can express here that mutates data, so there is nothing for
+  //      `assertReadOnly` to catch — its absence removes no protection.
+  //      `explorerSession.ts` guards only its five SQL engines the same way and
+  //      never applies `assertReadOnly` to this path.
+  //
+  //   2. `ensureLimit` DOES belong here — this is the ONE engine it was written
+  //      for. It appends `" | limit N"`, which is Logs Insights syntax (a syntax
+  //      error on Trino/PartiQL, which is why the SQL paths use a row cap
+  //      instead). It deliberately skips a query that already contains `limit`
+  //      and skips `stats` aggregations; both behaviors are preserved by calling
+  //      core's `ensureLimit` verbatim.
+  //
+  //   3. It needs an explicit time window; there is no "all time". We compute it
+  //      exactly as `explorerSession.ts` does: `endTimeMs = Date.now()`,
+  //      `startTimeMs = endTimeMs - timeRangeMs`.
+  if (isLogDestination(cfg)) {
+    return runLogsInsightsReadOnly(cfg, sql, opts);
+  }
+
   // 1. Engine label per destination. Unsupported types are rejected up front.
   let engine: string;
   switch (cfg.destinationType) {
@@ -80,11 +166,36 @@ export async function runReadOnlyQuery(
     case "s3":
       engine = "Trino/Presto SQL";
       break;
+    case "aurora":
+      engine = "PostgreSQL";
+      break;
+    case "redshift":
+      engine = "Redshift SQL";
+      break;
+    case "opensearch":
+      engine = "OpenSearch SQL";
+      break;
+    case "sqs":
+      // SQS is deliberately NOT a fall-through to the generic "unsupported"
+      // error: it is not a queryable store at all. It is a message queue this
+      // host can only TAIL (long-poll for new messages via core's
+      // `listenToQueue`); there is no query runner for it and never will be
+      // (see explorerSession.ts: "SQS isn't queryable and never reaches here").
+      // Reject it explicitly with an error that says so, so an agent does not
+      // keep retrying a query it can never make work.
+      throw new Error(
+        `Query is not supported for destination type "sqs": SQS is a message ` +
+          `queue, not a queryable data store. This host can only TAIL an SQS ` +
+          `queue (long-poll for new messages), not run SQL/PartiQL against it. ` +
+          `There is no query engine for SQS.`,
+      );
     default:
       throw new Error(
         `Query is not supported for destination type "${cfg.destinationType}" ` +
-          `in this version. Supported destinations: "dynamodb", "s3". Aurora, ` +
-          `Redshift, OpenSearch, SQS and CloudWatch Logs are planned for Phase 4.`,
+          `in this version. Supported destinations: "dynamodb", "s3", "aurora", ` +
+          `"redshift", "opensearch", and the CloudWatch Logs destinations ` +
+          `("cloudwatch-logs-exporter", "lambda-log-exporter", handled on the ` +
+          `Logs Insights path above).`,
       );
   }
 
@@ -129,13 +240,90 @@ export async function runReadOnlyQuery(
   // dynamodb: a single ExecuteStatementCommand with no pagination loop, so it is
   // page-bounded already. There is no `truncated` flag from the runner, so if the
   // returned row count reaches the cap we report truncation and slice to the cap.
-  const result = await runDynamoDBQuery({
-    region: cfg.region,
-    credentials,
-    tableName: cfg.dynamodbTableName,
-    statement: sql,
-  });
-  const truncated = result.count >= MAX_ROWS;
+  if (cfg.destinationType === "dynamodb") {
+    const result = await runDynamoDBQuery({
+      region: cfg.region,
+      credentials,
+      tableName: cfg.dynamodbTableName,
+      statement: sql,
+    });
+    const truncated = result.count >= MAX_ROWS;
+    const rows = truncated ? result.rows.slice(0, MAX_ROWS) : result.rows;
+    return {
+      columns: result.columns,
+      rows,
+      count: rows.length,
+      truncated,
+      engine,
+    };
+  }
+
+  // Aurora / Redshift / OpenSearch: unlike Athena, NONE of these runners bound
+  // their own result — they return whatever the API produced (Redshift even
+  // pages through EVERY NextToken page). The cap is therefore this package's
+  // responsibility: dispatch, then slice to MAX_ROWS and flag truncation when
+  // the runner handed back more than the cap. `capUnbounded` centralizes that so
+  // the three branches cannot drift.
+  if (cfg.destinationType === "aurora") {
+    const result = await runAuroraQuery({
+      region: cfg.region,
+      credentials,
+      resourceArn: cfg.auroraResourceArn,
+      secretArn: cfg.auroraSecretArn,
+      database: cfg.auroraDatabase,
+      sql,
+    });
+    return capUnbounded(result, engine);
+  }
+
+  if (cfg.destinationType === "redshift") {
+    const result = await runRedshiftQuery({
+      region: cfg.region,
+      credentials,
+      database: cfg.redshiftDatabase,
+      workgroupName: cfg.redshiftWorkgroupName || undefined,
+      clusterIdentifier: cfg.redshiftClusterIdentifier || undefined,
+      dbUser: cfg.redshiftDbUser || undefined,
+      secretArn: cfg.redshiftSecretArn || undefined,
+      sql,
+    });
+    return capUnbounded(result, engine);
+  }
+
+  if (cfg.destinationType === "opensearch") {
+    const result = await runOpenSearchQuery({
+      region: cfg.region,
+      credentials,
+      endpoint: cfg.opensearchEndpoint,
+      sql,
+    });
+    return capUnbounded(result, engine);
+  }
+
+  // Unreachable: the engine-label switch above returns a label only for the
+  // destinations handled here and throws for everything else. This satisfies
+  // the return type and guards against a new engine label being added without a
+  // matching dispatch branch.
+  throw new Error(
+    `Internal error: no dispatch branch for destination type ` +
+      `"${cfg.destinationType}".`,
+  );
+}
+
+/**
+ * Bound an unbounded runner result to {@link MAX_ROWS} in this package.
+ *
+ * For Aurora, Redshift and OpenSearch the runner applies no cap of its own, so
+ * a query whose LIMIT the caller omitted would pull the entire result set into
+ * this process. Slice to the cap and report `truncated: true` when we did — the
+ * same guarantee Athena gets from `maxRows` and DynamoDB gets from its post-hoc
+ * slice, so EVERY destination returns at most MAX_ROWS rows.
+ */
+function capUnbounded(
+  result: { columns: string[]; rows: string[][] },
+  engine: string,
+): ReadOnlyQueryResult {
+  const truncated = result.rows.length > MAX_ROWS;
   const rows = truncated ? result.rows.slice(0, MAX_ROWS) : result.rows;
   return {
     columns: result.columns,
@@ -143,5 +331,68 @@ export async function runReadOnlyQuery(
     count: rows.length,
     truncated,
     engine,
+  };
+}
+
+/**
+ * Execute a CloudWatch Logs Insights query, read-only.
+ *
+ * This is the log-destination counterpart to the SQL dispatch in
+ * {@link runReadOnlyQuery}, kept inside the same choke point so `runReadOnlyQuery`
+ * remains the ONE place a query executes. Two things differ from the SQL paths,
+ * both intentional and documented at the call site:
+ *
+ *   - No `assertReadOnly`. The Logs Insights language has no write/DDL forms and
+ *     `StartQuery` can only read, so read-only is guaranteed by the API surface,
+ *     not by a SELECT/WITH prefix check (which would reject every valid query).
+ *   - Bounding is via core's `ensureLimit`, the function written for exactly this
+ *     syntax. It appends `" | limit MAX_ROWS"` unless the query already has a
+ *     `limit` or is a `stats` aggregation, in which case it is left untouched.
+ *
+ * Logs Insights requires an explicit `[startTime, endTime]`; we derive it the
+ * same way `explorerSession.ts` does — `endTimeMs = Date.now()`, `startTimeMs =
+ * endTimeMs - timeRangeMs` — using the caller's window or the 24h default.
+ */
+async function runLogsInsightsReadOnly(
+  cfg: InsightConfig,
+  queryString: string,
+  opts: RunReadOnlyQueryOptions,
+): Promise<ReadOnlyQueryResult> {
+  // Bound the result with the function written for this syntax. `ensureLimit`
+  // is a no-op for queries that already carry a `limit` (e.g. the structured
+  // tools, which append their own) or that aggregate with `stats`.
+  const bounded = ensureLimit(queryString, MAX_ROWS);
+
+  const credentials = resolveCredentials(cfg.awsProfile);
+
+  // Explicit, always-present window. There is no "all time" in Logs Insights.
+  const endTimeMs = Date.now();
+  const timeRangeMs =
+    opts.timeRangeMs !== undefined && opts.timeRangeMs > 0
+      ? opts.timeRangeMs
+      : DEFAULT_LOG_TIME_RANGE_MS;
+  const startTimeMs = endTimeMs - timeRangeMs;
+
+  // Log groups are a LIST on InsightConfig (core derives `logGroupNames` from
+  // the comma-separated `logGroupName` setting). Pass the array through as-is.
+  const table = await runLogsInsightsQuery({
+    region: cfg.region,
+    credentials,
+    logGroupNames: cfg.logGroupNames,
+    queryString: bounded,
+    startTimeMs,
+    endTimeMs,
+  });
+
+  // The runner does not carry a `truncated` flag; `ensureLimit` caps a
+  // non-aggregating query at MAX_ROWS, so reaching the cap is our truncation
+  // signal (a `stats`/pre-limited query that returns fewer rows reports false).
+  const truncated = table.rows.length >= MAX_ROWS;
+  return {
+    columns: table.columns,
+    rows: table.rows,
+    count: table.rows.length,
+    truncated,
+    engine: LOGS_INSIGHTS_ENGINE,
   };
 }

--- a/packages/durable-insight-mcp/src/readOnlyQuery.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.ts
@@ -29,7 +29,7 @@ import {
   runOpenSearchQuery,
   runRedshiftQuery,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 
 /**
  * Hard cap on rows pulled into this process from any single query.

--- a/packages/durable-insight-mcp/src/readOnlyQuery.ts
+++ b/packages/durable-insight-mcp/src/readOnlyQuery.ts
@@ -54,6 +54,49 @@ import {
 export const MAX_ROWS = 1000;
 
 /**
+ * WHY `truncated` IS DERIVED THREE DIFFERENT WAYS.
+ *
+ * A reader comparing the engine branches below will find three comparisons and no
+ * explanation, which reads like drift. It is not: the runners genuinely differ in
+ * what they hand back, and each comparison is the correct one for its source.
+ *
+ *   - Athena (`>= cap`, plus the runner's own flag): the runner is TOLD the cap and
+ *     stops paging there, so it knows whether it stopped early and says so. We
+ *     surface its flag rather than re-deriving one.
+ *
+ *   - DynamoDB (`>= cap` OR `hasMore`): one non-paginating `ExecuteStatement`
+ *     bounded by DynamoDB's ~1 MB response limit. Reaching the cap is one reason to
+ *     be incomplete; the response's `NextToken` is a second, INDEPENDENT one that
+ *     the row count cannot reveal -- 400 rows of 5,000 look like a complete 400.
+ *
+ *   - Aurora / Redshift / OpenSearch (`> cap`): these runners apply no bound at all
+ *     and return everything they got, so a result LARGER than the cap is the only
+ *     evidence of truncation. `>=` would be wrong here: exactly `cap` rows means the
+ *     result happened to fit, not that it was cut.
+ *
+ *   - Logs Insights (`>= cap`): bounded by `ensureLimit` appending `| limit cap` to
+ *     the query, so reaching the cap means the limit bit. An aggregating or
+ *     already-limited query returns fewer and correctly reports false.
+ *
+ * The distinction that matters in all four: `truncated` means "there may be more
+ * matching data than this", never "we trimmed the array we were given".
+ */
+
+/**
+ * Clamp a requested row ceiling into `[1, MAX_ROWS]`.
+ *
+ * Absent, zero, negative and non-finite all fall back to the hard cap rather than
+ * to zero rows: a malformed hint must not silently turn a query into an empty
+ * result, which an agent reads as "no data" rather than as a bad parameter.
+ */
+export function effectiveCap(requested?: number): number {
+  if (requested === undefined || !Number.isFinite(requested)) return MAX_ROWS;
+  const floored = Math.floor(requested);
+  if (floored < 1) return MAX_ROWS;
+  return Math.min(floored, MAX_ROWS);
+}
+
+/**
  * The engine label for the two CloudWatch Logs Insights destinations
  * (`cloudwatch-logs-exporter`, `lambda-log-exporter`). Unlike the five SQL
  * labels this is NOT a SQL dialect — Logs Insights is a pipe language — and it
@@ -83,6 +126,16 @@ export interface RunReadOnlyQueryOptions {
    * SQL destinations.
    */
   timeRangeMs?: number;
+
+  /**
+   * Per-call ceiling on returned rows. Clamped into `[1, MAX_ROWS]`, so a caller
+   * can ask for FEWER rows but never more -- {@link MAX_ROWS} stays the hard cap.
+   *
+   * This exists because rows cost tokens. In an agent an unbounded-but-capped
+   * result is not free the way it is in a UI: 1000 rows the caller did not want
+   * are still 1000 rows it pays to read.
+   */
+  maxRows?: number;
 }
 
 /** True for the two CloudWatch Logs Insights destinations. */
@@ -125,6 +178,10 @@ export async function runReadOnlyQuery(
   sql: string,
   opts: RunReadOnlyQueryOptions = {},
 ): Promise<ReadOnlyQueryResult> {
+  // Resolve the effective row ceiling ONCE so every engine path below is bounded
+  // by the same number and none can drift. A caller may lower it; nothing raises it.
+  const cap = effectiveCap(opts.maxRows);
+
   // ── CloudWatch Logs Insights path — DELIBERATELY NOT SQL ──────────────────
   //
   // This path is fundamentally different from the five SQL engines below and is
@@ -154,7 +211,7 @@ export async function runReadOnlyQuery(
   //      exactly as `explorerSession.ts` does: `endTimeMs = Date.now()`,
   //      `startTimeMs = endTimeMs - timeRangeMs`.
   if (isLogDestination(cfg)) {
-    return runLogsInsightsReadOnly(cfg, sql, opts);
+    return runLogsInsightsReadOnly(cfg, sql, opts, cap);
   }
 
   // 1. Engine label per destination. Unsupported types are rejected up front.
@@ -226,7 +283,7 @@ export async function runReadOnlyQuery(
       // error text names it.
       outputLocation: cfg.athenaOutputLocation || undefined,
       query: sql,
-      maxRows: MAX_ROWS,
+      maxRows: cap,
     });
     return {
       columns: result.columns,
@@ -247,8 +304,15 @@ export async function runReadOnlyQuery(
       tableName: cfg.dynamodbTableName,
       statement: sql,
     });
-    const truncated = result.count >= MAX_ROWS;
-    const rows = truncated ? result.rows.slice(0, MAX_ROWS) : result.rows;
+    // Two independent reasons this result may be incomplete, and BOTH must be
+    // reported. Reaching the cap is ours. `hasMore` is DynamoDB's: this runner
+    // issues one non-paginating ExecuteStatement and DynamoDB bounds a response at
+    // ~1 MB, so a query matching 5,000 items can return 400 with a NextToken. Before
+    // `hasMore` existed, that came back as `truncated: false` — a complete answer as
+    // far as the agent could tell, which it would then state as one.
+    const cappedHere = result.count >= cap;
+    const truncated = cappedHere || result.hasMore;
+    const rows = cappedHere ? result.rows.slice(0, cap) : result.rows;
     return {
       columns: result.columns,
       rows,
@@ -273,7 +337,7 @@ export async function runReadOnlyQuery(
       database: cfg.auroraDatabase,
       sql,
     });
-    return capUnbounded(result, engine);
+    return capUnbounded(result, engine, cap);
   }
 
   if (cfg.destinationType === "redshift") {
@@ -287,7 +351,7 @@ export async function runReadOnlyQuery(
       secretArn: cfg.redshiftSecretArn || undefined,
       sql,
     });
-    return capUnbounded(result, engine);
+    return capUnbounded(result, engine, cap);
   }
 
   if (cfg.destinationType === "opensearch") {
@@ -297,7 +361,7 @@ export async function runReadOnlyQuery(
       endpoint: cfg.opensearchEndpoint,
       sql,
     });
-    return capUnbounded(result, engine);
+    return capUnbounded(result, engine, cap);
   }
 
   // Unreachable: the engine-label switch above returns a label only for the
@@ -322,9 +386,10 @@ export async function runReadOnlyQuery(
 function capUnbounded(
   result: { columns: string[]; rows: string[][] },
   engine: string,
+  cap: number,
 ): ReadOnlyQueryResult {
-  const truncated = result.rows.length > MAX_ROWS;
-  const rows = truncated ? result.rows.slice(0, MAX_ROWS) : result.rows;
+  const truncated = result.rows.length > cap;
+  const rows = truncated ? result.rows.slice(0, cap) : result.rows;
   return {
     columns: result.columns,
     rows,
@@ -357,11 +422,12 @@ async function runLogsInsightsReadOnly(
   cfg: InsightConfig,
   queryString: string,
   opts: RunReadOnlyQueryOptions,
+  cap: number,
 ): Promise<ReadOnlyQueryResult> {
   // Bound the result with the function written for this syntax. `ensureLimit`
   // is a no-op for queries that already carry a `limit` (e.g. the structured
   // tools, which append their own) or that aggregate with `stats`.
-  const bounded = ensureLimit(queryString, MAX_ROWS);
+  const bounded = ensureLimit(queryString, cap);
 
   const credentials = resolveCredentials(cfg.awsProfile);
 
@@ -387,7 +453,7 @@ async function runLogsInsightsReadOnly(
   // The runner does not carry a `truncated` flag; `ensureLimit` caps a
   // non-aggregating query at MAX_ROWS, so reaching the cap is our truncation
   // signal (a `stats`/pre-limited query that returns fewer rows reports false).
-  const truncated = table.rows.length >= MAX_ROWS;
+  const truncated = table.rows.length >= cap;
   return {
     columns: table.columns,
     rows: table.rows,

--- a/packages/durable-insight-mcp/src/readme.test.ts
+++ b/packages/durable-insight-mcp/src/readme.test.ts
@@ -1,0 +1,86 @@
+/**
+ * AC-5.3: the README is a contract, not free prose. These assertions make it
+ * impossible for the README to (a) document a `DURABLE_INSIGHT_*` variable that
+ * does not exist, (b) fall out of sync with the set of tools the server
+ * actually registers, (c) quote a row cap that differs from the code, or (d)
+ * quietly drop the Legal-approved data-disclosure commitment.
+ *
+ * Everything here is derived from the CODE (imported constants), never from a
+ * copy of a value pasted into the test — so the README is checked against the
+ * source of truth, and a drift in either direction fails the build.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { TOOL_DESCRIPTIONS } from "./tools";
+import { MAX_ROWS } from "./readOnlyQuery";
+import { envVarFor, MCP_SETTING_KEYS } from "./envKeys";
+import { PROMPTS } from "./prompts";
+
+const README = readFileSync(join(__dirname, "..", "README.md"), "utf8");
+
+/** The exact set of `DURABLE_INSIGHT_*` variables this host accepts. */
+const ACCEPTED_ENV_VARS = new Set(MCP_SETTING_KEYS.map((k) => envVarFor(k)));
+
+/** Every `DURABLE_INSIGHT_*` token the README actually contains, de-duplicated. */
+function envVarTokensInReadme(): string[] {
+  const matches = README.match(/DURABLE_INSIGHT_[A-Z0-9_]+/g) ?? [];
+  return [...new Set(matches)];
+}
+
+describe("README variable existence", () => {
+  it("1. every DURABLE_INSIGHT_* token in the README is a real accepted variable", () => {
+    const tokens = envVarTokensInReadme();
+    // Sanity: the README does document some variables (guards against a regex
+    // that silently matches nothing making this test vacuously pass).
+    expect(tokens.length).toBeGreaterThan(0);
+
+    const unknown = tokens.filter((t) => !ACCEPTED_ENV_VARS.has(t));
+    // A non-empty array here names the offending (typo'd or renamed) variable,
+    // which is exactly the support burden this assertion prevents.
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe("README tool coverage", () => {
+  const toolNames = TOOL_DESCRIPTIONS.map((t) => t.name);
+
+  it("2a. every registered tool name is mentioned in the README", () => {
+    const missing = toolNames.filter((name) => !README.includes(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("2b. every tool-looking name the README claims exists is a real tool or prompt", () => {
+    // Tokens the README presents in backticks that look like an identifier
+    // (lower snake_case with at least one underscore) must be a real tool name,
+    // a real prompt name, or an explicitly allowed non-tool identifier — never
+    // an invented tool.
+    const allowed = new Set<string>([
+      ...toolNames,
+      ...PROMPTS.map((p) => p.name),
+      "workflow_insight", // the default table name for the SQL destinations
+    ]);
+    const backticked = README.match(/`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`/g) ?? [];
+    const identifiers = backticked.map((m) => m.replace(/`/g, ""));
+    const offending = identifiers.filter((id) => !allowed.has(id));
+    expect([...new Set(offending)]).toEqual([]);
+  });
+});
+
+describe("README row cap", () => {
+  it("3. the README quotes the MAX_ROWS value the code defines", () => {
+    expect(README).toContain(String(MAX_ROWS));
+  });
+});
+
+describe("README data disclosure", () => {
+  it("4. the disclosure section exists and states payloads are returned verbatim", () => {
+    // Section exists.
+    expect(README.toLowerCase()).toContain("disclosure");
+    // The Legal-committed fact: input/output payloads are returned verbatim.
+    // "verbatim" is used ONLY in that sentence, so deleting it fails here.
+    expect(README).toContain("verbatim");
+    expect(README).toContain("`input`");
+    expect(README).toContain("`output`");
+  });
+});

--- a/packages/durable-insight-mcp/src/server.test.ts
+++ b/packages/durable-insight-mcp/src/server.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration test for the MCP server. This exercises the REAL protocol: it
+ * spawns the BUILT `dist/server.js` as a child process and talks to it with the
+ * MCP SDK's own client over a stdio transport. Nothing here is mocked — a
+ * passing run means an actual MCP client completed a handshake and a tool call
+ * against the shipped binary.
+ *
+ * The missing-config assertion deliberately runs with an incomplete environment
+ * and NO AWS credentials, exercising the path that returns before any AWS call.
+ */
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const SERVER_PATH = path.resolve(__dirname, "..", "dist", "server.js");
+const SERVER_BUILT = existsSync(SERVER_PATH);
+
+// A hanging stdio test is worse than a failing one: cap every test, and if the
+// built binary is missing, skip loudly rather than spawn something that hangs.
+const TIMEOUT_MS = 30_000;
+
+if (!SERVER_BUILT) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[server.test] ${SERVER_PATH} not found — skipping integration tests. ` +
+      `Run \`npm run build\` first (the package's \`test\` script does this).`,
+  );
+}
+
+const describeIfBuilt = SERVER_BUILT ? describe : describe.skip;
+
+describeIfBuilt("durable-insight MCP server (spawned binary)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: process.execPath, // this node binary
+      args: [SERVER_PATH],
+      // Deliberately minimal, credential-free environment. We select the
+      // dynamodb destination but leave DURABLE_INSIGHT_DYNAMODB_TABLE_NAME
+      // unset, so test_destination must report the missing variable WITHOUT
+      // touching AWS. PATH is passed only so `node` can resolve.
+      env: {
+        PATH: process.env.PATH ?? "",
+        DURABLE_INSIGHT_DESTINATION_TYPE: "dynamodb",
+      },
+      stderr: "pipe",
+    });
+
+    client = new Client(
+      { name: "durable-insight-test-client", version: "0.0.0" },
+      { capabilities: {} },
+    );
+
+    await client.connect(transport);
+  }, TIMEOUT_MS);
+
+  afterAll(async () => {
+    // Closing the transport terminates the child process; without this jest
+    // could hang waiting on an open handle.
+    await client?.close();
+  });
+
+  it(
+    "completes the initialize handshake and reports its server name",
+    () => {
+      const info = client.getServerVersion();
+      expect(info?.name).toBe("durable-insight");
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "lists test_destination with a non-empty, bounded description",
+    async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("test_destination");
+
+      const tool = tools.find((t) => t.name === "test_destination");
+      expect(tool?.description).toBeDefined();
+      expect(tool!.description!.length).toBeGreaterThan(0);
+      // Long descriptions degrade agent performance; keep well under the cap.
+      expect(tool!.description!.length).toBeLessThan(10_000);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "names the missing env var on an incomplete, credential-free environment",
+    async () => {
+      const result = await client.callTool({
+        name: "test_destination",
+        arguments: {},
+      });
+
+      // A missing-config finding is a successful tool call, not a tool error.
+      expect(result.isError).toBeFalsy();
+
+      const content = result.content as Array<{ type: string; text?: string }>;
+      const textBlock = content.find((c) => c.type === "text");
+      expect(textBlock?.text).toBeDefined();
+
+      // The result MUST be machine-readable JSON, never prose.
+      const payload = JSON.parse(textBlock!.text!);
+      expect(payload.ok).toBe(false);
+      expect(payload.destinationType).toBe("dynamodb");
+      expect(Array.isArray(payload.missingEnvVars)).toBe(true);
+      // The actionable environment variable name — not the UI label.
+      expect(payload.missingEnvVars).toContain(
+        "DURABLE_INSIGHT_DYNAMODB_TABLE_NAME",
+      );
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "keeps stdout clean — a full MCP session is itself the evidence",
+    async () => {
+      // If the server wrote any non-frame bytes to stdout, the SDK client's
+      // JSON-RPC parser would have thrown before now and these prior calls
+      // would have failed. A second successful round-trip reconfirms the
+      // transport is still an uncorrupted protocol stream.
+      const { tools } = await client.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "writes NOTHING to stdout before any request (direct stdout-purity check)",
+    async () => {
+      // The SDK client is deliberately lenient: its read loop catches a bad
+      // line, reports it to an (unset) onerror, and continues — so a stray
+      // `console.log` on its own line is SKIPPED and a session still succeeds.
+      // A successful session therefore does NOT catch a stray stdout write.
+      // This asserts stdout purity directly instead: a correct MCP server emits
+      // zero bytes on stdout until it receives a request, so spawning it with an
+      // immediately-closed stdin must produce empty stdout. Any startup-time
+      // stdout write (e.g. console.log) fails this.
+      const stdout = await new Promise<string>((resolve, reject) => {
+        const child = spawn(process.execPath, [SERVER_PATH], {
+          env: {
+            PATH: process.env.PATH ?? "",
+            DURABLE_INSIGHT_DESTINATION_TYPE: "dynamodb",
+          },
+          stdio: ["pipe", "pipe", "ignore"],
+        });
+        let out = "";
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+          out += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", () => resolve(out));
+        // No request — just close stdin so the server sees EOF and exits.
+        child.stdin.end();
+        // Safety net so a hung child can never hang the test.
+        const killer = setTimeout(
+          () => child.kill("SIGKILL"),
+          TIMEOUT_MS - 5_000,
+        );
+        child.on("close", () => clearTimeout(killer));
+      });
+
+      expect(stdout).toBe("");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/durable-insight-mcp/src/server.test.ts
+++ b/packages/durable-insight-mcp/src/server.test.ts
@@ -170,4 +170,48 @@ describeIfBuilt("durable-insight MCP server (spawned binary)", () => {
     },
     TIMEOUT_MS,
   );
+
+  it(
+    "lists both registered prompts over the real protocol (AC-5.1)",
+    async () => {
+      const { prompts } = await client.listPrompts();
+      const names = prompts.map((p) => p.name);
+      // Prove reachability through the protocol, not by unit-testing handlers.
+      expect(names).toContain("investigate_workflow_failure");
+      expect(names).toContain("explore_recent_executions");
+
+      const investigate = prompts.find(
+        (p) => p.name === "investigate_workflow_failure",
+      );
+      expect(investigate?.description).toBeDefined();
+      expect(investigate!.description!.length).toBeGreaterThan(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  it(
+    "returns usable messages from prompts/get, honoring arguments",
+    async () => {
+      const result = await client.getPrompt({
+        name: "investigate_workflow_failure",
+        arguments: { functionName: "checkout-fn", lookbackHours: "12" },
+      });
+
+      expect(Array.isArray(result.messages)).toBe(true);
+      expect(result.messages.length).toBeGreaterThan(0);
+
+      const first = result.messages[0];
+      expect(first.role).toBe("user");
+      expect(first.content.type).toBe("text");
+      const text = (first.content as { type: "text"; text: string }).text;
+      // The guidance encodes the ORDER of operations and delegates schema to
+      // describe_schema — never inlines destination-specific schema facts.
+      expect(text).toContain("describe_schema");
+      expect(text).toContain("list_executions");
+      // Supplied arguments are woven into the rendered guidance.
+      expect(text).toContain("checkout-fn");
+      expect(text).toContain("12");
+    },
+    TIMEOUT_MS,
+  );
 });

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -17,8 +17,20 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { testDestination, type InsightConfig } from "durable-insight-core";
+import { z } from "zod";
 import { readConfigFromEnv } from "./config";
 import { missingRequiredEnvVars } from "./config";
+import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
+import {
+  buildDescribeSchemaResult,
+  DESCRIBE_SCHEMA_DESCRIPTION,
+  GET_EXECUTION_DESCRIPTION,
+  LIST_EXECUTIONS_DESCRIPTION,
+  QUERY_DESCRIPTION,
+  runGetExecution,
+  runListExecutions,
+  TEST_DESTINATION_DESCRIPTION,
+} from "./tools";
 
 /**
  * The package's own version. esbuild replaces this token at build time with the
@@ -34,19 +46,40 @@ function logStderr(message: string): void {
   process.stderr.write(`${message}\n`);
 }
 
-/**
- * One or two sentences, well under the 10,000-char cap. Bulk detail lives in the
- * tool result (machine-readable JSON), not in this description.
- */
-const TEST_DESTINATION_DESCRIPTION =
-  "Run read-only connectivity and completeness checks against the configured " +
-  "Insight destination (configured via DURABLE_INSIGHT_* environment variables) " +
-  "and return a machine-readable JSON report. If required environment variables " +
-  "are unset it names them and returns without making any AWS calls.";
+/** Wrap a JSON-serializable payload in the MCP text-content result shape. */
+function jsonResult(payload: unknown, isError = false) {
+  const result = {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+  return isError ? { ...result, isError: true } : result;
+}
 
 /**
- * Registers the single `test_destination` tool. The `config` is captured from
- * startup (read once) so the tool never re-reads the environment.
+ * The tools that make AWS calls (`query`, `get_execution`, `list_executions`)
+ * must never touch the network with incomplete config. Returns a
+ * SUCCESSFUL-tool-call result naming the missing DURABLE_INSIGHT_* variables
+ * when any are unset, or `null` when config is complete and the tool may
+ * proceed. A missing-config finding is not a tool error — the tool did exactly
+ * what it was asked to.
+ */
+function missingConfigResult(config: InsightConfig) {
+  const missingEnvVars = missingRequiredEnvVars(config);
+  if (missingEnvVars.length === 0) return null;
+  return jsonResult({
+    ok: false,
+    summary:
+      `Destination configuration is incomplete: ${missingEnvVars.length} ` +
+      `required environment variable(s) unset. Set them and try again.`,
+    destinationType: config.destinationType,
+    missingEnvVars,
+  });
+}
+
+/**
+ * Registers the `test_destination` and `query` tools. The `config` is captured
+ * from startup (read once) so the tools never re-read the environment.
  */
 function registerTools(server: McpServer, config: InsightConfig): void {
   server.registerTool(
@@ -120,6 +153,233 @@ function registerTools(server: McpServer, config: InsightConfig): void {
           ],
           isError: true,
         };
+      }
+    },
+  );
+
+  server.registerTool(
+    "query",
+    {
+      title: "Run a read-only query",
+      description: QUERY_DESCRIPTION,
+      inputSchema: {
+        sql: z
+          .string()
+          .describe(
+            "A single read-only SQL/PartiQL SELECT (or WITH ... SELECT) " +
+              "statement. Data-modifying and DDL statements are rejected.",
+          ),
+        // `limit` is validated at the protocol boundary to be within the hard
+        // cap. The real bound is MAX_ROWS, enforced inside runReadOnlyQuery, so
+        // this parameter is advisory — it cannot raise the cap.
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(MAX_ROWS)
+          .optional()
+          .describe(
+            `Optional hint for the maximum number of rows to return (<= ${MAX_ROWS}). ` +
+              `Results are always capped at ${MAX_ROWS} regardless.`,
+          ),
+      },
+    },
+    async ({ sql }) => {
+      // 1. Completeness check first — a missing-config finding must never make a
+      //    network call (mirrors test_destination). Returns actionable
+      //    DURABLE_INSIGHT_* variable NAMES.
+      const missingEnvVars = missingRequiredEnvVars(config);
+      if (missingEnvVars.length > 0) {
+        const payload = {
+          ok: false,
+          summary:
+            `Destination configuration is incomplete: ${missingEnvVars.length} ` +
+            `required environment variable(s) unset. Set them and try again.`,
+          destinationType: config.destinationType,
+          missingEnvVars,
+        };
+        // A missing-config finding is a SUCCESSFUL tool call, not an error.
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+        };
+      }
+
+      // 2. Execute through the single choke point. This is the ONLY place the
+      //    tool does anything — it never touches a runner directly.
+      try {
+        const result = await runReadOnlyQuery(config, sql);
+        const payload = {
+          columns: result.columns,
+          rows: result.rows,
+          count: result.count,
+          truncated: result.truncated,
+          engine: result.engine,
+          destinationType: config.destinationType,
+        };
+        // A query that runs and returns zero rows is a SUCCESS with an empty
+        // result — not an error.
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+        };
+      } catch (err) {
+        // A rejected (non-read-only) or failed query is a legitimate tool ERROR:
+        // the agent should see that it failed and why. assertReadOnly's message
+        // is already specific and actionable, so surface it verbatim.
+        const message = err instanceof Error ? err.message : String(err);
+        const payload = {
+          error: message,
+          destinationType: config.destinationType,
+        };
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // describe_schema — pure guidance, no AWS call. Returns the destination's
+  // record schema + dialect guidance (from core's buildSystemPrompt) in the
+  // RESULT, never the description. No missing-config gate: it makes no network
+  // call, so it can help the agent even before a destination is fully set up.
+  server.registerTool(
+    "describe_schema",
+    {
+      title: "Describe the Insight destination schema",
+      description: DESCRIBE_SCHEMA_DESCRIPTION,
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        return jsonResult(buildDescribeSchemaResult(config));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult(
+          { error: message, destinationType: config.destinationType },
+          true,
+        );
+      }
+    },
+  );
+
+  // get_execution — single-record lookup by execution ARN. One required
+  // parameter; optional Athena partition components for pruning. A missing
+  // record is a success with found=false.
+  server.registerTool(
+    "get_execution",
+    {
+      title: "Get a single execution record",
+      description: GET_EXECUTION_DESCRIPTION,
+      inputSchema: {
+        executionArn: z
+          .string()
+          .describe(
+            "The execution ARN to fetch (DynamoDB partition key / Athena " +
+              "executionarn column).",
+          ),
+        year: z
+          .string()
+          .optional()
+          .describe(
+            "Optional Athena/S3 partition year (digits) for partition pruning.",
+          ),
+        month: z
+          .string()
+          .optional()
+          .describe(
+            "Optional Athena/S3 partition month (digits) for partition pruning.",
+          ),
+        day: z
+          .string()
+          .optional()
+          .describe(
+            "Optional Athena/S3 partition day (digits) for partition pruning.",
+          ),
+      },
+    },
+    async ({ executionArn, year, month, day }) => {
+      const gate = missingConfigResult(config);
+      if (gate) return gate;
+      try {
+        return jsonResult(
+          await runGetExecution(config, { executionArn, year, month, day }),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult(
+          { error: message, destinationType: config.destinationType },
+          true,
+        );
+      }
+    },
+  );
+
+  // list_executions — the common "show me executions" case with no SQL from the
+  // agent. Every filter is validated/escaped in tools.ts before the SELECT is
+  // built, then executed through the same read-only choke point as `query`.
+  server.registerTool(
+    "list_executions",
+    {
+      title: "List execution records",
+      description: LIST_EXECUTIONS_DESCRIPTION,
+      inputSchema: {
+        status: z
+          .string()
+          .optional()
+          .describe("Filter by status: RUNNING, SUCCEEDED, or FAILED."),
+        functionName: z
+          .string()
+          .optional()
+          .describe("Filter by Lambda function name (exact match)."),
+        since: z
+          .string()
+          .optional()
+          .describe(
+            "Only executions with startTime >= this ISO-8601 date/date-time.",
+          ),
+        until: z
+          .string()
+          .optional()
+          .describe(
+            "Only executions with startTime <= this ISO-8601 date/date-time.",
+          ),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(MAX_ROWS)
+          .optional()
+          .describe(
+            `Maximum rows to return (<= ${MAX_ROWS}). Defaults to a bounded ` +
+              `page; the ${MAX_ROWS} cap always applies.`,
+          ),
+      },
+    },
+    async ({ status, functionName, since, until, limit }) => {
+      const gate = missingConfigResult(config);
+      if (gate) return gate;
+      try {
+        return jsonResult(
+          await runListExecutions(config, {
+            status,
+            functionName,
+            since,
+            until,
+            limit,
+          }),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult(
+          { error: message, destinationType: config.destinationType },
+          true,
+        );
       }
     },
   );

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -16,7 +16,7 @@
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { testDestination, type InsightConfig } from "durable-insight-core";
+import { testDestination, type InsightConfig } from "@aws/durable-insight-core";
 import { z } from "zod";
 import { readConfigFromEnv } from "./config";
 import { missingRequiredEnvVars } from "./config";

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import { readConfigFromEnv } from "./config";
 import { missingRequiredEnvVars } from "./config";
 import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
+import { registerPrompts } from "./prompts";
 import {
   buildDescribeSchemaResult,
   DESCRIBE_SCHEMA_DESCRIPTION,
@@ -425,6 +426,7 @@ async function main(): Promise<void> {
   });
 
   registerTools(server, config);
+  registerPrompts(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -31,6 +31,7 @@ import {
   runGetExecution,
   runListExecutions,
   TEST_DESTINATION_DESCRIPTION,
+  DEFAULT_RECORD_LOOKBACK_HOURS,
 } from "./tools";
 
 /**
@@ -170,9 +171,9 @@ function registerTools(server: McpServer, config: InsightConfig): void {
             "A single read-only SQL/PartiQL SELECT (or WITH ... SELECT) " +
               "statement. Data-modifying and DDL statements are rejected.",
           ),
-        // `limit` is validated at the protocol boundary to be within the hard
-        // cap. The real bound is MAX_ROWS, enforced inside runReadOnlyQuery, so
-        // this parameter is advisory — it cannot raise the cap.
+        // Validated at the protocol boundary to be within the hard cap, then
+        // passed to runReadOnlyQuery, which clamps it into [1, MAX_ROWS]. It can
+        // therefore lower the bound but never raise it.
         limit: z
           .number()
           .int()
@@ -180,8 +181,9 @@ function registerTools(server: McpServer, config: InsightConfig): void {
           .max(MAX_ROWS)
           .optional()
           .describe(
-            `Optional hint for the maximum number of rows to return (<= ${MAX_ROWS}). ` +
-              `Results are always capped at ${MAX_ROWS} regardless.`,
+            `Maximum rows to return (<= ${MAX_ROWS}). Lowering this is worth doing ` +
+              `whenever you only need a few rows: every row costs tokens to read. ` +
+              `Results are capped at ${MAX_ROWS} whether or not this is set.`,
           ),
         // Time window for CloudWatch Logs Insights destinations ONLY
         // (cloudwatch-logs-exporter / lambda-log-exporter). Logs Insights has no
@@ -202,7 +204,7 @@ function registerTools(server: McpServer, config: InsightConfig): void {
           ),
       },
     },
-    async ({ sql, lookbackHours }) => {
+    async ({ sql, limit, lookbackHours }) => {
       // 1. Completeness check first — a missing-config finding must never make a
       //    network call (mirrors test_destination). Returns actionable
       //    DURABLE_INSIGHT_* variable NAMES.
@@ -234,7 +236,10 @@ function registerTools(server: McpServer, config: InsightConfig): void {
           lookbackHours !== undefined
             ? lookbackHours * 60 * 60 * 1000
             : undefined;
-        const result = await runReadOnlyQuery(config, sql, { timeRangeMs });
+        const result = await runReadOnlyQuery(config, sql, {
+          timeRangeMs,
+          maxRows: limit,
+        });
         const payload = {
           columns: result.columns,
           rows: result.rows,
@@ -324,16 +329,36 @@ function registerTools(server: McpServer, config: InsightConfig): void {
           .string()
           .optional()
           .describe(
-            "Optional Athena/S3 partition day (digits) for partition pruning.",
+            "Optional Athena/S3 partition day (digits) for partition pruning. " +
+              "Ignored on other destinations, which report it back in " +
+              "`ignoredParams`.",
+          ),
+        lookbackHours: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            `For CloudWatch Logs destinations only: how many hours back to ` +
+              `search (default ${DEFAULT_RECORD_LOOKBACK_HOURS}). Logs Insights ` +
+              `requires an explicit window, so an execution older than this ` +
+              `reports found=false; widen it before concluding the execution ` +
+              `does not exist. The window searched is returned as ` +
+              `searchedLookbackHours.`,
           ),
       },
     },
-    async ({ executionArn, year, month, day }) => {
+    async ({ executionArn, year, month, day, lookbackHours }) => {
       const gate = missingConfigResult(config);
       if (gate) return gate;
       try {
         return jsonResult(
-          await runGetExecution(config, { executionArn, year, month, day }),
+          await runGetExecution(config, {
+            executionArn,
+            year,
+            month,
+            day,
+            lookbackHours,
+          }),
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -409,9 +409,20 @@ function registerTools(server: McpServer, config: InsightConfig): void {
             `Maximum rows to return (<= ${MAX_ROWS}). Defaults to a bounded ` +
               `page; the ${MAX_ROWS} cap always applies.`,
           ),
+        lookbackHours: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            "For CloudWatch Logs destinations only: how many hours back to scan. " +
+              "Usually unnecessary — when `since` is given the scanned window is " +
+              "derived from it. Set this to widen a search that has no `since`. " +
+              "The window scanned is returned as searchedLookbackHours; if it is " +
+              "narrower than you expected, results may be partial.",
+          ),
       },
     },
-    async ({ status, functionName, since, until, limit }) => {
+    async ({ status, functionName, since, until, limit, lookbackHours }) => {
       const gate = missingConfigResult(config);
       if (gate) return gate;
       try {
@@ -422,6 +433,7 @@ function registerTools(server: McpServer, config: InsightConfig): void {
             since,
             until,
             limit,
+            lookbackHours,
           }),
         );
       } catch (err) {

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Durable Insight MCP server (stdio transport).
+ *
+ * This is the `bin` target for the package. It exposes the Insight destination
+ * tooling to an MCP client (e.g. an agent) over stdio.
+ *
+ * STDOUT DISCIPLINE — read before editing:
+ *   stdout is the MCP transport. Every byte written to it MUST be a protocol
+ *   frame emitted by the SDK. A stray `console.log` (or anything else writing to
+ *   process.stdout) injects non-JSON-RPC bytes into the stream and corrupts the
+ *   session — the client typically fails to parse and the server appears broken
+ *   for no obvious reason. All diagnostics therefore go to STDERR via
+ *   {@link logStderr}. Never use `console.log` in this file or anything it calls
+ *   on the startup path.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { testDestination, type InsightConfig } from "durable-insight-core";
+import { readConfigFromEnv } from "./config";
+import { missingRequiredEnvVars } from "./config";
+
+/**
+ * The package's own version. esbuild replaces this token at build time with the
+ * `version` string read from this package's package.json (see esbuild.mjs), so
+ * there is exactly one source of truth and no second copy is hard-coded here.
+ * Declared (not imported) so it also type-checks under the package's CommonJS
+ * tsconfig, which forbids `import.meta`.
+ */
+declare const DURABLE_INSIGHT_MCP_VERSION: string;
+
+/** All diagnostics go to stderr — stdout is reserved for the MCP transport. */
+function logStderr(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+/**
+ * One or two sentences, well under the 10,000-char cap. Bulk detail lives in the
+ * tool result (machine-readable JSON), not in this description.
+ */
+const TEST_DESTINATION_DESCRIPTION =
+  "Run read-only connectivity and completeness checks against the configured " +
+  "Insight destination (configured via DURABLE_INSIGHT_* environment variables) " +
+  "and return a machine-readable JSON report. If required environment variables " +
+  "are unset it names them and returns without making any AWS calls.";
+
+/**
+ * Registers the single `test_destination` tool. The `config` is captured from
+ * startup (read once) so the tool never re-reads the environment.
+ */
+function registerTools(server: McpServer, config: InsightConfig): void {
+  server.registerTool(
+    "test_destination",
+    {
+      title: "Test Insight destination",
+      description: TEST_DESTINATION_DESCRIPTION,
+      // No parameters: the destination is taken entirely from the environment.
+      inputSchema: {},
+    },
+    async () => {
+      // 1. Completeness check first — a missing-config finding must never make a
+      //    network call. `missingRequiredEnvVars` returns DURABLE_INSIGHT_* NAMES
+      //    (actionable to an MCP user), unlike core's UI labels.
+      const missingEnvVars = missingRequiredEnvVars(config);
+      if (missingEnvVars.length > 0) {
+        const payload = {
+          ok: false,
+          summary:
+            `Destination configuration is incomplete: ${missingEnvVars.length} ` +
+            `required environment variable(s) unset. Set them and try again.`,
+          checks: [],
+          destinationType: config.destinationType,
+          region: config.region,
+          missingEnvVars,
+        };
+        // A negative finding about configuration is a SUCCESSFUL tool call, not
+        // a tool error — the tool did exactly what it was asked to.
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+        };
+      }
+
+      // 2. Config is complete — run the real read-only probes.
+      try {
+        const report = await testDestination(config);
+        const payload = {
+          ok: report.ok,
+          summary: report.summary,
+          checks: report.checks,
+          destinationType: config.destinationType,
+          region: config.region,
+          // Nothing was missing on this path; report it explicitly so the
+          // result shape is stable regardless of branch.
+          missingEnvVars: [] as string[],
+        };
+        // NOTE: report.ok === false here is a reachable-destination negative
+        // finding, NOT a tool error. isError is reserved for genuine failures
+        // (thrown exceptions) below.
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const payload = {
+          ok: false,
+          summary: `test_destination failed unexpectedly: ${message}`,
+          error: message,
+          checks: [],
+          destinationType: config.destinationType,
+          region: config.region,
+          missingEnvVars: [] as string[],
+        };
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+async function main(): Promise<void> {
+  // Read config ONCE at startup. Do NOT exit on missing destination config — a
+  // server that refuses to start surfaces in a client as an unexplained
+  // failure. Emit warnings to stderr; the test_destination tool diagnoses the
+  // rest.
+  const { config, warnings } = readConfigFromEnv();
+  for (const warning of warnings) {
+    logStderr(`[durable-insight] warning: ${warning}`);
+  }
+
+  const server = new McpServer({
+    name: "durable-insight",
+    version: DURABLE_INSIGHT_MCP_VERSION,
+  });
+
+  registerTools(server, config);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logStderr("[durable-insight] MCP server ready on stdio.");
+}
+
+main().catch((err) => {
+  const message =
+    err instanceof Error ? (err.stack ?? err.message) : String(err);
+  logStderr(`[durable-insight] fatal: ${message}`);
+  process.exit(1);
+});

--- a/packages/durable-insight-mcp/src/server.ts
+++ b/packages/durable-insight-mcp/src/server.ts
@@ -182,9 +182,26 @@ function registerTools(server: McpServer, config: InsightConfig): void {
             `Optional hint for the maximum number of rows to return (<= ${MAX_ROWS}). ` +
               `Results are always capped at ${MAX_ROWS} regardless.`,
           ),
+        // Time window for CloudWatch Logs Insights destinations ONLY
+        // (cloudwatch-logs-exporter / lambda-log-exporter). Logs Insights has no
+        // "all time" — it requires an explicit [start, end] window — so this
+        // controls how far back the query looks: [now - lookbackHours, now].
+        // Ignored by the five SQL destinations, which are not time-windowed.
+        // Defaults to 24 hours when omitted. Fractional values are allowed
+        // (e.g. 0.5 = last 30 minutes) so an agent investigating a narrow
+        // incident window ("last night") can control it.
+        lookbackHours: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            "For CloudWatch Logs destinations only: how many hours back to " +
+              "search, measured from now (default 24). Logs Insights requires " +
+              "an explicit time window. Ignored for SQL destinations.",
+          ),
       },
     },
-    async ({ sql }) => {
+    async ({ sql, lookbackHours }) => {
       // 1. Completeness check first — a missing-config finding must never make a
       //    network call (mirrors test_destination). Returns actionable
       //    DURABLE_INSIGHT_* variable NAMES.
@@ -209,7 +226,14 @@ function registerTools(server: McpServer, config: InsightConfig): void {
       // 2. Execute through the single choke point. This is the ONLY place the
       //    tool does anything — it never touches a runner directly.
       try {
-        const result = await runReadOnlyQuery(config, sql);
+        // Translate the log-only lookback window (hours) into the choke point's
+        // millisecond option. Undefined for SQL destinations (and when the
+        // agent omits it), letting runReadOnlyQuery apply its 24h default.
+        const timeRangeMs =
+          lookbackHours !== undefined
+            ? lookbackHours * 60 * 60 * 1000
+            : undefined;
+        const result = await runReadOnlyQuery(config, sql, { timeRangeMs });
         const payload = {
           columns: result.columns,
           rows: result.rows,

--- a/packages/durable-insight-mcp/src/skill/SKILL.md
+++ b/packages/durable-insight-mcp/src/skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: durable-insight
+description: Query AWS Lambda durable function execution history through the durable-insight MCP server — use when investigating workflow failures, execution timing, or step-level errors across DynamoDB, Athena/S3, Aurora, Redshift, OpenSearch, or CloudWatch Logs destinations.
+---
+
+# Durable Insight
+
+The durable-insight MCP server gives you READ-ONLY access to the execution
+history that AWS Lambda durable functions emit to a configured destination. Use
+it to investigate failures, timing, and step-level errors. The destination is
+chosen by the operator through `DURABLE_INSIGHT_*` environment variables; you do
+not pick it and must not assume which one is in play.
+
+## The one rule that makes this skill correct: ask the server for the schema
+
+This skill deliberately contains ZERO destination-specific schema facts — no
+field names, no column casing, no dialect syntax. That is not an omission; it is
+the design:
+
+- **Drift becomes impossible, not merely detectable.** Any schema prose copied
+  here would silently rot the moment the server's schema changed. There is
+  nothing to keep in sync because there is nothing duplicated.
+- **Token economy.** One destination's guidance alone is over ten thousand
+  characters. Inlining every destination's schema would load all of it on every
+  invocation, whether or not you are on that destination.
+- **Correctness.** Only the running server knows the configured destination. A
+  static file would have to hedge across every backend and would be wrong for
+  six of them at any given moment.
+
+So: **call `describe_schema` before you write a `query`.** It returns the record
+fields and query idioms for whatever destination is actually configured,
+authoritatively. Writing a query without it is guessing.
+
+## The five tools, and when to reach for each
+
+- `test_destination` — Run first. Confirms the destination is reachable and its
+  configuration is complete. If required environment variables are unset it
+  names them and returns without any AWS call. Stop and report if it fails.
+- `describe_schema` — Call before any `query`. Returns the configured
+  destination's record schema, query engine/dialect, the table or log group in
+  play, and the row cap. Makes no AWS call, so it is safe even before setup is
+  complete.
+- `list_executions` — The common case: list executions filtered by any of
+  status, functionName, since, and until, with no SQL required. Prefer this over
+  a hand-written `query` — it cannot be got wrong and costs fewer tokens.
+- `get_execution` — Fetch a single execution record by its execution ARN. A
+  record that does not exist is a success with found=false, not an error.
+- `query` — Escape hatch for questions the structured tools cannot express. Only
+  after `describe_schema`, so field names and syntax match the destination.
+
+## Guarantees and limits you can rely on
+
+- **Read-only.** For the SQL destinations, any statement that is not a
+  SELECT/WITH is refused before any AWS call is made; the CloudWatch Logs query
+  language has no write forms at all. You cannot mutate data through this server.
+- **Row cap.** Every result is capped at a fixed maximum row count (MAX_ROWS,
+  currently 1000). A truncated flag tells you when the cap was hit — narrow
+  your filters rather than assuming you saw everything.
+- **Log destinations need a lookback window.** CloudWatch Logs queries have no
+  "all time"; pass a lookback window (hours) or accept the 24-hour default. This
+  is ignored by the SQL destinations, which are not time-windowed.
+
+## Suggested order for a failure investigation
+
+1. `test_destination` — confirm reachability and configuration.
+2. `describe_schema` — learn this destination's fields and idioms.
+3. `list_executions` — narrow to the executions of interest (start with FAILED).
+4. `get_execution` — drill into a specific record for step-level detail.
+5. `query` — only when the structured tools cannot express the question.

--- a/packages/durable-insight-mcp/src/skillDrift.test.ts
+++ b/packages/durable-insight-mcp/src/skillDrift.test.ts
@@ -22,7 +22,7 @@
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { buildSystemPrompt } from "durable-insight-core";
+import { buildSystemPrompt } from "@aws/durable-insight-core";
 import { TOOL_DESCRIPTIONS } from "./tools";
 import { allPromptText, PROMPTS } from "./prompts";
 

--- a/packages/durable-insight-mcp/src/skillDrift.test.ts
+++ b/packages/durable-insight-mcp/src/skillDrift.test.ts
@@ -1,0 +1,164 @@
+/**
+ * AC-T4 — the mechanical anti-drift guard.
+ *
+ * The design contract of the skill and the prompts is that they carry ZERO
+ * destination-specific schema knowledge: every such fact is owned by core's
+ * `buildSystemPrompt` and delegated to at runtime via the `describe_schema`
+ * tool. This suite makes that property mechanical rather than aspirational:
+ *
+ *   1. It builds a list of schema-owned tokens and FIRST proves each really
+ *      appears in some destination's `buildSystemPrompt` output — otherwise the
+ *      guard would be checking for strings nobody uses and pass vacuously. Any
+ *      candidate that appears nowhere is dropped (and reported).
+ *   2. It asserts none of the genuinely-present tokens appears in `SKILL.md` or
+ *      in any registered prompt's text.
+ *   3. It asserts `SKILL.md` DOES instruct calling `describe_schema` — so the
+ *      delegation is real, not merely an absence of schema prose.
+ *   4. It asserts `SKILL.md` parses: frontmatter present, non-empty `name` and a
+ *      `description` specific enough (over a minimum length) that it cannot
+ *      degrade to something like "Insight skill".
+ *   5. It cross-checks tool names both ways: every tool `SKILL.md` mentions
+ *      exists in `TOOL_DESCRIPTIONS`, and all five tools are mentioned.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { buildSystemPrompt } from "durable-insight-core";
+import { TOOL_DESCRIPTIONS } from "./tools";
+import { allPromptText, PROMPTS } from "./prompts";
+
+const SKILL_PATH = path.resolve(__dirname, "skill", "SKILL.md");
+const SKILL = readFileSync(SKILL_PATH, "utf8");
+
+/** Every destination `buildSystemPrompt` supports (the queryable + log set). */
+const DESTINATIONS = [
+  "cloudwatch-logs-exporter",
+  "lambda-log-exporter",
+  "dynamodb",
+  "aurora",
+  "redshift",
+  "opensearch",
+  "s3",
+] as const;
+
+/**
+ * Candidate schema-owned tokens: distinctive identifiers that only `schema.ts`
+ * should own. Each is VERIFIED below to actually appear in some destination's
+ * prompt before it is used as a guard token.
+ */
+const CANDIDATE_TOKENS = [
+  "operationsByName",
+  "json_extract_scalar",
+  "recordType",
+  "schemaVersion",
+  "executionarn",
+  "record_json",
+  "@timestamp",
+];
+
+/** The `buildSystemPrompt` output for every destination (schema authority). */
+const PROMPT_OUTPUTS: string[] = DESTINATIONS.map((d) =>
+  buildSystemPrompt(d, {
+    tableName: d === "s3" ? "workflow_insight" : undefined,
+  }),
+);
+
+function tokenAppears(token: string): boolean {
+  return PROMPT_OUTPUTS.some((o) => o.includes(token));
+}
+
+/** Only tokens genuinely present in some destination's schema output. */
+const PRESENT_TOKENS = CANDIDATE_TOKENS.filter(tokenAppears);
+const ABSENT_TOKENS = CANDIDATE_TOKENS.filter((t) => !tokenAppears(t));
+
+// Surface exactly which tokens are load-bearing and which were dropped.
+// eslint-disable-next-line no-console
+console.log(
+  `[skillDrift] schema-owned tokens verified present: ${JSON.stringify(
+    PRESENT_TOKENS,
+  )}; dropped (absent from every buildSystemPrompt output): ${JSON.stringify(
+    ABSENT_TOKENS,
+  )}`,
+);
+
+/** Minimal YAML frontmatter parse: the block between the first two `---`. */
+function parseFrontmatter(md: string): Record<string, string> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(md);
+  if (!match) return {};
+  const out: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = /^([a-zA-Z0-9_-]+):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1]] = kv[2].trim();
+  }
+  return out;
+}
+
+describe("skill/prompt anti-drift guard (AC-T4)", () => {
+  it("uses only schema-owned tokens that genuinely appear in buildSystemPrompt output", () => {
+    // The guard is meaningless if it checks for strings nobody uses.
+    expect(PRESENT_TOKENS.length).toBeGreaterThan(0);
+    for (const token of PRESENT_TOKENS) {
+      expect(tokenAppears(token)).toBe(true);
+    }
+    // And the reported "dropped" set really is absent everywhere.
+    for (const token of ABSENT_TOKENS) {
+      expect(tokenAppears(token)).toBe(false);
+    }
+  });
+
+  it.each(PRESENT_TOKENS)(
+    "SKILL.md contains no schema-owned token: %s",
+    (token) => {
+      expect(SKILL.includes(token)).toBe(false);
+    },
+  );
+
+  it.each(PRESENT_TOKENS)(
+    "no registered prompt text contains schema-owned token: %s",
+    (token) => {
+      expect(allPromptText().includes(token)).toBe(false);
+    },
+  );
+
+  it("SKILL.md instructs calling describe_schema (delegation is real)", () => {
+    expect(SKILL.includes("describe_schema")).toBe(true);
+  });
+
+  it("SKILL.md has valid frontmatter with a non-empty name and a specific description", () => {
+    const fm = parseFrontmatter(SKILL);
+    expect(fm.name).toBeDefined();
+    expect(fm.name.length).toBeGreaterThan(0);
+    expect(fm.description).toBeDefined();
+    // Specific enough that it cannot degrade to "Insight skill".
+    expect(fm.description.length).toBeGreaterThan(80);
+  });
+
+  it("every tool named in SKILL.md exists in TOOL_DESCRIPTIONS", () => {
+    const toolNames = new Set(TOOL_DESCRIPTIONS.map((t) => t.name));
+    // Backticked all-lowercase identifiers in SKILL.md are tool references
+    // (uppercase names like MAX_ROWS / DURABLE_INSIGHT_* are excluded by the
+    // pattern). Each must be a real tool — a reference to a renamed or removed
+    // tool is worse than no skill.
+    const referenced = [...SKILL.matchAll(/`([a-z][a-z_]*)`/g)].map(
+      (m) => m[1],
+    );
+    expect(referenced.length).toBeGreaterThan(0);
+    for (const name of referenced) {
+      expect(toolNames.has(name)).toBe(true);
+    }
+  });
+
+  it("SKILL.md mentions all five tools", () => {
+    for (const { name } of TOOL_DESCRIPTIONS) {
+      expect(SKILL.includes(name)).toBe(true);
+    }
+  });
+
+  it("registers one or two prompts, all with client-valid names", () => {
+    expect(PROMPTS.length).toBeGreaterThanOrEqual(1);
+    expect(PROMPTS.length).toBeLessThanOrEqual(2);
+    for (const p of PROMPTS) {
+      expect(p.name).toMatch(/^[a-zA-Z][a-zA-Z0-9_]*$/);
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/durable-insight-mcp/src/sqlSafe.ts
+++ b/packages/durable-insight-mcp/src/sqlSafe.ts
@@ -1,0 +1,123 @@
+/**
+ * SQL value sanitization for the structured tools (`get_execution`,
+ * `list_executions`).
+ *
+ * WHY THIS FILE EXISTS — read before touching a value that reaches SQL:
+ *   Every parameter these tools accept is AGENT-supplied text that ends up
+ *   interpolated into a query string. Athena's `StartQueryExecutionCommand`
+ *   takes a single query string with NO parameter binding, so there is no
+ *   `?`-placeholder to lean on — the only mitigations are (a) validating a value
+ *   against the shape it is allowed to have and rejecting anything else, and
+ *   (b) escaping what remains the exact way core does (doubling single quotes).
+ *
+ *   `assertReadOnly` (invoked inside `runReadOnlyQuery`) is the BACKSTOP, not
+ *   the sanitizer: it rejects a write keyword or an injected second statement,
+ *   but an injected `' OR '1'='1` is still a perfectly valid single SELECT and
+ *   it will happily allow it. Preventing a tautology from ever being built is
+ *   THIS module's job, applied before the SQL string is assembled.
+ *
+ *   This module imports no runner and executes nothing — it only transforms and
+ *   validates strings, so it stays outside the query choke point by design.
+ */
+
+/**
+ * The only execution statuses a WorkflowInsight record can carry (see core's
+ * schema.ts record schemas). `status` is validated against this exact set and a
+ * value outside it is REJECTED — preferred over escaping, because a status is a
+ * closed enumeration and anything else is either a mistake or an attack.
+ */
+export const KNOWN_STATUSES = ["RUNNING", "SUCCEEDED", "FAILED"] as const;
+export type KnownStatus = (typeof KNOWN_STATUSES)[number];
+
+/**
+ * Escape a string for safe interpolation into a single-quoted SQL/PartiQL
+ * literal, the SAME way core does it (`fetchAthenaRecord`,
+ * `fetchDynamoDBRecord`): double every single quote. A closing quote inside the
+ * value therefore cannot terminate the literal, so the value can never break
+ * out into surrounding SQL — it stays one literal, and any `OR`/`;`/`--` inside
+ * it is just literal text.
+ */
+export function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Validate an execution `status`. Returns the value unchanged if it is one of
+ * {@link KNOWN_STATUSES}; throws otherwise. Rejection (not escaping) is the
+ * right mitigation for a closed enumeration.
+ */
+export function validateStatus(status: string): KnownStatus {
+  if ((KNOWN_STATUSES as readonly string[]).includes(status)) {
+    return status as KnownStatus;
+  }
+  throw new Error(
+    `Invalid status "${status}". Must be one of: ${KNOWN_STATUSES.join(", ")}.`,
+  );
+}
+
+/**
+ * ISO-8601 date or date-time, quote-free by construction. Accepts:
+ *   2024-01-31
+ *   2024-01-31T12:34
+ *   2024-01-31T12:34:56
+ *   2024-01-31T12:34:56.789Z
+ *   2024-01-31 12:34:56+00:00
+ * There is deliberately no way for a `'`, `;`, or whitespace-then-keyword to
+ * appear in a value that matches this, so a matching value is safe to
+ * interpolate; a non-matching value is REJECTED rather than escaped.
+ */
+const ISO_TIMESTAMP =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/**
+ * Validate a `since`/`until` bound as an ISO-8601 date or date-time. Returns the
+ * value unchanged if it matches {@link ISO_TIMESTAMP}; throws otherwise. The
+ * matched shape cannot contain a quote, so it is injection-safe by validation.
+ */
+export function validateTimestamp(label: string, value: string): string {
+  if (ISO_TIMESTAMP.test(value)) {
+    return value;
+  }
+  throw new Error(
+    `Invalid ${label} "${value}". Expected an ISO-8601 date or date-time, ` +
+      `e.g. 2024-01-31 or 2024-01-31T12:34:56Z.`,
+  );
+}
+
+/**
+ * An Athena Hive partition component (`year`/`month`/`day`). These are digit
+ * strings by definition (the Glue table projects them as `integer`), so a
+ * value that is not all digits is REJECTED — this both prunes correctly and
+ * makes the value injection-safe (no quote can appear in `\d+`).
+ */
+export function validatePartitionComponent(
+  label: string,
+  value: string,
+): string {
+  if (/^\d{1,4}$/.test(value)) {
+    return value;
+  }
+  throw new Error(
+    `Invalid ${label} "${value}". Expected a numeric partition value (digits only).`,
+  );
+}
+
+/**
+ * Coerce an agent-supplied `limit` to a bounded positive integer in
+ * `[1, max]`, falling back to `fallback` for an absent or non-finite value.
+ * Never returns a value above `max` — the hard row cap cannot be raised through
+ * this parameter.
+ */
+export function coerceLimit(
+  raw: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  if (raw === undefined || !Number.isFinite(raw)) {
+    return Math.min(fallback, max);
+  }
+  const floored = Math.floor(raw);
+  if (floored < 1) return 1;
+  if (floored > max) return max;
+  return floored;
+}

--- a/packages/durable-insight-mcp/src/sqlSafe.ts
+++ b/packages/durable-insight-mcp/src/sqlSafe.ts
@@ -36,8 +36,38 @@ export type KnownStatus = (typeof KNOWN_STATUSES)[number];
  * value therefore cannot terminate the literal, so the value can never break
  * out into surrounding SQL — it stays one literal, and any `OR`/`;`/`--` inside
  * it is just literal text.
+ *
+ * BACKSLASHES ARE REJECTED, NOT ESCAPED, and that asymmetry is deliberate.
+ *
+ * Quote-doubling alone is not sufficient on every engine here. Redshift's own
+ * `QUOTE_LITERAL` "appropriately doubles any embedded single quotation marks AND
+ * BACKSLASHES", which only makes sense because backslash is an escape character in
+ * its string literals (Redshift derives from PostgreSQL 8.0.2, before
+ * `standard_conforming_strings` defaulted on). So a value ending in a single
+ * backslash yields `'foo\'`, where the doubled quote is itself escaped and the
+ * literal continues — the same trailing-backslash breakout that made the log path
+ * need core's `escapeQuotedString`.
+ *
+ * Escaping backslashes instead would be WRONG for the other engines: in
+ * Athena/Trino a backslash is an ordinary character, so doubling it would turn a
+ * search for `foo\` into a search for `foo\\` and quietly return nothing. There is
+ * no single escaping that is correct everywhere.
+ *
+ * Rejection avoids the choice entirely and is lossless in practice: the only values
+ * that reach this function are execution ARNs and Lambda function names, and neither
+ * can legally contain a backslash. Anything that does is malformed input, not a
+ * search term someone lost.
  */
 export function escapeSqlString(value: string): string {
+  if (value.includes("\\")) {
+    throw new Error(
+      `Value contains a backslash, which is not permitted: ${JSON.stringify(value)}. ` +
+        `Backslash is an escape character in some SQL dialects (Redshift) and a ` +
+        `literal character in others (Athena), so no single escaping is correct for ` +
+        `all destinations. Execution ARNs and Lambda function names cannot contain ` +
+        `one.`,
+    );
+  }
   return value.replace(/'/g, "''");
 }
 

--- a/packages/durable-insight-mcp/src/toolDescriptions.test.ts
+++ b/packages/durable-insight-mcp/src/toolDescriptions.test.ts
@@ -1,0 +1,35 @@
+/**
+ * AC-3.3: every registered tool's description must be non-empty and under the
+ * 10,000-character cap (descriptions over ~10k measurably degrade agent
+ * tool-selection). This is the guard that keeps the large `buildSystemPrompt`
+ * guidance in `describe_schema`'s RESULT rather than any tool description —
+ * embedding the guidance in a description makes this suite fail.
+ *
+ * `TOOL_DESCRIPTIONS` is the single source of truth the server registers from,
+ * so asserting over it covers exactly the descriptions that ship.
+ */
+import { TOOL_DESCRIPTIONS } from "./tools";
+
+const DESCRIPTION_CAP = 10_000;
+
+describe("tool descriptions", () => {
+  it("registers exactly the five expected tools", () => {
+    expect(TOOL_DESCRIPTIONS.map((t) => t.name).sort()).toEqual(
+      [
+        "describe_schema",
+        "get_execution",
+        "list_executions",
+        "query",
+        "test_destination",
+      ].sort(),
+    );
+  });
+
+  it.each(TOOL_DESCRIPTIONS)(
+    "$name has a non-empty description under the cap",
+    ({ description }) => {
+      expect(description.length).toBeGreaterThan(0);
+      expect(description.length).toBeLessThan(DESCRIPTION_CAP);
+    },
+  );
+});

--- a/packages/durable-insight-mcp/src/toolWiring.test.ts
+++ b/packages/durable-insight-mcp/src/toolWiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Structural guard: every parameter a tool DECLARES must be read by its handler.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * `query` declared a `limit` parameter, validated it (`.max(MAX_ROWS)`), and
+ * described it to the model as the maximum number of rows to return -- then the
+ * handler destructured only `{ sql, lookbackHours }` and nothing ever read it. An
+ * agent asking for 10 rows got up to 1000. Every existing test passed: the schema
+ * was valid, the description was accurate about the hard cap, and the tool worked.
+ * The only thing wrong was that a promise in the schema had no implementation, and
+ * nothing compared the two halves.
+ *
+ * WHY THIS READS THE AST:
+ * The MCP SDK offers no way to ask a registered tool which arguments its handler
+ * consumes -- once the schema and the callback are inside `registerTool`, the
+ * connection between them is gone. They are only comparable at the source level.
+ * A hand-rolled text scan was tried first and got this wrong (zod chains, template
+ * literals and comments all contain brackets), so this uses the TypeScript parser
+ * the repo already depends on. A guard that breaks on innocuous edits is worse
+ * than no guard, because it gets deleted.
+ *
+ * A DELIBERATE LIMITATION:
+ * This proves a declared parameter is *taken*, not that it changes behavior. A
+ * parameter destructured and then dropped still passes. It catches the specific,
+ * silent mistake of declaring a parameter and forgetting the handler.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as ts from "typescript";
+
+const SERVER_PATH = join(__dirname, "server.ts");
+
+interface RegisteredTool {
+  name: string;
+  declared: string[];
+  destructured: string[];
+}
+
+function parseRegisteredTools(): RegisteredTool[] {
+  const source = ts.createSourceFile(
+    SERVER_PATH,
+    readFileSync(SERVER_PATH, "utf-8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const tools: RegisteredTool[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "registerTool"
+    ) {
+      const [nameArg, configArg, handlerArg] = node.arguments;
+      if (nameArg && ts.isStringLiteral(nameArg)) {
+        const declared: string[] = [];
+        if (configArg && ts.isObjectLiteralExpression(configArg)) {
+          for (const prop of configArg.properties) {
+            if (
+              ts.isPropertyAssignment(prop) &&
+              ts.isIdentifier(prop.name) &&
+              prop.name.text === "inputSchema" &&
+              ts.isObjectLiteralExpression(prop.initializer)
+            ) {
+              for (const field of prop.initializer.properties) {
+                if (field.name && ts.isIdentifier(field.name)) {
+                  declared.push(field.name.text);
+                }
+              }
+            }
+          }
+        }
+
+        const destructured: string[] = [];
+        if (
+          handlerArg &&
+          (ts.isArrowFunction(handlerArg) ||
+            ts.isFunctionExpression(handlerArg)) &&
+          handlerArg.parameters.length > 0
+        ) {
+          const first = handlerArg.parameters[0].name;
+          if (ts.isObjectBindingPattern(first)) {
+            for (const element of first.elements) {
+              const key = element.propertyName ?? element.name;
+              if (ts.isIdentifier(key)) destructured.push(key.text);
+            }
+          }
+        }
+
+        tools.push({ name: nameArg.text, declared, destructured });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return tools;
+}
+
+const tools = parseRegisteredTools();
+const byName = new Map(tools.map((t) => [t.name, t]));
+
+describe("every declared tool parameter is read by its handler", () => {
+  it("parsed all five tools out of server.ts", () => {
+    // Non-vacuity: a silently empty parse would make every assertion below pass
+    // while checking nothing.
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "describe_schema",
+      "get_execution",
+      "list_executions",
+      "query",
+      "test_destination",
+    ]);
+  });
+
+  it("found parameters known to exist", () => {
+    // Aimed at the parser rather than the server: failing here means the parse
+    // broke, not that a tool is wired wrongly.
+    expect(byName.get("query")?.declared).toEqual(
+      expect.arrayContaining(["sql", "limit", "lookbackHours"]),
+    );
+    expect(byName.get("get_execution")?.declared).toEqual(
+      expect.arrayContaining(["executionArn", "year", "month", "day"]),
+    );
+    expect(byName.get("query")?.destructured).toContain("sql");
+  });
+
+  it.each(tools.map((t) => [t.name, t] as const))(
+    "%s reads every parameter it declares",
+    (_name, tool) => {
+      const unread = tool.declared.filter(
+        (p) => !tool.destructured.includes(p),
+      );
+      // A parameter here is one the model is told about, may spend tokens
+      // setting, and which cannot possibly have an effect.
+      expect(unread).toEqual([]);
+    },
+  );
+
+  it.each(tools.map((t) => [t.name, t] as const))(
+    "%s declares every parameter its handler destructures",
+    (_name, tool) => {
+      // The mirror direction: a handler argument the schema never declares can
+      // only ever be undefined.
+      const undeclared = tool.destructured.filter(
+        (p) => !tool.declared.includes(p),
+      );
+      expect(undeclared).toEqual([]);
+    },
+  );
+});

--- a/packages/durable-insight-mcp/src/tools.test.ts
+++ b/packages/durable-insight-mcp/src/tools.test.ts
@@ -72,9 +72,47 @@ describe("describe_schema result", () => {
     expect(r.guidance.length).toBeGreaterThan(500);
   });
 
-  it("throws for an unsupported destination this phase", () => {
-    expect(() => buildDescribeSchemaResult(cfgFor("aurora"))).toThrow(/aurora/);
+  // T4.1: describe_schema now covers all five SQL destinations. buildSystemPrompt
+  // already had guidance for all 8 types, so this needed no per-engine work —
+  // this asserts each supported type returns a sensible, non-trivial result with
+  // the right engine label and a self-consistent guidanceLength.
+  it.each([
+    ["s3", "Trino/Presto SQL", "Trino/Presto SQL"],
+    ["dynamodb", "PartiQL", "PartiQL"],
+    ["aurora", "PostgreSQL", "PostgreSQL"],
+    ["redshift", "Redshift SQL", "Redshift SQL"],
+    ["opensearch", "OpenSearch SQL", "OpenSearch SQL"],
+  ] as const)(
+    "%s: engine=%s, guidance is non-trivial and self-consistent",
+    (dest, engine, needle) => {
+      const r = buildDescribeSchemaResult(cfgFor(dest));
+      expect(r.destinationType).toBe(dest);
+      expect(r.engine).toBe(engine);
+      expect(r.maxRows).toBe(MAX_ROWS);
+      expect(r.guidance.length).toBeGreaterThan(500);
+      expect(r.guidanceLength).toBe(r.guidance.length);
+      expect(r.guidance).toContain(needle);
+    },
+  );
+
+  it("throws for a non-queryable destination (SQS)", () => {
+    // SQS is a message queue, not a queryable store; describe_schema must
+    // reject it by naming the type.
+    expect(() => buildDescribeSchemaResult(cfgFor("sqs"))).toThrow(/sqs/);
   });
+
+  it.each([["cloudwatch-logs-exporter"], ["lambda-log-exporter"]] as const)(
+    "%s: now supported — reports the CloudWatch Logs Insights engine with guidance",
+    (dest) => {
+      // As of Phase 4 the log destinations ARE supported (Logs Insights, not
+      // SQL). describe_schema returns the logs engine and non-empty guidance
+      // rather than throwing.
+      const r = buildDescribeSchemaResult(cfgFor(dest));
+      expect(r.engine).toBe("CloudWatch Logs Insights");
+      expect(r.guidance.length).toBeGreaterThan(0);
+      expect(r.guidanceLength).toBe(r.guidance.length);
+    },
+  );
 });
 
 describe("get_execution found semantics", () => {

--- a/packages/durable-insight-mcp/src/tools.test.ts
+++ b/packages/durable-insight-mcp/src/tools.test.ts
@@ -9,6 +9,7 @@ import {
   runDynamoDBQuery,
   runAuroraQuery,
   runRedshiftQuery,
+  runLogsInsightsQuery,
   fetchLogsInsightsRecord,
   resolveCredentials,
   type InsightConfig,
@@ -31,6 +32,7 @@ jest.mock("@aws/durable-insight-core", () => {
     runDynamoDBQuery: jest.fn(),
     runAuroraQuery: jest.fn(),
     runRedshiftQuery: jest.fn(),
+    runLogsInsightsQuery: jest.fn(),
     fetchLogsInsightsRecord: jest.fn(),
     resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
   };
@@ -41,6 +43,9 @@ const runAuroraMock = runAuroraQuery as jest.MockedFunction<
 >;
 const runRedshiftMock = runRedshiftQuery as jest.MockedFunction<
   typeof runRedshiftQuery
+>;
+const runLogsMock = runLogsInsightsQuery as jest.MockedFunction<
+  typeof runLogsInsightsQuery
 >;
 const logsRecordMock = fetchLogsInsightsRecord as jest.MockedFunction<
   typeof fetchLogsInsightsRecord
@@ -272,5 +277,167 @@ describe("get_execution reports its window and its ignored parameters", () => {
       executionArn: ARN,
     });
     expect(result.ignoredParams).toBeUndefined();
+  });
+});
+
+/**
+ * The Logs Insights API window must cover the range the caller asked to filter on.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * A Logs Insights result is bounded by TWO things: the `StartQuery` window, and the
+ * `filter` stages inside the pipe query. `since`/`until` only ever became filters,
+ * while the window stayed at its 24-hour default -- so `list_executions({ since:
+ * <a week ago> })` scanned one day, applied a filter that everything in that day
+ * satisfied, and returned a plausible partial answer with `truncated: false`. Nothing
+ * in the result hinted six days were missing, which is the worst version of this bug:
+ * an agent will state a partial answer as a complete one.
+ *
+ * These assert on the window handed to the runner, not on the query text, because the
+ * query text was already correct -- that is exactly why the bug was invisible.
+ */
+describe("list_executions derives the log scan window from its bounds", () => {
+  const LOGS = "cloudwatch-logs-exporter";
+  const emptyLogs = { columns: [], rows: [], count: 0 };
+  const windowHours = () => {
+    const call = runLogsMock.mock.calls[0][0];
+    return (call.endTimeMs - call.startTimeMs) / (60 * 60 * 1000);
+  };
+
+  beforeEach(() => {
+    runLogsMock.mockResolvedValue(emptyLogs);
+  });
+
+  it("scans back to `since` rather than the 24-hour default", async () => {
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const result = await runListExecutions(cfgFor(LOGS), { since });
+    // A week, not a day. Anything at or below 24 means the window ignored `since`.
+    expect(windowHours()).toBeGreaterThan(7 * 24);
+    expect(result.searchedLookbackHours).toBeGreaterThan(7 * 24);
+  });
+
+  it("never scans less than the requested span", async () => {
+    // The margin exists so an exact boundary cannot clip the oldest matching event.
+    for (const days of [1, 3, 30, 365]) {
+      runLogsMock.mockClear();
+      const since = new Date(
+        Date.now() - days * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      await runListExecutions(cfgFor(LOGS), { since });
+      expect(windowHours()).toBeGreaterThanOrEqual(days * 24);
+    }
+  });
+
+  it("uses the 24-hour default when no bound is given", async () => {
+    const result = await runListExecutions(cfgFor(LOGS), {});
+    expect(windowHours()).toBe(24);
+    expect(result.searchedLookbackHours).toBe(24);
+  });
+
+  it("lets an explicit lookbackHours win over since", async () => {
+    const since = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    await runListExecutions(cfgFor(LOGS), { since, lookbackHours: 500 });
+    // The caller stated the window outright; deriving a narrower one from `since`
+    // would override an explicit instruction.
+    expect(windowHours()).toBe(500);
+  });
+
+  it.each(["not-a-date", ""])(
+    "rejects an unparseable since (%s) before any window is computed",
+    async (since) => {
+      // Worth pinning the ORDER: the query builder runs first and validates the
+      // timestamp shape, so a malformed bound is a clean rejection rather than a
+      // silent fall back to 24 hours. `logWindowFor`'s own fallback is therefore
+      // unreachable through this tool -- it exists so the helper is total, not
+      // because a bad value can arrive here.
+      await expect(runListExecutions(cfgFor(LOGS), { since })).rejects.toThrow(
+        /Invalid since/,
+      );
+      expect(runLogsMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores a future since rather than scanning a negative window", async () => {
+    const since = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await runListExecutions(cfgFor(LOGS), { since });
+    expect(windowHours()).toBe(24);
+  });
+
+  it("reports no window for SQL destinations, which are not time-scoped", async () => {
+    // Acceptance: reporting one on Aurora would imply a bound that does not exist.
+    runAuroraMock.mockResolvedValue({
+      columns: [],
+      rows: [],
+      count: 0,
+      numericColumns: [],
+    });
+    const result = await runListExecutions(cfgFor("aurora"), {
+      since: new Date(Date.now() - 7 * 864e5).toISOString(),
+    });
+    expect(result.searchedLookbackHours).toBeUndefined();
+  });
+});
+
+/**
+ * The Redshift query target must be schema-qualified.
+ *
+ * THE FAILURE THIS PREVENTS:
+ * `redshiftSchema` is a documented setting defaulting to `public`, and core qualifies
+ * with it everywhere it builds Redshift SQL. This package used the bare table name,
+ * which passed every test because with `public` the unqualified name resolves through
+ * `search_path` identically. With DURABLE_INSIGHT_REDSHIFT_SCHEMA set to anything
+ * else, the same SQL silently reads a DIFFERENT table, or fails.
+ *
+ * `describe_schema` is asserted alongside the generated SQL because a target the agent
+ * is TAUGHT that differs from the one queried is its own bug: it would write
+ * correct-looking SQL against a table nobody is reading.
+ */
+describe("redshift targets are schema-qualified", () => {
+  const withSchema = (schema: string): InsightConfig =>
+    configFromWireSettings({
+      destinationType: "redshift",
+      redshiftWorkgroupName: "wg",
+      redshiftSchema: schema,
+      redshiftTable: "workflow_insight",
+    });
+
+  beforeEach(() => {
+    runRedshiftMock.mockResolvedValue({
+      columns: [],
+      rows: [],
+      count: 0,
+      numericColumns: [],
+    });
+  });
+
+  it.each(["analytics", "reporting"])(
+    "qualifies list_executions SQL with schema %s",
+    async (schema) => {
+      await runListExecutions(withSchema(schema), {});
+      expect(runRedshiftMock.mock.calls[0][0].sql).toContain(
+        `${schema}.workflow_insight`,
+      );
+    },
+  );
+
+  it("qualifies get_execution SQL", async () => {
+    await runGetExecution(withSchema("analytics"), { executionArn: ARN });
+    expect(runRedshiftMock.mock.calls[0][0].sql).toContain(
+      "analytics.workflow_insight",
+    );
+  });
+
+  it("teaches describe_schema the same qualified target", async () => {
+    const result = buildDescribeSchemaResult(withSchema("analytics"));
+    // If these two ever disagree the agent writes SQL against the wrong table.
+    expect(result.table).toBe("analytics.workflow_insight");
+  });
+
+  it("still qualifies with the public default", async () => {
+    // The default is where this hid: `public.workflow_insight` and
+    // `workflow_insight` behave the same, so only an explicit assertion pins it.
+    await runListExecutions(withSchema(""), {});
+    expect(runRedshiftMock.mock.calls[0][0].sql).toContain(
+      "public.workflow_insight",
+    );
   });
 });

--- a/packages/durable-insight-mcp/src/tools.test.ts
+++ b/packages/durable-insight-mcp/src/tools.test.ts
@@ -7,6 +7,9 @@ import {
   configFromWireSettings,
   runAthenaQuery,
   runDynamoDBQuery,
+  runAuroraQuery,
+  runRedshiftQuery,
+  fetchLogsInsightsRecord,
   resolveCredentials,
   type InsightConfig,
 } from "@aws/durable-insight-core";
@@ -15,6 +18,7 @@ import {
   buildDescribeSchemaResult,
   runGetExecution,
   runListExecutions,
+  DEFAULT_RECORD_LOOKBACK_HOURS,
 } from "./tools";
 
 jest.mock("@aws/durable-insight-core", () => {
@@ -25,10 +29,24 @@ jest.mock("@aws/durable-insight-core", () => {
     ...actual,
     runAthenaQuery: jest.fn(),
     runDynamoDBQuery: jest.fn(),
+    runAuroraQuery: jest.fn(),
+    runRedshiftQuery: jest.fn(),
+    fetchLogsInsightsRecord: jest.fn(),
     resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
   };
 });
 
+const runAuroraMock = runAuroraQuery as jest.MockedFunction<
+  typeof runAuroraQuery
+>;
+const runRedshiftMock = runRedshiftQuery as jest.MockedFunction<
+  typeof runRedshiftQuery
+>;
+const logsRecordMock = fetchLogsInsightsRecord as jest.MockedFunction<
+  typeof fetchLogsInsightsRecord
+>;
+/** A representative execution ARN for point lookups. */
+const ARN = "arn:aws:lambda:us-east-1:123456789012:function:fn:1#exec-1";
 const runAthenaMock = runAthenaQuery as jest.MockedFunction<
   typeof runAthenaQuery
 >;
@@ -122,6 +140,7 @@ describe("get_execution found semantics", () => {
       rows: [],
       count: 0,
       numericColumns: [],
+      hasMore: false,
     });
     const r = await runGetExecution(cfgFor("dynamodb"), {
       executionArn: "nope",
@@ -137,6 +156,7 @@ describe("get_execution found semantics", () => {
       rows: [["arn:1", "SUCCEEDED"]],
       count: 1,
       numericColumns: [false, false],
+      hasMore: false,
     });
     const r = await runGetExecution(cfgFor("dynamodb"), {
       executionArn: "arn:1",
@@ -160,5 +180,97 @@ describe("list_executions result shape", () => {
     expect(r.columns).toEqual(["executionarn", "status"]);
     expect(r.count).toBe(1);
     expect(r.truncated).toBe(false);
+  });
+});
+
+/**
+ * `get_execution` must say what it searched, and what it ignored.
+ *
+ * TWO FAILURES THIS PREVENTS:
+ *
+ *   1. On a log destination the lookup inherited core's 7-day window with no way to
+ *      widen it, and reported a miss as `found: false` -- identical to the result for
+ *      an execution that never existed. An agent cannot distinguish "not in the last
+ *      week" from "does not exist", so it will confidently report the wrong one.
+ *
+ *   2. `year`/`month`/`day` are Athena partition hints. Passing them to any other
+ *      destination produced no error, no warning and no change in behavior, which
+ *      teaches an agent they worked.
+ */
+describe("get_execution reports its window and its ignored parameters", () => {
+  it("reports the default window when none is given", async () => {
+    logsRecordMock.mockResolvedValueOnce(undefined);
+    const result = await runGetExecution(cfgFor("cloudwatch-logs-exporter"), {
+      executionArn: ARN,
+    });
+    expect(result.found).toBe(false);
+    // Without this an agent cannot tell a miss from an absence.
+    expect(result.searchedLookbackHours).toBe(DEFAULT_RECORD_LOOKBACK_HOURS);
+  });
+
+  it("passes a wider window through to core and reports it", async () => {
+    logsRecordMock.mockResolvedValueOnce(undefined);
+    const result = await runGetExecution(cfgFor("cloudwatch-logs-exporter"), {
+      executionArn: ARN,
+      lookbackHours: 720,
+    });
+    expect(logsRecordMock.mock.calls[0][0].lookbackMs).toBe(
+      720 * 60 * 60 * 1000,
+    );
+    expect(result.searchedLookbackHours).toBe(720);
+  });
+
+  it.each([0, -5])(
+    "falls back to the default for a %s window",
+    async (lookbackHours) => {
+      logsRecordMock.mockResolvedValueOnce(undefined);
+      const result = await runGetExecution(cfgFor("cloudwatch-logs-exporter"), {
+        executionArn: ARN,
+        lookbackHours,
+      });
+      // A zero-hour window would search nothing and always report found=false.
+      expect(result.searchedLookbackHours).toBe(DEFAULT_RECORD_LOOKBACK_HOURS);
+    },
+  );
+
+  it.each(["dynamodb", "aurora", "redshift"])(
+    "reports year/month/day as ignored on %s",
+    async (destination) => {
+      const empty = {
+        columns: [],
+        rows: [],
+        count: 0,
+        numericColumns: [],
+        hasMore: false,
+      };
+      runDynamoDBMock.mockResolvedValue(empty);
+      runAuroraMock.mockResolvedValue(empty);
+      runRedshiftMock.mockResolvedValue(empty);
+      const result = await runGetExecution(cfgFor(destination), {
+        executionArn: ARN,
+        year: "2024",
+        month: "01",
+      });
+      expect(result.ignoredParams).toEqual(["year", "month"]);
+    },
+  );
+
+  it("does not report partition params as ignored on s3", async () => {
+    // Acceptance: on Athena they prune the scan, so flagging them there would be
+    // wrong and would train the agent to stop sending them.
+    const result = await runGetExecution(cfgFor("s3"), {
+      executionArn: ARN,
+      year: "2024",
+      month: "01",
+      day: "31",
+    });
+    expect(result.ignoredParams).toBeUndefined();
+  });
+
+  it("omits ignoredParams entirely when nothing was ignored", async () => {
+    const result = await runGetExecution(cfgFor("dynamodb"), {
+      executionArn: ARN,
+    });
+    expect(result.ignoredParams).toBeUndefined();
   });
 });

--- a/packages/durable-insight-mcp/src/tools.test.ts
+++ b/packages/durable-insight-mcp/src/tools.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Functional tests for the structured tools' RESULT shapes (AC-3.2: every
+ * result is machine-readable data, never prose). Injection/escaping is covered
+ * separately in `injection.test.ts`.
+ */
+import {
+  configFromWireSettings,
+  runAthenaQuery,
+  runDynamoDBQuery,
+  resolveCredentials,
+  type InsightConfig,
+} from "durable-insight-core";
+import { MAX_ROWS } from "./readOnlyQuery";
+import {
+  buildDescribeSchemaResult,
+  runGetExecution,
+  runListExecutions,
+} from "./tools";
+
+jest.mock("durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("durable-insight-core")>(
+    "durable-insight-core",
+  );
+  return {
+    ...actual,
+    runAthenaQuery: jest.fn(),
+    runDynamoDBQuery: jest.fn(),
+    resolveCredentials: jest.fn(() => "FAKE_CREDENTIALS"),
+  };
+});
+
+const runAthenaMock = runAthenaQuery as jest.MockedFunction<
+  typeof runAthenaQuery
+>;
+const runDynamoDBMock = runDynamoDBQuery as jest.MockedFunction<
+  typeof runDynamoDBQuery
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+function cfgFor(destinationType: string): InsightConfig {
+  return configFromWireSettings({
+    destinationType,
+    region: "us-east-1",
+    dynamodbTableName: "my_ddb_table",
+    athenaDatabase: "insight_db",
+    athenaTable: "my_athena_table",
+    athenaOutputLocation: "s3://results-bucket/athena/",
+  });
+}
+
+describe("describe_schema result", () => {
+  it("dynamodb: PartiQL label, table, cap, and the SDK guidance in the result", () => {
+    const r = buildDescribeSchemaResult(cfgFor("dynamodb"));
+    expect(r.destinationType).toBe("dynamodb");
+    expect(r.engine).toBe("PartiQL");
+    expect(r.table).toBe("my_ddb_table");
+    expect(r.maxRows).toBe(MAX_ROWS);
+    // Guidance is present, non-trivial, and its measured length matches.
+    expect(r.guidance.length).toBeGreaterThan(500);
+    expect(r.guidanceLength).toBe(r.guidance.length);
+    // The whole point: the guidance is far larger than any tool description,
+    // which is why it lives in the result and not a description.
+    expect(r.guidance).toContain("PartiQL");
+  });
+
+  it("s3: Trino/Presto SQL label and the Athena table in play", () => {
+    const r = buildDescribeSchemaResult(cfgFor("s3"));
+    expect(r.engine).toBe("Trino/Presto SQL");
+    expect(r.table).toBe("my_athena_table");
+    expect(r.guidanceLength).toBe(r.guidance.length);
+    expect(r.guidance.length).toBeGreaterThan(500);
+  });
+
+  it("throws for an unsupported destination this phase", () => {
+    expect(() => buildDescribeSchemaResult(cfgFor("aurora"))).toThrow(/aurora/);
+  });
+});
+
+describe("get_execution found semantics", () => {
+  it("reports found=false for a missing record (a success, not an error)", async () => {
+    runDynamoDBMock.mockResolvedValue({
+      columns: [],
+      rows: [],
+      count: 0,
+      numericColumns: [],
+    });
+    const r = await runGetExecution(cfgFor("dynamodb"), {
+      executionArn: "nope",
+    });
+    expect(r.found).toBe(false);
+    expect(r.record).toBeUndefined();
+    expect(r.executionArn).toBe("nope");
+  });
+
+  it("reports found=true and maps columns/rows into a record", async () => {
+    runDynamoDBMock.mockResolvedValue({
+      columns: ["pk", "status"],
+      rows: [["arn:1", "SUCCEEDED"]],
+      count: 1,
+      numericColumns: [false, false],
+    });
+    const r = await runGetExecution(cfgFor("dynamodb"), {
+      executionArn: "arn:1",
+    });
+    expect(r.found).toBe(true);
+    expect(r.record).toEqual({ pk: "arn:1", status: "SUCCEEDED" });
+  });
+});
+
+describe("list_executions result shape", () => {
+  it("returns normalized columns/rows/count/truncated", async () => {
+    runAthenaMock.mockResolvedValue({
+      columns: ["executionarn", "status"],
+      rows: [["arn:1", "FAILED"]],
+      count: 1,
+      numericColumns: [false, false],
+      truncated: false,
+    });
+    const r = await runListExecutions(cfgFor("s3"), { status: "FAILED" });
+    expect(r.engine).toBe("Trino/Presto SQL");
+    expect(r.columns).toEqual(["executionarn", "status"]);
+    expect(r.count).toBe(1);
+    expect(r.truncated).toBe(false);
+  });
+});

--- a/packages/durable-insight-mcp/src/tools.test.ts
+++ b/packages/durable-insight-mcp/src/tools.test.ts
@@ -9,7 +9,7 @@ import {
   runDynamoDBQuery,
   resolveCredentials,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import { MAX_ROWS } from "./readOnlyQuery";
 import {
   buildDescribeSchemaResult,
@@ -17,9 +17,9 @@ import {
   runListExecutions,
 } from "./tools";
 
-jest.mock("durable-insight-core", () => {
-  const actual = jest.requireActual<typeof import("durable-insight-core")>(
-    "durable-insight-core",
+jest.mock("@aws/durable-insight-core", () => {
+  const actual = jest.requireActual<typeof import("@aws/durable-insight-core")>(
+    "@aws/durable-insight-core",
   );
   return {
     ...actual,

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -36,6 +36,7 @@ import {
   type InsightConfig,
 } from "@aws/durable-insight-core";
 import {
+  DEFAULT_LOG_TIME_RANGE_MS,
   LOGS_INSIGHTS_ENGINE,
   MAX_ROWS,
   runReadOnlyQuery,
@@ -132,6 +133,30 @@ function isLogDestination(cfg: InsightConfig): boolean {
 }
 
 /** Engine label + table name for a destination, matching `readOnlyQuery.ts`. */
+/**
+ * The Redshift query target, schema-qualified.
+ *
+ * `redshiftSchema` is a documented setting that defaults to `public`, and core
+ * qualifies with it everywhere it builds Redshift SQL (`explorerSession.ts` in three
+ * places, `destinationTest.ts` in one). This package used the bare table name, which
+ * survived every test for a reason worth knowing: with the default `public` the
+ * unqualified name resolves through `search_path` and behaves identically. Set
+ * DURABLE_INSIGHT_REDSHIFT_SCHEMA to anything else and the same SQL silently reads a
+ * DIFFERENT table, or fails.
+ *
+ * Both the generated SQL and the guidance `describe_schema` hands the agent go
+ * through here, because a target the agent is TAUGHT that differs from the target
+ * queried is its own bug: the agent would write correct-looking SQL against a table
+ * that is not the one being read.
+ *
+ * Only Redshift is qualified this way, matching core exactly: Aurora has no schema
+ * setting, Athena's database is passed to the runner as a separate parameter, and
+ * DynamoDB and OpenSearch have no schema concept.
+ */
+function redshiftTarget(cfg: InsightConfig): string {
+  return `${cfg.redshiftSchema}.${cfg.redshiftTable}`;
+}
+
 function engineAndTable(cfg: InsightConfig): { engine: string; table: string } {
   switch (cfg.destinationType) {
     case "dynamodb":
@@ -141,7 +166,7 @@ function engineAndTable(cfg: InsightConfig): { engine: string; table: string } {
     case "aurora":
       return { engine: "PostgreSQL", table: cfg.auroraTable };
     case "redshift":
-      return { engine: "Redshift SQL", table: cfg.redshiftTable };
+      return { engine: "Redshift SQL", table: redshiftTarget(cfg) };
     case "opensearch":
       // The OpenSearch "table" is the index; buildSystemPrompt wraps it in
       // backticks in the FROM clause it generates.
@@ -357,7 +382,7 @@ function dialectFor(cfg: InsightConfig): Dialect {
     case "redshift":
       return {
         engine: "Redshift SQL",
-        from: cfg.redshiftTable,
+        from: redshiftTarget(cfg),
         idColumn: "execution_arn",
         listSelect:
           "execution_arn, status, function_name, start_time, end_time, duration_ms",
@@ -552,12 +577,65 @@ export async function runGetExecution(
 
 // ── list_executions ──────────────────────────────────────────────────────────
 
+/**
+ * Resolve the Logs Insights API window for a `list_executions` call.
+ *
+ * PRECEDENCE, and why:
+ *   1. An explicit `lookbackHours` wins -- the caller stated the window outright.
+ *   2. Otherwise `since` derives it, because a lower bound the caller asked to filter
+ *      on is worthless if the API never scanned that far back.
+ *   3. Otherwise the 24-hour default, matching `query`.
+ *
+ * The derived window is rounded UP to the next whole hour and given a small margin,
+ * so a `since` of "exactly 7 days ago" cannot land a fraction of a second inside the
+ * boundary and clip the oldest matching event.
+ *
+ * An unparseable `since` falls back to the default rather than throwing, which keeps
+ * this helper total. Note that this branch is UNREACHABLE through the tool: the query
+ * is built first, and `validateTimestamp` rejects a malformed bound there, so a bad
+ * value never arrives here. `tools.test.ts` pins that ordering, since it is the
+ * difference between a clean rejection and a silent 24-hour window.
+ */
+function logWindowFor(params: ListExecutionsParams): {
+  timeRangeMs: number;
+  lookbackHours: number;
+} {
+  const fromHours = (hours: number) => ({
+    timeRangeMs: hours * 60 * 60 * 1000,
+    lookbackHours: hours,
+  });
+
+  if (params.lookbackHours !== undefined && params.lookbackHours > 0) {
+    return fromHours(params.lookbackHours);
+  }
+
+  if (params.since !== undefined) {
+    const sinceMs = Date.parse(params.since);
+    if (!Number.isNaN(sinceMs)) {
+      const spanMs = Date.now() - sinceMs;
+      if (spanMs > 0) {
+        // +1 hour of margin, then round up: never scan less than asked for.
+        const hours = Math.ceil(spanMs / (60 * 60 * 1000)) + 1;
+        return fromHours(hours);
+      }
+    }
+  }
+
+  return fromHours(DEFAULT_LOG_TIME_RANGE_MS / (60 * 60 * 1000));
+}
+
 export interface ListExecutionsParams {
   status?: string;
   since?: string;
   until?: string;
   functionName?: string;
   limit?: number;
+  /**
+   * Log destinations only: how many hours back `StartQuery` should scan. Normally
+   * unnecessary -- when `since` is given the window is derived from it -- but needed
+   * to widen a search that has no lower bound.
+   */
+  lookbackHours?: number;
 }
 
 /**
@@ -734,6 +812,15 @@ export interface ListExecutionsResult {
   rows: string[][];
   count: number;
   truncated: boolean;
+  /**
+   * The window `StartQuery` actually scanned, in hours, for log destinations.
+   *
+   * Reported because a Logs Insights result is bounded by TWO things that can
+   * disagree: the API window, and the `filter` stages inside the query. If the window
+   * is narrower than the filters ask for, the result is silently partial -- so the
+   * window has to be visible to be trusted.
+   */
+  searchedLookbackHours?: number;
 }
 
 /**
@@ -750,6 +837,19 @@ export async function runListExecutions(
   const query = isLogDestination(cfg)
     ? buildListExecutionsLogsQuery(cfg, params)
     : buildListExecutionsSql(cfg, params);
+
+  // On a log destination `since`/`until` are only `filter` stages INSIDE the pipe
+  // query. The API window is separate, and defaulted to 24 hours -- so asking for
+  // executions since last week scanned one day, applied a filter that everything in
+  // that day satisfied, and returned a plausible partial answer with
+  // `truncated: false`. Nothing in the result hinted that six days were missing.
+  //
+  // The window is therefore derived from the bounds the caller actually gave. It is
+  // deliberately a SUPERSET of `[since, until]`: `timeRangeMs` is a duration measured
+  // back from now, so an `until` in the past cannot narrow the top of the window --
+  // the in-query filters do that. A superset returns correct results; a subset is the
+  // bug being fixed.
+  const logWindow = isLogDestination(cfg) ? logWindowFor(params) : undefined;
   // Also pass the caller's limit as the row cap, NOT only as query text. For most
   // destinations the generated `LIMIT`/`limit` already bounds the result, but
   // DynamoDB PartiQL supports neither ORDER BY nor LIMIT, so its statement carries
@@ -757,6 +857,7 @@ export async function runListExecutions(
   // rows, which is the token cost this tool exists to avoid.
   const result = await runReadOnlyQuery(cfg, query, {
     maxRows: coerceLimit(params.limit, DEFAULT_LIST_LIMIT, MAX_ROWS),
+    ...(logWindow !== undefined ? { timeRangeMs: logWindow.timeRangeMs } : {}),
   });
   return {
     destinationType: cfg.destinationType,
@@ -765,5 +866,8 @@ export async function runListExecutions(
     rows: result.rows,
     count: result.count,
     truncated: result.truncated,
+    ...(logWindow !== undefined
+      ? { searchedLookbackHours: logWindow.lookbackHours }
+      : {}),
   };
 }

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -172,6 +172,41 @@ export interface DescribeSchemaResult {
   maxRows: number;
   guidance: string;
   guidanceLength: number;
+  /**
+   * How to actually run the SQL that `guidance` teaches you to write. Present
+   * because `guidance` comes from a function shared with the VS Code extension,
+   * whose closing instruction names tools that do not exist in this host -- see
+   * `stripForeignToolInstruction`.
+   */
+  howToRun: string;
+}
+
+/**
+ * Tools that exist in the VS Code extension's own LLM loop but NOT in this MCP
+ * host. `buildSystemPrompt` ends with an instruction to call one of them, which
+ * is wrong here: an agent that followed it would call an unknown tool and stall.
+ *
+ * Found by running `describe_schema` against a real Aurora destination -- the
+ * unit tests asserted the guidance was long and self-consistent, which it was;
+ * they could not know that its closing sentence addressed a different host.
+ */
+const FOREIGN_TOOL_MARKERS = ['Call the "emit_query" tool', "emit_query"];
+
+/**
+ * Remove the trailing "call <extension tool>" instruction from shared guidance,
+ * keeping the part that is actually valuable here: the record schema and the
+ * per-destination query idioms.
+ *
+ * Deliberately conservative. If the marker is absent (because core reworded it)
+ * the guidance is returned untouched rather than being cut at a guess, and
+ * `howToRun` still tells the agent what to do. `describeSchema.test.ts` asserts
+ * the returned guidance never mentions a foreign tool, so a reword that breaks
+ * this is caught rather than silently shipped.
+ */
+function stripForeignToolInstruction(guidance: string): string {
+  const idx = guidance.indexOf(FOREIGN_TOOL_MARKERS[0]);
+  if (idx === -1) return guidance.trim();
+  return guidance.slice(0, idx).trim();
 }
 
 /**
@@ -185,9 +220,11 @@ export function buildDescribeSchemaResult(
   cfg: InsightConfig,
 ): DescribeSchemaResult {
   const { engine, table } = engineAndTable(cfg);
-  const guidance = buildSystemPrompt(cfg.destinationType, {
-    tableName: table || undefined,
-  });
+  const guidance = stripForeignToolInstruction(
+    buildSystemPrompt(cfg.destinationType, {
+      tableName: table || undefined,
+    }),
+  );
   return {
     destinationType: cfg.destinationType,
     engine,
@@ -195,6 +232,11 @@ export function buildDescribeSchemaResult(
     maxRows: MAX_ROWS,
     guidance,
     guidanceLength: guidance.length,
+    howToRun:
+      `Run the SQL you write with the "query" tool. Prefer "list_executions" ` +
+      `for simple filtered listings and "get_execution" to fetch one record by ` +
+      `ARN. Results are capped at ${MAX_ROWS} rows. Only read queries are ` +
+      `permitted; anything that is not SELECT/WITH is refused.`,
   };
 }
 

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -1,0 +1,346 @@
+/**
+ * The structured Insight tools: `describe_schema`, `get_execution`,
+ * `list_executions`, plus the two tools' shared descriptions.
+ *
+ * DESIGN — every caller-supplied value reaches SQL through ONE path:
+ *   `get_execution` and `list_executions` both BUILD a SELECT here and execute
+ *   it through {@link runReadOnlyQuery} — the package's single query choke
+ *   point — so they inherit `assertReadOnly` and the {@link MAX_ROWS} row cap
+ *   for free. Neither imports a core runner (that is what
+ *   `queryChokePoint.test.ts` enforces). We deliberately do NOT call core's
+ *   `fetchAthenaRecord`/`fetchDynamoDBRecord` for `get_execution`: those escape
+ *   internally, which would (a) route caller SQL AROUND the choke point /
+ *   `assertReadOnly`, and (b) make the escaping in THIS package non-load-bearing
+ *   (it lives in core, which we may not modify). Building the SELECT here keeps
+ *   the sanitization — and the responsibility for it — in this package, and
+ *   under the same read-only guard as every other query.
+ *
+ *   The values themselves are sanitized in `sqlSafe.ts` BEFORE the string is
+ *   assembled: a closed enum (`status`) and partition digits are VALIDATED (and
+ *   a bad value rejected), free-form text (`functionName`, the execution id) is
+ *   quote-escaped exactly as core does. `assertReadOnly` is the backstop, never
+ *   the sanitizer — an injected `' OR '1'='1` is a valid SELECT it would allow.
+ *
+ * DESCRIPTIONS — a tool description must stay small. Descriptions over ~10,000
+ *   characters measurably degrade agent tool-selection, so the large,
+ *   destination-specific schema guidance (from core's `buildSystemPrompt`) is
+ *   returned by `describe_schema` in its RESULT, never embedded in a
+ *   description. `toolDescriptions.test.ts` asserts every description here is
+ *   non-empty and under the cap.
+ */
+import { buildSystemPrompt, type InsightConfig } from "durable-insight-core";
+import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
+import {
+  coerceLimit,
+  escapeSqlString,
+  validatePartitionComponent,
+  validateStatus,
+  validateTimestamp,
+} from "./sqlSafe";
+
+/** Default number of rows `list_executions` returns when no `limit` is given. */
+export const DEFAULT_LIST_LIMIT = 100;
+
+// ── Tool descriptions (kept small; see the file header) ──────────────────────
+
+/**
+ * One or two sentences, well under the 10,000-char cap. Bulk detail lives in the
+ * tool result (machine-readable JSON), not in this description.
+ */
+export const TEST_DESTINATION_DESCRIPTION =
+  "Run read-only connectivity and completeness checks against the configured " +
+  "Insight destination (configured via DURABLE_INSIGHT_* environment variables) " +
+  "and return a machine-readable JSON report. If required environment variables " +
+  "are unset it names them and returns without making any AWS calls.";
+
+/**
+ * Short by design (well under the 10,000-char cap). The security contract — the
+ * query is validated read-only before any AWS call — is stated so the agent
+ * knows a write will be refused rather than silently mutating data.
+ */
+export const QUERY_DESCRIPTION =
+  "Execute a single READ-ONLY SQL/PartiQL query against the configured Insight " +
+  "destination (set via DURABLE_INSIGHT_* environment variables) and return the " +
+  "result as machine-readable JSON (columns, rows, count, truncated, engine, " +
+  "destinationType). Only SELECT/WITH is permitted: any data-modifying or DDL " +
+  "statement is rejected before any AWS call is made. Results are capped at " +
+  `${MAX_ROWS} rows; "truncated" is true when the cap was hit. If required ` +
+  "environment variables are unset it names them and returns without calling AWS.";
+
+export const DESCRIBE_SCHEMA_DESCRIPTION =
+  "Describe the configured Insight destination's record schema and query " +
+  "idioms as machine-readable JSON: the destination type, the query engine/" +
+  "dialect label, the table (or log group) in play, the row cap, and a large " +
+  "guidance string (from the SDK) covering the record fields and dialect-" +
+  "specific query patterns. Call this before writing a query so the query you " +
+  "pass to the `query` tool uses the right field names and syntax.";
+
+export const GET_EXECUTION_DESCRIPTION =
+  "Fetch a single Workflow Insight execution record by its execution ARN and " +
+  "return it as machine-readable JSON. A record that does not exist is a " +
+  "success with found=false, not an error. For the Athena/S3 destination you " +
+  "may also pass year/month/day to prune to one partition and avoid scanning " +
+  "the whole table. Runs as a read-only query behind the same guard as `query`.";
+
+export const LIST_EXECUTIONS_DESCRIPTION =
+  "List Workflow Insight execution records as machine-readable JSON, filtered " +
+  "by any of status, functionName, since, until, with a bounded limit — no SQL " +
+  "required from the caller for the common case. The query is built and " +
+  "executed read-only behind the same guard as `query`; results are capped at " +
+  `${MAX_ROWS} rows.`;
+
+/**
+ * Every tool this server registers, paired with its description. The single
+ * source of truth for `toolDescriptions.test.ts`, which asserts each is
+ * non-empty and under the 10,000-char cap — the guard that keeps the large
+ * `buildSystemPrompt` guidance in `describe_schema`'s RESULT and out of any
+ * description.
+ */
+export const TOOL_DESCRIPTIONS: ReadonlyArray<{
+  name: string;
+  description: string;
+}> = [
+  { name: "test_destination", description: TEST_DESTINATION_DESCRIPTION },
+  { name: "query", description: QUERY_DESCRIPTION },
+  { name: "describe_schema", description: DESCRIBE_SCHEMA_DESCRIPTION },
+  { name: "get_execution", description: GET_EXECUTION_DESCRIPTION },
+  { name: "list_executions", description: LIST_EXECUTIONS_DESCRIPTION },
+];
+
+// ── describe_schema ──────────────────────────────────────────────────────────
+
+/** Engine label + table name for a destination, matching `readOnlyQuery.ts`. */
+function engineAndTable(cfg: InsightConfig): { engine: string; table: string } {
+  switch (cfg.destinationType) {
+    case "dynamodb":
+      return { engine: "PartiQL", table: cfg.dynamodbTableName };
+    case "s3":
+      return { engine: "Trino/Presto SQL", table: cfg.athenaTable };
+    default:
+      throw new Error(
+        `describe_schema is not supported for destination type ` +
+          `"${cfg.destinationType}" in this version. Supported destinations: ` +
+          `"dynamodb", "s3".`,
+      );
+  }
+}
+
+export interface DescribeSchemaResult {
+  destinationType: string;
+  engine: string;
+  table: string;
+  maxRows: number;
+  guidance: string;
+  guidanceLength: number;
+}
+
+/**
+ * Build the `describe_schema` result. The heavy `guidance` string comes
+ * verbatim from core's `buildSystemPrompt` (do not paraphrase it — it already
+ * encodes each destination's record schema and query idioms). Its length is
+ * reported so the agent knows why it is large and that it belongs in the result
+ * rather than a description.
+ */
+export function buildDescribeSchemaResult(
+  cfg: InsightConfig,
+): DescribeSchemaResult {
+  const { engine, table } = engineAndTable(cfg);
+  const guidance = buildSystemPrompt(cfg.destinationType, {
+    tableName: table || undefined,
+  });
+  return {
+    destinationType: cfg.destinationType,
+    engine,
+    table,
+    maxRows: MAX_ROWS,
+    guidance,
+    guidanceLength: guidance.length,
+  };
+}
+
+// ── get_execution ────────────────────────────────────────────────────────────
+
+export interface GetExecutionParams {
+  executionArn: string;
+  year?: string;
+  month?: string;
+  day?: string;
+}
+
+/**
+ * Build the single-record lookup SELECT for `executionArn`.
+ *
+ * The id is quote-escaped (never interpolated raw), so the predicate is always
+ * a single equality against the id as a LITERAL — an injected `' OR '1'='1`
+ * becomes the escaped literal `'x'' OR ''1''=''1'`, not a tautology. For Athena,
+ * validated year/month/day (digits only) add an equality predicate on the
+ * partition columns so Athena prunes instead of scanning the whole table.
+ */
+export function buildGetExecutionSql(
+  cfg: InsightConfig,
+  params: GetExecutionParams,
+): string {
+  const id = escapeSqlString(params.executionArn);
+  if (cfg.destinationType === "s3") {
+    const parts: string[] = [];
+    if (params.year !== undefined) {
+      parts.push(`year = '${validatePartitionComponent("year", params.year)}'`);
+    }
+    if (params.month !== undefined) {
+      parts.push(
+        `month = '${validatePartitionComponent("month", params.month)}'`,
+      );
+    }
+    if (params.day !== undefined) {
+      parts.push(`day = '${validatePartitionComponent("day", params.day)}'`);
+    }
+    const partitionPredicate = parts.map((p) => `${p} AND `).join("");
+    return (
+      `SELECT * FROM ${cfg.athenaTable} ` +
+      `WHERE ${partitionPredicate}executionarn = '${id}' LIMIT 1`
+    );
+  }
+  // dynamodb (PartiQL): no LIMIT clause (unsupported); the row cap in
+  // runReadOnlyQuery bounds it. Table name is double-quoted per the dialect.
+  return `SELECT * FROM "${cfg.dynamodbTableName}" WHERE pk = '${id}'`;
+}
+
+export interface GetExecutionResult {
+  destinationType: string;
+  engine: string;
+  found: boolean;
+  executionArn: string;
+  record?: Record<string, string>;
+}
+
+/**
+ * Execute `get_execution`: build the lookup SELECT and run it through the
+ * choke point. Zero rows is a successful `found: false`, not an error.
+ */
+export async function runGetExecution(
+  cfg: InsightConfig,
+  params: GetExecutionParams,
+): Promise<GetExecutionResult> {
+  const sql = buildGetExecutionSql(cfg, params);
+  const result = await runReadOnlyQuery(cfg, sql);
+  if (result.rows.length === 0) {
+    return {
+      destinationType: cfg.destinationType,
+      engine: result.engine,
+      found: false,
+      executionArn: params.executionArn,
+    };
+  }
+  const row = result.rows[0];
+  const record: Record<string, string> = {};
+  result.columns.forEach((col, i) => {
+    record[col] = row[i] ?? "";
+  });
+  return {
+    destinationType: cfg.destinationType,
+    engine: result.engine,
+    found: true,
+    executionArn: params.executionArn,
+    record,
+  };
+}
+
+// ── list_executions ──────────────────────────────────────────────────────────
+
+export interface ListExecutionsParams {
+  status?: string;
+  since?: string;
+  until?: string;
+  functionName?: string;
+  limit?: number;
+}
+
+/**
+ * Build the filtered list SELECT.
+ *
+ * `status` is validated against the known set (rejected if unknown);
+ * `since`/`until` are validated as ISO timestamps (rejected if malformed) —
+ * both are then safe to interpolate because their validated shapes cannot
+ * contain a quote. `functionName` is free-form text, so it is quote-escaped.
+ * Column names differ per engine (lowercase for Athena, camelCase for
+ * DynamoDB); the `recordType`/`recordtype` guard isolates insight records.
+ */
+export function buildListExecutionsSql(
+  cfg: InsightConfig,
+  params: ListExecutionsParams,
+): string {
+  const isS3 = cfg.destinationType === "s3";
+  const col = {
+    recordType: isS3 ? "recordtype" : "recordType",
+    status: "status",
+    functionName: isS3 ? "functionname" : "functionName",
+    startTime: isS3 ? "starttime" : "startTime",
+  };
+  const select = isS3
+    ? "executionarn, status, functionname, starttime, endtime, durationms"
+    : "pk, status, functionName, startTime, endTime, durationMs";
+  const from = isS3 ? cfg.athenaTable : `"${cfg.dynamodbTableName}"`;
+
+  const where: string[] = [`${col.recordType} = 'WorkflowInsight'`];
+  if (params.status !== undefined) {
+    where.push(`${col.status} = '${validateStatus(params.status)}'`);
+  }
+  if (params.functionName !== undefined) {
+    where.push(
+      `${col.functionName} = '${escapeSqlString(params.functionName)}'`,
+    );
+  }
+  if (params.since !== undefined) {
+    where.push(
+      `${col.startTime} >= '${validateTimestamp("since", params.since)}'`,
+    );
+  }
+  if (params.until !== undefined) {
+    where.push(
+      `${col.startTime} <= '${validateTimestamp("until", params.until)}'`,
+    );
+  }
+
+  const limit = coerceLimit(params.limit, DEFAULT_LIST_LIMIT, MAX_ROWS);
+  const whereClause = where.join(" AND ");
+
+  if (isS3) {
+    // Trino supports ORDER BY + LIMIT; most-recent-first is the useful default.
+    return (
+      `SELECT ${select} FROM ${from} WHERE ${whereClause} ` +
+      `ORDER BY ${col.startTime} DESC LIMIT ${limit}`
+    );
+  }
+  // dynamodb (PartiQL): ORDER BY and LIMIT are unsupported; the row cap in
+  // runReadOnlyQuery bounds the result to MAX_ROWS.
+  return `SELECT ${select} FROM ${from} WHERE ${whereClause}`;
+}
+
+export interface ListExecutionsResult {
+  destinationType: string;
+  engine: string;
+  columns: string[];
+  rows: string[][];
+  count: number;
+  truncated: boolean;
+}
+
+/**
+ * Execute `list_executions`: build the filtered SELECT and run it through the
+ * choke point (which applies `assertReadOnly` and the row cap).
+ */
+export async function runListExecutions(
+  cfg: InsightConfig,
+  params: ListExecutionsParams,
+): Promise<ListExecutionsResult> {
+  const sql = buildListExecutionsSql(cfg, params);
+  const result = await runReadOnlyQuery(cfg, sql);
+  return {
+    destinationType: cfg.destinationType,
+    engine: result.engine,
+    columns: result.columns,
+    rows: result.rows,
+    count: result.count,
+    truncated: result.truncated,
+  };
+}

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -34,7 +34,7 @@ import {
   fetchLogsInsightsRecord,
   resolveCredentials,
   type InsightConfig,
-} from "durable-insight-core";
+} from "@aws/durable-insight-core";
 import {
   LOGS_INSIGHTS_ENGINE,
   MAX_ROWS,

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -28,8 +28,18 @@
  *   description. `toolDescriptions.test.ts` asserts every description here is
  *   non-empty and under the cap.
  */
-import { buildSystemPrompt, type InsightConfig } from "durable-insight-core";
-import { MAX_ROWS, runReadOnlyQuery } from "./readOnlyQuery";
+import {
+  buildSystemPrompt,
+  escapeQuotedString,
+  fetchLogsInsightsRecord,
+  resolveCredentials,
+  type InsightConfig,
+} from "durable-insight-core";
+import {
+  LOGS_INSIGHTS_ENGINE,
+  MAX_ROWS,
+  runReadOnlyQuery,
+} from "./readOnlyQuery";
 import {
   coerceLimit,
   escapeSqlString,
@@ -59,11 +69,15 @@ export const TEST_DESTINATION_DESCRIPTION =
  * knows a write will be refused rather than silently mutating data.
  */
 export const QUERY_DESCRIPTION =
-  "Execute a single READ-ONLY SQL/PartiQL query against the configured Insight " +
+  "Execute a single READ-ONLY query against the configured Insight " +
   "destination (set via DURABLE_INSIGHT_* environment variables) and return the " +
   "result as machine-readable JSON (columns, rows, count, truncated, engine, " +
-  "destinationType). Only SELECT/WITH is permitted: any data-modifying or DDL " +
-  "statement is rejected before any AWS call is made. Results are capped at " +
+  "destinationType). For the SQL destinations (dynamodb, s3, aurora, redshift, " +
+  "opensearch) only SELECT/WITH is permitted: any data-modifying or DDL " +
+  "statement is rejected before any AWS call is made. For the CloudWatch Logs " +
+  "destinations (cloudwatch-logs-exporter, lambda-log-exporter) pass a CloudWatch " +
+  "Logs Insights pipe query (e.g. `filter ... | stats ...`), NOT SQL; use " +
+  "`lookbackHours` to set the time window. Results are capped at " +
   `${MAX_ROWS} rows; "truncated" is true when the cap was hit. If required ` +
   "environment variables are unset it names them and returns without calling AWS.";
 
@@ -109,6 +123,14 @@ export const TOOL_DESCRIPTIONS: ReadonlyArray<{
 
 // ── describe_schema ──────────────────────────────────────────────────────────
 
+/** True for the two CloudWatch Logs Insights destinations (NOT SQL). */
+function isLogDestination(cfg: InsightConfig): boolean {
+  return (
+    cfg.destinationType === "cloudwatch-logs-exporter" ||
+    cfg.destinationType === "lambda-log-exporter"
+  );
+}
+
 /** Engine label + table name for a destination, matching `readOnlyQuery.ts`. */
 function engineAndTable(cfg: InsightConfig): { engine: string; table: string } {
   switch (cfg.destinationType) {
@@ -116,11 +138,29 @@ function engineAndTable(cfg: InsightConfig): { engine: string; table: string } {
       return { engine: "PartiQL", table: cfg.dynamodbTableName };
     case "s3":
       return { engine: "Trino/Presto SQL", table: cfg.athenaTable };
+    case "aurora":
+      return { engine: "PostgreSQL", table: cfg.auroraTable };
+    case "redshift":
+      return { engine: "Redshift SQL", table: cfg.redshiftTable };
+    case "opensearch":
+      // The OpenSearch "table" is the index; buildSystemPrompt wraps it in
+      // backticks in the FROM clause it generates.
+      return { engine: "OpenSearch SQL", table: cfg.opensearchIndex };
+    case "cloudwatch-logs-exporter":
+    case "lambda-log-exporter":
+      // Logs Insights is not SQL and has no "table" — the query runs over one
+      // or more LOG GROUPS. Report them (comma-joined) so the agent sees what
+      // it is querying; buildSystemPrompt ignores tableName for these types.
+      return {
+        engine: LOGS_INSIGHTS_ENGINE,
+        table: cfg.logGroupNames.join(", "),
+      };
     default:
       throw new Error(
         `describe_schema is not supported for destination type ` +
           `"${cfg.destinationType}" in this version. Supported destinations: ` +
-          `"dynamodb", "s3".`,
+          `"dynamodb", "s3", "aurora", "redshift", "opensearch", ` +
+          `"cloudwatch-logs-exporter", "lambda-log-exporter".`,
       );
   }
 }
@@ -168,6 +208,129 @@ export interface GetExecutionParams {
 }
 
 /**
+ * Per-destination SQL idioms for the structured tools.
+ *
+ * The dialects genuinely DIVERGE — table quoting, column casing, whether a
+ * `recordType` discriminator column even exists, and whether ORDER BY/LIMIT are
+ * usable all differ — so each field is sourced from core's `buildSystemPrompt`
+ * guidance for that destination (schema.ts), never assumed portable:
+ *   - Table quoting: bare for Athena/Aurora/Redshift, double-quoted for DynamoDB
+ *     PartiQL, backtick-quoted for OpenSearch (its index name has a hyphen).
+ *   - Column casing: lowercase (Athena), snake_case (Aurora/Redshift),
+ *     camelCase (DynamoDB/OpenSearch).
+ *   - `recordType` guard: Athena/DynamoDB/OpenSearch store a recordType field
+ *     and filter on it; Aurora/Redshift store insight records in a DEDICATED
+ *     table with NO such column, so the guard is omitted (emitting it would be
+ *     a "column does not exist" error).
+ *   - ORDER BY/LIMIT: the four SQL engines support it; PartiQL for DynamoDB
+ *     supports neither (the runReadOnlyQuery cap bounds it instead).
+ */
+interface Dialect {
+  /** Engine label, matching runReadOnlyQuery / assertReadOnly. */
+  engine: string;
+  /** FROM-clause target, quoted the way THIS engine requires. */
+  from: string;
+  /** Column holding the execution id (get_execution equality predicate). */
+  idColumn: string;
+  /** Projection for list_executions. */
+  listSelect: string;
+  /** status column name (list_executions filter). */
+  statusColumn: string;
+  /** functionName column name (list_executions filter). */
+  functionNameColumn: string;
+  /** start-time column name (list_executions since/until filter + ordering). */
+  startTimeColumn: string;
+  /**
+   * The `recordType = 'WorkflowInsight'` discriminator column, or undefined when
+   * the destination has no such column (Aurora/Redshift dedicated table).
+   */
+  recordTypeColumn?: string;
+  /**
+   * Whether ORDER BY <startTime> DESC LIMIT n is appended in list_executions.
+   * For OpenSearch this is safe only because startTime is a DATE field — its SQL
+   * plugin forbids ORDER BY on a raw text field.
+   */
+  orderByAndLimit: boolean;
+}
+
+/** Resolve the {@link Dialect} for the configured destination. */
+function dialectFor(cfg: InsightConfig): Dialect {
+  switch (cfg.destinationType) {
+    case "s3":
+      return {
+        engine: "Trino/Presto SQL",
+        from: cfg.athenaTable,
+        idColumn: "executionarn",
+        listSelect:
+          "executionarn, status, functionname, starttime, endtime, durationms",
+        statusColumn: "status",
+        functionNameColumn: "functionname",
+        startTimeColumn: "starttime",
+        recordTypeColumn: "recordtype",
+        orderByAndLimit: true,
+      };
+    case "dynamodb":
+      return {
+        engine: "PartiQL",
+        from: `"${cfg.dynamodbTableName}"`,
+        idColumn: "pk",
+        listSelect: "pk, status, functionName, startTime, endTime, durationMs",
+        statusColumn: "status",
+        functionNameColumn: "functionName",
+        startTimeColumn: "startTime",
+        recordTypeColumn: "recordType",
+        orderByAndLimit: false,
+      };
+    case "aurora":
+      return {
+        engine: "PostgreSQL",
+        from: cfg.auroraTable,
+        idColumn: "execution_arn",
+        listSelect:
+          "execution_arn, status, function_name, start_time, end_time, duration_ms",
+        statusColumn: "status",
+        functionNameColumn: "function_name",
+        startTimeColumn: "start_time",
+        recordTypeColumn: undefined,
+        orderByAndLimit: true,
+      };
+    case "redshift":
+      return {
+        engine: "Redshift SQL",
+        from: cfg.redshiftTable,
+        idColumn: "execution_arn",
+        listSelect:
+          "execution_arn, status, function_name, start_time, end_time, duration_ms",
+        statusColumn: "status",
+        functionNameColumn: "function_name",
+        startTimeColumn: "start_time",
+        recordTypeColumn: undefined,
+        orderByAndLimit: true,
+      };
+    case "opensearch":
+      return {
+        engine: "OpenSearch SQL",
+        // Index name contains a hyphen -> MUST be backtick-quoted in FROM.
+        from: `\`${cfg.opensearchIndex}\``,
+        idColumn: "executionArn",
+        listSelect:
+          "executionArn, status, functionName, startTime, endTime, durationMs",
+        statusColumn: "status",
+        functionNameColumn: "functionName",
+        startTimeColumn: "startTime",
+        recordTypeColumn: "recordType",
+        orderByAndLimit: true,
+      };
+    default:
+      throw new Error(
+        `The structured tools are not supported for destination type ` +
+          `"${cfg.destinationType}" in this version. Supported destinations: ` +
+          `"dynamodb", "s3", "aurora", "redshift", "opensearch".`,
+      );
+  }
+}
+
+/**
  * Build the single-record lookup SELECT for `executionArn`.
  *
  * The id is quote-escaped (never interpolated raw), so the predicate is always
@@ -181,6 +344,8 @@ export function buildGetExecutionSql(
   params: GetExecutionParams,
 ): string {
   const id = escapeSqlString(params.executionArn);
+  const d = dialectFor(cfg);
+
   if (cfg.destinationType === "s3") {
     const parts: string[] = [];
     if (params.year !== undefined) {
@@ -196,13 +361,21 @@ export function buildGetExecutionSql(
     }
     const partitionPredicate = parts.map((p) => `${p} AND `).join("");
     return (
-      `SELECT * FROM ${cfg.athenaTable} ` +
-      `WHERE ${partitionPredicate}executionarn = '${id}' LIMIT 1`
+      `SELECT * FROM ${d.from} ` +
+      `WHERE ${partitionPredicate}${d.idColumn} = '${id}' LIMIT 1`
     );
   }
-  // dynamodb (PartiQL): no LIMIT clause (unsupported); the row cap in
-  // runReadOnlyQuery bounds it. Table name is double-quoted per the dialect.
-  return `SELECT * FROM "${cfg.dynamodbTableName}" WHERE pk = '${id}'`;
+
+  if (cfg.destinationType === "dynamodb") {
+    // PartiQL: no LIMIT clause (unsupported); the row cap in runReadOnlyQuery
+    // bounds it. Table name is double-quoted per the dialect.
+    return `SELECT * FROM ${d.from} WHERE ${d.idColumn} = '${id}'`;
+  }
+
+  // aurora / redshift / opensearch: a standard single-row lookup. All three
+  // support LIMIT 1; identifier quoting and the id column name come from the
+  // dialect (execution_arn for Aurora/Redshift, executionArn for OpenSearch).
+  return `SELECT * FROM ${d.from} WHERE ${d.idColumn} = '${id}' LIMIT 1`;
 }
 
 export interface GetExecutionResult {
@@ -221,6 +394,42 @@ export async function runGetExecution(
   cfg: InsightConfig,
   params: GetExecutionParams,
 ): Promise<GetExecutionResult> {
+  // CloudWatch Logs Insights: there is no SQL to build and no point-lookup API.
+  // We deliberately route this ONE case around the SQL choke point and call
+  // core's `fetchLogsInsightsRecord` instead, for reasons that are all
+  // load-bearing:
+  //   - It correctly handles BOTH log record shapes — "direct"
+  //     (cloudwatch-logs-exporter, raw JSON fields) and "nested"
+  //     (lambda-log-exporter, a JSON string inside a `message` field) — trying a
+  //     field match then a message-substring match. Rebuilding that
+  //     two-shape fallback here would duplicate core logic we must not touch.
+  //   - It already escapes the agent-supplied `executionArn` with
+  //     `escapeQuotedString` (backslashes-then-quotes) before embedding it in a
+  //     double-quoted Logs Insights literal — the correct escaper for this
+  //     language (NOT the SQL single-quote doubler).
+  //   - It is already bounded (`| limit 1`), and Logs Insights has no write
+  //     constructs, so the choke point's two jobs — `assertReadOnly` and the row
+  //     cap — add nothing on this path (the choke point does not apply
+  //     `assertReadOnly` to logs anyway). `fetchLogsInsightsRecord` is a fetch
+  //     helper, NOT a core runner, so calling it here does not violate the
+  //     one-runner-import rule that `queryChokePoint.test.ts` enforces.
+  if (isLogDestination(cfg)) {
+    const credentials = resolveCredentials(cfg.awsProfile);
+    const record = await fetchLogsInsightsRecord({
+      region: cfg.region,
+      credentials,
+      logGroupNames: cfg.logGroupNames,
+      executionArn: params.executionArn,
+    });
+    return {
+      destinationType: cfg.destinationType,
+      engine: LOGS_INSIGHTS_ENGINE,
+      found: record !== undefined,
+      executionArn: params.executionArn,
+      ...(record !== undefined ? { record } : {}),
+    };
+  }
+
   const sql = buildGetExecutionSql(cfg, params);
   const result = await runReadOnlyQuery(cfg, sql);
   if (result.rows.length === 0) {
@@ -262,58 +471,163 @@ export interface ListExecutionsParams {
  * `since`/`until` are validated as ISO timestamps (rejected if malformed) —
  * both are then safe to interpolate because their validated shapes cannot
  * contain a quote. `functionName` is free-form text, so it is quote-escaped.
- * Column names differ per engine (lowercase for Athena, camelCase for
- * DynamoDB); the `recordType`/`recordtype` guard isolates insight records.
+ * Everything engine-specific — column casing, table quoting, whether a
+ * `recordType` guard exists, and whether ORDER BY/LIMIT are appended — comes
+ * from {@link dialectFor}, because these idioms are NOT portable across Trino,
+ * PartiQL, PostgreSQL, Redshift and OpenSearch SQL.
  */
 export function buildListExecutionsSql(
   cfg: InsightConfig,
   params: ListExecutionsParams,
 ): string {
-  const isS3 = cfg.destinationType === "s3";
-  const col = {
-    recordType: isS3 ? "recordtype" : "recordType",
-    status: "status",
-    functionName: isS3 ? "functionname" : "functionName",
-    startTime: isS3 ? "starttime" : "startTime",
-  };
-  const select = isS3
-    ? "executionarn, status, functionname, starttime, endtime, durationms"
-    : "pk, status, functionName, startTime, endTime, durationMs";
-  const from = isS3 ? cfg.athenaTable : `"${cfg.dynamodbTableName}"`;
+  const d = dialectFor(cfg);
 
-  const where: string[] = [`${col.recordType} = 'WorkflowInsight'`];
+  const where: string[] = [];
+  // Aurora/Redshift have no recordType column (dedicated table) — omit the
+  // discriminator entirely there; it would be a "column does not exist" error.
+  if (d.recordTypeColumn !== undefined) {
+    where.push(`${d.recordTypeColumn} = 'WorkflowInsight'`);
+  }
   if (params.status !== undefined) {
-    where.push(`${col.status} = '${validateStatus(params.status)}'`);
+    where.push(`${d.statusColumn} = '${validateStatus(params.status)}'`);
   }
   if (params.functionName !== undefined) {
     where.push(
-      `${col.functionName} = '${escapeSqlString(params.functionName)}'`,
+      `${d.functionNameColumn} = '${escapeSqlString(params.functionName)}'`,
     );
   }
   if (params.since !== undefined) {
     where.push(
-      `${col.startTime} >= '${validateTimestamp("since", params.since)}'`,
+      `${d.startTimeColumn} >= '${validateTimestamp("since", params.since)}'`,
     );
   }
   if (params.until !== undefined) {
     where.push(
-      `${col.startTime} <= '${validateTimestamp("until", params.until)}'`,
+      `${d.startTimeColumn} <= '${validateTimestamp("until", params.until)}'`,
     );
   }
 
   const limit = coerceLimit(params.limit, DEFAULT_LIST_LIMIT, MAX_ROWS);
-  const whereClause = where.join(" AND ");
+  // With no recordType guard and no filters, the WHERE list can be empty
+  // (Aurora/Redshift with no params) — emit no WHERE clause in that case.
+  const whereClause = where.length > 0 ? ` WHERE ${where.join(" AND ")}` : "";
 
-  if (isS3) {
-    // Trino supports ORDER BY + LIMIT; most-recent-first is the useful default.
+  if (d.orderByAndLimit) {
+    // Trino, PostgreSQL, Redshift and OpenSearch SQL all support ORDER BY +
+    // LIMIT; most-recent-first is the useful default. (OpenSearch orders on
+    // startTime, a DATE field — ordering a raw text field there is rejected.)
     return (
-      `SELECT ${select} FROM ${from} WHERE ${whereClause} ` +
-      `ORDER BY ${col.startTime} DESC LIMIT ${limit}`
+      `SELECT ${d.listSelect} FROM ${d.from}${whereClause} ` +
+      `ORDER BY ${d.startTimeColumn} DESC LIMIT ${limit}`
     );
   }
   // dynamodb (PartiQL): ORDER BY and LIMIT are unsupported; the row cap in
   // runReadOnlyQuery bounds the result to MAX_ROWS.
-  return `SELECT ${select} FROM ${from} WHERE ${whereClause}`;
+  return `SELECT ${d.listSelect} FROM ${d.from}${whereClause}`;
+}
+
+/**
+ * Build the filtered `list_executions` query for a CloudWatch Logs Insights
+ * destination — a pipe query, NOT SQL.
+ *
+ * This is the log counterpart to {@link buildListExecutionsSql}. The two log
+ * shapes require different queries, both sourced from core's `buildSystemPrompt`
+ * dialect guidance (`schema.ts`):
+ *   - "direct" (cloudwatch-logs-exporter): fields are top-level, so filters read
+ *     them directly and the base discriminator is
+ *     `filter recordType = "WorkflowInsight"`.
+ *   - "nested" (lambda-log-exporter): the record is a JSON string inside
+ *     `message`, so we isolate insight records with
+ *     `filter level = "INFO" and message like /WorkflowInsight/`, `parse` the
+ *     needed fields out of the message, then filter on the parsed aliases.
+ *
+ * In BOTH shapes every agent-supplied value is interpolated into a
+ * DOUBLE-QUOTED Logs Insights literal and escaped with core's
+ * `escapeQuotedString` (the correct escaper for this language — NOT the SQL
+ * single-quote doubler). `status` is validated against the closed enum and
+ * `since`/`until` against the ISO-timestamp shape (rejected if malformed),
+ * exactly as the SQL builder does. A `limit` is appended here (bounded by
+ * {@link MAX_ROWS}); the choke point's `ensureLimit` then leaves it untouched.
+ */
+export function buildListExecutionsLogsQuery(
+  cfg: InsightConfig,
+  params: ListExecutionsParams,
+): string {
+  const limit = coerceLimit(params.limit, DEFAULT_LIST_LIMIT, MAX_ROWS);
+  const direct = cfg.destinationType === "cloudwatch-logs-exporter";
+  const stages: string[] = [];
+
+  if (direct) {
+    // Top-level fields: filter on them directly, discriminate on recordType.
+    const filters = ['recordType = "WorkflowInsight"'];
+    if (params.status !== undefined) {
+      filters.push(
+        `status = "${escapeQuotedString(validateStatus(params.status))}"`,
+      );
+    }
+    if (params.functionName !== undefined) {
+      filters.push(
+        `functionName = "${escapeQuotedString(params.functionName)}"`,
+      );
+    }
+    if (params.since !== undefined) {
+      filters.push(
+        `startTime >= "${escapeQuotedString(validateTimestamp("since", params.since))}"`,
+      );
+    }
+    if (params.until !== undefined) {
+      filters.push(
+        `startTime <= "${escapeQuotedString(validateTimestamp("until", params.until))}"`,
+      );
+    }
+    stages.push(`filter ${filters.join(" and ")}`);
+    stages.push(
+      "fields executionArn, status, functionName, startTime, endTime, durationMs",
+    );
+    stages.push("sort @timestamp desc");
+    stages.push(`limit ${limit}`);
+    return stages.join(" | ");
+  }
+
+  // Nested (lambda-log-exporter): isolate insight records, parse the fields we
+  // filter/return out of the JSON string, then filter on the parsed aliases so
+  // every agent value still lands in a double-quoted literal.
+  stages.push('filter level = "INFO" and message like /WorkflowInsight/');
+  stages.push('parse message "\\"executionArn\\":\\"*\\"" as executionArn');
+  stages.push('parse message "\\"status\\":\\"*\\"" as status');
+  stages.push('parse message "\\"functionName\\":\\"*\\"" as functionName');
+  stages.push('parse message "\\"startTime\\":\\"*\\"" as startTime');
+
+  const postFilters: string[] = [];
+  if (params.status !== undefined) {
+    postFilters.push(
+      `status = "${escapeQuotedString(validateStatus(params.status))}"`,
+    );
+  }
+  if (params.functionName !== undefined) {
+    postFilters.push(
+      `functionName = "${escapeQuotedString(params.functionName)}"`,
+    );
+  }
+  if (params.since !== undefined) {
+    postFilters.push(
+      `startTime >= "${escapeQuotedString(validateTimestamp("since", params.since))}"`,
+    );
+  }
+  if (params.until !== undefined) {
+    postFilters.push(
+      `startTime <= "${escapeQuotedString(validateTimestamp("until", params.until))}"`,
+    );
+  }
+  if (postFilters.length > 0) {
+    stages.push(`filter ${postFilters.join(" and ")}`);
+  }
+  stages.push(
+    "fields @timestamp, executionArn, status, functionName, startTime",
+  );
+  stages.push("sort @timestamp desc");
+  stages.push(`limit ${limit}`);
+  return stages.join(" | ");
 }
 
 export interface ListExecutionsResult {
@@ -333,8 +647,13 @@ export async function runListExecutions(
   cfg: InsightConfig,
   params: ListExecutionsParams,
 ): Promise<ListExecutionsResult> {
-  const sql = buildListExecutionsSql(cfg, params);
-  const result = await runReadOnlyQuery(cfg, sql);
+  // Log destinations build a Logs Insights pipe query; SQL destinations build
+  // SELECT. Both run through the single choke point, which applies the
+  // destination-appropriate bound (`ensureLimit` for logs, the row cap for SQL).
+  const query = isLogDestination(cfg)
+    ? buildListExecutionsLogsQuery(cfg, params)
+    : buildListExecutionsSql(cfg, params);
+  const result = await runReadOnlyQuery(cfg, query);
   return {
     destinationType: cfg.destinationType,
     engine: result.engine,

--- a/packages/durable-insight-mcp/src/tools.ts
+++ b/packages/durable-insight-mcp/src/tools.ts
@@ -190,7 +190,7 @@ export interface DescribeSchemaResult {
  * unit tests asserted the guidance was long and self-consistent, which it was;
  * they could not know that its closing sentence addressed a different host.
  */
-const FOREIGN_TOOL_MARKERS = ['Call the "emit_query" tool', "emit_query"];
+const FOREIGN_TOOL_MARKER = 'Call the "emit_query" tool';
 
 /**
  * Remove the trailing "call <extension tool>" instruction from shared guidance,
@@ -200,11 +200,13 @@ const FOREIGN_TOOL_MARKERS = ['Call the "emit_query" tool', "emit_query"];
  * Deliberately conservative. If the marker is absent (because core reworded it)
  * the guidance is returned untouched rather than being cut at a guess, and
  * `howToRun` still tells the agent what to do. `describeSchema.test.ts` asserts
- * the returned guidance never mentions a foreign tool, so a reword that breaks
- * this is caught rather than silently shipped.
+ * the returned guidance never mentions any foreign tool -- it keeps its own,
+ * broader list for that -- so a reword that breaks this is caught rather than
+ * silently shipped. There is deliberately ONE marker here: a second entry existed
+ * briefly and was never read, which read as a guard while guarding nothing.
  */
 function stripForeignToolInstruction(guidance: string): string {
-  const idx = guidance.indexOf(FOREIGN_TOOL_MARKERS[0]);
+  const idx = guidance.indexOf(FOREIGN_TOOL_MARKER);
   if (idx === -1) return guidance.trim();
   return guidance.slice(0, idx).trim();
 }
@@ -242,11 +244,27 @@ export function buildDescribeSchemaResult(
 
 // ── get_execution ────────────────────────────────────────────────────────────
 
+/**
+ * Default window for a log-destination point lookup, in hours.
+ *
+ * Mirrors core's `fetchLogsInsightsRecord` default (7 days) so that omitting
+ * `lookbackHours` behaves identically to before this parameter existed -- but now
+ * the value is reported back, so `found: false` says which window was searched.
+ */
+export const DEFAULT_RECORD_LOOKBACK_HOURS = 7 * 24;
+
 export interface GetExecutionParams {
   executionArn: string;
   year?: string;
   month?: string;
   day?: string;
+  /**
+   * Log destinations only: how many hours back to search. Logs Insights requires an
+   * explicit window, so without this the search is bounded by core's 7-day default
+   * and an older execution reports `found: false` -- indistinguishable from one that
+   * never existed.
+   */
+  lookbackHours?: number;
 }
 
 /**
@@ -426,6 +444,18 @@ export interface GetExecutionResult {
   found: boolean;
   executionArn: string;
   record?: Record<string, string>;
+  /**
+   * The window actually searched, for log destinations. Present so that
+   * `found: false` is interpretable: "not in the last 168 hours" is a different
+   * statement from "does not exist", and an agent cannot tell them apart without
+   * being told which one it got.
+   */
+  searchedLookbackHours?: number;
+  /**
+   * Parameters that were supplied and had no effect on this destination. Silently
+   * ignoring an argument teaches an agent that it worked.
+   */
+  ignoredParams?: string[];
 }
 
 /**
@@ -455,19 +485,39 @@ export async function runGetExecution(
   //     `assertReadOnly` to logs anyway). `fetchLogsInsightsRecord` is a fetch
   //     helper, NOT a core runner, so calling it here does not violate the
   //     one-runner-import rule that `queryChokePoint.test.ts` enforces.
+  // Partition components prune an Athena/S3 scan and mean nothing anywhere else.
+  // Report them rather than dropping them: a passed-but-ignored parameter that
+  // produces no signal is indistinguishable, from the agent's side, from one that
+  // was honored.
+  const ignoredParams =
+    cfg.destinationType === "s3"
+      ? []
+      : (["year", "month", "day"] as const).filter(
+          (k) => params[k] !== undefined,
+        );
+
   if (isLogDestination(cfg)) {
     const credentials = resolveCredentials(cfg.awsProfile);
+    const lookbackHours =
+      params.lookbackHours !== undefined && params.lookbackHours > 0
+        ? params.lookbackHours
+        : DEFAULT_RECORD_LOOKBACK_HOURS;
     const record = await fetchLogsInsightsRecord({
       region: cfg.region,
       credentials,
       logGroupNames: cfg.logGroupNames,
       executionArn: params.executionArn,
+      lookbackMs: lookbackHours * 60 * 60 * 1000,
     });
     return {
       destinationType: cfg.destinationType,
       engine: LOGS_INSIGHTS_ENGINE,
       found: record !== undefined,
       executionArn: params.executionArn,
+      searchedLookbackHours: lookbackHours,
+      ...(ignoredParams.length > 0
+        ? { ignoredParams: [...ignoredParams] }
+        : {}),
       ...(record !== undefined ? { record } : {}),
     };
   }
@@ -480,6 +530,9 @@ export async function runGetExecution(
       engine: result.engine,
       found: false,
       executionArn: params.executionArn,
+      ...(ignoredParams.length > 0
+        ? { ignoredParams: [...ignoredParams] }
+        : {}),
     };
   }
   const row = result.rows[0];
@@ -492,6 +545,7 @@ export async function runGetExecution(
     engine: result.engine,
     found: true,
     executionArn: params.executionArn,
+    ...(ignoredParams.length > 0 ? { ignoredParams: [...ignoredParams] } : {}),
     record,
   };
 }
@@ -563,8 +617,9 @@ export function buildListExecutionsSql(
       `ORDER BY ${d.startTimeColumn} DESC LIMIT ${limit}`
     );
   }
-  // dynamodb (PartiQL): ORDER BY and LIMIT are unsupported; the row cap in
-  // runReadOnlyQuery bounds the result to MAX_ROWS.
+  // dynamodb (PartiQL): ORDER BY and LIMIT are unsupported, so this statement
+  // carries no bound. `runListExecutions` passes the caller's limit as the row cap
+  // instead, which is what actually bounds this path.
   return `SELECT ${d.listSelect} FROM ${d.from}${whereClause}`;
 }
 
@@ -695,7 +750,14 @@ export async function runListExecutions(
   const query = isLogDestination(cfg)
     ? buildListExecutionsLogsQuery(cfg, params)
     : buildListExecutionsSql(cfg, params);
-  const result = await runReadOnlyQuery(cfg, query);
+  // Also pass the caller's limit as the row cap, NOT only as query text. For most
+  // destinations the generated `LIMIT`/`limit` already bounds the result, but
+  // DynamoDB PartiQL supports neither ORDER BY nor LIMIT, so its statement carries
+  // no bound at all -- without this, `limit: 10` on DynamoDB returns up to MAX_ROWS
+  // rows, which is the token cost this tool exists to avoid.
+  const result = await runReadOnlyQuery(cfg, query, {
+    maxRows: coerceLimit(params.limit, DEFAULT_LIST_LIMIT, MAX_ROWS),
+  });
   return {
     destinationType: cfg.destinationType,
     engine: result.engine,

--- a/packages/durable-insight-mcp/tsconfig.json
+++ b/packages/durable-insight-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/durable-insight-mcp/tsconfig.test.json
+++ b/packages/durable-insight-mcp/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
Customers have asked to use Workflow Insight from the AI agent they already work in —
  Claude Code, Kiro, Cursor — rather than through a VS Code extension or a desktop app.
  The competitive analysis in this repo already notes DBOS shipping an MCP server, so this
  is parity rather than differentiation.

  The real win isn't packaging, it's the follow-up question. Today a user asks one thing,
  gets a table, and starts over. In an agent, *"show me the input payloads for those three"*
  is just the next turn — no new UI, no new query mode, no chart config. That's a capability
  the extension structurally cannot offer.

  Third host on the seam #795 introduced, built on the core extracted in #809. The design
  document ships in this change; § references below point at it.

  ## What it is

  A stdio MCP server, published so `npx -y @aws/durable-insight-mcp` works, exposing five
  tools over all seven queryable destinations:

  | Tool | Purpose |
  | --- | --- |
  | `test_destination` | Connectivity check; names unset env vars with no AWS call |
  | `describe_schema` | Per-destination record schema and query idioms, from core |
  | `list_executions` | Filtered listing with **no SQL required** — cheaper and unfailable |
  | `get_execution` | One execution in full, including `input`/`output` payloads |
  | `query` | The escape hatch for anything the structured tools can't express |

  Configuration is environment-only (`DURABLE_INSIGHT_*`, with `AWS_REGION`/`AWS_PROFILE`
  honored), and **credentials need no configuration at all** — the standard chain already
  works. A typical customer sets two to four variables, making this the easiest of the three
  hosts to configure.

  **It drops a subsystem rather than adding one.** The agent is the model, so ~1,700 lines of
  provider plumbing don't come along: no provider selection, no model lists, no on-device
  binary, none of the Electron packaging friction. Eight settings are deliberately rejected,
  with a contract test asserting those eight plus the 25 accepted exactly partition
  `SETTING_KEYS`, so neither list can drift from the extension's manifest.

  ## The security shape, which is where review should concentrate

  In the other hosts `assertReadOnly` guards SQL our own prompt produced. Here it guards SQL
  from a model we don't control, in a loop, for a user who may approve without reading.

  There is also a structural hazard, verified: **`assertReadOnly` and `ensureLimit` are called
  only inside `explorerSession.ts`, never inside the engine runners.** This host deliberately
  bypasses `ExplorerSession` (§6.3), so the runners are reachable with no read-only
  enforcement — nothing in core would refuse a `DELETE`.

  The mitigation is deliberately not a call at each site, which is the pattern that let it be
  forgotten. **`readOnlyQuery.ts` is a single choke point** and `queryChokePoint.test.ts`
  mechanically asserts nothing else imports core's query surface.

  Three things worth knowing about the tests:

  - **Rejection is proven by asserting the runner mock was never invoked**, not merely that an
    error was thrown. A rejection that still reached AWS would be worthless. Covered for every
    engine: all 14 write keywords, multi-statement, comment-obfuscated, and both
    data-modifying CTE forms.
  - **Acceptance is tested too**, because a suite that only checks rejection passes on a
    function that rejects everything: plain `SELECT`, read-only `WITH`, a keyword inside a
    string literal, `REPLACE()` as a scalar function.
  - **`assertReadOnly` is the backstop, not the sanitizer.** An injected `' OR '1'='1` is a
    valid SELECT and it will allow it. Athena cannot parameterize, so agent-supplied values
    are escaped in `sqlSafe.ts`, closed vocabularies are *rejected* rather than escaped, and
    the injection tests assert on the **generated SQL text** so a reviewer can see the payload
    stayed one literal.

  ### The exception that looks like a bug

  **CloudWatch Logs Insights is deliberately not guarded by `assertReadOnly`** (§6.7). It's a
  pipe language — `fields @timestamp | filter … | stats …` — so a `SELECT`/`WITH` prefix check
  would reject *every valid query*. Read-only comes from the API surface instead: the language
  has no write forms and `StartQuery` can only read. `explorerSession.ts` draws the same line.

  Because "add the guard here too, for consistency" is such a plausible future change, **the
  test is inverted**: it asserts valid pipe queries are *accepted*. Adding `assertReadOnly`
  there fails 22 tests.

  Two consequences: `ensureLimit` is correct for that engine and wrong for every other (it
  emits `| limit N`, a syntax error on Trino/PartiQL), and the **escaping differs** — Logs
  Insights literals are double-quoted, so core's `escapeQuotedString` is required.

  `sqs` is refused outright rather than half-supported: it isn't queryable
  (`explorerSession.ts:828`, and `sqs.ts` exposes only `listenToQueue`).

  ## Skill delivery, in three layers

  Tools give an agent reach; these give it competence. Without schema guidance an agent writes
  plausible-but-wrong queries across seven subtly different backends and concludes the tool is
  broken.

  1. **`describe_schema` as a tool** — works in every client, zero setup. The floor.
  2. **Two MCP prompts** — ship *inside* the server, so Kiro lists them under `/prompts`.
  3. **`SKILL.md`** (4 KB) — for clients with skill support, loaded on demand.

  **None contains a single destination-specific schema fact.** They delegate to
  `describe_schema`, which makes drift impossible rather than merely detectable — and avoids
  loading Athena's 10,143 characters of guidance for a DynamoDB user. `skillDrift.test.ts`
  asserts schema-owned tokens appear nowhere in the skill or prompts, **and first asserts each
  token genuinely occurs** in some `buildSystemPrompt` output, so the guard cannot pass
  vacuously. That check earned its place immediately: a seventh candidate token appeared in no
  prompt output and was dropped.

  ## Verified against real data, not just green tests

  Driven over real stdio against a live Aurora Serverless v2 cluster with 5,808 records:

  - `test_destination` passes both checks in **0.7s**
  - `list_executions` returns real rows with correct `snake_case` columns
  - `get_execution` returns a failed execution's error, operations array, and input payload
  - A `GROUP BY` aggregate runs: `SUCCEEDED 5594 / 2308ms avg`, `FAILED 214 / 5986ms avg`
  - **Six write attempts refused with Admin credentials in hand** — `DELETE`, a data-modifying
    CTE, a multi-statement `DROP`, `UPDATE`, `TRUNCATE`, a comment-obfuscated `DELETE` — with
    the row count unchanged afterwards

  That exercise found a bug no unit test could: `describe_schema` told the agent to call
  `emit_query`, a tool that exists in the *extension's* LLM loop and not here. The existing
  tests asserted the guidance was long and self-consistent, and it was — nothing in them knew
  its closing sentence addressed a different host.

  ## Review round: six silent failures

  Every one of these passed CI, typecheck, and the full suite. They're grouped because they
  share a shape — a guard that could not fail, or a promise with no implementation.

  **The package was never published.** `iterate-publish-npm.sh` publishes from a hard-coded
  list this package wasn't in, so `npx -y @aws/durable-insight-mcp` — the entry point the
  entire README is written around — could not have worked. `packaging.test.ts` read as coverage
  for exactly this and wasn't: it asserted `private === false`, a manifest flag that *permits*
  publishing rather than causing it. The new invariant is keyed on the **`@aws/` scope**, not
  on `private !== true`, because three packages here are non-private and correctly never
  published — the broader rule would fail on state that is already right.

  **`query` declared a `limit` it never read.** Validated against the cap, described to the
  model as the row maximum, and the handler destructured `{ sql, lookbackHours }`. An agent
  asking for ten rows got a thousand — the token cost the structured tools exist to avoid. Now
  threaded through as a per-call cap that can lower the bound but never raise it. Fixing it
  exposed **the same bug in a second place the review didn't reach**: `list_executions` on
  DynamoDB, whose PartiQL supports neither `ORDER BY` nor `LIMIT`, so its statement carried no
  bound at all. Since schema and handler are only comparable as source,
  `toolWiring.test.ts` parses the TypeScript AST and asserts in both directions that every
  declared parameter is read.

  **A misspelled `DESTINATION_TYPE` was silent.** `normalizeConfig` ends in a fallback to
  `cloudwatch-logs-exporter` — right for the extension, where the value comes from a dropdown,
  and a trap for an environment-only host where `dynamo` or `DynamoDB` is the expected mistake.
  It produced a server reporting `DURABLE_INSIGHT_LOG_GROUP_NAME` as missing to someone who had
  configured DynamoDB correctly, and `missingRequiredEnvVars` could never name the real problem
  because by then the typo was gone. Core now exports the destination list at runtime and
  `normalizeConfig` resolves through it, so the warning cannot drift from the parser.

  **DynamoDB results could be incomplete while reporting `truncated: false`.** One
  non-paginating `ExecuteStatement`, a ~1 MB service response limit, and the `NextToken` saying
  more existed was discarded — so 400 rows of a matching 5,000 came back as a complete answer,
  which an agent will state as one. Core surfaces `hasMore`, **required rather than optional**
  so no construction site can omit it and default to falsy.

  **The choke-point guard was named too narrowly.** It forbade the six `run*Query` runners and
  missed six more core exports that execute a query, most by calling a runner internally —
  including `ensureAthenaTable`, which runs DDL. A file importing `fetchAthenaRecord` executed
  SQL while mentioning no runner, so the guard stayed green over the hole it exists to close.
  This is the `electron` blind spot from #809 in a new costume, so the fix is structural rather
  than three more names: the set is **derived from core's AST**, a meta-test fails when a new
  query-executing export appears, and the two deliberate exceptions carry written reasons plus
  an assertion that each is still used.

  **`escapeSqlString` doubled quotes only.** Redshift's own `QUOTE_LITERAL` doubles quotes *and
  backslashes*, because backslash escapes in its literals — so a trailing backslash yields
  `'foo\'` with the closing quote escaped and the literal running on. Doubling backslashes would
  be wrong for Athena, where they're ordinary characters. Backslashes are **rejected** instead,
  which is lossless: only execution ARNs and Lambda function names reach that code.

  Plus five smaller ones: `get_execution` on a log destination inherited a 7-day window with no
  way to widen it and reported a miss identically to an absence (now takes `lookbackHours` and
  returns `searchedLookbackHours`); partition hints passed to a non-Athena destination are
  reported in `ignoredParams` rather than dropped; the `AWS_REGION` fallback reads
  `AWS_DEFAULT_REGION` too, matching the `normalizeConfig` it shadows; a second unread entry in
  `FOREIGN_TOOL_MARKERS` is gone; and the three per-engine `truncated` derivations are
  documented where a reader compares them.

  ## Notes for the reviewer

  - **26 of 37 files are a new, self-contained package.** Of the rest, three are core
    (**55 insertions across 3 files** — `hasMore`, the runtime destination list, and
    `normalizeConfig` resolving through it), two are `.github`, plus the lockfile, root
    `package.json`, and the design doc. Nothing here can regress the extension or the desktop
    app, and both suites are unchanged at 33 and 48.
  - Of ~7,000 lines of real code, **3,281 are tests** and 1,258 are documentation; the
    lockfile's 2,570 lines can be skipped.
  - **The `hasMore` pinning test lives in core, not here** — and that's deliberate. This
    package mocks the runner, so a version that stopped reading `NextToken` still satisfied its
    tests; I confirmed that by mutation before moving the test. Same reasoning as the
    stdout-purity test: the obvious place to assert it can't see the failure.
  - **`stdout` purity is asserted directly.** stdout *is* the MCP transport, so a stray
    `console.log` corrupts it — yet injecting one did **not** fail an end-to-end session test,
    because the SDK client catches per-line parse errors, reports them to an unset handler, and
    continues. Only asserting the spawned binary emits nothing on stdout catches it.
  - **The published package declares only `@modelcontextprotocol/sdk` and `zod`.** Core is a
    `devDependency` because esbuild inlines it — it was briefly a runtime dependency, which made
    `npx` fail with E404 for every customer.
  - Bundle is **1.85 MB**. `quickjs` is fully tree-shaken despite core's barrel re-exporting the
    sandbox; `node-llama-cpp` stays external because it's only ever dynamically imported.
  - **`runSandboxedJs` is deliberately not exposed.** Arbitrary agent-authored JavaScript is a
    different risk class from a bounded read-only query, and the agent has its own code
    execution.
  - **Not shipped, deliberately:** charts and the interactive grid have no home in a text
    protocol, and SQS tailing needs a design for a request/response transport (§11, Phase 6).
  - When reviewing the guards, the useful question about each is **"what makes it fail?"**, not
    "does it pass?" — every gap found in this work came from injecting a fault or running a
    scanner, never from reading code.

  ## Testing (per CONTRIBUTING)

  Unit tests throughout — **391** in this package, **334** in core (up from 326 and 329) — plus
  an integration test that spawns the built binary and speaks real MCP over stdio, contract
  tests for the settings partition and the skill anti-drift rule, a packaging invariant test,
  and the AST-derived choke-point meta-guard. Every guard is mutation-verified: break the thing,
  watch the specific named case fail, restore. No conformance tests added. Not an SDK feature or
  API change, so no examples needed.