### PR TITLE
fix(otel): omit invocation attempt parent links

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -882,7 +882,7 @@ describe("InvocationOtelPlugin", () => {
       expect(attemptSpan!.attributes["durable.attempt.number"]).toBe(2);
     });
 
-    it("attempt span has Link to deterministic span ID", async () => {
+    it("attempt span links to Workflow without duplicating its parent", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onOperationStart(
         makeOperationInfo({ id: "op-link", name: "link-step" }),
@@ -898,13 +898,74 @@ describe("InvocationOtelPlugin", () => {
       );
       await plugin.onInvocationEnd(makeInvocationEndInfo());
 
-      const expectedSpanId = deriveSpanIdFromOperationId("op-link", TEST_ARN);
+      const operationSpan = findSpan("link-step");
+      const workflowSpan = findSpan("Workflow");
       const attemptSpan = getExportedSpans().find(
         (s) => s.attributes["durable.attempt.number"] === 1,
       );
       expect(attemptSpan).toBeDefined();
-      expect(attemptSpan!.links.length).toBeGreaterThan(0);
-      expect(attemptSpan!.links[0].context.spanId).toBe(expectedSpanId);
+      expect(attemptSpan!.parentSpanContext?.spanId).toBe(
+        operationSpan!.spanContext().spanId,
+      );
+      expect(attemptSpan!.links).toHaveLength(1);
+      expect(attemptSpan!.links[0].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
+      expect(attemptSpan!.links[0].context.spanId).not.toBe(
+        attemptSpan!.parentSpanContext?.spanId,
+      );
+    });
+
+    it("replay attempt also omits its operation parent link", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "op-replay-link",
+          name: "replay-link-step",
+          type: "STEP",
+          isReplay: true,
+        }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "op-replay-link",
+          name: "replay-link-step",
+          attempt: 2,
+          isReplay: true,
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "op-replay-link",
+          attempt: 2,
+          isReplay: true,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "op-replay-link",
+          name: "replay-link-step",
+          type: "STEP",
+          isReplay: true,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const workflowSpan = findSpan("Workflow");
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.attempt.number"] === 2,
+      );
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.links).toHaveLength(1);
+      expect(attemptSpan!.links[0].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
+      expect(
+        attemptSpan!.links.some(
+          (link) =>
+            link.context.spanId === attemptSpan!.parentSpanContext?.spanId,
+        ),
+      ).toBe(false);
     });
 
     it("onOperationAttemptEnd ends the attempt span", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -478,10 +478,6 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   }
 
   async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
-    const deterministicSpanId = deriveSpanIdFromOperationId(
-      info.id,
-      this.executionArn,
-    );
     const baseName = info.name ?? info.type;
     const spanName = `${baseName} attempt ${info.attempt}`;
 
@@ -490,11 +486,6 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     const parentContext = parentSpan
       ? trace.setSpan(context.active(), parentSpan)
       : context.active();
-
-    // Get current trace ID for the link
-    const currentTraceId =
-      this.invocationSpan?.spanContext().traceId ??
-      this.idGenerator.generateTraceId();
 
     const attributes: Record<string, string | number> = {
       "durable.execution.arn": this.executionArn,
@@ -512,23 +503,13 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       attributes["durable.operation.subtype"] = info.subType;
     }
 
-    // Create Attempt_Span as child of Operation_Span with Link to deterministic span
+    // The operation is already represented by the attempt's parent. Do not
+    // duplicate that relationship as a link in the invocation view.
     const attemptSpan = this.tracer.startSpan(
       spanName,
       {
         attributes,
-        // Self-link to the deterministic operation span first, then the
-        // Workflow link (order-significant per the conformance contract).
-        links: [
-          {
-            context: {
-              traceId: currentTraceId,
-              spanId: deterministicSpanId,
-              traceFlags: 1,
-            },
-          },
-          ...this.workflowLinks(),
-        ],
+        links: this.workflowLinks(),
         startTime: hrTime(),
       },
       parentContext,


### PR DESCRIPTION
## Summary
- keep the Workflow link on invocation-view attempt spans
- stop duplicating the attempt's operation parent as a deterministic span link
- cover both initial and replay attempt spans

## Context
Fixes the link-count mismatch reported by the invocation-view conformance cases in aws/aws-durable-execution-conformance-tests run 31441773571, job 93627831037.

## Verification
- `npm test -w packages/aws-durable-execution-sdk-js-otel -- --runInBand` (198 tests passed)
- focused `invocation-plugin.test.ts` run (77 tests passed)
- OTel package TypeScript check
- `git diff --check`

No conformance tests are added here; those remain in the separate conformance repository.