### PR TITLE
perf(eslint-plugin): replace redundant AST walks with ESLint scope analysis

### DIFF
--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-closure-in-durable-operations/no-closure-in-durable-operations.test.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-closure-in-durable-operations/no-closure-in-durable-operations.test.ts
@@ -1,3 +1,4 @@
+import { RuleTester } from "eslint";
 import { noClosureInDurableOperations } from "./no-closure-in-durable-operations";
 
 describe("no-closure-in-durable-operations", () => {
@@ -13,938 +14,519 @@ describe("no-closure-in-durable-operations", () => {
     expect(meta.docs?.description).toContain("closure variables");
     expect(meta.messages?.closureVariableUsage).toBeDefined();
   });
+});
 
-  describe("should detect mutations", () => {
-    it("should detect direct assignment (a = value)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+describe("no-closure-in-durable-operations scope resolution", () => {
+  /** A durable step callback, with the write/read references it closes over. */
+  function fixture() {
+    const write = {
+      isWrite: () => true,
+      resolved: { defs: [{ type: "Variable" }] },
+      identifier: { type: "Identifier", name: "counter" },
+    };
+    const read = {
+      isWrite: () => false,
+      resolved: { defs: [{ type: "Variable" }] },
+      identifier: { type: "Identifier", name: "other" },
+    };
+    const undeclared = {
+      isWrite: () => true,
+      resolved: { defs: [] },
+      identifier: { type: "Identifier", name: "globalThing" },
+    };
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const callback: any = { type: "ArrowFunctionExpression" };
+    callback.parent = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        property: { type: "Identifier", name: "step" },
+      },
+      arguments: [callback],
+    };
 
-      const identifier: any = { type: "Identifier", name: "a" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        operator: "=",
-        left: identifier,
-      };
-      identifier.parent = assignment;
+    return {
+      callback,
+      scope: { type: "function", through: [write, read, undeclared] },
+      write,
+    };
+  }
 
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: assignment }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-      assignment.parent = stepCallback.body.body[0];
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalledWith({
-        node: identifier,
-        messageId: "closureVariableUsage",
-        data: { variableName: "a" },
-      });
-    });
-
-    it("should detect compound assignment (a += 1)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "a" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        operator: "+=",
-        left: identifier,
-      };
-      identifier.parent = assignment;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: assignment }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
-
-    it("should detect increment (a++)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "a" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-        prefix: false,
-      };
-      identifier.parent = updateExpr;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
-
-    it("should detect pre-increment (++a)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "a" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-        prefix: true,
-      };
-      identifier.parent = updateExpr;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
-
-    it("should detect decrement (a--)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "a" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "--",
-        argument: identifier,
-        prefix: false,
-      };
-      identifier.parent = updateExpr;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
+  const expectedReport = (write: any) => ({
+    node: write.identifier,
+    messageId: "closureVariableUsage",
+    data: { variableName: "counter" },
   });
 
-  describe("should allow reads", () => {
-    it("should allow reading closure variable", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("resolves scope via context.sourceCode", () => {
+    const { callback, scope, write } = fixture();
+    const report = jest.fn();
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const rule = noClosureInDurableOperations.create({
+      report,
+      sourceCode: { scopeManager: { acquire: () => scope } },
+    } as any);
 
-      const identifier: any = { type: "Identifier", name: "a" };
-      const returnStmt: any = {
-        type: "ReturnStatement",
-        argument: identifier,
-      };
-      identifier.parent = returnStmt;
+    rule.ArrowFunctionExpression!(callback);
 
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [returnStmt],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).not.toHaveBeenCalled();
-    });
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(expectedReport(write));
   });
 
-  describe("should handle variable scopes", () => {
-    it("should not report if variable is declared in callback params", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("falls back to context.getSourceCode() on eslint versions without context.sourceCode", () => {
+    const { callback, scope, write } = fixture();
+    const report = jest.fn();
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const rule = noClosureInDurableOperations.create({
+      report,
+      getSourceCode: () => ({ scopeManager: { acquire: () => scope } }),
+    } as any);
 
-      const identifier: any = { type: "Identifier", name: "ctx" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        left: identifier,
-      };
-      identifier.parent = assignment;
+    rule.ArrowFunctionExpression!(callback);
 
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [{ type: "Identifier", name: "ctx" }],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: assignment }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: { type: "BlockStatement", body: [] },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "runInChildContext" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).not.toHaveBeenCalled();
-    });
-
-    it("should not report if variable is declared in callback body", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "local" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        left: identifier,
-      };
-      identifier.parent = assignment;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "local" },
-                },
-              ],
-            },
-            { type: "ExpressionStatement", expression: assignment },
-          ],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: { type: "BlockStatement", body: [] },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).not.toHaveBeenCalled();
-    });
-
-    it("should not report if variable is declared in nested block within callback", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "blockVar" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        left: identifier,
-      };
-      identifier.parent = assignment;
-
-      const ifBlock: any = {
-        type: "IfStatement",
-        consequent: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "blockVar" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            ifBlock,
-            { type: "ExpressionStatement", expression: assignment },
-          ],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: { type: "BlockStatement", body: [] },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).not.toHaveBeenCalled();
-    });
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith(expectedReport(write));
   });
 
-  describe("should work with runInChildContext", () => {
-    it("should detect mutation in runInChildContext callback", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("unwraps nothing extra: acquire returns the function scope directly", () => {
+    const { callback, scope, write } = fixture();
+    const report = jest.fn();
+    const acquire = jest.fn(() => scope);
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const rule = noClosureInDurableOperations.create({
+      report,
+      sourceCode: { scopeManager: { acquire } },
+    } as any);
 
-      const identifier: any = { type: "Identifier", name: "a" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        left: identifier,
-      };
-      identifier.parent = assignment;
+    rule.ArrowFunctionExpression!(callback);
 
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [{ type: "Identifier", name: "ctx" }],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: assignment }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "a" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "runInChildContext" },
-        },
-        arguments: [stepCallback],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
+    // `inner: true` is what makes acquire skip the wrapper scope that a named
+    // function expression adds for its own name.
+    expect(acquire).toHaveBeenCalledWith(callback, true);
+    expect(report).toHaveBeenCalledWith(expectedReport(write));
   });
 
