### PR TITLE
fix(otel): use monotonic timestamps for span containment

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -116,6 +116,20 @@ function findSpan(name: string): ReadableSpan | undefined {
   return getExportedSpans().find((s) => s.name === name);
 }
 
+function compareHrTime(
+  left: ReadableSpan["startTime"],
+  right: ReadableSpan["startTime"],
+): number {
+  return left[0] - right[0] || left[1] - right[1];
+}
+
+function expectSpanInside(child: ReadableSpan, parent: ReadableSpan): void {
+  expect(compareHrTime(child.startTime, parent.startTime)).toBeGreaterThanOrEqual(
+    0,
+  );
+  expect(compareHrTime(child.endTime, parent.endTime)).toBeLessThanOrEqual(0);
+}
+
 let idGenerator: DeterministicIdGenerator;
 
 beforeEach(() => {
@@ -534,47 +548,83 @@ describe("InvocationOtelPlugin", () => {
   });
 
   describe("operation span timing envelope", () => {
-    it("times operation spans with wall-clock so they nest within the Invocation span", async () => {
-      await plugin.onInvocationStart(makeInvocationInfo());
-      await plugin.onOperationStart(
-        makeOperationInfo({
-          id: "op-t",
-          type: "STEP",
-          name: "timed-step",
-          // Durable timestamp deliberately predates this invocation.
-          startTimestamp: new Date(Date.now() - 60_000),
-        }),
-      );
-      await plugin.onOperationEnd(
-        makeOperationEndInfo({
-          id: "op-t",
-          type: "STEP",
-          name: "timed-step",
-          status: "SUCCEEDED" as any,
-          endTimestamp: new Date(Date.now() + 60_000),
-        }),
-      );
-      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    it("uses a shared monotonic clock so nested spans stay strictly contained", async () => {
+      const wallClockStart = Date.now();
+      let wallClockCalls = 0;
+      const dateNow = jest
+        .spyOn(Date, "now")
+        .mockImplementation(() => wallClockStart + wallClockCalls++ * 100);
 
-      const inv = findSpan("Invocation")!;
-      const op = findSpan("timed-step")!;
-      const toMs = (t: [number, number]): number => t[0] * 1000 + t[1] / 1e6;
-      // The Invocation and operation spans are each anchored to an independent
-      // hrTime() reading taken when they were created, and this test does no
-      // work between their end() calls. Sub-millisecond disagreement between
-      // those anchors is enough to invert the comparison, so allow a small
-      // tolerance. The invariant worth protecting is that the op span is NOT
-      // backdated to the durable timestamp (which would put it ~60s outside the
-      // Invocation window) — a few ms of clock noise does not threaten that.
-      const CLOCK_TOLERANCE_MS = 5;
-      // The op span is NOT backdated to the durable timestamp; it nests inside
-      // the Invocation span's wall-clock [start, end] window.
-      expect(toMs(op.startTime)).toBeGreaterThanOrEqual(
-        toMs(inv.startTime) - CLOCK_TOLERANCE_MS,
-      );
-      expect(toMs(op.endTime)).toBeLessThanOrEqual(
-        toMs(inv.endTime) + CLOCK_TOLERANCE_MS,
-      );
+      try {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "ctx-t",
+            type: "CONTEXT",
+            name: "timed-context",
+            startTimestamp: new Date(wallClockStart - 60_000),
+          }),
+        );
+        await plugin.onOperationStart(
+          makeOperationInfo({
+            id: "op-t",
+            parentId: "ctx-t",
+            type: "STEP",
+            name: "timed-step",
+            startTimestamp: new Date(wallClockStart - 60_000),
+          }),
+        );
+        await plugin.onOperationAttemptStart(
+          makeAttemptInfo({
+            id: "op-t",
+            type: "STEP",
+            name: "timed-step",
+            attempt: 1,
+            startTimestamp: new Date(wallClockStart - 60_000),
+          }),
+        );
+        await plugin.onOperationAttemptEnd(
+          makeAttemptEndInfo({
+            id: "op-t",
+            type: "STEP",
+            name: "timed-step",
+            attempt: 1,
+            outcome: "SUCCEEDED" as any,
+            endTimestamp: new Date(wallClockStart + 60_000),
+          }),
+        );
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "op-t",
+            parentId: "ctx-t",
+            type: "STEP",
+            name: "timed-step",
+            status: "SUCCEEDED" as any,
+            endTimestamp: new Date(wallClockStart + 60_000),
+          }),
+        );
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "ctx-t",
+            type: "CONTEXT",
+            name: "timed-context",
+            status: "SUCCEEDED" as any,
+            endTimestamp: new Date(wallClockStart + 60_000),
+          }),
+        );
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+      } finally {
+        dateNow.mockRestore();
+      }
+
+      const invocation = findSpan("Invocation")!;
+      const contextSpan = findSpan("timed-context")!;
+      const operation = findSpan("timed-step")!;
+      const attempt = findSpan("timed-step attempt 1")!;
+
+      expectSpanInside(contextSpan, invocation);
+      expectSpanInside(operation, contextSpan);
+      expectSpanInside(attempt, operation);
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -17,6 +17,7 @@ import {
   SpanStatusCode,
   ROOT_CONTEXT,
 } from "@opentelemetry/api";
+import { hrTime } from "@opentelemetry/core";
 import {
   DeterministicIdGenerator,
   deriveTraceIdFromArn,
@@ -137,6 +138,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           "durable.execution.arn": info.executionArn,
           "durable.invocation.first": info.isFirstInvocation,
         },
