### PR TITLE
fix(sdk): name wait-for-callback child operations

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
@@ -40,6 +40,29 @@ describe("waitForCallback handler", () => {
   it("should handle waitForCallback with submitter function", async () => {
     const submitter = jest.fn().mockResolvedValue(undefined);
     const expectedResult = "callback result";
+    const createCallback = jest
+      .fn()
+      .mockResolvedValue([Promise.resolve(expectedResult), "callback-123"]);
+    const step = jest
+      .fn()
+      .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
+        const mockTelemetry = {
+          logger: {
+            log: jest.fn(),
+            error: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            debug: jest.fn(),
+          },
+        };
+
+        if (typeof stepNameOrFn === "function") {
+          return await stepNameOrFn(mockTelemetry);
+        } else if (typeof maybeFn === "function") {
+          return await maybeFn(mockTelemetry);
+        }
+        return undefined;
+      });
 
     // Mock runInChildContext to handle the unified signature (name, function)
     mockRunInChildContext.mockImplementation(async (name: any, fn: any) => {
@@ -48,31 +71,8 @@ describe("waitForCallback handler", () => {
 
       // Create a mock child context
       const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([Promise.resolve(expectedResult), "callback-123"]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            // Handle both overloads of step function
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
+        createCallback,
+        step,
       };
 
       return await fn(mockChildCtx);
@@ -99,40 +99,46 @@ describe("waitForCallback handler", () => {
         logger: expect.any(Object),
       }),
     );
+    expect(createCallback).toHaveBeenCalledWith("callback", undefined);
+    expect(step).toHaveBeenCalledWith(
+      "submitter",
+      expect.any(Function),
+      undefined,
+    );
   });
 
   it("should handle waitForCallback with name and submitter", async () => {
     const submitter = jest.fn().mockResolvedValue(undefined);
     const expectedResult = "named callback result";
     const callbackName = "myCallback";
+    const createCallback = jest
+      .fn()
+      .mockResolvedValue([Promise.resolve(expectedResult), "callback-456"]);
+    const step = jest
+      .fn()
+      .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
+        const mockTelemetry = {
+          logger: {
+            log: jest.fn(),
+            error: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            debug: jest.fn(),
+          },
+        };
+
+        if (typeof stepNameOrFn === "function") {
+          return await stepNameOrFn(mockTelemetry);
+        } else if (typeof maybeFn === "function") {
+          return await maybeFn(mockTelemetry);
+        }
+        return undefined;
+      });
 
     mockRunInChildContext.mockImplementation(async (name: string, fn: any) => {
       const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([Promise.resolve(expectedResult), "callback-456"]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            // Handle both overloads of step function
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
+        createCallback,
+        step,
       };
 
       return await fn(mockChildCtx);
@@ -157,6 +163,15 @@ describe("waitForCallback handler", () => {
       expect.objectContaining({
         logger: expect.any(Object),
       }),
+    );
+    expect(createCallback).toHaveBeenCalledWith(
+      "myCallback-callback",
+      undefined,
+    );
+    expect(step).toHaveBeenCalledWith(
+      "myCallback-submitter",
+      expect.any(Function),
+      undefined,
     );
   });
 
@@ -339,6 +354,7 @@ describe("waitForCallback handler", () => {
     const submitter = jest.fn().mockResolvedValue(undefined);
     const expectedResult = "config result";
 
+    let capturedName: string | undefined;
     let capturedConfig: any;
     mockRunInChildContext.mockImplementation(
       async (fnOrName: any, maybeFn?: any) => {
@@ -346,7 +362,8 @@ describe("waitForCallback handler", () => {
         const fn = maybeFn || fnOrName;
 
         const mockChildCtx = {
-          createCallback: jest.fn().mockImplementation((cfg) => {
+          createCallback: jest.fn().mockImplementation((name, cfg) => {
+            capturedName = name;
             capturedConfig = cfg;
             return Promise.resolve([
               Promise.resolve(expectedResult),
@@ -391,6 +408,7 @@ describe("waitForCallback handler", () => {
     const result = await handler(submitter, config);
 
     expect(result).toBe(expectedResult);
+    expect(capturedName).toBe("callback");
     expect(capturedConfig).toMatchObject({
       timeout: { minutes: 5 },
       heartbeatTimeout: { seconds: 30 },
@@ -484,6 +502,7 @@ describe("waitForCallback handler", () => {
         const deserializedResult = `deserialized-${name}`;
 
         let capturedRunInChildContextOptions: any;
+        let capturedCreateCallbackName: string | undefined;
         let capturedCreateCallbackConfig: any;
 
         // Mock safeDeserialize to return our expected result
@@ -501,7 +520,8 @@ describe("waitForCallback handler", () => {
             capturedRunInChildContextOptions = options;
 
             const mockChildCtx = {
-              createCallback: jest.fn().mockImplementation((cfg) => {
+              createCallback: jest.fn().mockImplementation((name, cfg) => {
+                capturedCreateCallbackName = name;
                 capturedCreateCallbackConfig = cfg;
                 return Promise.resolve([
                   Promise.resolve(rawResult),
@@ -556,6 +576,7 @@ describe("waitForCallback handler", () => {
 
         // Verify passthrough serdes is NOT passed to createCallback when no
         // defaultCallbackDeserializer is configured
+        expect(capturedCreateCallbackName).toBe("callback");
         expect(capturedCreateCallbackConfig).toMatchObject({
           timeout: config.timeout || undefined,
           heartbeatTimeout: config.heartbeatTimeout || undefined,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -93,9 +93,14 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
               }
             : undefined;
 
+        const callbackOperationName = name ? `${name}-callback` : "callback";
+        const submitterOperationName = name ? `${name}-submitter` : "submitter";
+
         // Create callback and get the promise + callbackId
-        const [callbackPromise, callbackId] =
-          await childCtx.createCallback(createCallbackConfig);
+        const [callbackPromise, callbackId] = await childCtx.createCallback(
+          callbackOperationName,
+          createCallbackConfig,
+        );
 
         log("🆔", "Callback created:", {
           callbackId,
@@ -104,6 +109,7 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
 
         // Execute the submitter step (submitter is now mandatory)
         await childCtx.step(
+          submitterOperationName,
           async (stepContext: StepContext<Logger>) => {
             // Use the step's built-in logger instead of creating a new one
             const callbackContext: WaitForCallbackContext<Logger> = {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

Name the callback and submitter operations created internally by `waitForCallback`.

Named wait-for-callback operations now produce `<name>-callback` and `<name>-submitter`. The unnamed overload uses stable `callback` and `submitter` names. This allows OpenTelemetry spans to include `durable.operation.name` and satisfies the strict naming requirements exercised by OTel conformance cases 10 and 17.

### Demo/Screenshots

N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Updated the wait-for-callback handler tests to cover names for both named and unnamed overloads, plus existing config and serdes paths.

- `npm test -w packages/aws-durable-execution-sdk-js -- --runInBand` (101 suites, 1,208 tests)
- `npm run lint -w packages/aws-durable-execution-sdk-js -- --no-warn-ignored`
- Prettier check for changed files
- `npm run build -w packages/aws-durable-execution-sdk-js`

#### Integration Tests

No new integration test. This is an isolated internal operation-naming fix covered by unit tests and the external conformance suite.

#### Examples

N/A