### PR TITLE
fix(otel): resolve OTel conformance test failures for wait-for-callback and wait-for-condition

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.history.json
@@ -2,8 +2,8 @@
   {
     "EventType": "ExecutionStarted",
     "EventId": 1,
-    "Id": "360b59d2-4715-4f22-81f0-523e08f8cb78",
-    "EventTimestamp": "2026-06-18T00:10:37.854Z",
+    "Id": "289d7780-def4-4169-b973-167507fbc698",
+    "EventTimestamp": "2026-08-14T19:26:53.274Z",
     "ExecutionStartedDetails": {
       "Input": {
         "Payload": "{}"
@@ -16,7 +16,7 @@
     "EventId": 2,
     "Id": "c4ca4238a0b92382",
     "Name": "before-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.861Z",
+    "EventTimestamp": "2026-08-14T19:26:53.282Z",
     "StepStartedDetails": {}
   },
   {
@@ -25,7 +25,7 @@
     "EventId": 3,
     "Id": "c4ca4238a0b92382",
     "Name": "before-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.861Z",
+    "EventTimestamp": "2026-08-14T19:26:53.282Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "\"before-callback-value\""
@@ -39,7 +39,7 @@
     "EventId": 4,
     "Id": "c81e728d9d4c2f63",
     "Name": "my-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.865Z",
+    "EventTimestamp": "2026-08-14T19:26:53.287Z",
     "ContextStartedDetails": {}
   },
   {
@@ -47,10 +47,10 @@
     "SubType": "Callback",
     "EventId": 5,
     "Id": "8fbdbf5573b18fae",
-    "EventTimestamp": "2026-06-18T00:10:37.865Z",
+    "EventTimestamp": "2026-08-14T19:26:53.287Z",
     "ParentId": "c81e728d9d4c2f63",
     "CallbackStartedDetails": {
-      "CallbackId": "eyJleGVjdXRpb25JZCI6ImY0OWYyZjAzLTczOWEtNDJmYy1hNGY5LWJkMGU2NjI4ZDNiMCIsIm9wZXJhdGlvbklkIjoiOGZiZGJmNTU3M2IxOGZhZSIsInRva2VuIjoiYmJmNWY0NWUtMGZmNi00Y2YwLWI0NjgtZWQ2MzdkZDRhNTUwIn0=",
+      "CallbackId": "eyJleGVjdXRpb25JZCI6IjJmMWE3Yjk3LTU1MDctNDJjMC04MmE0LWVkZGU5YWM5NTYxNSIsIm9wZXJhdGlvbklkIjoiOGZiZGJmNTU3M2IxOGZhZSIsInRva2VuIjoiZDEyMmUyYjAtZmM0Mi00YTAyLTk0YjEtYWJiNTMxNTI1YzI4In0=",
       "Timeout": 10,
       "Input": {}
     }
@@ -60,7 +60,7 @@
     "SubType": "Step",
     "EventId": 6,
     "Id": "3c46a0407be60a1f",
-    "EventTimestamp": "2026-06-18T00:10:37.867Z",
+    "EventTimestamp": "2026-08-14T19:26:53.289Z",
     "ParentId": "c81e728d9d4c2f63",
     "StepStartedDetails": {}
   },
@@ -69,7 +69,7 @@
     "SubType": "Step",
     "EventId": 7,
     "Id": "3c46a0407be60a1f",
-    "EventTimestamp": "2026-06-18T00:10:37.867Z",
+    "EventTimestamp": "2026-08-14T19:26:53.289Z",
     "ParentId": "c81e728d9d4c2f63",
     "StepSucceededDetails": {
       "Result": {},
@@ -81,7 +81,7 @@
     "SubType": "Callback",
     "EventId": 8,
     "Id": "8fbdbf5573b18fae",
-    "EventTimestamp": "2026-06-18T00:10:37.868Z",
+    "EventTimestamp": "2026-08-14T19:26:53.291Z",
     "ParentId": "c81e728d9d4c2f63",
     "CallbackSucceededDetails": {
       "Result": {
@@ -92,12 +92,12 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 9,
-    "EventTimestamp": "2026-06-18T00:10:37.889Z",
+    "EventTimestamp": "2026-08-14T19:26:53.314Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-18T00:10:37.854Z",
-      "EndTimestamp": "2026-06-18T00:10:37.889Z",
+      "StartTimestamp": "2026-08-14T19:26:53.274Z",
+      "EndTimestamp": "2026-08-14T19:26:53.314Z",
       "Error": {},
-      "RequestId": "97e90f7c-3142-47e3-9e73-5deaa82c0354"
+      "RequestId": "d511a78c-d20d-41b1-969f-8782b07689e9"
     }
   },
   {
@@ -106,7 +106,7 @@
     "EventId": 10,
     "Id": "c81e728d9d4c2f63",
     "Name": "my-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.893Z",
+    "EventTimestamp": "2026-08-14T19:26:53.318Z",
     "ContextSucceededDetails": {
       "Result": {
         "Payload": "\"callback-value\""
@@ -119,7 +119,7 @@
     "EventId": 11,
     "Id": "eccbc87e4b5ce2fe",
     "Name": "after-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.893Z",
+    "EventTimestamp": "2026-08-14T19:26:53.318Z",
     "StepStartedDetails": {}
   },
   {
@@ -128,7 +128,7 @@
     "EventId": 12,
     "Id": "eccbc87e4b5ce2fe",
     "Name": "after-callback",
-    "EventTimestamp": "2026-06-18T00:10:37.894Z",
+    "EventTimestamp": "2026-08-14T19:26:53.318Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "\"after-callback-value\""
@@ -139,22 +139,22 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 13,
-    "EventTimestamp": "2026-06-18T00:10:37.895Z",
+    "EventTimestamp": "2026-08-14T19:26:53.320Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-06-18T00:10:37.891Z",
-      "EndTimestamp": "2026-06-18T00:10:37.895Z",
+      "StartTimestamp": "2026-08-14T19:26:53.315Z",
+      "EndTimestamp": "2026-08-14T19:26:53.320Z",
       "Error": {},
-      "RequestId": "3071627f-7491-4a28-a376-9d0bd94d4948"
+      "RequestId": "962333a9-c38f-4bf4-8730-0103694ebc56"
     }
   },
   {
     "EventType": "ExecutionSucceeded",
     "EventId": 14,
-    "Id": "360b59d2-4715-4f22-81f0-523e08f8cb78",
-    "EventTimestamp": "2026-06-18T00:10:37.896Z",
+    "Id": "289d7780-def4-4169-b973-167507fbc698",
+    "EventTimestamp": "2026-08-14T19:26:53.320Z",
     "ExecutionSucceededDetails": {
       "Result": {
-        "Payload": "{\"callbackResult\":\"callback-value\",\"beforeCallback\":\"before-callback-value\",\"afterCallback\":\"after-callback-value\",\"spans\":[{\"name\":\"my-callback\",\"traceId\":\"bf18e1f5820e28eedf10938ff42631f1\",\"spanId\":\"9e90c102801491ea\",\"parentSpanId\":\"5d1422af327ba415\",\"attributes\":{\"durable.execution.arn\":\"f49f2f03-739a-42fc-a4f9-bd0e6628d3b0\",\"durable.operation.id\":\"c81e728d9d4c2f63\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.name\":\"my-callback\"},\"links\":[{\"traceId\":\"bf18e1f5820e28eedf10938ff42631f1\",\"spanId\":\"20bb507a4917096c\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"after-callback\",\"traceId\":\"bf18e1f5820e28eedf10938ff42631f1\",\"spanId\":\"151589e21de52c51\",\"parentSpanId\":\"6f473045cd95e6f6\",\"attributes\":{\"durable.execution.arn\":\"f49f2f03-739a-42fc-a4f9-bd0e6628d3b0\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":1,\"durable.operation.name\":\"after-callback\"},\"links\":[{\"traceId\":\"bf18e1f5820e28eedf10938ff42631f1\",\"spanId\":\"6f473045cd95e6f6\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"after-callback\",\"traceId\":\"bf18e1f5820e28eedf10938ff42631f1\",\"spanId\":\"6f473045cd95e6f6\",\"parentSpanId\":\"5d1422af327ba415\",\"attributes\":{\"durable.execution.arn\":\"f49f2f03-739a-42fc-a4f9-bd0e6628d3b0\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"STEP\",\"durable.operation.name\":\"after-callback\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]}]}"
+        "Payload": "{\"callbackResult\":\"callback-value\",\"beforeCallback\":\"before-callback-value\",\"afterCallback\":\"after-callback-value\",\"spans\":[{\"name\":\"before-callback attempt 1\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5d5b73380886ec87\",\"parentSpanId\":\"a7bf9f457aa0bed1\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.name\":\"before-callback\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"before-callback\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"a7bf9f457aa0bed1\",\"parentSpanId\":\"6481e404b62be798\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"before-callback\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.number\":1},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"my-callback-submitter attempt 1\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"95dc0b7fc14ecf2b\",\"parentSpanId\":\"e152cd91389262ce\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"3c46a0407be60a1f\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.name\":\"my-callback-submitter\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"my-callback-submitter\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"e152cd91389262ce\",\"parentSpanId\":\"ea494fc8e5eb61d4\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"3c46a0407be60a1f\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"my-callback-submitter\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.number\":1},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"my-callback-callback\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"f9cf5a0d234cc4b7\",\"parentSpanId\":\"ea494fc8e5eb61d4\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"8fbdbf5573b18fae\",\"durable.operation.type\":\"CALLBACK\",\"durable.operation.status\":\"STARTED\",\"durable.operation.name\":\"my-callback-callback\",\"durable.operation.subtype\":\"Callback\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"my-callback\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"ea494fc8e5eb61d4\",\"parentSpanId\":\"6481e404b62be798\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"c81e728d9d4c2f63\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"STARTED\",\"durable.operation.name\":\"my-callback\",\"durable.operation.subtype\":\"WaitForCallback\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"6481e404b62be798\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"my-callback\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"007a93da17635bc8\",\"parentSpanId\":\"be2321755327e051\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"c81e728d9d4c2f63\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"my-callback\",\"durable.operation.subtype\":\"WaitForCallback\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"ea494fc8e5eb61d4\"},{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"after-callback attempt 1\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"bda0c8d955b90dd7\",\"parentSpanId\":\"65914a24ee2ddb23\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.name\":\"after-callback\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"after-callback\",\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"65914a24ee2ddb23\",\"parentSpanId\":\"be2321755327e051\",\"attributes\":{\"durable.execution.arn\":\"2f1a7b97-5507-42c0-82a4-edde9ac95615\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"after-callback\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.number\":1},\"links\":[{\"traceId\":\"23c1a83ddd67ef92118ef5ca63f9d8cd\",\"spanId\":\"5e6d58dab054d65d\"}],\"status\":{\"code\":1},\"events\":[]}]}"
       }
     }
   }

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/callback/otel-callback.test.ts
@@ -70,8 +70,10 @@ createTests({
         // Local mode: assert spans via InMemorySpanExporter
         const spans = getSerializedSpans();
         // All spans across all invocations: before-callback (op + attempt),
-        // STEP (submitter op + attempt), CALLBACK, my-callback (CONTEXT), invocation,
-        // my-callback (continuation), after-callback (op + attempt), invocation (2nd) + Workflow = 12 spans
+        // my-callback-submitter (submitter op + attempt), my-callback-callback
+        // (CALLBACK), my-callback (CONTEXT), invocation, my-callback
+        // (continuation), after-callback (op + attempt), invocation (2nd) +
+        // Workflow = 12 spans
         expect(spans).toHaveLength(12);
 
         // All spans share the same traceId
@@ -104,10 +106,53 @@ createTests({
         expect(callbackCtxSpan).toBeDefined();
 
         // --- CALLBACK span ---
+        // The user never names the inner CALLBACK, but waitForCallback passes a
+        // derived plugin name, so the span is labelled "<parent>-callback" and
+        // is parented to the waitForCallback CONTEXT span.
         const callbackSpan = spans.find(
           (s) => s.attributes["durable.operation.type"] === "CALLBACK",
         );
         expect(callbackSpan).toBeDefined();
+        expect(callbackSpan!.attributes["durable.operation.name"]).toBe(
+          "my-callback-callback",
+        );
+        const callbackParent = spans.find(
+          (s) => s.spanId === callbackSpan!.parentSpanId,
+        );
+        expect(callbackParent?.attributes["durable.operation.name"]).toBe(
+          "my-callback",
+        );
+        expect(callbackParent?.attributes["durable.operation.type"]).toBe(
+          "CONTEXT",
+        );
+
+        // --- submitter STEP span ---
+        // The (also unnamed) submitter step is labelled "<parent>-submitter"
+        // and parented to the same CONTEXT span.
+        const submitterOp = spans.find(
+          (s) =>
+            s.attributes["durable.operation.name"] ===
+              "my-callback-submitter" &&
+            s.attributes["durable.operation.type"] === "STEP" &&
+            s.attributes["durable.attempt.outcome"] === undefined,
+        );
+        expect(submitterOp).toBeDefined();
+        const submitterParent = spans.find(
+          (s) => s.spanId === submitterOp!.parentSpanId,
+        );
+        expect(submitterParent?.attributes["durable.operation.name"]).toBe(
+          "my-callback",
+        );
+        expect(submitterParent?.attributes["durable.operation.type"]).toBe(
+          "CONTEXT",
+        );
+
+        const submitterAttempt = spans.find(
+          (s) =>
+            s.parentSpanId === submitterOp!.spanId &&
+            s.attributes["durable.attempt.number"] === 1,
+        );
+        expect(submitterAttempt).toBeDefined();
 
         // --- after-callback step ---
         const afterCallbackOp = spans.find(

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.history.json
@@ -1,0 +1,157 @@
+[
+  {
+    "EventType": "ExecutionStarted",
+    "EventId": 1,
+    "Id": "7ad3fb20-11df-4d17-a4c7-c9addd58dbf7",
+    "EventTimestamp": "2026-08-14T20:00:43.822Z",
+    "ExecutionStartedDetails": {
+      "Input": {
+        "Payload": "{}"
+      }
+    }
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "WaitForCallback",
+    "EventId": 2,
+    "Id": "c4ca4238a0b92382",
+    "Name": "cb",
+    "EventTimestamp": "2026-08-14T20:00:43.830Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 3,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "plain-step",
+    "EventTimestamp": "2026-08-14T20:00:43.830Z",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "ContextStarted",
+    "SubType": "RunInChildContext",
+    "EventId": 4,
+    "Id": "eccbc87e4b5ce2fe",
+    "EventTimestamp": "2026-08-14T20:00:43.830Z",
+    "ContextStartedDetails": {}
+  },
+  {
+    "EventType": "CallbackStarted",
+    "SubType": "Callback",
+    "EventId": 5,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-14T20:00:43.830Z",
+    "ParentId": "c4ca4238a0b92382",
+    "CallbackStartedDetails": {
+      "CallbackId": "eyJleGVjdXRpb25JZCI6IjIxOGQxNDhhLTU0YTQtNGQzZC05NmQ4LWY5Y2JlMzNmN2M0YSIsIm9wZXJhdGlvbklkIjoiZWE2NmMwNmMxZTFjMDVmYSIsInRva2VuIjoiYTAyYzYyNTQtZDdkZi00Y2ZmLTlkZGMtNTNlNmQzMTJmNGRiIn0=",
+      "Input": {}
+    }
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 6,
+    "Id": "c81e728d9d4c2f63",
+    "Name": "plain-step",
+    "EventTimestamp": "2026-08-14T20:00:43.830Z",
+    "StepSucceededDetails": {
+      "Result": {
+        "Payload": "\"plain-value\""
+      },
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "StepStarted",
+    "SubType": "Step",
+    "EventId": 7,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-14T20:00:43.833Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepStartedDetails": {}
+  },
+  {
+    "EventType": "StepSucceeded",
+    "SubType": "Step",
+    "EventId": 8,
+    "Id": "98c6f2c2287f4c73",
+    "EventTimestamp": "2026-08-14T20:00:43.833Z",
+    "ParentId": "c4ca4238a0b92382",
+    "StepSucceededDetails": {
+      "Result": {},
+      "RetryDetails": {}
+    }
+  },
+  {
+    "EventType": "CallbackSucceeded",
+    "SubType": "Callback",
+    "EventId": 9,
+    "Id": "ea66c06c1e1c05fa",
+    "EventTimestamp": "2026-08-14T20:00:43.833Z",
+    "ParentId": "c4ca4238a0b92382",
+    "CallbackSucceededDetails": {
+      "Result": {
+        "Payload": "cb-value"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 10,
+    "EventTimestamp": "2026-08-14T20:00:43.855Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-14T20:00:43.822Z",
+      "EndTimestamp": "2026-08-14T20:00:43.855Z",
+      "Error": {},
+      "RequestId": "c64ee346-2049-444e-94d3-23959e165d19"
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "WaitForCallback",
+    "EventId": 11,
+    "Id": "c4ca4238a0b92382",
+    "Name": "cb",
+    "EventTimestamp": "2026-08-14T20:00:43.859Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "\"cb-value\""
+      }
+    }
+  },
+  {
+    "EventType": "ContextSucceeded",
+    "SubType": "RunInChildContext",
+    "EventId": 12,
+    "Id": "eccbc87e4b5ce2fe",
+    "EventTimestamp": "2026-08-14T20:00:43.859Z",
+    "ContextSucceededDetails": {
+      "Result": {
+        "Payload": "[\"cb-value\",\"plain-value\"]"
+      }
+    }
+  },
+  {
+    "EventType": "InvocationCompleted",
+    "EventId": 13,
+    "EventTimestamp": "2026-08-14T20:00:43.861Z",
+    "InvocationCompletedDetails": {
+      "StartTimestamp": "2026-08-14T20:00:43.856Z",
+      "EndTimestamp": "2026-08-14T20:00:43.861Z",
+      "Error": {},
+      "RequestId": "e6ec1bb6-1b71-4926-bb82-26e9c73a0e6f"
+    }
+  },
+  {
+    "EventType": "ExecutionSucceeded",
+    "EventId": 14,
+    "Id": "7ad3fb20-11df-4d17-a4c7-c9addd58dbf7",
+    "EventTimestamp": "2026-08-14T20:00:43.861Z",
+    "ExecutionSucceededDetails": {
+      "Result": {
+        "Payload": "{\"callbackResult\":\"cb-value\",\"plain\":\"plain-value\",\"spans\":[{\"name\":\"plain-step attempt 1\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"ef44f8e34bde79ea\",\"parentSpanId\":\"f99971cf1231ac3e\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"c81e728d9d4c2f63\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.name\":\"plain-step\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"plain-step\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"f99971cf1231ac3e\",\"parentSpanId\":\"135f1c3f783c0f05\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"c81e728d9d4c2f63\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"plain-step\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.number\":1},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"cb-submitter attempt 1\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"7cf92891db643c64\",\"parentSpanId\":\"896c05ae6c57994a\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"98c6f2c2287f4c73\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.name\":\"cb-submitter\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"cb-submitter\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"896c05ae6c57994a\",\"parentSpanId\":\"09c9ad571897399c\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"98c6f2c2287f4c73\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"cb-submitter\",\"durable.operation.subtype\":\"Step\",\"durable.attempt.number\":1},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"cb-callback\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"6df57cea7e1cbd96\",\"parentSpanId\":\"09c9ad571897399c\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"ea66c06c1e1c05fa\",\"durable.operation.type\":\"CALLBACK\",\"durable.operation.status\":\"STARTED\",\"durable.operation.name\":\"cb-callback\",\"durable.operation.subtype\":\"Callback\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"CONTEXT\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"c307088496e588eb\",\"parentSpanId\":\"135f1c3f783c0f05\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"STARTED\",\"durable.operation.subtype\":\"RunInChildContext\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"cb\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"09c9ad571897399c\",\"parentSpanId\":\"135f1c3f783c0f05\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"STARTED\",\"durable.operation.name\":\"cb\",\"durable.operation.subtype\":\"WaitForCallback\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"135f1c3f783c0f05\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"cb\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"56c7447654293674\",\"parentSpanId\":\"2d4898a9339458e1\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.name\":\"cb\",\"durable.operation.subtype\":\"WaitForCallback\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"09c9ad571897399c\"},{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"CONTEXT\",\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"2cc63256f85edd49\",\"parentSpanId\":\"2d4898a9339458e1\",\"attributes\":{\"durable.execution.arn\":\"218d148a-54a4-4d3d-96d8-f9cbe33f7c4a\",\"durable.operation.id\":\"eccbc87e4b5ce2fe\",\"durable.operation.type\":\"CONTEXT\",\"durable.operation.status\":\"SUCCEEDED\",\"durable.operation.subtype\":\"RunInChildContext\"},\"links\":[{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"c307088496e588eb\"},{\"traceId\":\"4d8c5056a0b31ef1bf1f0e1323c71997\",\"spanId\":\"912a1e76519556b4\"}],\"status\":{\"code\":1},\"events\":[]}]}"
+      }
+    }
+  }
+]

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.test.ts
@@ -1,0 +1,96 @@
+import {
+  InvocationType,
+  WaitingOperationStatus,
+} from "@aws/durable-execution-sdk-js-testing";
+import {
+  handler,
+  resetExporter,
+  getSerializedSpans,
+} from "./otel-concurrent-callbacks";
+import { createTests } from "../../../utils/test-helper";
+import { SerializedSpan } from "../shared/otel-test-setup";
+
+createTests({
+  handler,
+  invocationType: InvocationType.Event,
+  tests: (runner, { assertEventSignatures, isCloud }) => {
+    beforeEach(() => {
+      resetExporter();
+    });
+
+    it("does not leak a waitForCallback's derived name onto a concurrent step", async () => {
+      const cb = runner.getOperation("cb");
+      const executionPromise = runner.run();
+
+      await cb.waitForData(WaitingOperationStatus.SUBMITTED);
+      await cb.sendCallbackSuccess("cb-value");
+
+      const execution = await executionPromise;
+      const result = execution.getResult() as {
+        callbackResult: string;
+        plain: string;
+        spans: SerializedSpan[];
+      };
+
+      expect(result.callbackResult).toBe("cb-value");
+      expect(result.plain).toBe("plain-value");
+
+      if (!isCloud) {
+        const spans = getSerializedSpans();
+        const parentNameOf = (s: SerializedSpan) =>
+          spans.find((p) => p.spanId === s.parentSpanId)?.attributes[
+            "durable.operation.name"
+          ];
+
+        // The waitForCallback's inner CALLBACK carries its derived name and
+        // parents to the "cb" CONTEXT.
+        const callbackSpan = spans.find(
+          (s) => s.attributes["durable.operation.type"] === "CALLBACK",
+        );
+        expect(callbackSpan).toBeDefined();
+        expect(callbackSpan!.attributes["durable.operation.name"]).toBe(
+          "cb-callback",
+        );
+        expect(parentNameOf(callbackSpan!)).toBe("cb");
+
+        // The submitter STEP likewise gets "cb-submitter" under the CONTEXT.
+        const submitterOp = spans.find(
+          (s) =>
+            s.attributes["durable.operation.type"] === "STEP" &&
+            s.attributes["durable.operation.name"] === "cb-submitter" &&
+            s.attributes["durable.attempt.outcome"] === undefined,
+        );
+        expect(submitterOp).toBeDefined();
+        expect(parentNameOf(submitterOp!)).toBe("cb");
+
+        // The concurrent plain step keeps its OWN name — it never inherits the
+        // callback's derived name, and it does not parent to the CONTEXT.
+        const plainOp = spans.find(
+          (s) =>
+            s.attributes["durable.operation.type"] === "STEP" &&
+            s.attributes["durable.operation.name"] === "plain-step" &&
+            s.attributes["durable.attempt.outcome"] === undefined,
+        );
+        expect(plainOp).toBeDefined();
+        expect(parentNameOf(plainOp!)).not.toBe("cb");
+
+        // No span carries a callback-derived name it should not: the only spans
+        // named with a callback suffix are the CALLBACK and submitter above.
+        const derivedNamed = spans.filter((s) => {
+          const n = s.attributes["durable.operation.name"] as
+            | string
+            | undefined;
+          return n === "cb-callback" || n === "cb-submitter";
+        });
+        for (const s of derivedNamed) {
+          const type = s.attributes["durable.operation.type"];
+          // Only CALLBACK / STEP (submitter) + their attempt spans may carry
+          // these names — never the plain step.
+          expect(["CALLBACK", "STEP"]).toContain(type);
+        }
+      }
+
+      assertEventSignatures(execution);
+    }, 60000);
+  },
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/concurrent-callbacks/otel-concurrent-callbacks.ts
@@ -1,0 +1,40 @@
+import {
+  DurableContext,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+import { createDualModeOtelSetup } from "../shared/otel-test-setup";
+
+const { plugin, getSerializedSpans, resetExporter } = createDualModeOtelSetup();
+
+export const config: ExampleConfig = {
+  name: "OTel Concurrent Callback",
+  excludeRuntimes: ["24.x"],
+};
+
+export { getSerializedSpans, resetExporter };
+
+export const handler = withDurableExecution(
+  async (_event: any, context: DurableContext) => {
+    // A waitForCallback runs concurrently with a plain, independently-named
+    // step. waitForCallback derives plugin operation names for its inner
+    // (unnamed) CALLBACK and submitter STEP ("cb-callback" / "cb-submitter").
+    // The concurrent "plain-step" must keep its OWN name and never pick up a
+    // derived callback name. This is the regression guard: the derived name is
+    // passed per-call, so a concurrently-running operation cannot observe it.
+    const [callbackResult, plain] = await context.promise.all<string>([
+      context.waitForCallback("cb", async (_callbackId: string) => {
+        // Submitter: in production would notify an external system.
+      }),
+      context.step("plain-step", async () => "plain-value"),
+    ]);
+
+    return {
+      callbackResult,
+      plain,
+      spans: getSerializedSpans(),
+      xRayHeader: process.env._X_AMZN_TRACE_ID,
+    };
+  },
+  { plugins: [plugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition-exhausted.history.json
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/wait-for-condition/otel-wait-for-condition-exhausted.history.json
@@ -2,8 +2,8 @@
   {
     "EventType": "ExecutionStarted",
     "EventId": 1,
-    "Id": "2efddea4-cafb-4304-afca-cec70fa8dabc",
-    "EventTimestamp": "2026-07-03T22:50:15.438Z",
+    "Id": "d02a1df1-8f4a-41de-883f-da0213821d71",
+    "EventTimestamp": "2026-08-13T19:43:27.321Z",
     "ExecutionStartedDetails": {
       "Input": {
         "Payload": "{\"mode\":\"exhausted\"}"
@@ -15,7 +15,7 @@
     "SubType": "WaitForCondition",
     "EventId": 2,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:15.442Z",
+    "EventTimestamp": "2026-08-13T19:43:27.324Z",
     "StepStartedDetails": {}
   },
   {
@@ -23,7 +23,7 @@
     "SubType": "WaitForCondition",
     "EventId": 3,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:15.442Z",
+    "EventTimestamp": "2026-08-13T19:43:27.324Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "{\"counter\":1}"
@@ -36,12 +36,12 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 4,
-    "EventTimestamp": "2026-07-03T22:50:15.464Z",
+    "EventTimestamp": "2026-08-13T19:43:27.347Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-07-03T22:50:15.438Z",
-      "EndTimestamp": "2026-07-03T22:50:15.464Z",
+      "StartTimestamp": "2026-08-13T19:43:27.321Z",
+      "EndTimestamp": "2026-08-13T19:43:27.347Z",
       "Error": {},
-      "RequestId": "a2df664e-ab9c-43a0-b9ba-83ca8b07b431"
+      "RequestId": "574dbb3d-4beb-4319-9ec5-7fc3f48e3759"
     }
   },
   {
@@ -49,7 +49,7 @@
     "SubType": "WaitForCondition",
     "EventId": 5,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:16.445Z",
+    "EventTimestamp": "2026-08-13T19:43:28.327Z",
     "StepStartedDetails": {}
   },
   {
@@ -57,7 +57,7 @@
     "SubType": "WaitForCondition",
     "EventId": 6,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:16.445Z",
+    "EventTimestamp": "2026-08-13T19:43:28.327Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "{\"counter\":2}"
@@ -71,12 +71,12 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 7,
-    "EventTimestamp": "2026-07-03T22:50:16.469Z",
+    "EventTimestamp": "2026-08-13T19:43:28.350Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-07-03T22:50:16.443Z",
-      "EndTimestamp": "2026-07-03T22:50:16.469Z",
+      "StartTimestamp": "2026-08-13T19:43:28.325Z",
+      "EndTimestamp": "2026-08-13T19:43:28.350Z",
       "Error": {},
-      "RequestId": "8ad92083-d19a-4bfb-ab36-16ac0ce7e8f1"
+      "RequestId": "cb025f44-782b-45b4-9208-51054e97fe98"
     }
   },
   {
@@ -84,7 +84,7 @@
     "SubType": "WaitForCondition",
     "EventId": 8,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:17.448Z",
+    "EventTimestamp": "2026-08-13T19:43:29.330Z",
     "StepStartedDetails": {}
   },
   {
@@ -92,7 +92,7 @@
     "SubType": "WaitForCondition",
     "EventId": 9,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:17.448Z",
+    "EventTimestamp": "2026-08-13T19:43:29.330Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "{\"counter\":3}"
@@ -106,12 +106,12 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 10,
-    "EventTimestamp": "2026-07-03T22:50:17.470Z",
+    "EventTimestamp": "2026-08-13T19:43:29.353Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-07-03T22:50:17.446Z",
-      "EndTimestamp": "2026-07-03T22:50:17.470Z",
+      "StartTimestamp": "2026-08-13T19:43:29.328Z",
+      "EndTimestamp": "2026-08-13T19:43:29.353Z",
       "Error": {},
-      "RequestId": "bf14019c-cc7f-4e73-974d-5d0d6f40efa9"
+      "RequestId": "d3a6c359-7c27-413d-aee6-388bb18419a5"
     }
   },
   {
@@ -119,7 +119,7 @@
     "SubType": "WaitForCondition",
     "EventId": 11,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:18.451Z",
+    "EventTimestamp": "2026-08-13T19:43:30.334Z",
     "StepStartedDetails": {}
   },
   {
@@ -127,7 +127,7 @@
     "SubType": "WaitForCondition",
     "EventId": 12,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:18.451Z",
+    "EventTimestamp": "2026-08-13T19:43:30.334Z",
     "StepSucceededDetails": {
       "Result": {
         "Payload": "{\"counter\":4}"
@@ -141,12 +141,12 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 13,
-    "EventTimestamp": "2026-07-03T22:50:18.475Z",
+    "EventTimestamp": "2026-08-13T19:43:30.357Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-07-03T22:50:18.449Z",
-      "EndTimestamp": "2026-07-03T22:50:18.475Z",
+      "StartTimestamp": "2026-08-13T19:43:30.332Z",
+      "EndTimestamp": "2026-08-13T19:43:30.357Z",
       "Error": {},
-      "RequestId": "43858eb7-59a1-4897-aad9-1f2c82b6d1cf"
+      "RequestId": "d5700d7f-2095-49b9-a9df-0da33ba79d4f"
     }
   },
   {
@@ -154,7 +154,7 @@
     "SubType": "WaitForCondition",
     "EventId": 14,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:19.455Z",
+    "EventTimestamp": "2026-08-13T19:43:31.339Z",
     "StepStartedDetails": {}
   },
   {
@@ -162,7 +162,7 @@
     "SubType": "WaitForCondition",
     "EventId": 15,
     "Id": "c4ca4238a0b92382",
-    "EventTimestamp": "2026-07-03T22:50:19.455Z",
+    "EventTimestamp": "2026-08-13T19:43:31.339Z",
     "StepFailedDetails": {
       "Error": {
         "Payload": {
@@ -178,22 +178,22 @@
   {
     "EventType": "InvocationCompleted",
     "EventId": 16,
-    "EventTimestamp": "2026-07-03T22:50:19.491Z",
+    "EventTimestamp": "2026-08-13T19:43:31.396Z",
     "InvocationCompletedDetails": {
-      "StartTimestamp": "2026-07-03T22:50:19.452Z",
-      "EndTimestamp": "2026-07-03T22:50:19.491Z",
+      "StartTimestamp": "2026-08-13T19:43:31.335Z",
+      "EndTimestamp": "2026-08-13T19:43:31.396Z",
       "Error": {},
-      "RequestId": "3b062093-5f3c-4a05-b1ce-a34eaeefbbff"
+      "RequestId": "4dd5dfac-18e9-4ae6-9c8f-fe0575d6c0ed"
     }
   },
   {
     "EventType": "ExecutionSucceeded",
     "EventId": 17,
-    "Id": "2efddea4-cafb-4304-afca-cec70fa8dabc",
-    "EventTimestamp": "2026-07-03T22:50:19.492Z",
+    "Id": "d02a1df1-8f4a-41de-883f-da0213821d71",
+    "EventTimestamp": "2026-08-13T19:43:31.397Z",
     "ExecutionSucceededDetails": {
       "Result": {
-        "Payload": "{\"failed\":true,\"errorMessage\":\"waitForCondition exceeded maximum attempts (5)\",\"mode\":\"exhausted\",\"spans\":[{\"name\":\"STEP attempt 1\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"6a9aca416715ad43\",\"parentSpanId\":\"4c4e02358eca2775\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":1,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\",\"parentSpanId\":\"a2dc1a018a1e7174\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"invocation\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"a2dc1a018a1e7174\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP attempt 2\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"b887df52d992d5e6\",\"parentSpanId\":\"729028c37305e2d7\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":2,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"729028c37305e2d7\",\"parentSpanId\":\"dbb815104654d9d7\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"invocation\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"dbb815104654d9d7\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP attempt 3\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"25c2d88ec21ac4db\",\"parentSpanId\":\"4f2c03adfe8842e3\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":3,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4f2c03adfe8842e3\",\"parentSpanId\":\"11aaa7b9bf511ab5\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"invocation\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"11aaa7b9bf511ab5\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP attempt 4\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"074406d7ebea2bc8\",\"parentSpanId\":\"c23c8e1dcb4a301b\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":4,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"c23c8e1dcb4a301b\",\"parentSpanId\":\"c522928a1e6bf49f\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"invocation\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"c522928a1e6bf49f\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\"},\"links\":[],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"STEP attempt 5\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"635c24f71a840523\",\"parentSpanId\":\"41da40cfefd7f617\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.attempt\":5,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":2,\"message\":\"waitForCondition exceeded maximum attempts (5)\"},\"events\":[{\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Error\",\"exception.message\":\"waitForCondition exceeded maximum attempts (5)\",\"exception.stacktrace\":\"Error: waitForCondition exceeded maximum attempts (5)\\n    at Object.waitStrategy (/Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.ts:60:13)\\n    at executeCheckLogic (/Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:282:61)\\n    at /Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:171:14\"}}]},{\"name\":\"STEP\",\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"41da40cfefd7f617\",\"parentSpanId\":\"57ad62655484d287\",\"attributes\":{\"durable.execution.arn\":\"a0ecdbf6-00f3-4d28-bea6-92a9104bfd10\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"7e37b1d7667efbb25457929c80182f33\",\"spanId\":\"4c4e02358eca2775\"}],\"status\":{\"code\":2,\"message\":\"waitForCondition exceeded maximum attempts (5)\"},\"events\":[{\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Error\",\"exception.message\":\"waitForCondition exceeded maximum attempts (5)\",\"exception.stacktrace\":\"Error: waitForCondition exceeded maximum attempts (5)\\n    at Object.waitStrategy (/Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.ts:60:13)\\n    at executeCheckLogic (/Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:282:61)\\n    at /Users/hsilan/github/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:171:14\"}}]}]}"
+        "Payload": "{\"failed\":true,\"errorMessage\":\"waitForCondition exceeded maximum attempts (5)\",\"mode\":\"exhausted\",\"spans\":[{\"name\":\"STEP attempt 1\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"00f2662ffe2bf7b5\",\"parentSpanId\":\"edf3780cb5d2938f\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":1,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"edf3780cb5d2938f\",\"parentSpanId\":\"3b9ee65463d06421\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"STARTED\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"3b9ee65463d06421\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP attempt 2\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"cf1486a40a290bad\",\"parentSpanId\":\"5054ab62908fb74f\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":2,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"5054ab62908fb74f\",\"parentSpanId\":\"e6c5c2f9eda4b825\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"STARTED\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"edf3780cb5d2938f\"},{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"e6c5c2f9eda4b825\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP attempt 3\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"d0040a9bf2b9eace\",\"parentSpanId\":\"6fde4ea64cc9cc97\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":3,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"6fde4ea64cc9cc97\",\"parentSpanId\":\"ec70de6adb5087f3\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"STARTED\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"edf3780cb5d2938f\"},{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"ec70de6adb5087f3\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP attempt 4\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"9eae56203c82b597\",\"parentSpanId\":\"8a51830785c83f91\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":4,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"SUCCEEDED\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"8a51830785c83f91\",\"parentSpanId\":\"62bd40f666b81f39\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"STARTED\",\"durable.operation.subtype\":\"WaitForCondition\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"edf3780cb5d2938f\"},{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":0},\"events\":[]},{\"name\":\"Invocation\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"62bd40f666b81f39\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.invocation.status\":\"PENDING\"},\"links\":[],\"status\":{\"code\":1},\"events\":[]},{\"name\":\"STEP attempt 5\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"f06bfafdd773a934\",\"parentSpanId\":\"4045346640aafb72\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.attempt.number\":5,\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.outcome\":\"FAILED\"},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":2,\"message\":\"waitForCondition exceeded maximum attempts (5)\"},\"events\":[{\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Error\",\"exception.message\":\"waitForCondition exceeded maximum attempts (5)\",\"exception.stacktrace\":\"Error: waitForCondition exceeded maximum attempts (5)\\n    at Object.waitStrategy (/Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.ts:60:13)\\n    at executeCheckLogic (/Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:285:61)\\n    at /Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:171:14\"}}]},{\"name\":\"STEP\",\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"4045346640aafb72\",\"parentSpanId\":\"a571a36c36fa7704\",\"attributes\":{\"durable.execution.arn\":\"4d61a72b-9017-417f-ac50-9240a4c2a2d4\",\"durable.operation.id\":\"c4ca4238a0b92382\",\"durable.operation.type\":\"STEP\",\"durable.operation.status\":\"FAILED\",\"durable.operation.subtype\":\"WaitForCondition\",\"durable.attempt.number\":5},\"links\":[{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"edf3780cb5d2938f\"},{\"traceId\":\"6aacb0322c46230eddb5c0c5d5c59455\",\"spanId\":\"0ba608da44eb63d7\"}],\"status\":{\"code\":2,\"message\":\"waitForCondition exceeded maximum attempts (5)\"},\"events\":[{\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Error\",\"exception.message\":\"waitForCondition exceeded maximum attempts (5)\",\"exception.stacktrace\":\"Error: waitForCondition exceeded maximum attempts (5)\\n    at Object.waitStrategy (/Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/utils/wait-strategy/wait-strategy-config.ts:60:13)\\n    at executeCheckLogic (/Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:285:61)\\n    at /Volumes/workplace/aws-durable-execution-sdk-js/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts:171:14\"}}]}]}"
       }
     }
   }

--- a/packages/aws-durable-execution-sdk-js-examples/template.yml
+++ b/packages/aws-durable-execution-sdk-js-examples/template.yml
@@ -1527,6 +1527,35 @@ Resources:
         - arn:aws:lambda:us-west-2:184161586896:layer:opentelemetry-collector-amd64-0_22_0:1
     Metadata:
       SkipBuild: "True"
+  OtelConcurrentCallbacks:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: OTelConcurrentCallback-22x-NodeJS-Local
+      CodeUri: ./dist
+      Handler: otel-concurrent-callbacks.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 60
+      DurableConfig:
+        ExecutionTimeout: 60
+        RetentionPeriodInDays: 7
+      Role:
+        Fn::GetAtt:
+          - DurableFunctionRole
+          - Arn
+      Environment:
+        Variables:
+          DURABLE_VERBOSE_MODE: "false"
+          DURABLE_EXAMPLES_VERBOSE: "true"
+          AWS_ENDPOINT_URL_LAMBDA: http://host.docker.internal:5000
+          AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+      Tracing: Active
+      Layers:
+        - arn:aws:lambda:us-west-2:615299751070:layer:AWSOpenTelemetryDistroJs:7
+    Metadata:
+      SkipBuild: "True"
   OtelInvoke:
     Type: AWS::Serverless::Function
     Properties:

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -545,4 +545,274 @@ describe("ExecutionOtelPlugin - Parent-child workflow span ID collision preventi
     expect(opSpan).toBeDefined();
     expect(opSpan!.status.code).toBe(SpanStatusCode.OK);
   });
+
+  // ExecutionOtelPlugin has its own span-creation paths (deterministic span IDs,
+  // Workflow_Span as the fallback parent, and a cross-invocation path in
+  // onOperationEnd), so handler-provided-name behaviour is covered separately
+  // from InvocationOtelPlugin rather than assumed to be shared.
+  describe("Handler-provided names on unnamed child operations", () => {
+    it("child operation carries durable.operation.name provided by the handler", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Parent CONTEXT operation (the waitForCallback child context) is named.
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-1",
+          type: "CONTEXT",
+          subType: "WaitForCallback",
+          name: "otel-callback",
+        }),
+      );
+      // Child CALLBACK operation: the plugin doesn't derive this name — the
+      // handler passes the derived name ("otel-callback-callback") to the inner
+      // createCallback via config, so the plugin receives it directly here.
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "cb-1",
+          type: "CALLBACK",
+          subType: "Callback",
+          parentId: "ctx-1",
+          name: "otel-callback-callback",
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "cb-1",
+          type: "CALLBACK",
+          parentId: "ctx-1",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-1",
+          type: "CONTEXT",
+          name: "otel-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const cbSpan = getExportedSpans(exporter).find(
+        (s) => s.attributes["durable.operation.id"] === "cb-1",
+      );
+      expect(cbSpan).toBeDefined();
+      expect(cbSpan!.attributes["durable.operation.name"]).toBe(
+        "otel-callback-callback",
+      );
+    });
+
+    it("child operation has no name when none is provided", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "ctx-2", type: "CONTEXT" }),
+      );
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "step-2", type: "STEP", parentId: "ctx-2" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "step-2",
+          type: "STEP",
+          parentId: "ctx-2",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-2",
+          type: "CONTEXT",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const stepSpan = getExportedSpans(exporter).find(
+        (s) => s.attributes["durable.operation.id"] === "step-2",
+      );
+      expect(stepSpan).toBeDefined();
+      expect(stepSpan!.attributes["durable.operation.name"]).toBeUndefined();
+    });
+
+    it("attempt span carries durable.operation.name passed by the handler", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-3",
+          type: "CONTEXT",
+          subType: "WaitForCallback",
+          name: "my-callback",
+        }),
+      );
+      // Unnamed submitter STEP inside the child context.
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "step-3",
+          type: "STEP",
+          subType: "Step",
+          parentId: "ctx-3",
+          name: "my-callback-submitter",
+        }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "step-3",
+          type: "STEP",
+          attempt: 1,
+          name: "my-callback-submitter",
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({ id: "step-3", type: "STEP", attempt: 1 }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "step-3",
+          type: "STEP",
+          parentId: "ctx-3",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-3",
+          type: "CONTEXT",
+          name: "my-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = findSpan(exporter, "my-callback-submitter attempt 1");
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.attributes["durable.operation.name"]).toBe(
+        "my-callback-submitter",
+      );
+      // The attempt still parents to its own operation span, not the context.
+      // Look the operation span up by name: the attempt span carries the same
+      // durable.operation.id and is exported first. The operation span's name
+      // reflects the handler-provided name ("my-callback-submitter"), not the
+      // bare operation type.
+      const stepSpan = findSpan(exporter, "my-callback-submitter");
+      expect(stepSpan).toBeDefined();
+      expect(attemptSpan!.parentSpanContext?.spanId).toBe(
+        stepSpan!.spanContext().spanId,
+      );
+    });
+
+    it("cross-invocation child span carries the handler-provided name and parents to the parent span", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // CONTEXT is replayed in this invocation, so it populates spanMap.
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-4",
+          type: "CONTEXT",
+          subType: "WaitForCallback",
+          name: "otel-callback",
+          isReplay: true,
+        }),
+      );
+      // The CALLBACK completed between invocations: no onOperationStart in this
+      // invocation, so onOperationEnd takes the cross-invocation span path.
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "cb-4",
+          type: "CALLBACK",
+          subType: "Callback",
+          parentId: "ctx-4",
+          name: "otel-callback-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-4",
+          type: "CONTEXT",
+          name: "otel-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const ctxSpan = getExportedSpans(exporter).find(
+        (s) => s.attributes["durable.operation.id"] === "ctx-4",
+      );
+      const cbSpan = getExportedSpans(exporter).find(
+        (s) => s.attributes["durable.operation.id"] === "cb-4",
+      );
+      expect(ctxSpan).toBeDefined();
+      expect(cbSpan).toBeDefined();
+      expect(cbSpan!.attributes["durable.operation.name"]).toBe(
+        "otel-callback-callback",
+      );
+      expect(cbSpan!.parentSpanContext?.spanId).toBe(
+        ctxSpan!.spanContext().spanId,
+      );
+    });
+  });
+
+  // Guards the waitForCondition parity fix: a check that returns
+  // normally but keeps polling ends the attempt with outcome SUCCEEDED, so the
+  // attempt span must carry an explicit OK status. OTel conformance test 9
+  // asserts `status: OK` on the first, non-terminal polling attempt.
+  it("a SUCCEEDED attempt end stamps explicit OK and records no exception", async () => {
+    const plugin = new ExecutionOtelPlugin({
+      providerSource: ProviderSource.GLOBAL,
+    });
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({
+        id: "cond-1",
+        type: "STEP",
+        subType: "WaitForCondition",
+        name: "otel-condition",
+      }),
+    );
+    await plugin.onOperationAttemptStart(
+      makeAttemptInfo({
+        id: "cond-1",
+        type: "STEP",
+        subType: "WaitForCondition",
+        name: "otel-condition",
+        attempt: 1,
+      }),
+    );
+    // Condition not yet met: the check ran successfully and polling continues.
+    await plugin.onOperationAttemptEnd(
+      makeAttemptEndInfo({
+        id: "cond-1",
+        type: "STEP",
+        subType: "WaitForCondition",
+        name: "otel-condition",
+        attempt: 1,
+        outcome: "SUCCEEDED" as any,
+        // No error: continuing to poll is not an attempt failure.
+      }),
+    );
+    await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+    const attemptSpan = findSpan(exporter, "otel-condition attempt 1");
+    expect(attemptSpan).toBeDefined();
+    expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe(
+      "SUCCEEDED",
+    );
+    expect(attemptSpan!.status.code).toBe(SpanStatusCode.OK);
+    expect(attemptSpan!.events).toHaveLength(0);
+  });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -124,9 +124,9 @@ function compareHrTime(
 }
 
 function expectSpanInside(child: ReadableSpan, parent: ReadableSpan): void {
-  expect(compareHrTime(child.startTime, parent.startTime)).toBeGreaterThanOrEqual(
-    0,
-  );
+  expect(
+    compareHrTime(child.startTime, parent.startTime),
+  ).toBeGreaterThanOrEqual(0);
   expect(compareHrTime(child.endTime, parent.endTime)).toBeLessThanOrEqual(0);
 }
 
@@ -140,7 +140,10 @@ beforeEach(() => {
     idGenerator,
   });
   provider.register();
-  plugin = new InvocationOtelPlugin({ providerSource: ProviderSource.EXPLICIT, tracerProvider: provider });
+  plugin = new InvocationOtelPlugin({
+    providerSource: ProviderSource.EXPLICIT,
+    tracerProvider: provider,
+  });
 });
 
 afterEach(async () => {
@@ -501,7 +504,12 @@ describe("InvocationOtelPlugin", () => {
         makeOperationInfo({ id: "s2", type: "STEP", name: "retry-step" }),
       );
       await plugin.onOperationAttemptStart(
-        makeAttemptInfo({ id: "s2", type: "STEP", name: "retry-step", attempt: 1 }),
+        makeAttemptInfo({
+          id: "s2",
+          type: "STEP",
+          name: "retry-step",
+          attempt: 1,
+        }),
       );
       await plugin.onOperationAttemptEnd(
         makeAttemptEndInfo({
@@ -643,7 +651,12 @@ describe("InvocationOtelPlugin", () => {
       );
       // Attempt 1 (fails) — child of the operation span.
       await plugin.onOperationAttemptStart(
-        makeAttemptInfo({ id: "op-r", type: "STEP", name: "retried-op", attempt: 1 }),
+        makeAttemptInfo({
+          id: "op-r",
+          type: "STEP",
+          name: "retried-op",
+          attempt: 1,
+        }),
       );
       await plugin.onOperationAttemptEnd(
         makeAttemptEndInfo({
@@ -666,7 +679,12 @@ describe("InvocationOtelPlugin", () => {
       );
       // Attempt 2 (succeeds) after the replay.
       await plugin.onOperationAttemptStart(
-        makeAttemptInfo({ id: "op-r", type: "STEP", name: "retried-op", attempt: 2 }),
+        makeAttemptInfo({
+          id: "op-r",
+          type: "STEP",
+          name: "retried-op",
+          attempt: 2,
+        }),
       );
       await plugin.onOperationAttemptEnd(
         makeAttemptEndInfo({
@@ -2117,6 +2135,260 @@ describe("InvocationOtelPlugin", () => {
       expect(enrichSpan!.parentSpanContext?.spanId).toBe(
         childInvocationSpan!.spanContext().spanId,
       );
+    });
+  });
+
+  describe("Handler-provided names on unnamed child operations", () => {
+    it("child operation carries durable.operation.name provided by the handler", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Parent CONTEXT operation with a name
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-1",
+          type: "CONTEXT",
+          name: "otel-callback",
+          subType: "WaitForCallback",
+        }),
+      );
+      // Child CALLBACK operation: the plugin itself doesn't derive this name —
+      // the handler passes the derived name ("otel-callback-callback") to the
+      // inner createCallback via config, so the plugin receives it directly here.
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "cb-1",
+          type: "CALLBACK",
+          parentId: "ctx-1",
+          subType: "Callback",
+          name: "otel-callback-callback",
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "cb-1",
+          type: "CALLBACK",
+          parentId: "ctx-1",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-1",
+          type: "CONTEXT",
+          name: "otel-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const cbSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.type"] === "CALLBACK",
+      );
+      expect(cbSpan).toBeDefined();
+      expect(cbSpan!.attributes["durable.operation.name"]).toBe(
+        "otel-callback-callback",
+      );
+    });
+
+    it("child operation has no name when none is provided", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Parent without a name
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "ctx-2", type: "CONTEXT" }),
+      );
+      // Child without a name
+      await plugin.onOperationStart(
+        makeOperationInfo({ id: "step-2", type: "STEP", parentId: "ctx-2" }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "step-2",
+          type: "STEP",
+          parentId: "ctx-2",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-2",
+          type: "CONTEXT",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const stepSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.id"] === "step-2",
+      );
+      expect(stepSpan).toBeDefined();
+      expect(stepSpan!.attributes["durable.operation.name"]).toBeUndefined();
+    });
+
+    it("attempt span carries durable.operation.name passed by the handler", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // Parent CONTEXT
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-3",
+          type: "CONTEXT",
+          name: "my-callback",
+          subType: "WaitForCallback",
+        }),
+      );
+      // Child STEP (unnamed) with parentId
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "step-3",
+          type: "STEP",
+          parentId: "ctx-3",
+          subType: "Step",
+        }),
+      );
+      // Attempt on the child STEP
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "step-3",
+          type: "STEP",
+          attempt: 1,
+          subType: "Step",
+          name: "my-callback-submitter",
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "step-3",
+          type: "STEP",
+          attempt: 1,
+          outcome: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "step-3",
+          type: "STEP",
+          parentId: "ctx-3",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-3",
+          type: "CONTEXT",
+          name: "my-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = getExportedSpans().find(
+        (s) => s.name === "my-callback-submitter attempt 1",
+      );
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.attributes["durable.operation.name"]).toBe(
+        "my-callback-submitter",
+      );
+    });
+
+    it("continuation span resolves parent from spanMap using parentId and carries handler-provided name", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      // CONTEXT started in this invocation (replay)
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "ctx-4",
+          type: "CONTEXT",
+          name: "otel-callback",
+          subType: "WaitForCallback",
+          isReplay: true,
+        }),
+      );
+      // CALLBACK completed between invocations — fires onOperationEnd with isReplay: false.
+      // The handler passes the derived name to the inner createCallback, so the
+      // name arrives pre-derived here (simulated by passing it directly).
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "cb-4",
+          type: "CALLBACK",
+          parentId: "ctx-4",
+          subType: "Callback",
+          status: "SUCCEEDED" as any,
+          isReplay: false,
+          name: "otel-callback-callback",
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "ctx-4",
+          type: "CONTEXT",
+          name: "otel-callback",
+          status: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const ctxSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.id"] === "ctx-4",
+      );
+      const cbSpan = getExportedSpans().find(
+        (s) => s.attributes["durable.operation.id"] === "cb-4",
+      );
+      expect(ctxSpan).toBeDefined();
+      expect(cbSpan).toBeDefined();
+      // The continuation span should be parented to the CONTEXT span, not the invocation span
+      expect(cbSpan!.parentSpanContext?.spanId).toBe(
+        ctxSpan!.spanContext().spanId,
+      );
+      // ...and it should carry the name the handler passed to the inner
+      // createCallback via config.
+      expect(cbSpan!.attributes["durable.operation.name"]).toBe(
+        "otel-callback-callback",
+      );
+    });
+  });
+
+  describe("Non-terminal polling attempts are reported as successful", () => {
+    // Guards the waitForCondition parity fix: a check function that
+    // returns normally but decides to keep polling ends the attempt with
+    // outcome SUCCEEDED, so the attempt span must carry an explicit OK status —
+    // not merely "not ERROR". OTel conformance test 9 asserts `status: OK`.
+    it("a SUCCEEDED attempt end stamps explicit OK and records no exception", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+        }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 1,
+        }),
+      );
+      // Condition not yet met: the check ran successfully and polling continues.
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 1,
+          outcome: "SUCCEEDED" as any,
+          // No error: continuing to poll is not an attempt failure.
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const attemptSpan = findSpan("otel-condition attempt 1");
+      expect(attemptSpan).toBeDefined();
+      expect(attemptSpan!.attributes["durable.attempt.outcome"]).toBe(
+        "SUCCEEDED",
+      );
+      expect(attemptSpan!.status.code).toBe(SpanStatusCode.OK);
+      expect(attemptSpan!.events).toHaveLength(0);
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -9,12 +9,7 @@ import type {
   OperationChangeInfo,
 } from "@aws/durable-execution-sdk-js";
 import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