+        startTime: hrTime(),
       },
       context.active(),
     );
@@ -156,10 +158,12 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   }
 
   async onInvocationEnd(info: InvocationEndInfo): Promise<void> {
+    const endTime = hrTime();
+
     // 1. End all spans in the stack in reverse order
     while (this.spanStack.length > 0) {
       const span = this.spanStack.pop()!;
-      span.end();
+      span.end(endTime);
     }
 
     // 2. End the invocation span if it exists
@@ -185,7 +189,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       }
       // RETRYING: leave status UNSET (default)
 
-      this.invocationSpan.end();
+      this.invocationSpan.end(endTime);
     }
 
     // 3. Handle Workflow span based on terminal status. The Workflow span is
@@ -205,7 +209,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         } else {
           this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
         }
-        this.workflowSpan.end();
+        this.workflowSpan.end(endTime);
       }
       // Non-terminal (PENDING/RETRYING): do NOT end — status stays UNSET and the
       // span is dropped without export
@@ -241,15 +245,12 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       return;
     }
 
-    // Operation, continuation, and attempt spans are timed with wall-clock
-    // (the tracer's current time) rather than the durable start/end
-    // timestamps. The Invocation span is a wall-clock span for the current
-    // invocation, and these spans parent to it; using durable timestamps
-    // (which can predate this invocation's start, e.g. an operation created in
-    // an earlier invocation of the same execution) would push a child outside
-    // its parent's [start, end] window and break the parent-timing envelope
-    // the conformance suite enforces. Only the root Workflow span keeps a
-    // backdated start (it is parentless). Matches the Python/Java reference.
+    // Operation, continuation, and attempt spans use explicit monotonic
+    // timestamps rather than durable start/end timestamps. Durable timestamps
+    // can predate this invocation, while letting each span use the tracer's
+    // default timestamp can give it an independent wall-clock anchor. A shared
+    // monotonic clock keeps children inside their parent timing envelopes.
+    // Only the parentless Workflow span keeps a backdated start.
     const deterministicSpanId = deriveSpanIdFromOperationId(
       info.id,
       this.executionArn,
@@ -296,6 +297,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         {
           attributes,
           links: this.workflowLinks(),
+          startTime: hrTime(),
         },
         parentContext,
       );
@@ -316,6 +318,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
             },
             ...this.workflowLinks(),
           ],
+          startTime: hrTime(),
         },
         parentContext,
       );
@@ -393,7 +396,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       }
 
       // End the span
-      span.end();
+      span.end(hrTime());
 
       // Remove from map
       this.spanMap.delete(info.id);
@@ -448,6 +451,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
             },
             ...this.workflowLinks(),
           ],
+          startTime: hrTime(),
         },
         parentContext,
       );
@@ -469,7 +473,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       }
 
       // Immediately end
-      continuationSpan.end();
+      continuationSpan.end(hrTime());
     }
   }
 
@@ -525,6 +529,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           },
           ...this.workflowLinks(),
         ],
+        startTime: hrTime(),
       },
       parentContext,
     );
@@ -559,7 +564,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         // Non-failed attempt: stamp explicit OK (matches Python OTel #604).
         attemptSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      attemptSpan.end();
+      attemptSpan.end(hrTime());
       this.spanMap.delete(key);
     }
   }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

- Conformance failure: https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/31229807266/job/93031267378?pr=44

### Description

The invocation-scoped OTel plugin previously let each span use OpenTelemetry's default timestamp handling. That handling can take separate wall-clock and monotonic-clock readings for each span. Small differences between those independently calculated clock anchors allowed a child span to appear to end slightly after its parent under ADOT/X-Ray, violating strict span containment.

`hrTime()` is OpenTelemetry's high-resolution timestamp function. It returns an `HrTime` tuple containing `[secondsSinceUnixEpoch, nanosecondsWithinSecond]`, calculated from the stable `performance.timeOrigin` plus monotonic `performance.now()`. The result remains an epoch-based timestamp suitable for exported traces, but its progression is not affected by changes to the system wall clock such as `Date.now()` adjustments.

Explicit `hrTime()` values are needed here so every span in the invocation hierarchy uses the same monotonic clock basis. This prevents independently anchored timestamps from inverting parent/child boundaries. At invocation shutdown, open descendants, the Invocation span, and the terminal Workflow span also share one captured end timestamp, guaranteeing that those children cannot end after their parent.

This change:

- uses explicit `hrTime()` timestamps for invocation, operation, replay, continuation, and attempt spans
- uses explicit monotonic end timestamps and shares the invocation-end timestamp across open descendants, the Invocation span, and the terminal Workflow span
- preserves the Workflow span's durable, backdated start timestamp
- replaces the timing tolerance test with deterministic strict containment checks for Invocation -> context -> operation -> attempt

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. The regression test advances `Date.now()` by 100 ms per call to expose independent clock anchors, then verifies strict nested-span containment.

- `npm run test -w packages/aws-durable-execution-sdk-js-otel` (197 tests passed)
- `npm run lint -w packages/aws-durable-execution-sdk-js-otel`
- `npm run build:types -w packages/aws-durable-execution-sdk-js-otel`

#### Integration Tests

No new integration test was added. The linked conformance workflow exercises the affected invocation/ADOT/X-Ray path.

#### Examples

Not applicable.

🤖 Assisted by fix-integration-test