### PR TITLE
chore: release eslint plugin 1.1.1 with license field

### DIFF
--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@aws/durable-execution-sdk-js-eslint-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint plugin for AWS Lambda durable functions best practices",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",


### PR DESCRIPTION
*Description of changes:*
Adds the missing Apache-2.0 license field to the ESLint plugin package.json and bumps version from 1.1.0 -> 1.1.1 so that this change can be released.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