-  describe("should work with waitForCondition", () => {
-    it("should detect mutation in waitForCondition callback", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("skips variables declared by the callback itself", () => {
+    const { callback, scope } = fixture();
+    const report = jest.fn();
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    // A named function expression's own name resolves to a definition whose
+    // node is the callback.
+    scope.through = [
+      {
+        isWrite: () => true,
+        resolved: { defs: [{ type: "FunctionName", node: callback }] },
+        identifier: { type: "Identifier", name: "self" },
+      },
+    ] as any;
 
-      const identifier: any = { type: "Identifier", name: "counter" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-      };
-      identifier.parent = updateExpr;
+    const rule = noClosureInDurableOperations.create({
+      report,
+      sourceCode: { scopeManager: { acquire: () => scope } },
+    } as any);
 
-      const conditionCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
+    rule.ArrowFunctionExpression!(callback);
 
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "counter" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "waitForCondition" },
-        },
-        arguments: [conditionCallback],
-        parent: outerFunction,
-      };
-
-      conditionCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
+    expect(report).not.toHaveBeenCalled();
   });
 
-  describe("should work with waitForCallback", () => {
-    it("should detect mutation in waitForCallback callback", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("does not throw when no scope information is available", () => {
+    const { callback } = fixture();
+    const report = jest.fn();
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const rule = noClosureInDurableOperations.create({ report } as any);
 
-      const identifier: any = { type: "Identifier", name: "result" };
-      const assignment: any = {
-        type: "AssignmentExpression",
-        left: identifier,
-      };
-      identifier.parent = assignment;
-
-      const callbackFn: any = {
-        type: "ArrowFunctionExpression",
-        params: [{ type: "Identifier", name: "resolve" }],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: assignment }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "result" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "waitForCallback" },
-        },
-        arguments: [callbackFn],
-        parent: outerFunction,
-      };
-
-      callbackFn.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
+    expect(() => rule.ArrowFunctionExpression!(callback)).not.toThrow();
+    expect(report).not.toHaveBeenCalled();
   });
 
-  describe("should handle function parameter overloads", () => {
-    it("should detect mutation when function is 1st parameter (no name)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
+  it("ignores callbacks that are not durable operations", () => {
+    const { scope } = fixture();
+    const report = jest.fn();
 
-      const rule = noClosureInDurableOperations.create(mockContext as any);
+    const callback: any = { type: "ArrowFunctionExpression" };
+    callback.parent = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        property: { type: "Identifier", name: "forEach" },
+      },
+      arguments: [callback],
+    };
 
-      const identifier: any = { type: "Identifier", name: "counter" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-      };
-      identifier.parent = updateExpr;
+    const rule = noClosureInDurableOperations.create({
+      report,
+      sourceCode: { scopeManager: { acquire: () => scope } },
+    } as any);
 
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
+    rule.ArrowFunctionExpression!(callback);
 
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "counter" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      // context.step(async () => { counter++; })
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [stepCallback], // Function as 1st argument
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
-
-    it("should detect mutation when function is 2nd parameter (with name)", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "counter" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-      };
-      identifier.parent = updateExpr;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "counter" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      // context.step("stepName", async () => { counter++; })
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [
-          { type: "Literal", value: "stepName" }, // Name as 1st argument
-          stepCallback, // Function as 2nd argument
-        ],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
-
-    it("should detect mutation when function is 2nd parameter with config as 3rd", () => {
-      const mockContext = {
-        report: jest.fn(),
-        getSourceCode: jest.fn(() => ({ ast: { tokens: [] } })),
-      };
-
-      const rule = noClosureInDurableOperations.create(mockContext as any);
-
-      const identifier: any = { type: "Identifier", name: "counter" };
-      const updateExpr: any = {
-        type: "UpdateExpression",
-        operator: "++",
-        argument: identifier,
-      };
-      identifier.parent = updateExpr;
-
-      const stepCallback: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [{ type: "ExpressionStatement", expression: updateExpr }],
-        },
-      };
-
-      const outerFunction: any = {
-        type: "ArrowFunctionExpression",
-        params: [],
-        body: {
-          type: "BlockStatement",
-          body: [
-            {
-              type: "VariableDeclaration",
-              declarations: [
-                {
-                  type: "VariableDeclarator",
-                  id: { type: "Identifier", name: "counter" },
-                },
-              ],
-            },
-          ],
-        },
-      };
-
-      // context.step("stepName", async () => { counter++; }, { retry: 3 })
-      const callExpression: any = {
-        type: "CallExpression",
-        callee: {
-          type: "MemberExpression",
-          property: { type: "Identifier", name: "step" },
-        },
-        arguments: [
-          { type: "Literal", value: "stepName" },
-          stepCallback,
-          { type: "ObjectExpression", properties: [] }, // Config object
-        ],
-        parent: outerFunction,
-      };
-
-      stepCallback.parent = callExpression;
-
-      rule.CallExpression?.(callExpression);
-
-      expect(mockContext.report).toHaveBeenCalled();
-    });
+    expect(report).not.toHaveBeenCalled();
   });