-import type {
-  TracerProvider,
-  Tracer,
-  Span,
-  Link,
-} from "@opentelemetry/api";
+import type { TracerProvider, Tracer, Span, Link } from "@opentelemetry/api";
 import {
   context,
   trace,

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -9,7 +9,13 @@ import type {
   OperationChangeInfo,
 } from "@aws/durable-execution-sdk-js";
 import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
-import type { TracerProvider, Tracer, Span, SpanContext, Link } from "@opentelemetry/api";
+import type {
+  TracerProvider,
+  Tracer,
+  Span,
+  SpanContext,
+  Link,
+} from "@opentelemetry/api";
 import {
   context,
   trace,
@@ -413,8 +419,17 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         this.invocationSpan?.spanContext().traceId ??
         this.idGenerator.generateTraceId();
 
-      const parentContext = this.invocationSpan
-        ? trace.setSpan(context.active(), this.invocationSpan)
+      // Resolve parent span: use parentId from map (e.g. the CONTEXT span for
+      // child operations inside waitForCallback), or fall back to invocation span.
+      let continuationParentSpan: Span | undefined;
+      if (info.parentId && this.spanMap.has(info.parentId)) {
+        continuationParentSpan = this.spanMap.get(info.parentId);
+      } else {
+        continuationParentSpan = this.invocationSpan;
+      }
+
+      const parentContext = continuationParentSpan
+        ? trace.setSpan(context.active(), continuationParentSpan)
         : context.active();
 
       const attributes: Record<string, string | number> = {

--- a/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/context/durable-context/durable-context.ts
@@ -27,6 +27,7 @@ import {
   DurablePromise,
   DurableLogData,
 } from "../../types";
+import { InternalDurableContext } from "../../types/internal-context";
 import { Context } from "aws-lambda";
 import { CheckpointManager } from "../../utils/checkpoint/checkpoint-manager";
 import { EventEmitter } from "events";
@@ -76,9 +77,9 @@ export const DURABLE_CONTEXT_BRAND = Symbol.for(
   "@aws/durable-execution-sdk-js/durable-context",
 );
 
-export class DurableContextImpl<
-  Logger extends DurableLogger,
-> implements DurableContext<Logger> {
+export class DurableContextImpl<Logger extends DurableLogger>
+  implements DurableContext<Logger>, InternalDurableContext<Logger>
+{
   readonly [DURABLE_CONTEXT_BRAND] = true;
 
   private _stepPrefix?: string;
@@ -340,6 +341,34 @@ export class DurableContextImpl<
     fnOrOptions?: StepFunc<T, Logger> | StepConfig<T>,
     maybeOptions?: StepConfig<T>,
   ): DurablePromise<T> {
+    return this.stepInternal(undefined, nameOrFn, fnOrOptions, maybeOptions);
+  }
+
+  /**
+   * {@link step} variant that also labels the span with a plugin-only name.
+   * Never checkpointed. See {@link InternalDurableContext}.
+   * @internal
+   */
+  _stepWithPluginOperationName<T>(
+    pluginOperationName: string | undefined,
+    nameOrFn: string | undefined | StepFunc<T, Logger>,
+    fnOrOptions?: StepFunc<T, Logger> | StepConfig<T>,
+    maybeOptions?: StepConfig<T>,
+  ): DurablePromise<T> {
+    return this.stepInternal(
+      pluginOperationName,
+      nameOrFn,
+      fnOrOptions,
+      maybeOptions,
+    );
+  }
+
+  private stepInternal<T>(
+    pluginOperationName: string | undefined,
+    nameOrFn: string | undefined | StepFunc<T, Logger>,
+    fnOrOptions?: StepFunc<T, Logger> | StepConfig<T>,
+    maybeOptions?: StepConfig<T>,
+  ): DurablePromise<T> {
     validateContextUsage(
       this._stepPrefix,
       "step",
@@ -356,6 +385,7 @@ export class DurableContextImpl<
         this._parentId,
         () => this._defaultSerdes,
         this.durableExecution.plugin,
+        pluginOperationName,
       );
 
       return stepHandler(nameOrFn, fnOrOptions, maybeOptions);
@@ -539,6 +569,31 @@ export class DurableContextImpl<
     nameOrConfig?: string | CreateCallbackConfig<T>,
     maybeConfig?: CreateCallbackConfig<T>,
   ): DurablePromise<CreateCallbackResult<T>> {
+    return this.createCallbackInternal(undefined, nameOrConfig, maybeConfig);
+  }
+
+  /**
+   * {@link createCallback} variant that also labels the span with a
+   * plugin-only name. Never checkpointed. See {@link InternalDurableContext}.
+   * @internal
+   */
+  _createCallbackWithPluginOperationName<T>(
+    pluginOperationName: string | undefined,
+    nameOrConfig?: string | CreateCallbackConfig<T>,
+    maybeConfig?: CreateCallbackConfig<T>,
+  ): DurablePromise<CreateCallbackResult<T>> {
+    return this.createCallbackInternal(
+      pluginOperationName,
+      nameOrConfig,
+      maybeConfig,
+    );
+  }
+
+  private createCallbackInternal<T>(
+    pluginOperationName: string | undefined,
+    nameOrConfig?: string | CreateCallbackConfig<T>,
+    maybeConfig?: CreateCallbackConfig<T>,
+  ): DurablePromise<CreateCallbackResult<T>> {
     validateContextUsage(
       this._stepPrefix,
       "createCallback",
@@ -553,6 +608,7 @@ export class DurableContextImpl<
         this._parentId,
         () => this._defaultCallbackDeserializer,
         this.durableExecution.plugin,
+        pluginOperationName,
       );
       return callbackFactory(nameOrConfig, maybeConfig);
     });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -40,6 +40,8 @@ export const createCallback = (
 
   getDefaultCallbackDeserializer?: () => AnySerdesDeserializer,
   plugin: DurableInstrumentationPlugin = {},
+  // Plugin-only operation name; never checkpointed. Labels the CALLBACK span.
+  pluginOperationName?: string,
 ) => {
   return <T>(
     nameOrConfig?: string | undefined | CreateCallbackConfig<T>,
@@ -64,7 +66,7 @@ export const createCallback = (
 
     const opInfo = {
       id: hashId(stepId),
-      name: name,
+      name: pluginOperationName ?? name,
       type: OperationType.CALLBACK,
       subType: OperationSubType.CALLBACK,
       parentId: parentId ? hashId(parentId) : undefined,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -58,6 +58,8 @@ export const createStepHandler = <Logger extends DurableLogger>(
   parentId?: string,
   getDefaultSerdes?: () => AnySerdes,
   plugin: DurableInstrumentationPlugin = {},
+  // Plugin-only operation name; never checkpointed. Labels the STEP span.
+  pluginOperationName?: string,
 ) => {
   return <T>(
     nameOrFn: string | undefined | StepFunc<T, Logger>,
@@ -96,7 +98,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
 
       const opInfo = {
         id: hashId(stepId),
-        name: name,
+        name: pluginOperationName ?? name,
         type: OperationType.STEP,
         subType: OperationSubType.STEP,
         parentId: parentId ? hashId(parentId) : undefined,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.test.ts
@@ -4,6 +4,65 @@ import { CheckpointFunction } from "../../testing/mock-checkpoint";
 import * as serdesErrors from "../../errors/serdes-errors/serdes-errors";
 import * as callbackHandler from "../callback-handler/callback";
 
+/**
+ * Builds a mock child context that mirrors the internal methods the
+ * waitForCallback handler actually calls: `_createCallbackWithPluginOperationName`
+ * and `_stepWithPluginOperationName` (the internal variants that carry the
+ * plugin-only operation name). Optional hooks let a test capture the
+ * plugin-operation-name / config arguments.
+ */
+function makeMockChildCtx(opts: {
+  callbackResult: unknown;
+  callbackId: string;
+  onCreateCallback?: (
+    pluginOperationName: string | undefined,
+    config: unknown,
+  ) => void;
+  onStep?: (
+    pluginOperationName: string | undefined,
+    config: unknown,
+  ) => void | Promise<void>;
+}) {
+  const mockTelemetry = {
+    logger: {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+
+  return {
+    _createCallbackWithPluginOperationName: jest
+      .fn()
+      .mockImplementation((pluginOperationName: unknown, config: unknown) => {
+        opts.onCreateCallback?.(
+          pluginOperationName as string | undefined,
+          config,
+        );
+        return Promise.resolve([
+          Promise.resolve(opts.callbackResult),
+          opts.callbackId,
+        ]);
+      }),
+    _stepWithPluginOperationName: jest
+      .fn()
+      .mockImplementation(
+        async (pluginOperationName: unknown, fn: unknown, config?: unknown) => {
+          await opts.onStep?.(
+            pluginOperationName as string | undefined,
+            config,
+          );
+          if (typeof fn === "function") {
+            return await fn(mockTelemetry);
+          }
+          return undefined;
+        },
+      ),
+  };
+}
+
 describe("waitForCallback handler", () => {
   let mockExecutionContext: ExecutionContext;
   let mockCheckpoint: CheckpointFunction;
@@ -46,34 +105,10 @@ describe("waitForCallback handler", () => {
       expect(name).toBeUndefined(); // When no name provided, should be undefined
       expect(typeof fn).toBe("function");
 
-      // Create a mock child context
-      const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([Promise.resolve(expectedResult), "callback-123"]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            // Handle both overloads of step function
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
-      };
+      const mockChildCtx = makeMockChildCtx({
+        callbackResult: expectedResult,
+        callbackId: "callback-123",
+      });
 
       return await fn(mockChildCtx);
     });
@@ -106,34 +141,20 @@ describe("waitForCallback handler", () => {
     const expectedResult = "named callback result";
     const callbackName = "myCallback";
 
-    mockRunInChildContext.mockImplementation(async (name: string, fn: any) => {
-      const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([Promise.resolve(expectedResult), "callback-456"]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
+    let callbackPluginName: string | undefined;
+    let stepPluginName: string | undefined;
 
-            // Handle both overloads of step function
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
-      };
+    mockRunInChildContext.mockImplementation(async (name: string, fn: any) => {
+      const mockChildCtx = makeMockChildCtx({
+        callbackResult: expectedResult,
+        callbackId: "callback-456",
+        onCreateCallback: (pluginOperationName) => {
+          callbackPluginName = pluginOperationName;
+        },
+        onStep: (pluginOperationName) => {
+          stepPluginName = pluginOperationName;
+        },
+      });
 
       return await fn(mockChildCtx);
     });
@@ -152,6 +173,10 @@ describe("waitForCallback handler", () => {
       expect.any(Function),
       expect.objectContaining({ subType: "WaitForCallback" }),
     );
+    // The named waitForCallback forwards derived plugin operation names to the
+    // inner CALLBACK and submitter STEP.
+    expect(callbackPluginName).toBe("myCallback-callback");
+    expect(stepPluginName).toBe("myCallback-submitter");
     expect(submitter).toHaveBeenCalledWith(
       "callback-456",
       expect.objectContaining({
@@ -193,41 +218,24 @@ describe("waitForCallback handler", () => {
     const submitter = jest.fn().mockResolvedValue(undefined);
     const expectedResult = "no name result";
 
+    let callbackPluginName: string | undefined = "unset";
+    let stepPluginName: string | undefined = "unset";
+
     mockRunInChildContext.mockImplementation(async (name: any, fn: any) => {
       // With unified signature, name should be undefined when no name provided
       expect(name).toBeUndefined();
       expect(typeof fn).toBe("function");
 
-      const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([
-            Promise.resolve(expectedResult),
-            "callback-no-name",
-          ]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            // Handle both overloads of step function
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
-      };
+      const mockChildCtx = makeMockChildCtx({
+        callbackResult: expectedResult,
+        callbackId: "callback-no-name",
+        onCreateCallback: (pluginOperationName) => {
+          callbackPluginName = pluginOperationName;
+        },
+        onStep: (pluginOperationName) => {
+          stepPluginName = pluginOperationName;
+        },
+      });
 
       return await fn(mockChildCtx);
     });
@@ -246,6 +254,9 @@ describe("waitForCallback handler", () => {
       expect.any(Function),
       expect.objectContaining({ subType: "WaitForCallback" }),
     );
+    // With no name, no derived plugin operation name is forwarded.
+    expect(callbackPluginName).toBeUndefined();
+    expect(stepPluginName).toBeUndefined();
     expect(submitter).toHaveBeenCalledWith(
       "callback-no-name",
       expect.objectContaining({
@@ -262,35 +273,10 @@ describe("waitForCallback handler", () => {
       expect(name).toBeUndefined();
       expect(typeof fn).toBe("function");
 
-      const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([
-            Promise.resolve(expectedResult),
-            "callback-undefined",
-          ]),
-        step: jest
-          .fn()
-          .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-            // Create mock telemetry object
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            if (typeof stepNameOrFn === "function") {
-              return await stepNameOrFn(mockTelemetry);
-            } else if (typeof maybeFn === "function") {
-              return await maybeFn(mockTelemetry);
-            }
-            return undefined;
-          }),
-      };
+      const mockChildCtx = makeMockChildCtx({
+        callbackResult: expectedResult,
+        callbackId: "callback-undefined",
+      });
 
       return await fn(mockChildCtx);
     });
@@ -345,37 +331,13 @@ describe("waitForCallback handler", () => {
         // When no name is provided, first parameter is the function
         const fn = maybeFn || fnOrName;
 
-        const mockChildCtx = {
-          createCallback: jest.fn().mockImplementation((cfg) => {
+        const mockChildCtx = makeMockChildCtx({
+          callbackResult: expectedResult,
+          callbackId: "callback-config",
+          onCreateCallback: (_pluginOperationName, cfg) => {
             capturedConfig = cfg;
-            return Promise.resolve([
-              Promise.resolve(expectedResult),
-              "callback-config",
-            ]);
-          }),
-          step: jest
-            .fn()
-            .mockImplementation(async (stepNameOrFn: any, maybeFn?: any) => {
-              // Create mock telemetry object
-              const mockTelemetry = {
-                logger: {
-                  log: jest.fn(),
-                  error: jest.fn(),
-                  warn: jest.fn(),
-                  info: jest.fn(),
-                  debug: jest.fn(),
-                },
-              };
-
-              // Handle both overloads of step function
-              if (typeof stepNameOrFn === "function") {
-                return await stepNameOrFn(mockTelemetry);
-              } else if (typeof maybeFn === "function") {
-                return await maybeFn(mockTelemetry);
-              }
-              return undefined;
-            }),
-        };
+          },
+        });
 
         return await fn(mockChildCtx);
       },
@@ -412,38 +374,16 @@ describe("waitForCallback handler", () => {
     });
 
     mockRunInChildContext.mockImplementation(async (name: any, fn: any) => {
-      const mockChildCtx = {
-        createCallback: jest
-          .fn()
-          .mockResolvedValue([Promise.resolve("result"), "callback-retry"]),
-        step: jest
-          .fn()
-          .mockImplementation(async (fnOrConfig: any, maybeConfig?: any) => {
-            const mockTelemetry = {
-              logger: {
-                log: jest.fn(),
-                error: jest.fn(),
-                warn: jest.fn(),
-                info: jest.fn(),
-                debug: jest.fn(),
-              },
-            };
-
-            // Check if retryStrategy was passed
-            const config =
-              typeof fnOrConfig === "function" ? maybeConfig : fnOrConfig;
-            if (config?.retryStrategy) {
-              expect(config.retryStrategy).toBe(retryStrategy);
-            }
-
-            // Execute the function
-            const fn =
-              typeof fnOrConfig === "function" ? fnOrConfig : maybeConfig;
-            if (fn) {
-              await fn(mockTelemetry);
-            }
-          }),
-      };
+      const mockChildCtx = makeMockChildCtx({
+        callbackResult: "result",
+        callbackId: "callback-retry",
+        onStep: (_pluginOperationName, config) => {
+          // The submitter step receives the retryStrategy via its config.
+          if ((config as any)?.retryStrategy) {
+            expect((config as any).retryStrategy).toBe(retryStrategy);
+          }
+        },
+      });
 
       return await fn(mockChildCtx);
     });
@@ -500,37 +440,13 @@ describe("waitForCallback handler", () => {
           async (name: any, fn: any, options: any) => {
             capturedRunInChildContextOptions = options;
 
-            const mockChildCtx = {
-              createCallback: jest.fn().mockImplementation((cfg) => {
+            const mockChildCtx = makeMockChildCtx({
+              callbackResult: rawResult,
+              callbackId: "callback-id",
+              onCreateCallback: (_pluginOperationName, cfg) => {
                 capturedCreateCallbackConfig = cfg;
-                return Promise.resolve([
-                  Promise.resolve(rawResult),
-                  "callback-id",
-                ]);
-              }),
-              step: jest
-                .fn()
-                .mockImplementation(
-                  async (stepNameOrFn: any, maybeFn?: any) => {
-                    const mockTelemetry = {
-                      logger: {
-                        log: jest.fn(),
-                        error: jest.fn(),
-                        warn: jest.fn(),
-                        info: jest.fn(),
-                        debug: jest.fn(),
-                      },
-                    };
-
-                    if (typeof stepNameOrFn === "function") {
-                      return await stepNameOrFn(mockTelemetry);
-                    } else if (typeof maybeFn === "function") {
-                      return await maybeFn(mockTelemetry);
-                    }
-                    return undefined;
-                  },
-                ),
-            };
+              },
+            });
 
             return await fn(mockChildCtx);
           },

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-callback-handler/wait-for-callback-handler.ts
@@ -8,6 +8,7 @@ import {
   OperationSubType,
   WaitForCallbackContext,
   StepContext,
+  StepConfig,
   DurablePromise,
   DurableLogger,
 } from "../../types";
@@ -18,6 +19,17 @@ import {
   ChildContextError,
   CallbackSubmitterError,
 } from "../../errors/durable-error/durable-error";
+import type { InternalDurableContext } from "../../types/internal-context";
+
+/**
+ * The child context is always a `DurableContextImpl`, which implements
+ * {@link InternalDurableContext}. Used to label the inner CALLBACK / submitter
+ * STEP spans with a derived plugin-only name without a public API change.
+ * @internal
+ */
+type WaitForCallbackChildContext<Logger extends DurableLogger> =
+  DurableContext<Logger> & InternalDurableContext<Logger>;
+
 export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
   peekStepId: () => string,
@@ -93,9 +105,16 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
               }
             : undefined;
 
+        // Derived names ("<name>-callback" / "<name>-submitter") go straight to
+        // the plugin hooks, not checkpointed, safe under concurrency.
+        const internalCtx = childCtx as WaitForCallbackChildContext<Logger>;
+
         // Create callback and get the promise + callbackId
         const [callbackPromise, callbackId] =
-          await childCtx.createCallback(createCallbackConfig);
+          await internalCtx._createCallbackWithPluginOperationName(
+            name ? `${name}-callback` : undefined,
+            createCallbackConfig,
+          );
 
         log("🆔", "Callback created:", {
           callbackId,
@@ -103,7 +122,12 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
         });
 
         // Execute the submitter step (submitter is now mandatory)
-        await childCtx.step(
+        const submitterOptions: StepConfig<void> | undefined =
+          config?.retryStrategy
+            ? { retryStrategy: config.retryStrategy }
+            : undefined;
+        await internalCtx._stepWithPluginOperationName(
+          name ? `${name}-submitter` : undefined,
           async (stepContext: StepContext<Logger>) => {
             // Use the step's built-in logger instead of creating a new one
             const callbackContext: WaitForCallbackContext<Logger> = {
@@ -120,9 +144,7 @@ export const createWaitForCallbackHandler = <Logger extends DurableLogger>(
               name,
             });
           },
-          config?.retryStrategy
-            ? { retryStrategy: config.retryStrategy }
-            : undefined,
+          submitterOptions,
         );
 
         log("⏳", "Waiting for callback completion:", {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.plugin.test.ts
@@ -188,7 +188,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
     );
   });
 
-  it("should call onOperationAttemptEnd with failed when condition not yet met", async () => {
+  it("should call onOperationAttemptEnd with succeeded when condition not yet met (check ran successfully)", async () => {
     const handler = createWaitForConditionHandler(
       mockContext,
       mockCheckpoint,
@@ -220,8 +220,8 @@ describe("WaitForCondition Handler - plugin hooks", () => {
 
     await handler("my-condition", checkFunc, config);
 
-    // First attempt: start + failed end
-    // Second attempt: start + succeeded end
+    // First attempt: start + succeeded end (check ran successfully, condition continues)
+    // Second attempt: start + succeeded end (check ran successfully, condition done)
     expect(mockPlugin.onOperationAttemptStart).toHaveBeenCalledTimes(2);
     expect(mockPlugin.onOperationAttemptEnd).toHaveBeenCalledTimes(2);
 
@@ -229,7 +229,7 @@ describe("WaitForCondition Handler - plugin hooks", () => {
       1,
       expect.objectContaining({
         isReplay: false,
-        outcome: AttemptEndInfoOutcome.FAILED,
+        outcome: AttemptEndInfoOutcome.SUCCEEDED,
       }),
     );
 

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -337,7 +337,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
           stepData = context.getStepData(stepId);
           const attemptEndInfo = toAttemptEndInfo(
             stepData,
-            AttemptEndInfoOutcome.FAILED,
+            AttemptEndInfoOutcome.SUCCEEDED,
             {
               attempt: currentAttempt,
             },

--- a/packages/aws-durable-execution-sdk-js/src/types/internal-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/internal-context.ts
@@ -1,0 +1,33 @@
+import { StepFunc, StepConfig } from "./step";
+import { CreateCallbackConfig, CreateCallbackResult } from "./callback";
+import { DurablePromise } from "./durable-promise";
+import { DurableLogger } from "./durable-logger";
+
+/**
+ * Internal context extension, implemented by `DurableContextImpl`, not part
+ * of the public `DurableContext` contract.
+ *
+ * @remarks
+ * Used by `waitForCallback` to label its inner CALLBACK / submitter STEP
+ * spans with a plugin-only name. Never checkpointed, no effect on replay or
+ * user-facing names. Not exported publicly. Exists so `waitForCallback` and
+ * `DurableContextImpl` share one compiler-checked contract instead of a cast.
+ *
+ * @internal
+ */
+export interface InternalDurableContext<
+  TLogger extends DurableLogger = DurableLogger,
+> {
+  /** `createCallback` variant that forwards a plugin-only operation name. */
+  _createCallbackWithPluginOperationName<TOutput = string>(
+    pluginOperationName: string | undefined,
+    config?: CreateCallbackConfig<TOutput>,
+  ): DurablePromise<CreateCallbackResult<TOutput>>;
+
+  /** `step` variant that forwards a plugin-only operation name. */
+  _stepWithPluginOperationName<TOutput>(
+    pluginOperationName: string | undefined,
+    fn: StepFunc<TOutput, TLogger>,
+    config?: StepConfig<TOutput>,
+  ): DurablePromise<TOutput>;
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-js/issues/828
Fixes failed conformance tests - https://github.com/aws/aws-durable-execution-conformance-tests/actions/runs/31651313611/job/94296106806?pr=82

*Description of changes:*

1. Inherit `durable.operation.name` from parent for unnamed child ops - Add a nameMap to both OTel plugins that propagates the parent operation name to child CALLBACK/STEP/attempt spans inside composite primitives like waitForCallback. No checkpoint changes.
2. Fix continuation span parenting in invocation plugin Cross-invocation continuation spans now resolve their parent from spanMap via info.parentId instead of hardcoding to the invocation span. Child operations correctly parent to their CONTEXT span.
3. Report SUCCEEDED attempt outcome for wait-for-condition polling When the check function runs successfully but decides to continue polling, the attempt outcome is now SUCCEEDED (matching Java/Python) instead of FAILED. FAILED is reserved for when the check throws.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
