### PR TITLE
fix(insight): replace the JSON-extraction ReDoS and guard the whole class

### DIFF
--- a/packages/durable-insight-core/src/jsonExtract.test.ts
+++ b/packages/durable-insight-core/src/jsonExtract.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Guards the linear-time replacements for three polynomial-ReDoS regexes.
+ *
+ * WHAT WAS WRONG:
+ * `verdict.ts` and `llm.ts` (twice) pulled JSON out of free-text model output with
+ * `/\{[\s\S]*<marker>[\s\S]*\}/`. Two unbounded `[\s\S]*` around a literal is
+ * polynomial: on input that starts a plausible object and never finishes one, the
+ * engine retries the inner scan from every start position. CodeQL flagged the
+ * `verdict.ts` instance as `js/polynomial-redos` (high). The input is a model reply,
+ * whose length is not ours to bound.
+ *
+ * TWO KINDS OF ASSERTION HERE, and both are needed:
+ *
+ *   1. EQUIVALENCE. The replacement must accept and reject exactly what the regex
+ *      did, or this is a behavior change wearing a performance fix. The old pattern
+ *      is reconstructed here and differentially tested against the new function,
+ *      including a fuzz over a brace-heavy alphabet. Note what the regex actually
+ *      meant: because both quantifiers are greedy and matching is leftmost-longest,
+ *      it always resolved to "first `{` to last `}`, marker somewhere between". It
+ *      never balanced braces, and neither does the replacement.
+ *
+ *   2. TIMING. A bound on pathological input, so reintroducing the regex fails
+ *      rather than merely being slower. The bound is deliberately loose (1s against
+ *      a measured ~2ms) so it cannot flake on a slow CI runner while still catching
+ *      a quadratic blowup, which at this input size takes tens of seconds.
+ */
+import { extractJsonObject, stripTrailingParenthetical } from "./jsonExtract";
+
+/** The regex that used to do this, rebuilt for differential testing. */
+function legacyExtract(text: string, marker: string): string | undefined {
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (
+    text.match(new RegExp("\\{[\\s\\S]*" + escaped + "[\\s\\S]*\\}"))?.[0] ??
+    undefined
+  );
+}
+
+const MARKER = '"satisfied"';
+
+describe("extractJsonObject matches the regex it replaced", () => {
+  it.each([
+    ["empty string", ""],
+    ["no braces at all", "no json here"],
+    ["empty object without the marker", "{}"],
+    ["bare object", '{"satisfied":true}'],
+    ["object wrapped in prose", 'prose {"satisfied":true} more prose'],
+    ["markdown fenced", '```json\n{"satisfied":false,"reason":"x"}\n```'],
+    [
+      "two objects — spans both, as the regex did",
+      '{"satisfied":1} {"satisfied":2}',
+    ],
+    ["nested braces", '{ outer {"satisfied":true} }'],
+    ["marker absent", '{"other":1}'],
+    ["closing before opening", "}{"],
+    ["only an opening brace", "{"],
+    ["only a closing brace", "}"],
+    ["unterminated object", '{"satisfied":true'],
+    ["marker outside any object", '{}"satisfied"{}'],
+    ["marker only after the last brace", '{"a":1}"satisfied"'],
+    ["marker immediately after the brace", '{"satisfied"}'],
+  ])("agrees on %s", (_label, input) => {
+    expect(extractJsonObject(input, MARKER)).toBe(legacyExtract(input, MARKER));
+  });
+
+  it("agrees across a fuzz over a brace-heavy alphabet", () => {
+    // Random short strings from an alphabet dense in the characters that drive this
+    // pattern. Hand-written cases prove the ones we thought of; this covers the
+    // combinations we did not.
+    const alphabet = ["{", "}", '"q"', "a", " ", "\n", ":", ",", '"'];
+    const marker = '"q"';
+    const mismatches: string[] = [];
+    for (let i = 0; i < 20000; i++) {
+      let s = "";
+      const len = 1 + (i % 12);
+      for (let j = 0; j < len; j++) {
+        s += alphabet[Math.floor(Math.random() * alphabet.length)];
+      }
+      if (extractJsonObject(s, marker) !== legacyExtract(s, marker)) {
+        mismatches.push(s);
+        if (mismatches.length > 3) break;
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it("treats the marker as a literal, never as a pattern", () => {
+    // `indexOf`, not a regex: a marker containing regex metacharacters must match
+    // itself. Passing one to `new RegExp` unescaped would either throw or match
+    // something else entirely.
+    expect(extractJsonObject('{"a.c":1}', '"a.c"')).toBe('{"a.c":1}');
+    expect(extractJsonObject('{"abc":1}', '"a.c"')).toBeUndefined();
+  });
+});
+
+describe("extractJsonObject is linear on pathological input", () => {
+  it("returns promptly on a long run of opening braces", () => {
+    // The exact shape CodeQL named: starts with `{{`, repeats, never completes an
+    // object. The old regex took ~1.5s at 32k characters and ~24s at 128k.
+    const pathological = "{".repeat(200_000) + "x";
+    const started = process.hrtime.bigint();
+    const result = extractJsonObject(pathological, MARKER);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    expect(result).toBeUndefined();
+    // Loose on purpose: measured ~2ms, so 1s cannot flake but still fails a
+    // quadratic implementation by orders of magnitude.
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  it("returns promptly when the marker is absent from a long object", () => {
+    const pathological = "{" + "a".repeat(200_000);
+    const started = process.hrtime.bigint();
+    expect(extractJsonObject(pathological, MARKER)).toBeUndefined();
+    expect(Number(process.hrtime.bigint() - started) / 1e6).toBeLessThan(1000);
+  });
+});
+
+describe("stripTrailingParenthetical", () => {
+  it.each([
+    ["Phi-3.5-mini (smaller, good quality-per-GB, ~2.4 GB)", "Phi-3.5-mini"],
+    [
+      "Llama-3-Groq-8B Tool-Use (best tool-calling, ~4.9 GB)",
+      "Llama-3-Groq-8B Tool-Use",
+    ],
+    ["NoParens", "NoParens"],
+    // Leftmost match: both parentheticals go.
+    ["Trailing (a) (b)", "Trailing"],
+    ["(only)", ""],
+    ["", ""],
+    ["Unclosed (a", "Unclosed (a"],
+  ])("strips %s", (input, expected) => {
+    expect(stripTrailingParenthetical(input)).toBe(expected);
+    // Equivalence with the regex it replaced.
+    expect(stripTrailingParenthetical(input)).toBe(
+      input.replace(/\s*\(.*\)$/, ""),
+    );
+  });
+
+  it("is linear on a whitespace run that does not end the trimmed prefix", () => {
+    // The naive fix here is `.replace(/\s+$/, "")`, the SAME trailing-anchor shape
+    // removed from this package in #809.
+    //
+    // The input shape matters, and a first attempt at this test got it wrong:
+    // `"name" + " ".repeat(n) + "(x)"` does NOT catch that regex, because after
+    // slicing at `(` the prefix ENDS in whitespace, so `\s+$` succeeds on its first
+    // viable start position — linear. The quadratic case is a run that is followed by
+    // a non-space, so the anchor is never reachable and the engine retries from every
+    // position. Hence the trailing "x" before the parenthesis.
+    const pathological = " ".repeat(200_000) + "x(y)";
+    const started = process.hrtime.bigint();
+    expect(stripTrailingParenthetical(pathological)).toBe(
+      " ".repeat(200_000) + "x",
+    );
+    expect(Number(process.hrtime.bigint() - started) / 1e6).toBeLessThan(1000);
+  });
+});

--- a/packages/durable-insight-core/src/jsonExtract.test.ts
+++ b/packages/durable-insight-core/src/jsonExtract.test.ts
@@ -136,6 +136,15 @@ describe("stripTrailingParenthetical", () => {
     );
   });
 
+  it("strips a multi-line parenthetical, the one intended divergence", () => {
+    // The regex left this alone because `.` does not match a newline. Stripping is
+    // what a caller wants, and no current input can reach it -- the only labels are
+    // three single-line constants -- so it is documented as the contract rather than
+    // asserted as equivalence.
+    expect(stripTrailingParenthetical("name (a\nb)")).toBe("name");
+    expect("name (a\nb)".replace(/\s*\(.*\)$/, "")).toBe("name (a\nb)");
+  });
+
   it("is linear on a whitespace run that does not end the trimmed prefix", () => {
     // The naive fix here is `.replace(/\s+$/, "")`, the SAME trailing-anchor shape
     // removed from this package in #809.

--- a/packages/durable-insight-core/src/jsonExtract.ts
+++ b/packages/durable-insight-core/src/jsonExtract.ts
@@ -1,0 +1,88 @@
+/**
+ * Linear-time extraction of a JSON object from free-text model output.
+ *
+ * THE FAILURE THIS REPLACES:
+ * Three call sites independently used the same idiom to pull JSON out of a model
+ * reply that may be wrapped in prose or markdown fences:
+ *
+ *     text.match(/\{[\s\S]*"satisfied"[\s\S]*\}/)   // verdict.ts
+ *     text.match(/\{[\s\S]*"query"[\s\S]*\}/)       // llm.ts, twice
+ *
+ * Two unbounded `[\s\S]*` around a literal is polynomial: on input that begins a
+ * plausible object and never completes one, the engine retries the inner scan from
+ * every starting position. Measured growth is 4x per doubling of input — 6ms at 2k
+ * characters, 96ms at 8k, 1.5s at 32k, and roughly 24s at 128k. The input is a model
+ * response, so its length is not ours to bound, and a verbose reply reaches those
+ * sizes easily. CodeQL flagged the `verdict.ts` instance as `js/polynomial-redos`
+ * (high); the other two are the same expression against a different marker.
+ *
+ * WHAT THE REGEX ACTUALLY MEANT:
+ * Because both quantifiers are greedy and a regex match is leftmost-longest, that
+ * pattern always resolved to "from the FIRST `{` to the LAST `}`, provided the marker
+ * appears somewhere between them". It was never a JSON parser and never balanced
+ * braces. This function computes that same span by index, which is linear, and
+ * `jsonExtract.test.ts` asserts the two agree across a corpus that includes the
+ * pathological inputs.
+ */
+
+/**
+ * Return the substring from the first `{` to the last `}` when the marker appears
+ * strictly between them, mirroring `/\{[\s\S]*<marker>[\s\S]*\}/`.
+ *
+ * @param text   Free-text model output, possibly with prose or fences around JSON.
+ * @param marker A literal that must appear inside the object, e.g. `"satisfied"`.
+ *               Compared as a plain substring, never as a pattern.
+ * @returns The candidate JSON text, or `undefined` when there is no such span. The
+ *          result is NOT validated as JSON — callers still parse it and handle
+ *          failure, exactly as they did with the regex.
+ */
+export function extractJsonObject(
+  text: string,
+  marker: string,
+): string | undefined {
+  const start = text.indexOf("{");
+  if (start === -1) return undefined;
+
+  const end = text.lastIndexOf("}");
+  // `\}` has to match at or after the position `\{` matched, and the marker needs
+  // room between them, so an end at or before the start is no match.
+  if (end <= start) return undefined;
+
+  // The marker must lie strictly inside: the leading `\{` consumes index `start`
+  // and the trailing `\}` consumes index `end`, so the searchable region is the
+  // interior. `indexOf` here is a substring search, not a pattern match, so it
+  // cannot backtrack.
+  const interior = text.slice(start + 1, end);
+  if (!interior.includes(marker)) return undefined;
+
+  return text.slice(start, end + 1);
+}
+
+/**
+ * Strip a trailing parenthetical from a label: `"Phi-3.5-mini (smaller, ~2.4 GB)"`
+ * becomes `"Phi-3.5-mini"`.
+ *
+ * Replaces `label.replace(/\s*\(.*\)$/, "")`, which has the same polynomial shape as
+ * the extraction above (unbounded `.*` before an anchored `\)`). That instance was
+ * NOT exploitable — its input is one of three hardcoded preset labels, which is why
+ * CodeQL did not flag it — but the shape is removed so that making labels dynamic
+ * later cannot quietly reintroduce a slow path.
+ */
+export function stripTrailingParenthetical(label: string): string {
+  if (!label.endsWith(")")) return label;
+  // FIRST `(`, not the last. A regex match is leftmost, so `\s*\(.*\)$` anchors on
+  // the earliest `(` that still has the final `)` after it: "Trailing (a) (b)"
+  // becomes "Trailing", not "Trailing (a)". Using `lastIndexOf` here looked obviously
+  // right and was caught only by asserting equivalence with the regex it replaces.
+  const open = label.indexOf("(");
+  if (open === -1) return label;
+  // Drop the parenthetical, then the whitespace that preceded it — `\s*` sat outside
+  // the group in the original, so it was removed too.
+  //
+  // `trimEnd()`, deliberately NOT `.replace(/\s+$/, "")`: that is the same
+  // trailing-anchor shape removed from this package in #809, and writing it here
+  // while removing it two functions above would be absurd. `trimEnd` strips exactly
+  // the set JavaScript's `\s` matches (WhiteSpace plus LineTerminator), in linear
+  // time.
+  return label.slice(0, open).trimEnd();
+}

--- a/packages/durable-insight-core/src/jsonExtract.ts
+++ b/packages/durable-insight-core/src/jsonExtract.ts
@@ -62,6 +62,14 @@ export function extractJsonObject(
  * Strip a trailing parenthetical from a label: `"Phi-3.5-mini (smaller, ~2.4 GB)"`
  * becomes `"Phi-3.5-mini"`.
  *
+ * CONTRACT, where it differs from the regex it replaces: a parenthetical containing a
+ * NEWLINE is stripped here, whereas the regex left it in place because `.` does not
+ * match a line terminator. This is the only divergence, it is unreachable today -- the
+ * only inputs are three single-line preset labels -- and stripping is the behavior the
+ * caller wants, so it is the intended contract rather than an accident. Every
+ * single-line input agrees exactly, which `jsonExtract.test.ts` asserts against the
+ * original pattern.
+ *
  * Replaces `label.replace(/\s*\(.*\)$/, "")`, which has the same polynomial shape as
  * the extraction above (unbounded `.*` before an anchored `\)`). That instance was
  * NOT exploitable — its input is one of three hardcoded preset labels, which is why

--- a/packages/durable-insight-core/src/llm.ts
+++ b/packages/durable-insight-core/src/llm.ts
@@ -598,14 +598,14 @@ async function generateViaCopilot(
   ]);
 
   // Parse JSON from the response (handle potential markdown wrapping)
-  const jsonMatch = extractJsonObject(text, '"query"');
-  if (jsonMatch === undefined) {
+  const jsonText = extractJsonObject(text, '"query"');
+  if (jsonText === undefined) {
     throw new Error(
       "Copilot did not return a valid query. Try rephrasing your question.",
     );
   }
 
-  const parsed = JSON.parse(jsonMatch) as {
+  const parsed = JSON.parse(jsonText) as {
     query?: string;
     explanation?: string;
     timeRangeMs?: number;
@@ -825,14 +825,14 @@ async function generateViaLocal(
     await context.dispose();
   }
 
-  const jsonMatch = extractJsonObject(response, '"query"');
-  if (jsonMatch === undefined) {
+  const jsonText = extractJsonObject(response, '"query"');
+  if (jsonText === undefined) {
     throw new Error(
       "Local model did not return a valid query. Try rephrasing your question.",
     );
   }
 
-  const parsed = JSON.parse(jsonMatch) as {
+  const parsed = JSON.parse(jsonText) as {
     query?: string;
     explanation?: string;
     timeRangeMs?: number;

--- a/packages/durable-insight-core/src/llm.ts
+++ b/packages/durable-insight-core/src/llm.ts
@@ -10,6 +10,7 @@ import { buildSystemPrompt, type DestinationType } from "./schema";
 import { parseChartSpec } from "./chartSpec";
 import { parseLocalServerQueryResponse } from "./localServerParse";
 import { stripTrailingSlashes } from "./hostModuleScan";
+import { extractJsonObject, stripTrailingParenthetical } from "./jsonExtract";
 import {
   parseVerdict,
   buildVerifyInstruction,
@@ -597,14 +598,14 @@ async function generateViaCopilot(
   ]);
 
   // Parse JSON from the response (handle potential markdown wrapping)
-  const jsonMatch = text.match(/\{[\s\S]*"query"[\s\S]*\}/);
-  if (!jsonMatch) {
+  const jsonMatch = extractJsonObject(text, '"query"');
+  if (jsonMatch === undefined) {
     throw new Error(
       "Copilot did not return a valid query. Try rephrasing your question.",
     );
   }
 
-  const parsed = JSON.parse(jsonMatch[0]) as {
+  const parsed = JSON.parse(jsonMatch) as {
     query?: string;
     explanation?: string;
     timeRangeMs?: number;
@@ -724,7 +725,7 @@ export async function ensureModel(
 
   fs.mkdirSync(MODEL_DIR, { recursive: true });
   statusCallback?.(
-    `Downloading ${preset.label.replace(/\s*\(.*\)$/, "")} (${preset.sizeLabel}, one time)...`,
+    `Downloading ${stripTrailingParenthetical(preset.label)} (${preset.sizeLabel}, one time)...`,
   );
 
   const response = await fetch(preset.url);
@@ -824,14 +825,14 @@ async function generateViaLocal(
     await context.dispose();
   }
 
-  const jsonMatch = response.match(/\{[\s\S]*"query"[\s\S]*\}/);
-  if (!jsonMatch) {
+  const jsonMatch = extractJsonObject(response, '"query"');
+  if (jsonMatch === undefined) {
     throw new Error(
       "Local model did not return a valid query. Try rephrasing your question.",
     );
   }
 
-  const parsed = JSON.parse(jsonMatch[0]) as {
+  const parsed = JSON.parse(jsonMatch) as {
     query?: string;
     explanation?: string;
     timeRangeMs?: number;

--- a/packages/durable-insight-core/src/redosGuard.test.ts
+++ b/packages/durable-insight-core/src/redosGuard.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Class-level guard against polynomial-ReDoS regexes in this package.
+ *
+ * WHY THIS EXISTS:
+ * This is the third round of the same finding. #809 fixed three trailing-anchor
+ * regexes (`/\/+$/`, `/\s+$/`) after CodeQL flagged one of them. CodeQL then flagged
+ * a fourth in `verdict.ts` — a different shape, two unbounded `[\s\S]*` around a
+ * literal — and sweeping for THAT shape turned up three more the scanner had not
+ * reported.
+ *
+ * Each round fixed instances. The recurring mistake was scoping the sweep to the
+ * shape that had just been found, so the next shape was invisible: exactly the
+ * mistake made with `HOST_MODULES` (guarding `vscode` and missing `electron`) and with
+ * the query choke point (guarding `run*Query` and missing `fetchAthenaRecord`). So
+ * this guard is about the CLASS: any regex with two or more unbounded quantifiers must
+ * be justified, whatever its shape.
+ *
+ * HOW IT WORKS:
+ * Every regex literal in this package's non-test sources is extracted and scored by
+ * how many unbounded quantifiers it contains (`.*`, `.+`, `[^x]*`, `\s+`, ...). Two or
+ * more means the engine can be made to retry an inner scan from many start positions,
+ * which is the necessary condition for polynomial backtracking. Such a pattern must
+ * appear in ALLOWED below, with a note on why it is safe.
+ *
+ * WHY AN ALLOWLIST RATHER THAN A BAN:
+ * Two unbounded quantifiers are necessary but not sufficient — seven patterns here are
+ * genuinely linear because their quantifiers cannot overlap (different character
+ * classes, or a literal pinned between them). Every entry was MEASURED, not reasoned
+ * about: growth from 2k to 8k characters of adversarial input, where quadratic shows
+ * as ~16x and linear as ~1x. Banning the shape outright would force pointless rewrites
+ * of correct code, and a guard that cries wolf gets deleted.
+ *
+ * ADDING AN ENTRY IS THE POINT AT WHICH TO MEASURE. If you cannot state the input that
+ * would be pathological and show it is not, the pattern does not belong here.
+ *
+ * Test files are excluded from the scan on purpose: this file's own ALLOWLIST contains
+ * pattern text, and two earlier scanners in this repo flagged their own documentation.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = __dirname;
+
+/**
+ * Patterns with two or more unbounded quantifiers that are nonetheless linear.
+ * Keyed by the regex SOURCE rather than by file and line, so ordinary edits do not
+ * invalidate the list.
+ */
+const ALLOWED = new Map<string, string>([
+  [
+    String.raw`\bfrom\s*["'](\.[^"']*)["']`,
+    "hostModuleScan: `\\s*` matches only whitespace and `[^\"']*` stops at a quote, " +
+      "so the two cannot compete for the same characters. Measured flat from 2k to 8k.",
+  ],
+  [
+    String.raw`(?:^|;)\s*import\s*["'](\.[^"']*)["']`,
+    "hostModuleScan: as above — disjoint character classes separated by literals.",
+  ],
+  [
+    String.raw`\brequire\s*\(\s*["'](\.[^"']*)["']\s*\)`,
+    "hostModuleScan: as above.",
+  ],
+  [
+    String.raw`\bimport\s*\(\s*["'](\.[^"']*)["']\s*\)`,
+    "hostModuleScan: as above.",
+  ],
+  [
+    String.raw`\blimit\s+\d+`,
+    "agentLoop: `\\s+` and `\\d+` are disjoint, so neither can absorb the other's " +
+      "characters. Measured flat.",
+  ],
+  [
+    String.raw`\|\s*fields\s+([^|]+)`,
+    "queryShape: `[^|]+` runs to the next pipe or end of input, and the `fields` " +
+      "literal pins the start. Measured flat.",
+  ],
+  [
+    String.raw`^\s*\*\s*$`,
+    "queryShape: anchored at both ends with a literal `*` between the quantifiers, " +
+      "so there is one candidate split. Measured flat.",
+  ],
+  [
+    String.raw`\*\s*,|\bselect\s+\*`,
+    "queryShape: an alternation of two short anchored branches, not nested " +
+      "quantifiers. Measured flat.",
+  ],
+  [
+    String.raw`^([\s\S]*?)(\s+from\s)`,
+    "queryShape: start-anchored, and the first quantifier is LAZY, so it extends one " +
+      "character at a time toward a single required literal rather than backtracking " +
+      "over the whole input. Measured flat.",
+  ],
+]);
+
+/** Every non-test `.ts` file in this package, recursively. */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Found {
+  file: string;
+  line: number;
+  source: string;
+  unbounded: number;
+}
+
+/**
+ * Extract regex literals and count unbounded quantifiers.
+ *
+ * Deliberately a lexical scan rather than a parse. It can miss a literal spelled in an
+ * unusual way, and it does not see `new RegExp(...)` built from variables — so it is a
+ * floor on coverage, not a proof of absence. CodeQL remains the primary detector; this
+ * exists to stop a KNOWN class from being reintroduced between scans, and to force the
+ * measurement conversation when someone adds one.
+ */
+function findRiskyRegexes(): Found[] {
+  const found: Found[] = [];
+  // A quantified atom that can consume arbitrary characters: `.`, a character class,
+  // or a whitespace/word/digit class, followed by `*` or `+`.
+  const unboundedAtom = /(\[\^?(?:\\.|[^\]])*\]|\.|\\[sSwWdD])[*+]/g;
+
+  for (const file of sourceFiles(SRC)) {
+    readFileSync(file, "utf-8")
+      .split("\n")
+      .forEach((line, index) => {
+        // Skip comment lines: prose about a pattern is not a pattern.
+        if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
+        for (const match of line.matchAll(
+          /\/((?:\\.|\[(?:\\.|[^\]])*\]|[^/\n\\])+)\/[gimsuy]*/g,
+        )) {
+          const source = match[1];
+          const count = [...source.matchAll(unboundedAtom)].length;
+          if (count >= 2) {
+            found.push({
+              file: file.slice(SRC.length + 1),
+              line: index + 1,
+              source,
+              unbounded: count,
+            });
+          }
+        }
+      });
+  }
+  return found;
+}
+
+const risky = findRiskyRegexes();
+
+describe("no unjustified polynomial-ReDoS candidates", () => {
+  it("scans the package and finds the patterns it is meant to see", () => {
+    // Non-vacuity. A scan that silently matched nothing — a changed literal syntax, a
+    // renamed directory — would make the assertion below trivially true, which is the
+    // failure mode of every scanner in this repo that has needed fixing.
+    expect(risky.length).toBeGreaterThanOrEqual(ALLOWED.size);
+    const sources = risky.map((r) => r.source);
+    expect(sources).toContain(String.raw`^([\s\S]*?)(\s+from\s)`);
+    expect(sources).toContain(String.raw`\blimit\s+\d+`);
+  });
+
+  it("has no allowlist entry that is no longer present", () => {
+    // A stale entry silently widens the rule. If a pattern is gone, its exemption
+    // should go with it.
+    const sources = new Set(risky.map((r) => r.source));
+    const orphans = [...ALLOWED.keys()].filter((k) => !sources.has(k));
+    expect(orphans).toEqual([]);
+  });
+
+  it("every risky pattern is allowlisted with a reason", () => {
+    const unjustified = risky
+      .filter((r) => !ALLOWED.has(r.source))
+      .map((r) => `${r.file}:${r.line}  /${r.source}/`);
+    // A pattern here has two or more unbounded quantifiers and no measured
+    // justification. Measure it: build the adversarial input, time it at 2k and 8k
+    // characters, and either fix it or add it to ALLOWED with the numbers.
+    expect(unjustified).toEqual([]);
+  });
+
+  it("the JSON extraction that caused this guard is gone", () => {
+    // The specific regression, named. `extractJsonObject` replaced three copies of
+    // this; if one comes back, fail here rather than waiting for the next CodeQL scan.
+    // CODE lines only. `jsonExtract.ts` DOCUMENTS the pattern it replaced, and a
+    // whole-file scan flags that documentation — the fourth time a scanner in this
+    // repo has reported its own prose. The rule is now settled: a name or a pattern in
+    // a comment is not a use, so every scanner here skips comments.
+    const offenders: string[] = [];
+    for (const file of sourceFiles(SRC)) {
+      const codeLines = readFileSync(file, "utf-8")
+        .split("\n")
+        .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line));
+      if (/\[\\s\\S\]\*[^/]*\[\\s\\S\]\*/.test(codeLines.join("\n"))) {
+        offenders.push(file.slice(SRC.length + 1));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/durable-insight-core/src/redosGuard.test.ts
+++ b/packages/durable-insight-core/src/redosGuard.test.ts
@@ -118,17 +118,56 @@ const ALLOWED = new Map<string, string>([
       "character at a time toward a single required literal rather than backtracking " +
       "over the whole input. Measured flat.",
   ],
+  [
+    String.raw`\s*\(.*\)$`,
+    "jsonExtract.test.ts: this IS the vulnerable pattern, kept deliberately to assert " +
+      "that `stripTrailingParenthetical` is equivalent to what it replaced. Applied only " +
+      "to the short literals in that file, never to input. Removing it would remove the " +
+      "equivalence proof, which is worth more than the shape is worth avoiding in a " +
+      "fixture.",
+  ],
+  [
+    String.raw`(\[\^?(?:\\.|[^\]\\])*\]|\.|\\[sSwWdD])(?:[*+]|\{\d+,\})`,
+    "This file's WIDE_QUANTIFIER. R3 fires on the outer capture group, but that group is " +
+      "not repeated -- a quantifier alternation follows it -- and the alternatives inside " +
+      "begin with distinct characters. Measured flat to 4k characters on the witness " +
+      "CodeQL named for alert 248.",
+  ],
+  [
+    String.raw`(\\.|\[\^?(?:\\.|[^\]\\])*\]|\.|\([^)]*\)|[^\\[\](){}*+?|^$])(?:[*+]|\{\d+,\})`,
+    "This file's ANY_QUANTIFIER. As above; measured flat to 4k characters across four " +
+      "witness shapes.",
+  ],
+  [
+    String.raw`\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\[])+)\/[gimsuy]*`,
+    "This file's regex-literal extractor. It WAS exponential -- 2x per `[]`, 40ms at 22 " +
+      "repetitions, CodeQL alerts 249/251 -- because a `[` could be consumed either by " +
+      "the character-class alternative or as a plain character. Excluding `[` from the " +
+      "fallback leaves one parse; measured flat to 2k repetitions and verified to extract " +
+      "identically across all 11,417 lines of this package.",
+  ],
 ]);
 
-/** Every non-test `.ts` file in this package, recursively. */
+/**
+ * Every `.ts` file in this package, TESTS INCLUDED, recursively.
+ *
+ * Tests were excluded at first, to stop the sweep flagging the pattern text in this
+ * file's own documentation. That exclusion also blinded it to the one place a regex is
+ * most likely to be exotic: the scanner below. CodeQL then flagged three regexes in this
+ * very file (alerts 248-251, `js/redos`, EXPONENTIAL) which the guard could not
+ * structurally have found -- a ReDoS in the ReDoS detector, invisible to itself.
+ *
+ * So tests are scanned, and the narrower fix is used instead: skip COMMENT LINES rather
+ * than whole files. Prose about a pattern is not a pattern. The `String.raw` entries in
+ * ALLOWED and in the self-tests are string literals rather than regex literals, so the
+ * extractor never saw them anyway.
+ */
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) out.push(...sourceFiles(full));
-    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
-      out.push(full);
-    }
+    else if (entry.name.endsWith(".ts")) out.push(full);
   }
   return out;
 }
@@ -209,7 +248,15 @@ function findRiskyRegexes(): Found[] {
         // Skip comment lines: prose about a pattern is not a pattern.
         if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
         for (const match of line.matchAll(
-          /\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\])+)\/[gimsuy]*/g,
+          // `[^/\n\\[]` — the trailing `[` exclusion is load-bearing, not tidiness.
+          // Without it a `[` could be consumed EITHER by the character-class
+          // alternative or as a plain character, so `/[][][]...` had two parses per
+          // repetition and this regex was EXPONENTIAL: 2x per `[]`, 40ms at 22
+          // repetitions, ~40s at 32. CodeQL alerts 249/251 (js/redos, high). Excluding
+          // `[` from the fallback leaves exactly one parse, and a bare `[` outside a
+          // class is not valid in a regex literal anyway. Verified to extract
+          // identically across all 11,417 lines of this package.
+          /\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\[])+)\/[gimsuy]*/g,
         )) {
           const risks = riskRules(match[1]);
           if (risks.length > 0) {
@@ -314,12 +361,21 @@ describe("no unjustified polynomial-ReDoS candidates", () => {
   it("the JSON extraction that caused this guard is gone", () => {
     // The specific regression, named. `extractJsonObject` replaced three copies of
     // this; if one comes back, fail here rather than waiting for the next CodeQL scan.
-    // CODE lines only. `jsonExtract.ts` DOCUMENTS the pattern it replaced, and a
-    // whole-file scan flags that documentation — the fourth time a scanner in this
-    // repo has reported its own prose. The rule is now settled: a name or a pattern in
-    // a comment is not a use, so every scanner here skips comments.
+    // NON-TEST files, and CODE lines only, for two different reasons.
+    //
+    // Comments: `jsonExtract.ts` DOCUMENTS the pattern it replaced, and a whole-file
+    // scan flags that documentation — the fourth time a scanner in this repo has
+    // reported its own prose.
+    //
+    // Tests: this file's own self-tests carry the pattern as DATA, on ordinary code
+    // lines, so scanning tests here would flag the very assertions that prove the
+    // detector works. Unlike the class sweep above, which handles tests through
+    // ALLOWED, this check is a hardcoded assertion about production code — so it is
+    // scoped to production code.
     const offenders: string[] = [];
-    for (const file of sourceFiles(SRC)) {
+    for (const file of sourceFiles(SRC).filter(
+      (f) => !f.endsWith(".test.ts"),
+    )) {
       const codeLines = readFileSync(file, "utf-8")
         .split("\n")
         .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line));

--- a/packages/durable-insight-core/src/redosGuard.test.ts
+++ b/packages/durable-insight-core/src/redosGuard.test.ts
@@ -74,79 +74,120 @@ const SRC = __dirname;
  * linear, each with the reason. Keyed by the regex SOURCE rather than by file and line,
  * so ordinary edits do not invalidate the list.
  */
-const ALLOWED = new Map<string, string>([
-  [
-    String.raw`\bfrom\s*["'](\.[^"']*)["']`,
-    "hostModuleScan: `\\s*` matches only whitespace and `[^\"']*` stops at a quote, " +
+const ALLOWED_ENTRIES: ReadonlyArray<{
+  file: string;
+  source: string;
+  reason: string;
+}> = [
+  {
+    file: "hostModuleScan.ts",
+    source: String.raw`\bfrom\s*["'](\.[^"']*)["']`,
+    reason:
+      "hostModuleScan: `\\s*` matches only whitespace and `[^\"']*` stops at a quote, " +
       "so the two cannot compete for the same characters. Measured flat from 2k to 8k.",
-  ],
-  [
-    String.raw`(?:^|;)\s*import\s*["'](\.[^"']*)["']`,
-    "hostModuleScan: as above — disjoint character classes separated by literals.",
-  ],
-  [
-    String.raw`\brequire\s*\(\s*["'](\.[^"']*)["']\s*\)`,
-    "hostModuleScan: as above.",
-  ],
-  [
-    String.raw`\bimport\s*\(\s*["'](\.[^"']*)["']\s*\)`,
-    "hostModuleScan: as above.",
-  ],
-  [
-    String.raw`\blimit\s+\d+`,
-    "agentLoop: `\\s+` and `\\d+` are disjoint, so neither can absorb the other's " +
+  },
+  {
+    file: "hostModuleScan.ts",
+    source: String.raw`(?:^|;)\s*import\s*["'](\.[^"']*)["']`,
+    reason:
+      "hostModuleScan: as above — disjoint character classes separated by literals.",
+  },
+  {
+    file: "hostModuleScan.ts",
+    source: String.raw`\brequire\s*\(\s*["'](\.[^"']*)["']\s*\)`,
+    reason: "hostModuleScan: as above.",
+  },
+  {
+    file: "hostModuleScan.ts",
+    source: String.raw`\bimport\s*\(\s*["'](\.[^"']*)["']\s*\)`,
+    reason: "hostModuleScan: as above.",
+  },
+  {
+    file: "agentLoop.ts",
+    source: String.raw`\blimit\s+\d+`,
+    reason:
+      "agentLoop: `\\s+` and `\\d+` are disjoint, so neither can absorb the other's " +
       "characters. Measured flat.",
-  ],
-  [
-    String.raw`\|\s*fields\s+([^|]+)`,
-    "queryShape: `[^|]+` runs to the next pipe or end of input, and the `fields` " +
+  },
+  {
+    file: "queryShape.ts",
+    source: String.raw`\|\s*fields\s+([^|]+)`,
+    reason:
+      "queryShape: `[^|]+` runs to the next pipe or end of input, and the `fields` " +
       "literal pins the start. Measured flat.",
-  ],
-  [
-    String.raw`^\s*\*\s*$`,
-    "queryShape: anchored at both ends with a literal `*` between the quantifiers, " +
+  },
+  {
+    file: "queryShape.ts",
+    source: String.raw`^\s*\*\s*$`,
+    reason:
+      "queryShape: anchored at both ends with a literal `*` between the quantifiers, " +
       "so there is one candidate split. Measured flat.",
-  ],
-  [
-    String.raw`\*\s*,|\bselect\s+\*`,
-    "queryShape: an alternation of two short anchored branches, not nested " +
+  },
+  {
+    file: "queryShape.ts",
+    source: String.raw`\*\s*,|\bselect\s+\*`,
+    reason:
+      "queryShape: an alternation of two short anchored branches, not nested " +
       "quantifiers. Measured flat.",
-  ],
-  [
-    String.raw`^([\s\S]*?)(\s+from\s)`,
-    "queryShape: start-anchored, and the first quantifier is LAZY, so it extends one " +
+  },
+  {
+    file: "queryShape.ts",
+    source: String.raw`^([\s\S]*?)(\s+from\s)`,
+    reason:
+      "queryShape: start-anchored, and the first quantifier is LAZY, so it extends one " +
       "character at a time toward a single required literal rather than backtracking " +
       "over the whole input. Measured flat.",
-  ],
-  [
-    String.raw`\s*\(.*\)$`,
-    "jsonExtract.test.ts: this IS the vulnerable pattern, kept deliberately to assert " +
+  },
+  {
+    file: "jsonExtract.test.ts",
+    source: String.raw`\s*\(.*\)$`,
+    reason:
+      "jsonExtract.test.ts: this IS the vulnerable pattern, kept deliberately to assert " +
       "that `stripTrailingParenthetical` is equivalent to what it replaced. Applied only " +
       "to the short literals in that file, never to input. Removing it would remove the " +
       "equivalence proof, which is worth more than the shape is worth avoiding in a " +
       "fixture.",
-  ],
-  [
-    String.raw`(\[\^?(?:\\.|[^\]\\])*\]|\.|\\[sSwWdD])(?:[*+]|\{\d+,\})`,
-    "This file's WIDE_QUANTIFIER. R3 fires on the outer capture group, but that group is " +
+  },
+  {
+    file: "redosGuard.test.ts",
+    source: String.raw`(\[\^?(?:\\.|[^\]\\])*\]|\.|\\[sSwWdD])(?:[*+]|\{\d+,\})`,
+    reason:
+      "This file's WIDE_QUANTIFIER. R3 fires on the outer capture group, but that group is " +
       "not repeated -- a quantifier alternation follows it -- and the alternatives inside " +
       "begin with distinct characters. Measured flat to 4k characters on the witness " +
       "CodeQL named for alert 248.",
-  ],
-  [
-    String.raw`(\\.|\[\^?(?:\\.|[^\]\\])*\]|\.|\([^)]*\)|[^\\[\](){}*+?|^$])(?:[*+]|\{\d+,\})`,
-    "This file's ANY_QUANTIFIER. As above; measured flat to 4k characters across four " +
+  },
+  {
+    file: "redosGuard.test.ts",
+    source: String.raw`(\\.|\[\^?(?:\\.|[^\]\\])*\]|\.|\([^)]*\)|[^\\[\](){}*+?|^$])(?:[*+]|\{\d+,\})`,
+    reason:
+      "This file's ANY_QUANTIFIER. As above; measured flat to 4k characters across four " +
       "witness shapes.",
-  ],
-  [
-    String.raw`\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\[])+)\/[gimsuy]*`,
-    "This file's regex-literal extractor. It WAS exponential -- 2x per `[]`, 40ms at 22 " +
+  },
+  {
+    file: "redosGuard.test.ts",
+    source: String.raw`\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\[])+)\/[gimsuy]*`,
+    reason:
+      "This file's regex-literal extractor. It WAS exponential -- 2x per `[]`, 40ms at 22 " +
       "repetitions, CodeQL alerts 249/251 -- because a `[` could be consumed either by " +
       "the character-class alternative or as a plain character. Excluding `[` from the " +
       "fallback leaves one parse; measured flat to 2k repetitions and verified to extract " +
       "identically across all 11,417 lines of this package.",
-  ],
-]);
+  },
+];
+
+/**
+ * `file\u0000source` for every exemption.
+ *
+ * KEYED BY FILE AS WELL AS PATTERN, and that is the whole point. Keying on the pattern
+ * alone meant the exemption written for the deliberately-vulnerable fixture in
+ * `jsonExtract.test.ts` ALSO exempted the identical regex anywhere else -- including
+ * production code. Demonstrated: adding `/\s*\(.*\)$/` to `verdict.ts` left the guard
+ * green. A justification is about a pattern IN A PLACE, so the key has to carry both.
+ */
+const ALLOWED = new Set(
+  ALLOWED_ENTRIES.map((e) => `${e.file}\u0000${e.source}`),
+);
 
 /**
  * Every `.ts` file in this package, TESTS INCLUDED, recursively.
@@ -198,6 +239,56 @@ const ANY_QUANTIFIER =
 const REPEATED_GROUP = /\)(?:[*+]|\{\d+,\})/;
 
 /**
+ * Split a pattern into the fragments that an anchor could independently govern:
+ * on `|` at any depth, and at group boundaries.
+ *
+ * Deliberately over-splits. A fragment that is not really a separate branch can only
+ * cause an extra finding, which the allowlist absorbs after a measurement; a branch that
+ * is missed hides a quadratic path, which is the defect this rule exists to catch.
+ * Character classes are stepped over so a `|` or `(` inside one is not a boundary.
+ */
+function alternationBranches(source: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let inClass = false;
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    // An escape is a backslash that is not itself escaped.
+    const escaped =
+      i > 0 && source[i - 1] === "\\" && !(i > 1 && source[i - 2] === "\\");
+    if (escaped) {
+      current += char;
+      continue;
+    }
+    if (inClass) {
+      current += char;
+      if (char === "]") inClass = false;
+      continue;
+    }
+    if (char === "[") {
+      inClass = true;
+      current += char;
+      continue;
+    }
+    if (char === "|" || char === "(" || char === ")") {
+      out.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  out.push(current);
+  // The whole pattern counts as a branch too, for the single-alternative case.
+  return [source, ...out].filter((s) => s.length > 0);
+}
+
+/** True when a fragment ends in `$`, is not start-anchored, and has a quantifier. */
+function hasTrailingAnchorRisk(fragment: string): boolean {
+  if (!fragment.endsWith("$") || fragment.startsWith("^")) return false;
+  return [...fragment.matchAll(ANY_QUANTIFIER)].length >= 1;
+}
+
+/**
  * Score one pattern against the three shapes that produce super-linear backtracking.
  *
  * The first version of this guard implemented only R1, which is how it managed to pass
@@ -213,12 +304,17 @@ function riskRules(source: string): string[] {
   const wide = [...source.matchAll(WIDE_QUANTIFIER)].length;
   if (wide >= 2) found.push(`R1: ${wide} wide quantifiers`);
 
-  // R2 -- one quantifier plus an END anchor and no START anchor. When the anchor is
+  // R2 -- a quantifier plus an END anchor and no START anchor. When the anchor is
   // unreachable the engine retries from every position, which is exactly the shape
   // CodeQL flagged in #809 (`/\/+$/`, `/\s+$/`). A start anchor removes it: there is
   // then only one place to begin.
-  const anyQuantifier = [...source.matchAll(ANY_QUANTIFIER)].length;
-  if (anyQuantifier >= 1 && source.endsWith("$") && !source.startsWith("^")) {
+  //
+  // APPLIED PER BRANCH, not to the whole pattern. Testing `source.endsWith("$")` and
+  // `source.startsWith("^")` assumes those anchors govern every alternative, and they
+  // do not: `/a+$|x/` does not end with `$`, `/^x|a+$/` does start with `^`, and BOTH
+  // have a quadratic `a+$` branch -- measured 6ms at 2k characters rising 4x per
+  // doubling to 394ms at 16k. Both scored zero before this.
+  if (alternationBranches(source).some(hasTrailingAnchorRisk)) {
     found.push("R2: quantifier with a trailing $ and no leading ^");
   }
 
@@ -306,6 +402,15 @@ describe("the detector catches every shape this package has had to remove", () =
     [String.raw`(a|aa)+$`, "R3"],
     // Repeated group without nesting: still worth a justification.
     [String.raw`(ab)+c`, "R3"],
+    // ALTERNATION. Neither of these is caught by testing the whole pattern's first and
+    // last characters -- the first does not end with `$`, the second does start with
+    // `^` -- yet both have a quadratic `a+$` branch, measured 6ms at 2k characters
+    // rising 4x per doubling to 394ms at 16k. Both scored zero until R2 became
+    // per-branch.
+    [String.raw`a+$|x`, "R2"],
+    [String.raw`^x|a+$`, "R2"],
+    // The same escape inside a group rather than a bare alternation.
+    [String.raw`^(?:x|a+$)`, "R2"],
   ])("flags %s under %s", (pattern, rule) => {
     const risks = riskRules(pattern);
     expect(risks.length).toBeGreaterThan(0);
@@ -319,6 +424,8 @@ describe("the detector catches every shape this package has had to remove", () =
     String.raw`\s*`,
     // No quantifier at all.
     String.raw`\bselect\b`,
+    // Every branch start-anchored: no branch can retry from many positions.
+    String.raw`^a+$|^b+$`,
   ])("does not flag the benign pattern %s", (pattern) => {
     // Acceptance matters as much as detection: a detector that flagged everything
     // would satisfy the cases above while making the allowlist meaningless.
@@ -331,23 +438,46 @@ describe("no unjustified polynomial-ReDoS candidates", () => {
     // Non-vacuity. A scan that silently matched nothing — a changed literal syntax, a
     // renamed directory — would make the assertion below trivially true, which is the
     // failure mode of every scanner in this repo that has needed fixing.
-    expect(risky.length).toBeGreaterThanOrEqual(ALLOWED.size);
+    expect(risky.length).toBeGreaterThanOrEqual(ALLOWED_ENTRIES.length);
     const sources = risky.map((r) => r.source);
     expect(sources).toContain(String.raw`^([\s\S]*?)(\s+from\s)`);
     expect(sources).toContain(String.raw`\blimit\s+\d+`);
   });
 
+  it("does not exempt a pattern outside the file it was justified in", () => {
+    // THE LEAK THIS CLOSES:
+    // `ALLOWED` was keyed by regex source alone, so the exemption written for the
+    // deliberately-vulnerable fixture in `jsonExtract.test.ts` also exempted the
+    // identical regex in production. Demonstrated by adding `/\s*\(.*\)$/` to
+    // `verdict.ts`, which left the guard green.
+    //
+    // Fixing that structurally is not enough on its own -- reverting the key to
+    // source-only passes every other test in this file, which is how the leak existed
+    // in the first place. This asserts the keying directly.
+    const fixture = ALLOWED_ENTRIES.find(
+      (e) => e.file === "jsonExtract.test.ts",
+    );
+    expect(fixture).toBeDefined();
+    const source = fixture?.source ?? "";
+    expect(ALLOWED.has(`jsonExtract.test.ts\u0000${source}`)).toBe(true);
+    // The same pattern in production code is NOT covered by that justification.
+    expect(ALLOWED.has(`verdict.ts\u0000${source}`)).toBe(false);
+    expect(ALLOWED.has(`llm.ts\u0000${source}`)).toBe(false);
+  });
+
   it("has no allowlist entry that is no longer present", () => {
     // A stale entry silently widens the rule. If a pattern is gone, its exemption
     // should go with it.
-    const sources = new Set(risky.map((r) => r.source));
-    const orphans = [...ALLOWED.keys()].filter((k) => !sources.has(k));
+    const present = new Set(risky.map((r) => `${r.file}\u0000${r.source}`));
+    const orphans = ALLOWED_ENTRIES.filter(
+      (e) => !present.has(`${e.file}\u0000${e.source}`),
+    ).map((e) => `${e.file}  /${e.source}/`);
     expect(orphans).toEqual([]);
   });
 
   it("every risky pattern is allowlisted with a reason", () => {
     const unjustified = risky
-      .filter((r) => !ALLOWED.has(r.source))
+      .filter((r) => !ALLOWED.has(`${r.file}\u0000${r.source}`))
       .map(
         (r) => `${r.file}:${r.line}  /${r.source}/  [${r.risks.join("; ")}]`,
       );

--- a/packages/durable-insight-core/src/redosGuard.test.ts
+++ b/packages/durable-insight-core/src/redosGuard.test.ts
@@ -109,24 +109,71 @@ interface Found {
   file: string;
   line: number;
   source: string;
-  unbounded: number;
+  risks: string[];
 }
 
 /**
- * Extract regex literals and count unbounded quantifiers.
+ * A quantified atom whose character class is WIDE -- it can consume many different
+ * characters, so two of them in one pattern can compete for the same input.
+ */
+const WIDE_QUANTIFIER =
+  /(\[\^?(?:\\.|[^\]\\])*\]|\.|\\[sSwWdD])(?:[*+]|\{\d+,\})/g;
+
+/**
+ * ANY quantified atom, wide or not -- including a single escaped literal such as
+ * `\/+`. Needed because the trailing-anchor shape does not require a wide class:
+ * `/\/+$/` is quadratic on a run of slashes.
+ */
+const ANY_QUANTIFIER =
+  /(\\.|\[\^?(?:\\.|[^\]\\])*\]|\.|\([^)]*\)|[^\\[\](){}*+?|^$])(?:[*+]|\{\d+,\})/g;
+
+/** A repeated GROUP: `(...)*`, `(...)+`, `(...){2,}`. */
+const REPEATED_GROUP = /\)(?:[*+]|\{\d+,\})/;
+
+/**
+ * Score one pattern against the three shapes that produce super-linear backtracking.
+ *
+ * The first version of this guard implemented only R1, which is how it managed to pass
+ * clean on BOTH regexes #809 removed and on `(a+)+$`, the textbook exponential case --
+ * while its own header argued against scoping a sweep to the shape just found. R2 and
+ * R3 close that, and cost nothing: they add no new findings in this package today.
+ */
+function riskRules(source: string): string[] {
+  const found: string[] = [];
+
+  // R1 -- two or more wide quantifiers can compete for the same characters, which is
+  // the JSON-extraction shape (`[\s\S]*` ... `[\s\S]*`).
+  const wide = [...source.matchAll(WIDE_QUANTIFIER)].length;
+  if (wide >= 2) found.push(`R1: ${wide} wide quantifiers`);
+
+  // R2 -- one quantifier plus an END anchor and no START anchor. When the anchor is
+  // unreachable the engine retries from every position, which is exactly the shape
+  // CodeQL flagged in #809 (`/\/+$/`, `/\s+$/`). A start anchor removes it: there is
+  // then only one place to begin.
+  const anyQuantifier = [...source.matchAll(ANY_QUANTIFIER)].length;
+  if (anyQuantifier >= 1 && source.endsWith("$") && !source.startsWith("^")) {
+    found.push("R2: quantifier with a trailing $ and no leading ^");
+  }
+
+  // R3 -- a repeated group. `(a+)+` is exponential rather than merely polynomial, and
+  // even `(ab)+` can backtrack across alternatives. Rare here, and cheap to require a
+  // justification for.
+  if (REPEATED_GROUP.test(source)) found.push("R3: repeated group");
+
+  return found;
+}
+
+/**
+ * Extract regex literals and score them.
  *
  * Deliberately a lexical scan rather than a parse. It can miss a literal spelled in an
- * unusual way, and it does not see `new RegExp(...)` built from variables — so it is a
+ * unusual way, and it does not see `new RegExp(...)` built from variables -- so it is a
  * floor on coverage, not a proof of absence. CodeQL remains the primary detector; this
  * exists to stop a KNOWN class from being reintroduced between scans, and to force the
  * measurement conversation when someone adds one.
  */
 function findRiskyRegexes(): Found[] {
   const found: Found[] = [];
-  // A quantified atom that can consume arbitrary characters: `.`, a character class,
-  // or a whitespace/word/digit class, followed by `*` or `+`.
-  const unboundedAtom = /(\[\^?(?:\\.|[^\]])*\]|\.|\\[sSwWdD])[*+]/g;
-
   for (const file of sourceFiles(SRC)) {
     readFileSync(file, "utf-8")
       .split("\n")
@@ -134,16 +181,15 @@ function findRiskyRegexes(): Found[] {
         // Skip comment lines: prose about a pattern is not a pattern.
         if (/^\s*(\/\/|\*|\/\*)/.test(line)) return;
         for (const match of line.matchAll(
-          /\/((?:\\.|\[(?:\\.|[^\]])*\]|[^/\n\\])+)\/[gimsuy]*/g,
+          /\/((?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\])+)\/[gimsuy]*/g,
         )) {
-          const source = match[1];
-          const count = [...source.matchAll(unboundedAtom)].length;
-          if (count >= 2) {
+          const risks = riskRules(match[1]);
+          if (risks.length > 0) {
             found.push({
               file: file.slice(SRC.length + 1),
               line: index + 1,
-              source,
-              unbounded: count,
+              source: match[1],
+              risks,
             });
           }
         }
@@ -153,6 +199,57 @@ function findRiskyRegexes(): Found[] {
 }
 
 const risky = findRiskyRegexes();
+
+/**
+ * Self-tests for the detector, against every shape this repository has actually had to
+ * remove.
+ *
+ * WHY THESE ARE THE MOST IMPORTANT TESTS IN THE FILE:
+ * The assertions below prove that the CURRENT sources are clean. They say nothing about
+ * whether the detector could find anything, so they pass just as well if it is narrowed
+ * to uselessness. The first version of this guard implemented only R1 and therefore
+ * scored `/\/+$/` -- the regex CodeQL flagged in #809 -- at ZERO, while its header
+ * argued against exactly that mistake. These cases are what stop the spec from drifting
+ * away from the prose again.
+ *
+ * Every entry is a real historical pattern or a canonical textbook case, not an
+ * invention.
+ */
+describe("the detector catches every shape this package has had to remove", () => {
+  it.each([
+    // #809: CodeQL js/polynomial-redos, trailing slash strip. Measured 174s at 320k.
+    [String.raw`\/+$`, "R2"],
+    // #809: trailing whitespace strip, two instances in moved files.
+    [String.raw`\s+$`, "R2"],
+    // This change: CodeQL alert #247, JSON extraction from model output.
+    [String.raw`\{[\s\S]*"satisfied"[\s\S]*\}`, "R1"],
+    [String.raw`\{[\s\S]*"query"[\s\S]*\}`, "R1"],
+    // This change: label parenthetical strip -- caught by both rules.
+    [String.raw`\s*\(.*\)$`, "R1"],
+    // Canonical exponential backtracking. Not present here, and must never be.
+    [String.raw`(a+)+$`, "R3"],
+    [String.raw`(a|aa)+$`, "R3"],
+    // Repeated group without nesting: still worth a justification.
+    [String.raw`(ab)+c`, "R3"],
+  ])("flags %s under %s", (pattern, rule) => {
+    const risks = riskRules(pattern);
+    expect(risks.length).toBeGreaterThan(0);
+    expect(risks.join(" ")).toContain(rule);
+  });
+
+  it.each([
+    // Start-anchored: one place to begin, so no retry-from-every-position.
+    String.raw`^\d+$`,
+    // A single wide quantifier with no end anchor.
+    String.raw`\s*`,
+    // No quantifier at all.
+    String.raw`\bselect\b`,
+  ])("does not flag the benign pattern %s", (pattern) => {
+    // Acceptance matters as much as detection: a detector that flagged everything
+    // would satisfy the cases above while making the allowlist meaningless.
+    expect(riskRules(pattern)).toEqual([]);
+  });
+});
 
 describe("no unjustified polynomial-ReDoS candidates", () => {
   it("scans the package and finds the patterns it is meant to see", () => {

--- a/packages/durable-insight-core/src/redosGuard.test.ts
+++ b/packages/durable-insight-core/src/redosGuard.test.ts
@@ -1,5 +1,5 @@
 /**
- * Class-level guard against polynomial-ReDoS regexes in this package.
+ * Class-level guard against super-linear-backtracking regexes in this package.
  *
  * WHY THIS EXISTS:
  * This is the third round of the same finding. #809 fixed three trailing-anchor
@@ -11,30 +11,58 @@
  * Each round fixed instances. The recurring mistake was scoping the sweep to the
  * shape that had just been found, so the next shape was invisible: exactly the
  * mistake made with `HOST_MODULES` (guarding `vscode` and missing `electron`) and with
- * the query choke point (guarding `run*Query` and missing `fetchAthenaRecord`). So
- * this guard is about the CLASS: any regex with two or more unbounded quantifiers must
- * be justified, whatever its shape.
+ * the query choke point (guarding `run*Query` and missing `fetchAthenaRecord`).
+ *
+ * This guard was itself written that way first, which is the best evidence that the
+ * mistake is easy to make. Its original rule was "two or more wide quantifiers", so it
+ * scored BOTH regexes #809 removed below threshold — `/\/+$/` at literally zero,
+ * because an escaped literal is not a wide character class — and `(a+)+$`, the textbook
+ * exponential case, at zero as well. The paragraphs above were already here while the
+ * code enforced something narrower than they described.
  *
  * HOW IT WORKS:
  * Every regex literal in this package's non-test sources is extracted and scored by
- * how many unbounded quantifiers it contains (`.*`, `.+`, `[^x]*`, `\s+`, ...). Two or
- * more means the engine can be made to retry an inner scan from many start positions,
- * which is the necessary condition for polynomial backtracking. Such a pattern must
- * appear in ALLOWED below, with a note on why it is safe.
+ * `riskRules` against THREE independent shapes. Matching any one of them means the
+ * pattern must appear in ALLOWED below with a note on why it is safe:
+ *
+ *   R1  Two or more WIDE quantifiers (`.*`, `[^x]+`, `\s*`, ...). Two atoms that can
+ *       each consume many different characters may compete for the same input, which
+ *       is the JSON-extraction shape that prompted this file.
+ *
+ *   R2  Any quantifier — wide or a single escaped literal — together with a trailing
+ *       `$` and no leading `^`. When the anchor is unreachable the engine retries from
+ *       every start position. This is precisely the #809 shape, and it needs no wide
+ *       class at all: `/\/+$/` is quadratic on a run of slashes. A leading `^` removes
+ *       the risk, because there is then only one place to begin.
+ *
+ *   R3  A repeated GROUP — `(...)*`, `(...)+`, `(...){2,}`. `(a+)+` is EXPONENTIAL
+ *       rather than merely polynomial, and even `(ab)+` can backtrack across
+ *       alternatives. None exist here today; the rule is cheap and the failure mode is
+ *       the worst of the three.
+ *
+ * The three rules are necessary conditions, not proofs of a defect — see below.
  *
  * WHY AN ALLOWLIST RATHER THAN A BAN:
- * Two unbounded quantifiers are necessary but not sufficient — seven patterns here are
- * genuinely linear because their quantifiers cannot overlap (different character
- * classes, or a literal pinned between them). Every entry was MEASURED, not reasoned
- * about: growth from 2k to 8k characters of adversarial input, where quadratic shows
- * as ~16x and linear as ~1x. Banning the shape outright would force pointless rewrites
- * of correct code, and a guard that cries wolf gets deleted.
+ * Nine patterns in this package match a rule and are genuinely linear, because their
+ * quantifiers cannot overlap: disjoint character classes, a literal pinned between
+ * them, a lazy quantifier, or an anchor at both ends. Every entry was MEASURED, not
+ * reasoned about — growth from 2k to 8k characters of adversarial input, where
+ * quadratic shows as ~16x and linear as ~1x. Banning these shapes outright would force
+ * pointless rewrites of correct code, and a guard that cries wolf gets deleted.
  *
  * ADDING AN ENTRY IS THE POINT AT WHICH TO MEASURE. If you cannot state the input that
- * would be pathological and show it is not, the pattern does not belong here.
+ * would be pathological and show that it is not, the pattern does not belong here.
  *
- * Test files are excluded from the scan on purpose: this file's own ALLOWLIST contains
- * pattern text, and two earlier scanners in this repo flagged their own documentation.
+ * THE DETECTOR HAS ITS OWN TESTS, and they matter more than the sweep. Asserting that
+ * today's sources are clean says nothing about whether the detector can find anything —
+ * those assertions pass just as well against a detector narrowed to uselessness, which
+ * is how the R1-only version shipped. `riskRules` is therefore tested directly against
+ * every shape this repository has actually had to remove, plus canonical exponential
+ * cases, plus benign patterns it must NOT flag.
+ *
+ * Test files are excluded from the sweep on purpose: this file's own ALLOWED map and
+ * self-tests contain pattern text, and three earlier scanners in this repo flagged
+ * their own documentation.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
@@ -42,9 +70,9 @@ import { join } from "node:path";
 const SRC = __dirname;
 
 /**
- * Patterns with two or more unbounded quantifiers that are nonetheless linear.
- * Keyed by the regex SOURCE rather than by file and line, so ordinary edits do not
- * invalidate the list.
+ * Patterns that match one of the three rules in `riskRules` and are nonetheless
+ * linear, each with the reason. Keyed by the regex SOURCE rather than by file and line,
+ * so ordinary edits do not invalidate the list.
  */
 const ALLOWED = new Map<string, string>([
   [
@@ -273,10 +301,13 @@ describe("no unjustified polynomial-ReDoS candidates", () => {
   it("every risky pattern is allowlisted with a reason", () => {
     const unjustified = risky
       .filter((r) => !ALLOWED.has(r.source))
-      .map((r) => `${r.file}:${r.line}  /${r.source}/`);
-    // A pattern here has two or more unbounded quantifiers and no measured
-    // justification. Measure it: build the adversarial input, time it at 2k and 8k
-    // characters, and either fix it or add it to ALLOWED with the numbers.
+      .map(
+        (r) => `${r.file}:${r.line}  /${r.source}/  [${r.risks.join("; ")}]`,
+      );
+    // A pattern here matches R1, R2 or R3 and has no measured justification. The
+    // failure message names the file, line, pattern and rule. Measure it: build the
+    // adversarial input the rule implies, time it at 2k and 8k characters, then either
+    // fix it or add it to ALLOWED with the numbers.
     expect(unjustified).toEqual([]);
   });
 

--- a/packages/durable-insight-core/src/verdict.ts
+++ b/packages/durable-insight-core/src/verdict.ts
@@ -4,6 +4,8 @@
  * `vscode` or AWS SDK imports and can be unit-tested directly.
  */
 
+import { extractJsonObject } from "./jsonExtract";
+
 /**
  * The model's verdict on whether a query's results actually answer the
  * user's question. Used by the verify/refine provider path (Copilot/local) to
@@ -27,15 +29,15 @@ export interface ResultVerdict {
  * never wedge the loop or hide results.
  */
 export function parseVerdict(text: string): ResultVerdict {
-  const jsonMatch = text.match(/\{[\s\S]*"satisfied"[\s\S]*\}/);
-  if (!jsonMatch) {
+  const jsonMatch = extractJsonObject(text, '"satisfied"');
+  if (jsonMatch === undefined) {
     return {
       satisfied: true,
       reason: "Could not parse a verdict; accepting the results as-is.",
     };
   }
   try {
-    const parsed = JSON.parse(jsonMatch[0]) as {
+    const parsed = JSON.parse(jsonMatch) as {
       satisfied?: unknown;
       reason?: unknown;
       suggestion?: unknown;

--- a/packages/durable-insight-core/src/verdict.ts
+++ b/packages/durable-insight-core/src/verdict.ts
@@ -29,15 +29,15 @@ export interface ResultVerdict {
  * never wedge the loop or hide results.
  */
 export function parseVerdict(text: string): ResultVerdict {
-  const jsonMatch = extractJsonObject(text, '"satisfied"');
-  if (jsonMatch === undefined) {
+  const jsonText = extractJsonObject(text, '"satisfied"');
+  if (jsonText === undefined) {
     return {
       satisfied: true,
       reason: "Could not parse a verdict; accepting the results as-is.",
     };
   }
   try {
-    const parsed = JSON.parse(jsonMatch) as {
+    const parsed = JSON.parse(jsonText) as {
       satisfied?: unknown;
       reason?: unknown;
       suggestion?: unknown;


### PR DESCRIPTION
CodeQL alert **#247** (`js/polynomial-redos`, **high**) on merged main, against
  `packages/durable-insight-core/src/verdict.ts:30`:

  ```js
  text.match(/\{[\s\S]*"satisfied"[\s\S]*\}/)

  Two unbounded [\s\S]* around a literal is polynomial. On input that starts a plausible
  object and never finishes one, the engine retries the inner scan from every start
  position. Measured at 4× per doubling:

  ┌───────┬───────┐
  │ input │ time  │
  ├───────┼───────┤
  │ 2k    │ 6 ms  │
  ├───────┼───────┤
  │ 8k    │ 96 ms │
  ├───────┼───────┤
  │ 32k   │ 1.5 s │
  ├───────┼───────┤
  │ ~128k │ ~24 s │
  └───────┴───────┘

  The input is a model reply, so its length is not ours to bound, and a verbose reply
  reaches those sizes easily.

  Sweeping the class found three more

  None of them flagged, all measured quadratic:

  ┌───────────────┬─────────────────────────────────┬────────────────────────┬─────────────────┐
  │ Location      │ Pattern                         │ Input                  │ Exploitable     │
  ├───────────────┼─────────────────────────────────┼────────────────────────┼─────────────────┤
  │ verdict.ts:30 │ /\{[\s\S]*"satisfied"[\s\S]*\}/ │ model reply            │ yes — the alert │
  ├───────────────┼─────────────────────────────────┼────────────────────────┼─────────────────┤
  │ llm.ts:600    │ /\{[\s\S]*"query"[\s\S]*\}/     │ model reply (Copilot)  │ yes             │
  ├───────────────┼─────────────────────────────────┼────────────────────────┼─────────────────┤
  │ llm.ts:827    │ /\{[\s\S]*"query"[\s\S]*\}/     │ model reply (local)    │ yes             │
  ├───────────────┼─────────────────────────────────┼────────────────────────┼─────────────────┤
  │ llm.ts:727    │ /\s*\(.*\)$/                    │ hardcoded preset label │ no              │
  └───────────────┴─────────────────────────────────┴────────────────────────┴─────────────────┘

  The fourth is fixed anyway — one line — but it is not a vulnerability and CodeQL was
  right not to report it. Its input is one of three compile-time constants; the shape is
  removed so that making labels dynamic later cannot quietly reintroduce a slow path.

  I also measured nine other candidates in this package and they are linear. Worth
  stating so this change isn't read as having missed them: queryShape.ts:113/178/179/302,
  agentLoop.ts:370, and the four hostModuleScan.ts import matchers. Their quantifiers
  cannot compete — disjoint character classes, a literal pinned between them, a lazy
  quantifier, or anchors at both ends. These are the nine allowlisted below.

  What the old regex actually meant

  Worth writing down, because it was never a JSON parser and never balanced braces. With
  both quantifiers greedy and matching leftmost-longest, it always resolved to "first {
  to last }, marker somewhere between". extractJsonObject computes that span by
  index, which is linear.

  Equivalence is asserted against the reconstructed regex over sixteen hand-picked cases
  plus a 20,000-input fuzz over a brace-heavy alphabet, because a performance fix that
  changes behavior is just a different bug.

  That check paid for itself immediately. stripTrailingParenthetical used
  lastIndexOf("("), which looks obviously right and is wrong: a regex match is leftmost,
  so \s*\(.*\)$ anchors on the earliest ( that still has the final ) after it.
  "Trailing (a) (b)" → "Trailing", not "Trailing (a)". Only the differential test
  caught it.

  The real fix is the guard, not the four edits

  This is the third round of this finding. #809 fixed three trailing-anchor regexes
  after CodeQL flagged one; then CodeQL flagged a fourth of a different shape, and sweeping
  for that shape turned up three more.

  Each round fixed instances. The recurring mistake was scoping the sweep to the shape just
  found, so the next shape stayed invisible — the same mistake as guarding vscode and
  missing electron (#809), and guarding run*Query and missing fetchAthenaRecord
  (#810). So redosGuard.test.ts works on the class, with three rules:

  - R1 — two or more wide quantifiers, which can compete for the same characters.

    The JSON-extraction shape.

  - R2 — any quantifier, wide or a single escaped literal, with a trailing $ and no

    leading ^. When the anchor is unreachable the engine retries from every start
    position. This is the #809 shape, and it needs no wide class at all. A leading ^
    removes the risk — one place to begin.

  - R3 — a repeated group. (a+)+ is exponential rather than polynomial, and (ab)+

    can backtrack across alternatives. None exist here today; the rule is cheap and the
    failure mode is the worst of the three.

  Anything matching a rule must be allowlisted with a measured justification. Nine
  patterns are, each timed at 2k and 8k characters of adversarial input rather than reasoned
  about — quadratic shows as ~16×, linear as ~1×. The failure message names file, line,
  pattern and matched rule, because the rule tells you which adversarial input to build.

  An allowlist rather than a ban because these shapes are necessary but not sufficient
  conditions, and a guard that cries wolf gets deleted. Adding an entry is the point at
  which to measure: if you cannot state the pathological input and show it is not, the
  pattern does not belong there.

  The guard was itself written to the narrower spec

  This is the substance of the second and third commits, and it is in the file's header
  rather than only here, because a PR description does not travel with the code.

  The first version implemented only R1, so it scored both regexes #809 removed below
  threshold — /\/+$/ at literally zero, since an escaped literal is not a wide class —
  and (a+)+$, the textbook exponential case, at zero as well. A file arguing at length
  against narrow sweeps was itself scoped to the shape just found. Widening it cost
  nothing in churn: the same nine patterns are found as before, so R2 and R3 earn their
  place entirely against the future.

  The more important addition is the detector self-tests. The sweep assertions prove the
  current sources are clean, which says nothing about whether the detector can find
  anything — they pass just as well against a detector narrowed to uselessness, which is
  exactly how v1 shipped. riskRules is now tested directly against every shape this
  repository has had to remove, plus two canonical exponential cases, plus three benign
  patterns it must not flag. Reverting to the R1-only spec fails five named tests.

  The third commit brings the header into line: four places still described the R1-only rule,
  so a reader formed that model and then met R2 and R3 seventy lines down in riskRules.
  That mismatch is the exact failure the widening existed to fix.

  Verification

  Mutation-verified in both directions:

  ┌───────────────────────────────────┬───────────────────────────────────────────────────┐
  │ Mutation                          │ Result                                            │
  ├───────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Reintroduce the extraction regex  │ pathological test takes 58 s, fails the 1 s bound │
  ├───────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Swap trimEnd() for /\s+$/         │ 65 s, fails                                       │
  ├───────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Add an unseen shape /<a.*href.*>/ │ reported by file, line and rule                   │
  ├───────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Revert to the R1-only detector    │ 5 named self-tests fail                           │
  ├───────────────────────────────────┼───────────────────────────────────────────────────┤
  │ Neuter the sweep to find nothing  │ non-vacuity assertions fail                       │
  └───────────────────────────────────┴───────────────────────────────────────────────────┘

  Timing bounds are deliberately loose — 1 s against a measured ~2 ms — so they cannot flake
  on a slow runner while still failing a quadratic implementation by orders of magnitude.

  Tests 336 → 380 in core. durable-insight-mcp (404), -vscode (33) and -desktop
  (48) are untouched. Lint, typecheck:hosts, renderer typecheck and both host bundles
  green.

  Notes for the reviewer

  - Three things I got wrong, all found by mutation or by review rather than by reading.

    My first timing test used "name" + " ".repeat(n) + "(x)", which does not catch
    /\s+$/ — after slicing at the parenthesis the prefix ends in whitespace, so the
    anchor succeeds on its first viable start and the scan is linear; the quadratic case
    needs the run followed by a non-space. The guard flagged jsonExtract.ts for
    documenting the pattern it replaced, the fourth time a scanner here has reported its
    own prose, so the sweep reads code lines only. And a comment claimed the failure message
    named the matched rule when it did not — fixed by making it true.

  - One intended divergence. A parenthetical containing a newline is stripped by

    stripTrailingParenthetical where the regex left it, because . does not match a line
    terminator. Unreachable today — the only inputs are three single-line preset labels —
    and stripping is what the caller wants. Documented as the contract and pinned by a test
    asserting both behaviors, rather than sitting silently next to an equivalence claim
    that does not hold for it.

  - CodeQL remains the primary detector. This guard is a lexical scan: it can miss a

    literal spelled unusually and does not see new RegExp built from variables. It is a
    floor on coverage, not a proof of absence — its job is stopping a known class from
    returning between scans, and forcing the measurement conversation when someone adds one.

  - The MCP package has zero patterns in this class today, so the guard stays in core

    rather than expanding this change. Generalizing it — the mirror-guard shape already used
    for hostAgnostic.test.ts — is a reasonable follow-up.

  - Alert #247 should close on the next scan.
  - The three commits are worth reading in order if you want the reasoning; the squash will

    flatten them.

  Testing (per CONTRIBUTING)

  Unit tests for both helpers, differential equivalence against the regexes they replace,
  timing bounds on pathological input, and the class guard with its own self-tests. Every
  guard mutation-verified. No conformance tests added. Not an SDK feature or API change, so
  no examples needed.