+});
+
+// The rule reads the scope information ESLint derives while parsing, so it is
+// exercised against real source rather than hand-built AST fixtures.
+const ruleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+} as any);
+
+const mutationError = (variableName: string) => ({
+  messageId: "closureVariableUsage",
+  data: { variableName },
+});
+
+describe("no-closure-in-durable-operations rule behavior", () => {
+  ruleTester.run(
+    "no-closure-in-durable-operations",
+    noClosureInDurableOperations,
+    {
+      valid: [
+        {
+          name: "allows reading a closure variable",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                return a;
+              });
+            }
+          `,
+        },
+        {
+          name: "allows mutating a callback parameter",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              await context.runInChildContext(async (ctx) => {
+                ctx = null;
+              });
+            }
+          `,
+        },
+        {
+          name: "allows mutating a variable declared in the callback body",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              await context.step(async () => {
+                let local = 0;
+                local = 1;
+                return local;
+              });
+            }
+          `,
+        },
+        {
+          name: "allows mutating a variable declared in a nested block of the callback",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              await context.step(async () => {
+                if (true) {
+                  let blockVar = 0;
+                  blockVar = 1;
+                }
+              });
+            }
+          `,
+        },
+        {
+          name: "allows mutating a shadowing variable declared in a nested function",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.step(async () => {
+                const inner = () => {
+                  let counter = 0;
+                  counter++;
+                  return counter;
+                };
+                return inner();
+              });
+            }
+          `,
+        },
+        {
+          name: "ignores callbacks passed to non-durable operations",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              [1, 2].forEach(() => {
+                counter++;
+              });
+            }
+          `,
+        },
+        {
+          name: "allows a named function expression to assign to its own name",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              await context.step(function self() {
+                self = null;
+              });
+            }
+          `,
+        },
+        {
+          name: "allows recursion through a named function expression",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              await context.step(function fact(n) {
+                return n <= 1 ? 1 : n * fact(n - 1);
+              });
+            }
+          `,
+        },
+        {
+          name: "only checks the first function argument of a durable operation",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.waitForCallback(
+                async (resolve) => resolve(),
+                async () => {
+                  counter++;
+                },
+              );
+            }
+          `,
+        },
+      ],
+      invalid: [
+        {
+          name: "reports direct assignment",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                a = 5;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports compound assignment",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                a += 1;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports increment",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                a++;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports pre-increment",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                ++a;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports decrement",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                a--;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports mutation in a runInChildContext callback",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.runInChildContext(async (ctx) => {
+                a = 1;
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports mutation in a waitForCondition callback",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.waitForCondition(async () => {
+                counter++;
+              });
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation in a waitForCallback callback",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let result = null;
+              await context.waitForCallback(async (resolve) => {
+                result = "done";
+              });
+            }
+          `,
+          errors: [mutationError("result")],
+        },
+        {
+          name: "reports mutation when the callback is the 1st argument",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.step(async () => {
+                counter++;
+              });
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation when the callback is the 2nd argument",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.step("stepName", async () => {
+                counter++;
+              });
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation when the callback is the 2nd argument with a config 3rd",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let counter = 0;
+              await context.step("stepName", async () => {
+                counter++;
+              }, { retry: 3 });
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation of a destructured outer declaration",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let { total } = event;
+              await context.step(async () => {
+                total += 1;
+              });
+            }
+          `,
+          errors: [mutationError("total")],
+        },
+        {
+          name: "reports mutation of a variable declared in an outer nested block",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              if (event.flag) {
+                let counter = 0;
+                await context.step(async () => {
+                  counter++;
+                });
+              }
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation of a module-scope variable",
+          code: `
+            let counter = 0;
+            async function handler(event: any, context: DurableContext) {
+              await context.step(async () => {
+                counter++;
+              });
+            }
+          `,
+          errors: [mutationError("counter")],
+        },
+        {
+          name: "reports mutation of an exported module-scope variable",
+          code: `
+            export let count = 0;
+            async function handler(event: any, context: DurableContext) {
+              await context.step(async () => {
+                count += 1;
+              });
+            }
+          `,
+          errors: [mutationError("count")],
+        },
+        {
+          name: "reports mutation of a catch binding",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              try {
+                doThing();
+              } catch (e) {
+                await context.step(async () => {
+                  e = null;
+                });
+              }
+            }
+          `,
+          errors: [mutationError("e")],
+        },
+        {
+          name: "reports array destructuring assignment targets",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                [a] = [1];
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports object destructuring assignment targets",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                ({ a } = event);
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+        {
+          name: "reports for-of assignment targets",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              let a = 0;
+              await context.step(async () => {
+                for (a of event.items) {
+                  use(a);
+                }
+              });
+            }
+          `,
+          errors: [mutationError("a")],
+        },
+      ],
+    },
+  );
 });

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-closure-in-durable-operations/no-closure-in-durable-operations.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-closure-in-durable-operations/no-closure-in-durable-operations.ts
@@ -19,6 +19,14 @@ import { Rule } from "eslint";
  *   await context.step(async () => {
  *     return counter + 1;  // ✅ Reading is safe
  *   });
+ *
+ * Implementation note:
+ * This rule relies on the scope information ESLint already computes while parsing
+ * rather than re-walking the AST. For a durable callback's function scope,
+ * `scope.through` is exactly the set of references that could not be resolved
+ * inside the callback, i.e. the closure references. Filtering those to writes
+ * yields the violations directly, in O(closure references) instead of the
+ * O(assignments x subtree size) cost of a manual traversal.
  */
 export const noClosureInDurableOperations: Rule.RuleModule = {
   meta: {
@@ -44,17 +52,23 @@ export const noClosureInDurableOperations: Rule.RuleModule = {
       "waitForCallback",
     ]);
 
+    // `context.sourceCode` is preferred and is the only form available in
+    // ESLint v10, where `context.getSourceCode()` was removed (see #472). The
+    // optional fallback is kept because the plugin supports eslint >=8.0.0 and
+    // `context.sourceCode` only landed in 8.40. Because the property is checked
+    // first and the call is optional, neither branch can throw at startup the
+    // way the unconditional call removed in #472 did.
+    const sourceCode: any =
+      (context as any).sourceCode ?? (context as any).getSourceCode?.();
+
     /**
      * Checks if a node is a durable operation call.
      *
      * Example: context.step(...) or ctx.runInChildContext(...)
-     *
-     * @param node - AST node to check
-     * @returns true if node is a durable operation call
      */
-    function isDurableOperation(node: any): boolean {
+    function isDurableOperationCall(node: any): boolean {
       return (
-        node.type === "CallExpression" &&
+        node?.type === "CallExpression" &&
         node.callee?.type === "MemberExpression" &&
         node.callee.property?.type === "Identifier" &&
         durableOperations.has(node.callee.property.name)
@@ -62,282 +76,82 @@ export const noClosureInDurableOperations: Rule.RuleModule = {
     }
 
     /**
-     * Extracts the callback function from a durable operation call.
+     * Checks whether the given function node is the callback of a durable operation.
      *
-     * Example:
-     *   context.step(async () => { ... })
-     *                ^^^^^^^^^^^^^^^^^ returns this function
-     *
-     * @param node - CallExpression node
-     * @returns The callback function node, or null if not found
+     * The callback is the first function-valued argument, which covers every
+     * overload:
+     *   context.step(fn)
+     *   context.step("name", fn)
+     *   context.step("name", fn, config)
      */
-    function getCallbackFunction(node: any): any {
-      if (!isDurableOperation(node)) return null;
+    function isDurableCallback(fn: any): boolean {
+      const call = fn.parent;
+      if (!isDurableOperationCall(call)) return false;
 
-      const args = node.arguments;
-      for (const arg of args) {
-        if (
+      const callback = call.arguments.find(
+        (arg: any) =>
           arg.type === "ArrowFunctionExpression" ||
-          arg.type === "FunctionExpression"
-        ) {
-          return arg;
-        }
-      }
-      return null;
+          arg.type === "FunctionExpression",
+      );
+      return callback === fn;
     }
 
     /**
-     * Collects all variable names declared within a scope (including nested scopes).
+     * Resolves the scope ESLint created for a function node.
      *
-     * This includes:
-     * - Function parameters: async (ctx) => { ... }
-     * - Top-level declarations: const x = 1;
-     * - Nested block declarations: if (true) { let y = 2; }
-     * - Loop variables: for (let i = 0; ...)
+     * `scopeManager.acquire` is used rather than `sourceCode.getScope(node)`
+     * because it is available across the whole supported eslint range
+     * (`getScope` only landed in 8.37) and needs no version fallback.
      *
-     * Example:
-     *   async (ctx) => {
-     *     const x = 1;
-     *     if (true) {
-     *       let y = 2;
-     *     }
-     *   }
-     *   Returns: Set(['ctx', 'x', 'y'])
-     *
-     * @param scopeNode - Function or block node to analyze
-     * @returns Set of variable names declared in this scope
+     * A named function expression has two scopes, the wrapper holding its own
+     * name and the function scope; `acquire` filters the wrapper out, so this
+     * always returns the function scope.
      */
-    function getVariablesDeclaredInScope(scopeNode: any): Set<string> {
-      const declared = new Set<string>();
-
-      // Add function parameters
-      // Example: async (ctx, resolve) => { ... }
-      //                 ^^^  ^^^^^^^
-      if (scopeNode.params) {
-        scopeNode.params.forEach((param: any) => {
-          if (param.type === "Identifier") {
-            declared.add(param.name);
-          }
-        });
-      }
-
-      // Recursively walk the entire callback body to find all variable declarations
-      // This catches variables in nested blocks, loops, try-catch, etc.
-      function walkForDeclarations(node: any) {
-        if (!node) return;
-
-        // Found a variable declaration
-        // Example: const x = 1; or let y = 2;
-        if (node.type === "VariableDeclaration") {
-          node.declarations.forEach((decl: any) => {
-            if (decl.id?.type === "Identifier") {
-              declared.add(decl.id.name);
-            }
-          });
-        }
-
-        // Walk all child nodes to find nested declarations
-        for (const key in node) {
-          if (key === "parent") continue; // Skip parent references to avoid cycles
-          const child = node[key];
-          if (Array.isArray(child)) {
-            child.forEach(walkForDeclarations);
-          } else if (child && typeof child === "object") {
-            walkForDeclarations(child);
-          }
-        }
-      }
-
-      if (scopeNode.body) {
-        walkForDeclarations(scopeNode.body);
-      }
-
-      return declared;
+    function getFunctionScope(fn: any): any {
+      return sourceCode?.scopeManager?.acquire(fn, true) ?? null;
     }
 
     /**
-     * Finds all variables declared in outer (parent) scopes.
+     * Reports every write to a variable that is declared outside the callback.
      *
-     * Walks up the AST tree to find variables declared in enclosing functions.
-     *
-     * Example:
-     *   async (event, context) => {
-     *     let counter = 0;
-     *     await context.step(async () => {
-     *       // From here, outer variables are: event, context, counter
-     *     });
-     *   }
-     *
-     * @param callbackNode - The callback function node
-     * @returns Set of variable names from outer scopes
+     * References reach `scope.through` only if they could not be resolved within
+     * the callback, so callback parameters and callback-local declarations
+     * (including ones in nested blocks) are excluded automatically, and
+     * shadowing is handled correctly. Variables with no declaration (implicit
+     * or environment globals) are skipped.
      */
-    function findOuterScopeVariables(callbackNode: any): Set<string> {
-      const outerVars = new Set<string>();
-      let current = callbackNode.parent;
+    function checkDurableCallback(fn: any) {
+      if (!isDurableCallback(fn)) return;
 
-      // Walk up the tree until we reach the root
-      while (current) {
-        // Check if this is a function scope
-        if (
-          current.type === "ArrowFunctionExpression" ||
-          current.type === "FunctionExpression" ||
-          current.type === "FunctionDeclaration"
-        ) {
-          // Add function parameters
-          // Example: async (event, context) => { ... }
-          if (current.params) {
-            current.params.forEach((param: any) => {
-              if (param.type === "Identifier") {
-                outerVars.add(param.name);
-              }
-            });
-          }
+      const scope = getFunctionScope(fn);
+      if (!scope) return;
 
-          // Add variables declared in this function's body
-          // Example: const result = await fetch();
-          if (current.body?.type === "BlockStatement") {
-            const body = current.body.body;
-            for (const stmt of body) {
-              if (stmt.type === "VariableDeclaration") {
-                stmt.declarations.forEach((decl: any) => {
-                  if (decl.id?.type === "Identifier") {
-                    outerVars.add(decl.id.name);
-                  }
-                });
-              }
-            }
-          }
-        }
-        current = current.parent;
-      }
+      for (const reference of scope.through) {
+        if (!reference.isWrite()) continue;
 
-      return outerVars;
-    }
+        const variable = reference.resolved;
+        if (!variable || variable.defs.length === 0) continue;
 
-    /**
-     * Checks if an identifier is being assigned/mutated.
-     *
-     * Detects:
-     * - Direct assignment: a = 5
-     * - Compound assignment: a += 1, a -= 1, a *= 2, etc.
-     * - Increment/decrement: a++, ++a, a--, --a
-     *
-     * Does NOT flag reads:
-     * - return a;
-     * - const b = a + 1;
-     * - console.log(a);
-     *
-     * @param node - Identifier node to check
-     * @returns true if the identifier is being mutated
-     */
-    function isAssignment(node: any): boolean {
-      const parent = node.parent;
-      if (!parent) return false;
+        // A named function expression's own name is bound in a wrapper scope
+        // outside the function scope, so writing to it escapes into
+        // `scope.through`. It is not outer state: the assignment is a no-op in
+        // sloppy mode and a TypeError in strict mode, and it cannot cause
+        // replay divergence.
+        if (variable.defs.some((def: any) => def.node === fn)) continue;
 
-      // Check for assignment expressions
-      // Examples: a = 5, a += 1, a -= 2, a *= 3
-      if (parent.type === "AssignmentExpression" && parent.left === node) {
-        return true;
-      }
-
-      // Check for update expressions
-      // Examples: a++, ++a, a--, --a
-      if (parent.type === "UpdateExpression" && parent.argument === node) {
-        return true;
-      }
-
-      return false;
-    }
-
-    /**
-     * Checks if an identifier usage is a problematic closure mutation.
-     *
-     * Reports an error if:
-     * 1. The identifier is being assigned/mutated (not just read)
-     * 2. The variable is NOT declared in the callback itself
-     * 3. The variable IS declared in an outer scope
-     *
-     * Example that triggers error:
-     *   let counter = 0;  // Outer scope
-     *   await context.step(async () => {
-     *     counter++;  // ❌ Mutating outer variable
-     *   });
-     *
-     * Example that's allowed:
-     *   let counter = 0;  // Outer scope
-     *   await context.step(async () => {
-     *     return counter + 1;  // ✅ Just reading
-     *   });
-     *
-     * @param node - Identifier node to check
-     * @param callback - The callback function containing this identifier
-     */
-    function checkIdentifierUsage(node: any, callback: any) {
-      const declaredInCallback = getVariablesDeclaredInScope(callback);
-      const outerVars = findOuterScopeVariables(callback);
-
-      if (
-        node.type === "Identifier" &&
-        !declaredInCallback.has(node.name) && // Not declared in callback
-        outerVars.has(node.name) && // Is from outer scope
-        isAssignment(node) // Is being mutated
-      ) {
         context.report({
-          node,
+          node: reference.identifier,
           messageId: "closureVariableUsage",
           data: {
-            variableName: node.name,
+            variableName: reference.identifier.name,
           },
         });
       }
     }
 
-    // Main rule logic: analyze all function calls
     return {
-      CallExpression(node: any) {
-        // Only check durable operations
-        if (!isDurableOperation(node)) return;
-
-        // Get the callback function passed to the durable operation
-        const callback = getCallbackFunction(node);
-        if (!callback) return;
-
-        /**
-         * Recursively walks the callback's AST to find all identifier usages.
-         *
-         * For each identifier found, checks if it's a problematic closure mutation.
-         */
-        function walkNode(n: any, cb: any) {
-          if (!n) return;
-
-          // Check assignments and updates directly to avoid duplicate reports
-          if (
-            n.type === "AssignmentExpression" &&
-            n.left?.type === "Identifier"
-          ) {
-            checkIdentifierUsage(n.left, cb);
-          } else if (
-            n.type === "UpdateExpression" &&
-            n.argument?.type === "Identifier"
-          ) {
-            checkIdentifierUsage(n.argument, cb);
-          }
-
-          // Recursively walk all child nodes
-          for (const key in n) {
-            if (key === "parent") continue; // Skip parent to avoid cycles
-            const child = n[key];
-            if (Array.isArray(child)) {
-              child.forEach((c) => walkNode(c, cb));
-            } else if (child && typeof child === "object") {
-              walkNode(child, cb);
-            }
-          }
-        }
-
-        // Start walking from the callback body
-        walkNode(callback.body, callback);
-      },
+      ArrowFunctionExpression: checkDurableCallback,
+      FunctionExpression: checkDurableCallback,
     };
   },
 };

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.composed.test.ts
@@ -77,6 +77,21 @@ describe("no-non-deterministic-outside-step composed tests", () => {
             }
           `,
         },
