### PR TITLE
chore(sdk): bump core SDK to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18432,7 +18432,7 @@
     },
     "packages/aws-durable-execution-sdk-js": {
       "name": "@aws/durable-execution-sdk-js",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.1014.0"
@@ -27807,7 +27807,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.2.0"
+        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.0"
       }
     },
     "packages/aws-durable-execution-sdk-js-testing/node_modules/@sinonjs/fake-timers": {

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -66,7 +66,7 @@
     "commander": "^14.0.2"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.2.0"
+    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.0"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",


### PR DESCRIPTION
Bumps @aws/durable-execution-sdk-js from 2.2.0 to 2.3.0. The only change here is the version field in packages/aws-durable-execution-sdk-js/package.json; this PR exists to cut the release tag for what has already landed on main.

**Added**

- Support for runtimes without AsyncLocalStorage or util.formatWithOptions (#817). Lightweight runtimes such as [LLRT](https://github.com/awslabs/llrt) implement a subset of the Node API, and both gaps were fatal: importing withDurableExecution threw at module scope, and the default logger threw on the first multi-argument log record. Both capabilities are now feature-detected, so durable functions can be deployed on a container image carrying a runtime Lambda does not manage. Checkpointing and replay are unaffected and checkpoint wire traffic is byte-identical to 2.2.0; what degrades is observability, and the SDK emits one warning per execution environment describing what. On a managed Node.js runtime neither fallback is reachable. See "Runtime requirements" in the SDK README.

- A neutral error contract for transports: DurableExecutionClientError with a scope of INVOCATION or EXECUTION (#790). Previously the SDK inferred whether a client failure was transient from the AWS SDK's error shape, so a non-AWS-shaped permanent failure was retried until the execution timed out. The scope is honoured both in classifyCheckpointError and in the top-level catch in withDurableExecution, defaults to INVOCATION, and is recognized structurally rather than via instanceof. AWS errors carry no marker and take the identical path as before.

**Changed**

- The SDK now owns the durable execution wire types (#788). The 22 protocol shapes and 3 enums (Operation, OperationUpdate, ErrorObject, the checkpoint/state request and response types, OperationType/OperationStatus/OperationAction) are declared in src/types/wire/ instead of imported from @aws-sdk/client-lambda across 28 source files, and are exported from the package root. The enums are as const string maps, so the resulting literal-union types and all runtime comparisons are identical to before. wire-model.aws-sdk-parity.test.ts guards the declaration against service-model drift and fails the build on divergence.

- Operation timestamps are normalized at the boundary (#788). The invocation event delivers ISO-8601 strings while the Lambda API delivers Date instances; both were typed as Date and merged into one history. Only the raw wire shapes now carry the string-or-Date union, and Operation and everything downstream of it — including the plugin surface — carry real Dates, so the public shape is unchanged.

- The Lambda client is loaded lazily (#788). DurableExecutionApiClient is the only module that touches @aws-sdk/client-lambda at runtime and now loads it with a dynamic import started from the constructor without blocking it. Time from process start until the client can issue a request is unchanged (median 97 ms lazy vs 102 ms eager); the SDK's own module load drops from ~69 ms to ~9 ms. A compute supplying its own DurableExecutionClient never loads the AWS SDK at all.

- Polling is bounded by the invocation deadline rather than a hard-coded duration (#793, fixes #794). MAX_POLL_DURATION_MS was one constant serving three unrelated purposes; it exceeded many configured timeouts, arming timers that could not fire and polling past the point where an invocation could act on a result. ExecutionContext gains getRemainingTimeMs, an explicit MAX_TIMER_DELAY_MS guards the setTimeout 32-bit overflow the old constant was accidentally preventing, and the scheduling and poll-loop thresholds now agree. Polling is bounded in rate instead of duration: the backoff ceiling widens from 10 s to 60 s after ~95 polls. CheckpointManager.dispose() is called from a finally around runHandler's exit funnel so poll timers no longer outlive their invocation in a reused execution environment. Billed invocation duration is unaffected. No public API change.

- client is deprecated in favour of durableExecutionClient (#790). It takes a LambdaClient, the last place the AWS SDK appears in this package's public type surface, and means nothing on a compute type that is not Lambda. It will be removed in the next major; supplying both is rejected by validateDurableExecutionConfig.

```
// before
withDurableExecution(handler, { client: myLambdaClient })
// after
withDurableExecution(handler, {
  durableExecutionClient: new DurableExecutionApiClient(myLambdaClient),
})
```
**Fixed**

- Summarized map/parallel replay no longer hangs (#759, fixes #751). When an aggregate result exceeded the 256 KB checkpoint limit the SDK reconstructs the BatchResult from child checkpoints, but skipNextOperation was bound to the outer context rather than the child context runInChildContext re-drives, so skipping an in-flight item left the child cursor unadvanced and the next terminal item received a never-resolving promise. A free-form custom summaryGenerator hit a second hang by falling back to concurrent execution. completionReason is now read from the summary (and validated) instead of re-inferred, and composeSummaryGenerator always records the SDK's load-bearing metadata with any custom output nested verbatim under a summary key.

- An invalid maxConcurrency (<= 0) terminates the execution instead of throwing (#765). It is a deterministic, non-retryable configuration error — the category the adjacent completionConfig guard already handled via terminationManager.terminate(). A plain throw propagated through Lambda's retry path, so a misconfigured call was retried only to fail identically. No public API or error message text changed.