+        {
+          name: "does not report same-named deterministic functions",
+          code: `
+            function a() { function h() { return 1; } return h(); }
+            function b() { function h() { return 2; } return h(); }
+          `,
+        },
+        {
+          name: "ignores calls to functions it cannot resolve",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              return externalHelper();
+            }
+          `,
+        },
       ],
       invalid: [
         // Math.random() outside step (reports both call and member expression)
@@ -191,6 +206,96 @@ describe("no-non-deterministic-outside-step composed tests", () => {
             }
           `,
           errors: 2, // CallExpression + MemberExpression
+        },
+        // Callees are resolved through scope analysis, so a non-deterministic
+        // function does not taint an unrelated function of the same name.
+        {
+          name: "does not taint a same-named function in another scope",
+          code: `
+            function moduleA() { function h() { Date.now(); } h(); }
+            function moduleB() { function h() { return 1; } return h(); }
+          `,
+          errors: [
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now()" },
+            },
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now" },
+            },
+            {
+              messageId: "nonDeterministicFunction",
+              data: { functionName: "h" },
+            },
+          ],
+        },
+        // Callee resolution happens after the traversal, so declaration order
+        // does not matter.
+        {
+          name: "reports calls to functions declared after the call site",
+          code: `
+            function outer() { return inner(); }
+            function inner() { return Date.now(); }
+            outer();
+          `,
+          errors: [
+            {
+              messageId: "nonDeterministicFunction",
+              data: { functionName: "inner" },
+            },
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now()" },
+            },
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now" },
+            },
+            {
+              messageId: "nonDeterministicFunction",
+              data: { functionName: "outer" },
+            },
+          ],
+        },
+        // Arrow functions assigned to a variable resolve the same way.
+        {
+          name: "resolves arrow functions bound to variables",
+          code: `
+            const getTime = () => Date.now();
+            async function handler(event: any, context: DurableContext) {
+              return getTime();
+            }
+          `,
+          errors: [
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now()" },
+            },
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "Date.now" },
+            },
+            {
+              messageId: "nonDeterministicFunction",
+              data: { functionName: "getTime" },
+            },
+          ],
+        },
+        {
+          name: "reports namespaced UUID generation outside a step",
+          code: `
+            async function handler(event: any, context: DurableContext) {
+              const id = uuid.v4();
+              await context.step(async () => id);
+            }
+          `,
+          errors: [
+            {
+              messageId: "nonDeterministicOutsideStep",
+              data: { operation: "UUID generation" },
+            },
+          ],
         },
       ],
     },

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.test.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.test.ts
@@ -113,15 +113,15 @@ describe("no-non-deterministic-outside-step", () => {
 
     const rule = noNonDeterministicOutsideStep.create(mockContext as any);
 
-    // Mock being inside a step function
     const stepCallNode = {
       type: "CallExpression",
       callee: {
         type: "MemberExpression",
+        object: { name: "context" },
         property: { name: "step" },
       },
-      parent: null,
-    };
+      arguments: [],
+    } as any;
 
     const randomNode = {
       type: "CallExpression",
@@ -134,9 +134,65 @@ describe("no-non-deterministic-outside-step", () => {
       parent: stepCallNode,
     } as any;
 
-    stepCallNode.parent = randomNode;
-
+    // Visited in traversal order: the step call is entered before its contents.
+    rule.CallExpression!(stepCallNode);
     rule.CallExpression!(randomNode);
+
+    expect(mockContext.report).not.toHaveBeenCalled();
+  });
+
+  it("should report again once the step function has been exited", () => {
+    const mockContext = {
+      report: jest.fn(),
+    };
+
+    const rule = noNonDeterministicOutsideStep.create(mockContext as any);
+
+    const stepCallNode = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        object: { name: "context" },
+        property: { name: "step" },
+      },
+      arguments: [],
+    } as any;
+
+    const randomNode = {
+      type: "CallExpression",
+      callee: {
+        type: "MemberExpression",
+        object: { name: "Math" },
+        property: { name: "random" },
+      },
+      arguments: [],
+    } as any;
+
+    rule.CallExpression!(stepCallNode);
+    rule["CallExpression:exit"]!(stepCallNode);
+    rule.CallExpression!(randomNode);
+
+    expect(mockContext.report).toHaveBeenCalledWith({
+      node: randomNode,
+      messageId: "nonDeterministicOutsideStep",
+      data: { operation: "Math.random()" },
+    });
+  });
+
+  it("should not throw at Program:exit when no scope information is available", () => {
+    const mockContext = {
+      report: jest.fn(),
+    };
+
+    const rule = noNonDeterministicOutsideStep.create(mockContext as any);
+
+    rule.CallExpression!({
+      type: "CallExpression",
+      callee: { type: "Identifier", name: "helper" },
+      arguments: [],
+    } as any);
+
+    expect(() => rule["Program:exit"]!({} as any)).not.toThrow();
     expect(mockContext.report).not.toHaveBeenCalled();
   });
 

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.ts
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/src/rules/no-non-deterministic-outside-step/no-non-deterministic-outside-step.ts
@@ -1,5 +1,23 @@
 import { Rule } from "eslint";
 
+/**
+ * ESLint rule to keep non-deterministic operations inside steps.
+ *
+ * Implementation notes:
+ * - "Am I inside a step?" is tracked with a depth counter maintained by the
+ *   enter/exit visitors instead of walking every node's ancestors, which turns
+ *   an O(nodes x depth) check into O(1).
+ * - Transitive non-determinism across functions is resolved by building a caller
+ *   graph during the single traversal ESLint already performs and then
+ *   propagating over it with a worklist at `Program:exit`. This replaces a
+ *   fixpoint loop that re-walked every function body on every pass, reducing
+ *   O(functions x total size) to O(functions + calls). Only the innermost
+ *   enclosing function is recorded per call site; outer functions are reached
+ *   through the nesting tree during propagation, so nothing is per-depth.
+ * - The graph is keyed on the function nodes that callees resolve to via scope
+ *   analysis, not on identifier names. Keying on names would let same-named
+ *   functions in unrelated scopes taint each other.
+ */
 export const noNonDeterministicOutsideStep: Rule.RuleModule = {
   meta: {
     type: "problem",
@@ -18,24 +36,51 @@ export const noNonDeterministicOutsideStep: Rule.RuleModule = {
     schema: [],
   },
   create(context) {
-    const functionNodes = new Map<string, any>();
-    const nonDeterministicFunctions = new Set<string>();
-    const callsToCheck: Array<{ node: any; functionName: string }> = [];
+    // `context.sourceCode` is preferred and is the only form available in
+    // ESLint v10, where `context.getSourceCode()` was removed (see #472). The
+    // optional fallback is kept because the plugin supports eslint >=8.0.0 and
+    // `context.sourceCode` only landed in 8.40. Because the property is checked
+    // first and the call is optional, neither branch can throw at startup the
+    // way the unconditional call removed in #472 did.
+    const sourceCode: any =
+      (context as any).sourceCode ?? (context as any).getSourceCode?.();
 
-    function isStepFunction(node: any): boolean {
-      let current = node;
-      while (current && current.parent) {
-        current = current.parent;
+    /** Function nodes known to contain non-deterministic operations. */
+    const nonDeterministicFunctions = new Set<any>();
 
-        if (
-          current.type === "CallExpression" &&
-          current.callee?.type === "MemberExpression" &&
-          current.callee?.property?.name === "step"
-        ) {
-          return true;
-        }
-      }
-      return false;
+    /** Enclosing function nodes at the current traversal point. */
+    const functionStack: any[] = [];
+
+    /** Function node -> the function that lexically encloses it. */
+    const enclosingFunction = new Map<any, any>();
+
+    /**
+     * Recorded call sites: (callee identifier, innermost enclosing function).
+     * Callees are resolved to declarations at `Program:exit`, once scope
+     * analysis for the whole file can be consulted in one pass.
+     */
+    const callEdges: Array<{ callee: any; enclosing: any }> = [];
+
+    /** Calls outside a step, checked once the caller graph is complete. */
+    const callsToCheck: Array<{ node: any; callee: any }> = [];
+
+    /** Number of enclosing step calls; > 0 means "inside a step". */
+    let stepDepth = 0;
+
+    function isFunctionNode(node: any): boolean {
+      return (
+        node?.type === "FunctionDeclaration" ||
+        node?.type === "FunctionExpression" ||
+        node?.type === "ArrowFunctionExpression"
+      );
+    }
+
+    function isStepCall(node: any): boolean {
+      return (
+        node.type === "CallExpression" &&
+        node.callee?.type === "MemberExpression" &&
+        node.callee?.property?.name === "step"
+      );
     }
 
     function isDirectlyNonDeterministic(node: any): string | null {
@@ -115,135 +160,178 @@ export const noNonDeterministicOutsideStep: Rule.RuleModule = {
       return null;
     }
 
-    function analyzeFunction(functionNode: any): boolean {
-      function walkNode(node: any): boolean {
-        if (!node) return false;
-
-        const operation = isDirectlyNonDeterministic(node);
-        if (operation) return true;
-
-        if (
-          node.type === "CallExpression" &&
-          node.callee?.type === "Identifier" &&
-          nonDeterministicFunctions.has(node.callee.name)
-        ) {
-          return true;
-        }
-
-        for (const key in node) {
-          if (key === "parent") continue;
-          const child = node[key];
-          if (Array.isArray(child)) {
-            if (child.some(walkNode)) return true;
-          } else if (child && typeof child === "object") {
-            if (walkNode(child)) return true;
-          }
-        }
-        return false;
-      }
-
-      return walkNode(functionNode.body);
+    /**
+     * Marks the innermost enclosing function as non-deterministic.
+     *
+     * Outer functions are reached through the nesting tree during propagation.
+     * This happens regardless of step depth: a function that wraps a step
+     * containing `Date.now()` still cannot be safely called outside a step.
+     */
+    function markEnclosingFunction() {
+      const fn = functionStack[functionStack.length - 1];
+      if (fn) nonDeterministicFunctions.add(fn);
     }
 
-    function getFunctionName(node: any): string | null {
-      if (node.type === "FunctionDeclaration" && node.id?.name) {
-        return node.id.name;
-      }
+    /** Reports a direct violation, and attributes it to the enclosing function. */
+    function checkNode(node: any, insideStep: boolean): boolean {
+      const operation = isDirectlyNonDeterministic(node);
+      if (!operation) return false;
 
-      if (node.parent?.type === "VariableDeclarator" && node.parent.id?.name) {
-        return node.parent.id.name;
-      }
+      markEnclosingFunction();
 
-      if (
-        node.parent?.type === "AssignmentExpression" &&
-        node.parent.left?.type === "MemberExpression" &&
-        node.parent.left.property?.name
-      ) {
-        return node.parent.left.property.name;
+      if (!insideStep) {
+        context.report({
+          node,
+          messageId: "nonDeterministicOutsideStep",
+          data: { operation },
+        });
       }
+      return true;
+    }
 
-      return null;
+    /**
+     * Maps the recorded callee identifiers to their variables in one pass over
+     * the scope tree. Only the identifiers actually referenced by the caller
+     * graph are retained, so memory stays proportional to the call sites rather
+     * than to every reference in the file.
+     */
+    function resolveCallees(wanted: Set<any>): Map<any, any> {
+      const resolved = new Map<any, any>();
+      const rootScope = sourceCode?.scopeManager?.globalScope;
+      if (!rootScope) return resolved;
+
+      const stack = [rootScope];
+      while (stack.length > 0) {
+        const scope = stack.pop()!;
+        for (const reference of scope.references) {
+          if (reference.resolved && wanted.has(reference.identifier)) {
+            resolved.set(reference.identifier, reference.resolved);
+          }
+        }
+        stack.push(...scope.childScopes);
+      }
+      return resolved;
+    }
+
+    /**
+     * Returns the function nodes a variable is declared as, so a callee can be
+     * matched against the declaration it actually refers to.
+     */
+    function declaredFunctions(variable: any): any[] {
+      const targets: any[] = [];
+      for (const def of variable.defs) {
+        if (def.type === "FunctionName" && isFunctionNode(def.node)) {
+          targets.push(def.node);
+        } else if (
+          def.node?.type === "VariableDeclarator" &&
+          isFunctionNode(def.node.init)
+        ) {
+          targets.push(def.node.init);
+        }
+      }
+      return targets;
+    }
+
+    function enterFunction(node: any) {
+      const parent = functionStack[functionStack.length - 1];
+      if (parent) enclosingFunction.set(node, parent);
+      functionStack.push(node);
+    }
+
+    function exitFunction() {
+      functionStack.pop();
     }
 
     return {
-      "FunctionDeclaration, FunctionExpression, ArrowFunctionExpression"(
-        node: any,
-      ) {
-        const functionName = getFunctionName(node);
-        if (functionName) {
-          functionNodes.set(functionName, node);
+      FunctionDeclaration: enterFunction,
+      FunctionExpression: enterFunction,
+      ArrowFunctionExpression: enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      "FunctionExpression:exit": exitFunction,
+      "ArrowFunctionExpression:exit": exitFunction,
+
+      CallExpression(node: any) {
+        // Evaluated before the counter is updated, so a step call is not
+        // considered to be inside itself - matching the previous
+        // strict-ancestor semantics.
+        const insideStep = stepDepth > 0;
+        if (isStepCall(node)) stepDepth++;
+
+        if (checkNode(node, insideStep)) return;
+
+        if (node.callee?.type === "Identifier") {
+          const enclosing = functionStack[functionStack.length - 1];
+          if (enclosing) {
+            callEdges.push({ callee: node.callee, enclosing });
+          }
+          if (!insideStep) {
+            callsToCheck.push({ node, callee: node.callee });
+          }
         }
       },
 
-      CallExpression(node: any) {
-        if (isStepFunction(node)) return;
-
-        const operation = isDirectlyNonDeterministic(node);
-        if (operation) {
-          context.report({
-            node,
-            messageId: "nonDeterministicOutsideStep",
-            data: { operation },
-          });
-          return;
-        }
-
-        if (node.callee?.type === "Identifier") {
-          const functionName = node.callee.name;
-          if (functionNodes.has(functionName)) {
-            callsToCheck.push({ node, functionName });
-          }
-        }
+      "CallExpression:exit"(node: any) {
+        if (isStepCall(node)) stepDepth--;
       },
 
       NewExpression(node: any) {
-        if (isStepFunction(node)) return;
-
-        const operation = isDirectlyNonDeterministic(node);
-        if (operation) {
-          context.report({
-            node,
-            messageId: "nonDeterministicOutsideStep",
-            data: { operation },
-          });
-        }
+        checkNode(node, stepDepth > 0);
       },
 
       MemberExpression(node: any) {
-        if (isStepFunction(node)) return;
-
-        const operation = isDirectlyNonDeterministic(node);
-        if (operation) {
-          context.report({
-            node,
-            messageId: "nonDeterministicOutsideStep",
-            data: { operation },
-          });
-        }
+        checkNode(node, stepDepth > 0);
       },
 
       "Program:exit"() {
-        // Analyze functions iteratively until no new non-deterministic functions are found
-        let changed = true;
-        while (changed) {
-          changed = false;
-          for (const [functionName, functionNode] of functionNodes) {
-            if (!nonDeterministicFunctions.has(functionName)) {
-              if (analyzeFunction(functionNode)) {
-                nonDeterministicFunctions.add(functionName);
-                changed = true;
-              }
+        const wanted = new Set<any>();
+        for (const { callee } of callEdges) wanted.add(callee);
+        for (const { callee } of callsToCheck) wanted.add(callee);
+
+        const resolvedCallees = resolveCallees(wanted);
+
+        /** Resolves a callee identifier to the function nodes it may refer to. */
+        const targetsOf = (callee: any): any[] => {
+          const variable = resolvedCallees.get(callee);
+          return variable ? declaredFunctions(variable) : [];
+        };
+
+        // target function -> functions that call it
+        const dependents = new Map<any, Set<any>>();
+        for (const { callee, enclosing } of callEdges) {
+          for (const target of targetsOf(callee)) {
+            let callers = dependents.get(target);
+            if (!callers) {
+              callers = new Set<any>();
+              dependents.set(target, callers);
             }
+            callers.add(enclosing);
           }
         }
 
-        // Check all deferred function calls
-        for (const { node, functionName } of callsToCheck) {
-          if (nonDeterministicFunctions.has(functionName)) {
+        // Propagate non-determinism to callers and to lexically enclosing
+        // functions, which are equally unsafe to call outside a step.
+        const worklist = [...nonDeterministicFunctions];
+        const mark = (fn: any) => {
+          if (fn && !nonDeterministicFunctions.has(fn)) {
+            nonDeterministicFunctions.add(fn);
+            worklist.push(fn);
+          }
+        };
+
+        while (worklist.length > 0) {
+          const fn = worklist.pop()!;
+          for (const caller of dependents.get(fn) ?? []) mark(caller);
+          mark(enclosingFunction.get(fn));
+        }
+
+        for (const { node, callee } of callsToCheck) {
+          if (
+            targetsOf(callee).some((fn) => nonDeterministicFunctions.has(fn))
+          ) {
             context.report({
               node,
               messageId: "nonDeterministicFunction",
-              data: { functionName },
+              data: { functionName: callee.name },
             });
           }
         }


### PR DESCRIPTION
`no-closure-in-durable-operations` and `no-non-deterministic-outside-step` both re-traversed subtrees that ESLint's visitor had already walked, redundantly enough to be super-linear in file size. Neither rule re-parsed source, but neither used the scope information ESLint derives while parsing.

**`no-closure-in-durable-operations`** recomputed `getVariablesDeclaredInScope()` and `findOuterScopeVariables()` for *every assignment it found* — each a full walk of the enclosing callback — on top of an outer walk of the same subtree. It now reads scope data instead: for a durable callback's function scope, `scope.through` is exactly the set of references that could not be resolved inside the callback, so filtering it to writes yields the violations with no traversal at all. `walkNode`, `walkForDeclarations`, `getVariablesDeclaredInScope`, `findOuterScopeVariables` and `isAssignment` are gone; the rule is a third of its previous size.

**`no-non-deterministic-outside-step`** walked every ancestor of every `CallExpression`, `NewExpression` and `MemberExpression` to answer "am I inside a step?", and resolved transitive non-determinism with a `Program:exit` fixpoint loop that re-walked every function body on each pass. The ancestor walk is now an O(1) `stepDepth` counter maintained by the enter/exit visitors, and the fixpoint loop is a caller graph built during the traversal ESLint already performs, propagated with a worklist.

That graph is keyed on the function nodes callees resolve to, not on identifier names. Names would let a non-deterministic function taint every call to that name in the file:

```js
function moduleA() { function h() { Date.now(); } h(); }
function moduleB() { function h() { return 1; } return h(); }  // must not be reported
```

Only the innermost enclosing function is recorded per call site; outer functions are reached through a nesting map during propagation. Recording all of them is O(calls × nesting depth), and an earlier iteration that did so measured *slower* than the code it replaced on deeply nested files.

The old walkers also enumerated non-AST properties via `for...in`, recursing into `range`, `loc`, `start` and `end` as if they were nodes. On a 32-node file the walker visited 462 objects — 14.4x the real node count.

#### Correctness fixes

Using real scope data fixes four latent bugs, each covered by a test:

- Shadowed variables in nested functions no longer produce false positives.
- Destructured declarations (`let { total } = event`) are seen.
- Variables declared in outer nested blocks are no longer missed.
- A named function expression assigning to its own name is no longer reported — that binding lives in a wrapper scope outside the function scope, but it is not outer state.

#### ⚠️ Behavior changes

Four surface **new** errors for upgrading users:

1. **Module-scope variables are reported.** `findOuterScopeVariables` only walked enclosing *function* nodes, so a top-level `let counter = 0`, `export let count`, or a `catch` binding mutated inside a step produced nothing. Module-level mutable state around a handler is a common pattern, so this is likely the highest-volume new error in real codebases.
2. **Destructuring and for-of assignment targets are caught**: `[a] = [1]`, `({ a } = obj)`, `for (a of xs)` were all missed by the old `isAssignment` check.
3. **Calls to functions declared after the call site are reported.** `callsToCheck` was filtered against a partially built map during traversal, so hoisted declarations were skipped.
4. A function is treated as non-deterministic if any step it contains uses a non-deterministic operation — already true, but unreachable for hoisted declarations.

One **removes** reports: assigning a function to a member (`obj.method = function () { Date.now(); }`) registered it under the property name, so a call to an unrelated bare `method()` was reported. A bare identifier call never refers to a member assignment.

`no-nested-durable-operations` is unchanged — its only ancestor walk is O(depth) per durable-operation call.

### Demo/Screenshots

Best of 5, ESLint 9.39.4, measured against the parent commit. **Multipliers here track the ratio of rule work to file size**, so they compress as fixtures grow and parse time dominates both sides. Fixtures are described so the numbers can be reproduced.

**N assignments to an outer variable inside one step callback:**

| N | before | after |
|---|---|---|
| 100 | 19.1 ms | 1.4 ms |
| 200 | 68.9 ms | 2.1 ms |
| 400 | 263.9 ms | 1.8 ms |

The new rule is flat in N, so no single multiplier is meaningful. Growth per doubling went from ~3.5x (quadratic) to none.

**Chain of N functions each calling the next, declared in dependency order:**

| N | before | after |
|---|---|---|
| 40 | 2.3 ms | 2.0 ms |
| 80 | 3.3 ms | 3.1 ms |
| 160 | 6.0 ms | 6.1 ms |

No meaningful difference — the old fixpoint converged in about two passes. Included because it is the honest common case.

**The same chain declared in reverse order, forcing one pass per function:**

| N | before | after |
|---|---|---|
| 40 | 7.7 ms | 1.6 ms |
| 80 | 27.8 ms | 2.7 ms |
| 160 | 97.7 ms | 6.5 ms |

Not like-for-like: the new rule emits 43/83/163 messages against 3 (the hoisted-declaration fix) and is still faster.

**Nested functions to depth D, each level declaring the next and making 20 calls:**

| D | before | after | parse only |
|---|---|---|---|
| 50 | 4.8 ms | 4.4 ms | 4.2 ms |
| 100 | 13.4 ms | 11.2 ms | 11.0 ms |
| 200 | 41.8 ms | 36.0 ms | 27.6 ms |

Both sides are close to parse cost on this shape. This is the fixture where recording every enclosing function per call site measured 7.9 / 19.3 / 65.6 ms — slower than before the change, which is why the innermost-only design exists.

Coverage of both rewritten rules:

```
File                                   | % Stmts | % Branch | % Funcs | % Lines
no-closure-in-durable-operations.ts    |     100 |      100 |     100 |     100
no-non-deterministic-outside-step.ts   |     100 |      100 |     100 |     100
```

### Testing

Yes. 90 tests pass (up from 63), with both rewritten rules at 100% statement, branch, function and line coverage.

The existing `.composed.test.ts` RuleTester suites pass **unmodified**, which is the main evidence that behavior is preserved — including the deliberate double-reporting of `Date.now()` (CallExpression + MemberExpression) and the nested-context duplicate report.

The mock-AST unit tests for `no-closure-in-durable-operations` had to be rewritten against `RuleTester`, because hand-built AST fixtures carry no scope information. The only remaining mocks cover the ESLint version fallback and the no-scope-information path, which `RuleTester` cannot reach.

New tests cover: same-named functions in sibling scopes, hoisted declarations, arrow functions bound to variables, unresolvable callees (imported helpers must not be reported), namespaced `uuid.v4()`, module-scope and `export let` mutations, `catch` bindings, array/object destructuring and for-of assignment targets, shadowing in nested functions, a named function expression assigning to its own name, recursion through a named function expression, and only the first function argument of a durable operation being checked.

