### PR TITLE
fix(otel): end spans on non-terminal invocations

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts
@@ -105,16 +105,25 @@ createTests({
         const traceId = spans[0].traceId;
         expect(spans.every((s) => s.traceId === traceId)).toBe(true);
 
-        // Verify Workflow span exists
-        const workflowSpan = spans.find((s) => s.name === "Workflow");
+        // This execution suspends on a wait, so it spans several invocations.
+        // One Workflow span, carrying the terminal status — exporting one per
+        // invocation would reuse the same deterministic span ID.
+        const workflowSpans = spans.filter((s) => s.name === "Workflow");
+        expect(workflowSpans).toHaveLength(1);
+        const workflowSpan = workflowSpans[0];
         expect(workflowSpan).toBeDefined();
         expect(workflowSpan!.attributes["durable.execution.arn"]).toBeDefined();
+        expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
+          "SUCCEEDED",
+        );
 
         // Verify Invocation span exists and is child of Workflow
         const invocationSpan = spans.find((s) => s.name === "Invocation");
         expect(invocationSpan).toBeDefined();
         expect(invocationSpan!.parentSpanId).toBe(workflowSpan!.spanId);
-        expect(invocationSpan!.attributes["durable.execution.arn"]).toBeDefined();
+        expect(
+          invocationSpan!.attributes["durable.execution.arn"],
+        ).toBeDefined();
 
         // Verify operation spans exist with correct attributes.
         // Filter out Context_Execution spans (which have "execution" in name)

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -119,14 +119,14 @@ Use code-based registration when you need a custom `OtelPluginConfig`.
 
 ## Choosing a Plugin
 
-| Aspect                   | `ExecutionOtelPlugin`                    | `InvocationOtelPlugin`                                                  |
-| ------------------------ | ---------------------------------------- | ----------------------------------------------------------------------- |
-| Trace root               | Workflow_Span (synthetic, deterministic) | Workflow_Span (community collector) or ADOT invocation span             |
-| Operation parent         | Workflow_Span                            | Invocation span (community collector) or ADOT invocation span           |
-| Invocation span role     | Sibling with span links                  | Parent of operations (community collector) or delegated to ADOT         |
-| Export timing            | Operations deferred until complete       | All spans exported immediately                                          |
-| Non-terminal invocations | Workflow_Span discarded (clean traces)   | Workflow_Span discarded (community collector); all spans emitted (ADOT) |
-| Trace continuity         | Single trace across all invocations      | Single trace (community collector) or per-invocation with links (ADOT)  |
+| Aspect                   | `ExecutionOtelPlugin`                                                                   | `InvocationOtelPlugin`                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Trace root               | Workflow_Span (synthetic, deterministic)                                                | Workflow_Span (community collector) or ADOT invocation span            |
+| Operation parent         | Workflow_Span                                                                           | Invocation span (community collector) or ADOT invocation span          |
+| Invocation span role     | Sibling with span links                                                                 | Parent of operations (community collector) or delegated to ADOT        |
+| Export timing            | Operations deferred until complete                                                      | All spans exported immediately                                         |
+| Non-terminal invocations | Workflow_Span held as a non-recording context; exported once at the terminal invocation | Same (community collector); all spans emitted (ADOT)                   |
+| Trace continuity         | Single trace across all invocations                                                     | Single trace (community collector) or per-invocation with links (ADOT) |
 
 **Use `ExecutionOtelPlugin` when** you want a single unified trace view across all invocations of a durable execution, with the workflow as the logical root.
 
@@ -153,12 +153,12 @@ Both plugins can use either Lambda layer. The layer provides span transport (a c
 
 ## Deployment Matrix
 
-| #   | Plugin                 | Layer                     | `providerSource`     | `AWS_LAMBDA_EXEC_WRAPPER` | `collector.yaml` needed? |
-| --- | ---------------------- | ------------------------- | -------------------- | ------------------------- | ------------------------ |
-| 1   | `ExecutionOtelPlugin`  | ADOT Layer                | `GLOBAL`             | `/opt/otel-instrument`    | No                       |
-| 2   | `ExecutionOtelPlugin`  | Community Collector Layer | `AUTO_OTLP`            | Do NOT set                | Yes                      |
-| 3   | `InvocationOtelPlugin` | ADOT Layer                | `GLOBAL`             | `/opt/otel-instrument`    | No                       |
-| 4   | `InvocationOtelPlugin` | Community Collector Layer | `AUTO_OTLP`            | Do NOT set                | Yes                      |
+| #   | Plugin                 | Layer                     | `providerSource` | `AWS_LAMBDA_EXEC_WRAPPER` | `collector.yaml` needed? |
+| --- | ---------------------- | ------------------------- | ---------------- | ------------------------- | ------------------------ |
+| 1   | `ExecutionOtelPlugin`  | ADOT Layer                | `GLOBAL`         | `/opt/otel-instrument`    | No                       |
+| 2   | `ExecutionOtelPlugin`  | Community Collector Layer | `AUTO_OTLP`      | Do NOT set                | Yes                      |
+| 3   | `InvocationOtelPlugin` | ADOT Layer                | `GLOBAL`         | `/opt/otel-instrument`    | No                       |
+| 4   | `InvocationOtelPlugin` | Community Collector Layer | `AUTO_OTLP`      | Do NOT set                | Yes                      |
 
 ### 1. ExecutionOtelPlugin + ADOT Layer
 
@@ -168,7 +168,9 @@ The ADOT layer provides both the collector and a global TracerProvider. The plug
 
 ```typescript
 import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
-const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+const plugin = new ExecutionOtelPlugin({
+  providerSource: ProviderSource.GLOBAL,
+});
 ```
 
 **SAM template:**
@@ -238,7 +240,9 @@ The ADOT layer provides both the collector and a global TracerProvider. The plug
 
 ```typescript
 import { InvocationOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
-const plugin = new InvocationOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+const plugin = new InvocationOtelPlugin({
+  providerSource: ProviderSource.GLOBAL,
+});
 ```
 
 **SAM template:**
@@ -267,7 +271,7 @@ MyFunction:
 
 ### 4. InvocationOtelPlugin + Community Collector Layer
 
-The plugin creates its own TracerProvider and exports spans to the collector on `localhost:4318`. Produces a Workflow_Span as the synthetic trace root (with a deterministic ID derived from the execution ARN) and an Invocation span as its child. The Workflow_Span is only exported on terminal status (SUCCEEDED/FAILED), ensuring clean traces without incomplete workflow spans from intermediate invocations.
+The plugin creates its own TracerProvider and exports spans to the collector on `localhost:4318`. Produces a Workflow_Span as the synthetic trace root (with a deterministic ID derived from the execution ARN) and an Invocation span as its child. The Workflow_Span is exported exactly once per execution, at the terminal invocation, backdated to the execution start; non-terminal invocations hold its identity as a non-recording context so no duplicate span identities are emitted.
 
 **Handler code:**
 
@@ -302,14 +306,14 @@ MyFunction:
 
 ### Which Combination Should I Use?
 
-| Scenario                                               | Recommendation                                        |
-| ------------------------------------------------------ | ----------------------------------------------------- |
-| New deployment, want unified trace per execution       | ExecutionOtelPlugin + Community Collector (option 2)  |
-| New deployment, want per-invocation traces             | InvocationOtelPlugin + Community Collector (option 4) |
-| Already have ADOT layer, want unified execution traces | ExecutionOtelPlugin + ADOT Layer (option 1)           |
-| Already have ADOT layer, want per-invocation traces    | InvocationOtelPlugin + ADOT Layer (option 3)          |
-| Want smallest layer size                               | Community Collector (collector-only, no bundled SDK)  |
-| Want zero-config auto-instrumentation from ADOT        | ADOT Layer with `providerSource: ProviderSource.GLOBAL`      |
+| Scenario                                               | Recommendation                                          |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| New deployment, want unified trace per execution       | ExecutionOtelPlugin + Community Collector (option 2)    |
+| New deployment, want per-invocation traces             | InvocationOtelPlugin + Community Collector (option 4)   |
+| Already have ADOT layer, want unified execution traces | ExecutionOtelPlugin + ADOT Layer (option 1)             |
+| Already have ADOT layer, want per-invocation traces    | InvocationOtelPlugin + ADOT Layer (option 3)            |
+| Want smallest layer size                               | Community Collector (collector-only, no bundled SDK)    |
+| Want zero-config auto-instrumentation from ADOT        | ADOT Layer with `providerSource: ProviderSource.GLOBAL` |
 
 ---
 
@@ -357,7 +361,9 @@ interface OtelPluginConfig {
 const plugin = new ExecutionOtelPlugin();
 
 // Use the ADOT layer's globally registered TracerProvider
-const plugin = new InvocationOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+const plugin = new InvocationOtelPlugin({
+  providerSource: ProviderSource.GLOBAL,
+});
 
 // Custom endpoint and headers (third-party vendor)
 const plugin = new ExecutionOtelPlugin({
@@ -554,7 +560,7 @@ MyFunction:
 Produces a hierarchical trace with Workflow_Span as the synthetic root:
 
 ```
-Workflow_Span (deterministic ID from execution ARN, exported on terminal status only)
+Workflow_Span (deterministic ID from execution ARN, exported once at the terminal invocation)
 ├── Invocation_Span (one per Lambda invocation, always exported)
 ├── Operation_Span: "fetch-data" (STEP)
 │   ├── Attempt_Span: "fetch-data attempt 1"
@@ -575,7 +581,7 @@ Workflow_Span (deterministic ID from execution ARN, exported on terminal status 
 Produces a per-invocation trace with the invocation span as root:
 
 ```
-Workflow_Span (deterministic ID from execution ARN, exported on terminal status only — community collector mode)
+Workflow_Span (deterministic ID from execution ARN, exported once at the terminal invocation — community collector mode)
 ├── Invocation_Span (one per Lambda invocation)
 │   ├── Operation_Span: "fetch-data" (STEP)
 │   │   ├── Attempt_Span: "fetch-data attempt 1"
@@ -601,31 +607,33 @@ Cross-invocation operations are correlated via span links to deterministic span 
 
 ### Span Status
 
-The **Workflow_Span** OTel status is derived from the terminal `PluginInvocationStatus`:
+The **Workflow_Span** covers the whole execution, so only the terminal invocation can complete it. It is exported **exactly once per execution**, at the terminal invocation, backdated to the execution start:
 
-| `PluginInvocationStatus` | Workflow_Span status |
-| ------------------------ | -------------------- |
-| `SUCCEEDED`              | `OK`                 |
+| `PluginInvocationStatus` | Workflow_Span                              |
+| ------------------------ | ------------------------------------------ |
+| `SUCCEEDED`              | exported, `OK`                             |
+| `FAILED`                 | exported, `ERROR` (with the error message) |
+| `PENDING`                | not exported (execution still in flight)   |
+| `RETRYING`               | not exported (execution still in flight)   |
+
+On a non-terminal invocation the plugin holds the Workflow identity as a **non-recording span context** instead of starting a real span. That keeps the deterministic ID available for parenting and links without creating a recording span that would have to be either abandoned un-ended (never exported) or ended — the latter emitting several spans that all claim the same `(traceId, spanId)`, which lets a backend overcount span metrics or keep an earlier `PENDING` copy in place of the terminal status.
+
+The **Invocation_Span** is scoped to a single Lambda invocation, so it always completes and is **always** ended and exported, one per invocation:
+
+| `PluginInvocationStatus` | Invocation_Span status                     |
+| ------------------------ | ------------------------------------------ |
+| `SUCCEEDED`              | `OK`                                       |
+| `PENDING`                | `OK` (a normal suspension, not an error)   |
 | `FAILED`                 | `ERROR` (with the execution error message) |
-| `PENDING`                | `UNSET` (span not ended/exported) |
-| `RETRYING`               | `UNSET` (span not ended/exported) |
+| `RETRYING`               | `UNSET`                                    |
 
-For non-terminal outcomes (`PENDING`/`RETRYING`) the Workflow_Span is intentionally left un-ended, so it is never exported and its status stays `UNSET`.
+`RETRYING` maps to `UNSET` rather than `ERROR` because the plugin cannot tell a genuine retry apart from a `STOPPED`/`TIMED_OUT` outcome (see the note below), so it does not assert an error status for it. The raw value is also recorded in the `durable.invocation.status` attribute.
 
-> **Note:** the OTel plugin does **not** know whether a failed workflow was `TIMED_OUT` or `STOPPED`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`. `TIMED_OUT` and `STOPPED` are operation-level states (`PluginOperationStatus`) and are not surfaced at the invocation/workflow level, so any such outcome is reported as `FAILED` → span status `ERROR`.
+An `Attempt_Span` still in flight when an invocation ends is now ended rather than abandoned un-ended. Attempt spans get random IDs and never span more than one invocation, so exporting one cannot collide with anything; its status is left `UNSET` since the attempt reached no outcome.
 
-The **Invocation_Span** uses a slightly different mapping, because a `PENDING` suspension is a normal outcome for an individual invocation:
+`Operation_Span` export stays **deferred**: a suspended operation's span holds the deterministic operation span ID, which the eventual completion re-derives. Exporting a partial segment at suspension would emit a second span with that same `(traceId, spanId)`, so the span is exported once, when the operation actually completes, with its full start-to-finish timing.
 
-| `PluginInvocationStatus` | Invocation_Span status |
-| ------------------------ | ---------------------- |
-| `SUCCEEDED`              | `OK`                   |
-| `PENDING`                | `OK`                   |
-| `FAILED`                 | `ERROR` (with the execution error message) |
-| `RETRYING`               | `UNSET`                |
-
-Unlike the Workflow_Span, the Invocation_Span is **always** ended and exported (one per Lambda invocation), so `PENDING`/`RETRYING` invocations are exported with the mapping above. The raw value is also recorded in the `durable.invocation.status` attribute.
-
-> **Note:** the OTel plugin does **not** know whether an invocation/workflow was `STOPPED` or `TIMED_OUT`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`; `STOPPED` and `TIMED_OUT` are operation-level states (`PluginOperationStatus`) that are not surfaced at the invocation/workflow level. This is also **why `RETRYING` maps to `UNSET`** rather than `ERROR`: the plugin cannot tell a genuine retry apart from a `STOPPED`/`TIMED_OUT` outcome, so it does not assert an error status for it.
+> **Note:** the OTel plugin does **not** know whether a failed workflow/invocation was `TIMED_OUT` or `STOPPED`. `PluginInvocationStatus` — the only status the plugin receives at `onInvocationEnd` — distinguishes just `SUCCEEDED`/`FAILED`/`PENDING`/`RETRYING`. `TIMED_OUT` and `STOPPED` are operation-level states (`PluginOperationStatus`) and are not surfaced at the invocation/workflow level, so any such outcome is reported as `FAILED` → span status `ERROR`.
 
 ---
 
@@ -715,13 +723,13 @@ After deploying with either plugin and either layer:
 
 ### Troubleshooting
 
-| Symptom                         | Likely Cause                                                                                                                                 |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| No traces appear                | Collector layer not attached, or config env var not set                                                                                      |
-| No traces with ADOT layer       | `AWS_LAMBDA_EXEC_WRAPPER` not set (when using `providerSource: ProviderSource.GLOBAL`)                                                              |
-| Traces fragmented across IDs    | X-Ray active tracing not enabled on the function                                                                                             |
-| Missing operation spans         | Sampling ratio set below 1.0                                                                                                                 |
-| Collector layer errors          | Check `collector.yaml` is in the function bundle at the path specified                                                                       |
+| Symptom                         | Likely Cause                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No traces appear                | Collector layer not attached, or config env var not set                                                                                          |
+| No traces with ADOT layer       | `AWS_LAMBDA_EXEC_WRAPPER` not set (when using `providerSource: ProviderSource.GLOBAL`)                                                           |
+| Traces fragmented across IDs    | X-Ray active tracing not enabled on the function                                                                                                 |
+| Missing operation spans         | Sampling ratio set below 1.0                                                                                                                     |
+| Collector layer errors          | Check `collector.yaml` is in the function bundle at the path specified                                                                           |
 | Duplicate spans with ADOT layer | `AWS_LAMBDA_EXEC_WRAPPER` is set but `providerSource` is not `GLOBAL` — either remove the env var or set `providerSource: ProviderSource.GLOBAL` |
 
 ## License

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   SpanKind,
 } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import type { Span } from "@opentelemetry/api";
 import type {
   InvocationInfo,
   InvocationEndInfo,
@@ -54,6 +55,21 @@ function makeInvocationEndInfo(
 
 function getExportedSpans(exporter: InMemorySpanExporter): ReadableSpan[] {
   return exporter.getFinishedSpans();
+}
+
+/**
+ * An OTel SpanId identifies exactly one span. Because span IDs here are derived
+ * deterministically from the execution ARN / operation ID so spans correlate
+ * across invocations, it is easy to accidentally export two spans claiming the
+ * same (traceId, spanId) — which makes generic OTLP backends retain duplicates,
+ * overcount span metrics, or (as X-Ray does) let an earlier incomplete segment
+ * overwrite the terminal one.
+ */
+function expectUniqueSpanIdentities(exporter: InMemorySpanExporter): void {
+  const ids = getExportedSpans(exporter).map(
+    (s) => `${s.spanContext().traceId}:${s.spanContext().spanId}`,
+  );
+  expect([...new Set(ids)]).toHaveLength(ids.length);
 }
 
 function findSpan(
@@ -407,66 +423,83 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       );
     });
 
-    it("clears attemptSpan after onInvocationEnd", async () => {
-      const plugin = new ExecutionOtelPlugin({
-        providerSource: ProviderSource.GLOBAL,
-      });
+    it.each(["PENDING", "RETRYING"])(
+      "clears attemptSpan after onInvocationEnd (%s)",
+      async (status) => {
+        const plugin = new ExecutionOtelPlugin({
+          providerSource: ProviderSource.GLOBAL,
+        });
 
-      // Start invocation and create an attempt span (but don't end it)
-      await plugin.onInvocationStart(makeInvocationInfo());
-      await plugin.onOperationStart({
-        id: "op-1",
-        type: "step",
-        name: "my-step",
-        isReplay: false,
-      });
-      await plugin.onOperationAttemptStart({
-        id: "op-1",
-        type: "step",
-        name: "my-step",
-        isReplay: false,
-        attempt: 1,
-      });
-
-      // End invocation without ending the attempt
-      await plugin.onInvocationEnd(
-        makeInvocationEndInfo({ status: "PENDING" as any }),
-      );
-
-      exporter.reset();
-
-      // Second invocation - wrapOperationAttemptFn should not use stale attempt span
-      await plugin.onInvocationStart(
-        makeInvocationInfo({ executionArn: "arn:second" }),
-      );
-
-      let capturedSpan: any;
-      const fn = () => {
-        capturedSpan = trace.getSpan(context.active());
-        return "result";
-      };
-
-      // Call wrapOperationAttemptFn - should not set any context since attemptSpan is cleared
-      plugin.wrapOperationAttemptFn(
-        {
-          id: "op-new",
+        // Start invocation and create an attempt span (but don't end it)
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart({
+          id: "op-1",
           type: "step",
+          name: "my-step",
+          isReplay: false,
+        });
+        await plugin.onOperationAttemptStart({
+          id: "op-1",
+          type: "step",
+          name: "my-step",
           isReplay: false,
           attempt: 1,
-        },
-        fn,
-      );
+        });
 
-      // capturedSpan should be undefined or the root since there's no active attempt span
-      expect(capturedSpan?.spanContext().spanId).not.toBeDefined();
+        // Live reference: assert the span stops recording, not just that it
+        // reaches the exporter.
+        const spanMap = (plugin as any).spanMap as Map<string, Span>;
+        const stepSpanRef = spanMap.get("op-1");
+        const attemptSpanRef = spanMap.get("op-1:attempt:1");
+        expect(stepSpanRef?.isRecording()).toBe(true);
+        expect(attemptSpanRef?.isRecording()).toBe(true);
 
-      await plugin.onInvocationEnd(
-        makeInvocationEndInfo({
-          executionArn: "arn:second",
-          status: "SUCCEEDED" as any,
-        }),
-      );
-    });
+        // End invocation without ending the attempt
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: status as any }),
+        );
+
+        // Both the in-flight attempt and the suspended operation are ended.
+        expect(attemptSpanRef?.isRecording()).toBe(false);
+        expect(stepSpanRef?.isRecording()).toBe(false);
+        expect(findSpan(exporter, "my-step attempt 1")).toBeDefined();
+        expect(findSpan(exporter, "my-step")).toBeDefined();
+
+        exporter.reset();
+
+        // Second invocation - wrapOperationAttemptFn should not use stale attempt span
+        await plugin.onInvocationStart(
+          makeInvocationInfo({ executionArn: "arn:second" }),
+        );
+
+        let capturedSpan: any;
+        const fn = () => {
+          capturedSpan = trace.getSpan(context.active());
+          return "result";
+        };
+
+        // Call wrapOperationAttemptFn - should not set any context since attemptSpan is cleared
+        plugin.wrapOperationAttemptFn(
+          {
+            id: "op-new",
+            type: "step",
+            isReplay: false,
+            attempt: 1,
+          },
+          fn,
+        );
+
+        // capturedSpan should be undefined or the root since there's no active attempt span
+        expect(capturedSpan?.spanContext().spanId).not.toBeDefined();
+
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({
+            executionArn: "arn:second",
+            status: "SUCCEEDED" as any,
+          }),
+        );
+      },
+    );
   });
 
   describe("Invocation_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
@@ -490,7 +523,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       ["SUCCEEDED", SpanStatusCode.OK],
       ["PENDING", SpanStatusCode.OK],
     ])("maps %s -> Invocation_Span status OK", async (status, expected) => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({ status: status as any }),
@@ -502,7 +537,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
 
     it("maps RETRYING -> Invocation_Span status UNSET (STOPPED/TIMED_OUT indistinguishable from RETRYING)", async () => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({ status: "RETRYING" as any }),
@@ -514,7 +551,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
 
     it("maps FAILED -> Invocation_Span status ERROR with the execution error message", async () => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({
@@ -532,7 +571,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
   describe("Workflow_Span status mapping (PluginInvocationStatus -> OTel span status)", () => {
     it("creates the Workflow_Span with SpanKind.INTERNAL", async () => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
@@ -544,7 +585,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
 
     it("maps SUCCEEDED -> span status OK", async () => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
@@ -559,7 +602,9 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
 
     it("maps FAILED -> span status ERROR with the execution error message", async () => {
-      const plugin = new ExecutionOtelPlugin({ providerSource: ProviderSource.GLOBAL });
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
       await plugin.onInvocationStart(makeInvocationInfo());
       await plugin.onInvocationEnd(
         makeInvocationEndInfo({
@@ -578,20 +623,198 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
     });
 
     it.each(["PENDING", "RETRYING"])(
-      "leaves the Workflow_Span un-ended (UNSET, never exported) for non-terminal status %s",
+      "creates no recording Workflow_Span to abandon on non-terminal status %s",
       async (status) => {
         const plugin = new ExecutionOtelPlugin({
           providerSource: ProviderSource.GLOBAL,
         });
         await plugin.onInvocationStart(makeInvocationInfo());
+
+        // Non-recording identity: nothing to end, nothing exported yet.
+        let capturedSpan: Span | undefined;
+        await plugin.wrapInvocation(makeInvocationInfo(), async () => {
+          capturedSpan = trace.getSpan(context.active());
+          return {} as any;
+        });
+        expect(capturedSpan).toBeDefined();
+        expect(capturedSpan!.isRecording()).toBe(false);
+
         await plugin.onInvocationEnd(
           makeInvocationEndInfo({ status: status as any }),
         );
 
-        // Non-terminal: the Workflow_Span is intentionally never ended, so it is
-        // never exported and its status stays UNSET.
+        expect(capturedSpan!.isRecording()).toBe(false);
         expect(findSpan(exporter, "Workflow")).toBeUndefined();
       },
     );
+
+    it("keeps a non-negative duration when executionStartTimestamp is omitted", async () => {
+      // Optional field; fallback is captured at onInvocationStart.
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ executionStartTimestamp: undefined }),
+      );
+      // Real gap: Date is ms-truncated, so a late fallback must be measurable.
+      await new Promise((r) => setTimeout(r, 15));
+
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "SUCCEEDED" as any,
+          executionStartTimestamp: undefined,
+        }),
+      );
+
+      const workflow = findSpan(exporter, "Workflow")!;
+      const invocation = findSpan(exporter, "Invocation")!;
+      expect(workflow).toBeDefined();
+      expect(invocation).toBeDefined();
+
+      // The Workflow_Span must contain the invocation it covers; a late
+      // fallback would start it after the invocation span began.
+      const cmp = (
+        a: ReadableSpan["startTime"],
+        b: ReadableSpan["startTime"],
+      ) => a[0] - b[0] || a[1] - b[1];
+      expect(cmp(workflow.startTime, invocation.startTime)).toBeLessThanOrEqual(
+        0,
+      );
+      expect(cmp(workflow.endTime, workflow.startTime)).toBeGreaterThanOrEqual(
+        0,
+      );
+    });
+
+    it("exports exactly one Workflow_Span identity across a suspend/resume pair", async () => {
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      // Invocation 1 suspends.
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "PENDING" as any }),
+      );
+
+      // Invocation 2 (same ARN) completes the execution.
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      // A second span with the same identity would let a backend keep the
+      // earlier PENDING copy over this SUCCEEDED one.
+      const workflowSpans = getExportedSpans(exporter).filter(
+        (s) => s.name === "Workflow",
+      );
+      expect(workflowSpans).toHaveLength(1);
+      expect(workflowSpans[0].attributes["durable.execution.status"]).toBe(
+        "SUCCEEDED",
+      );
+      expect(workflowSpans[0].status.code).toBe(SpanStatusCode.OK);
+      expectUniqueSpanIdentities(exporter);
+    });
+
+    it.each(["WAIT", "CALLBACK"] as const)(
+      "gives a suspended %s and its completion distinct identities",
+      async (type) => {
+        const plugin = new ExecutionOtelPlugin({
+          providerSource: ProviderSource.GLOBAL,
+        });
+        const name = `my-${type.toLowerCase()}`;
+
+        // Invocation 1: the operation starts and suspends.
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart({
+          id: "sus-1",
+          type,
+          name,
+          isReplay: false,
+        });
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: "PENDING" as any }),
+        );
+
+        // Invocation 2: it resolves (cross-invocation completion).
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd({
+          id: "sus-1",
+          type,
+          name,
+          isReplay: false,
+          status: "SUCCEEDED" as any,
+        });
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+        );
+
+        // Two segments — the partial one ended at suspension and the terminal
+        // completion — with DISTINCT identities, so the incomplete copy cannot
+        // overwrite the completed one.
+        const opSpans = getExportedSpans(exporter).filter(
+          (s) => s.name === name,
+        );
+        expect(opSpans).toHaveLength(2);
+        expect(opSpans[0].spanContext().spanId).not.toBe(
+          opSpans[1].spanContext().spanId,
+        );
+        expect(
+          opSpans.some(
+            (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+          ),
+        ).toBe(true);
+        expectUniqueSpanIdentities(exporter);
+      },
+    );
+
+    it("keeps exported identities unique for a STEP retried across three invocations", async () => {
+      // Regression guard: onOperationStart re-derives the deterministic ID on
+      // every replay, so ending those spans can emit duplicate identities.
+      const plugin = new ExecutionOtelPlugin({
+        providerSource: ProviderSource.GLOBAL,
+      });
+
+      for (let i = 1; i <= 3; i++) {
+        const base = {
+          id: "op-1",
+          type: "STEP",
+          name: "retry-step",
+          isReplay: i > 1,
+        };
+
+        await plugin.onInvocationStart(
+          makeInvocationInfo({ isFirstInvocation: i === 1 }),
+        );
+        await plugin.onOperationStart(base);
+        await plugin.onOperationAttemptStart({ ...base, attempt: i });
+        await plugin.onOperationAttemptEnd({
+          ...base,
+          attempt: i,
+          outcome: (i === 3 ? "SUCCEEDED" : "FAILED") as any,
+        });
+        if (i === 3) {
+          await plugin.onOperationEnd({
+            ...base,
+            isReplay: false,
+            status: "SUCCEEDED" as any,
+            attempt: 3,
+          });
+        }
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({
+            status: (i === 3 ? "SUCCEEDED" : "RETRYING") as any,
+          }),
+        );
+      }
+
+      expectUniqueSpanIdentities(exporter);
+      expect(
+        getExportedSpans(exporter)
+          .filter((s) => s.name === "retry-step")
+          .some(
+            (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+          ),
+      ).toBe(true);
+    });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -11,6 +11,7 @@ import {
   propagation,
 } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import type { Span } from "@opentelemetry/api";
 import { InvocationOtelPlugin } from "../invocation-plugin";
 import { ProviderSource } from "../otel-plugin-config";
 import {
@@ -110,6 +111,21 @@ function makeAttemptEndInfo(
 
 function getExportedSpans(): ReadableSpan[] {
   return exporter.getFinishedSpans();
+}
+
+/**
+ * An OTel SpanId identifies exactly one span. Because span IDs here are derived
+ * deterministically from the execution ARN / operation ID so spans correlate
+ * across invocations, it is easy to accidentally export two spans claiming the
+ * same (traceId, spanId) — which makes generic OTLP backends retain duplicates,
+ * overcount span metrics, or (as X-Ray does) let an earlier incomplete segment
+ * overwrite the terminal one.
+ */
+function expectUniqueSpanIdentities(): void {
+  const ids = getExportedSpans().map(
+    (s) => `${s.spanContext().traceId}:${s.spanContext().spanId}`,
+  );
+  expect([...new Set(ids)]).toHaveLength(ids.length);
 }
 
 function findSpan(name: string): ReadableSpan | undefined {
@@ -282,18 +298,81 @@ describe("InvocationOtelPlugin", () => {
     });
 
     it.each(["PENDING", "RETRYING"])(
-      "leaves the Workflow span un-ended (UNSET, never exported) for non-terminal status %s",
+      "creates no recording Workflow span to abandon on non-terminal status %s",
       async (status) => {
         await plugin.onInvocationStart(makeInvocationInfo());
+
+        // Non-recording identity: nothing to end, nothing exported yet.
+        const workflowSpanRef = (plugin as any).workflowSpan as Span;
+        expect(workflowSpanRef).toBeDefined();
+        expect(workflowSpanRef.isRecording()).toBe(false);
+
         await plugin.onInvocationEnd(
           makeInvocationEndInfo({ status: status as any }),
         );
 
+        expect(workflowSpanRef.isRecording()).toBe(false);
         expect(findSpan("Workflow")).toBeUndefined();
       },
     );
-  });
 
+    it("keeps a non-negative duration when executionStartTimestamp is omitted", async () => {
+      // Optional field; fallback is captured at onInvocationStart, since
+      // onInvocationEnd captures endTime first.
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ executionStartTimestamp: undefined }),
+      );
+      // Real gap: Date is ms-truncated, so a late fallback must be measurable.
+      await new Promise((r) => setTimeout(r, 15));
+
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: "SUCCEEDED" as any,
+          executionStartTimestamp: undefined,
+        }),
+      );
+
+      const workflow = findSpan("Workflow")!;
+      const invocation = findSpan("Invocation")!;
+      expect(workflow).toBeDefined();
+      expect(invocation).toBeDefined();
+
+      // The Workflow span must contain the invocation it covers; a late
+      // fallback would start it after the invocation span began.
+      expect(
+        compareHrTime(workflow.startTime, invocation.startTime),
+      ).toBeLessThanOrEqual(0);
+      expect(
+        compareHrTime(workflow.endTime, workflow.startTime),
+      ).toBeGreaterThanOrEqual(0);
+    });
+
+    it("exports exactly one Workflow span identity across a suspend/resume pair", async () => {
+      // Invocation 1 suspends.
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "PENDING" as any }),
+      );
+
+      // Invocation 2 (same ARN) completes the execution.
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      // A second span with the same identity would let a backend keep the
+      // earlier PENDING copy over this SUCCEEDED one.
+      const workflowSpans = getExportedSpans().filter(
+        (s) => s.name === "Workflow",
+      );
+      expect(workflowSpans).toHaveLength(1);
+      expect(workflowSpans[0].attributes["durable.execution.status"]).toBe(
+        "SUCCEEDED",
+      );
+      expect(workflowSpans[0].status.code).toBe(SpanStatusCode.OK);
+      expectUniqueSpanIdentities();
+    });
+  });
   describe("onInvocationEnd", () => {
     it("ends all open operation spans and invocation span", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
@@ -340,6 +419,137 @@ describe("InvocationOtelPlugin", () => {
       );
       // Only invocation span + Workflow span from second invocation, no leftover op-1
       expect(spans.length).toBe(2);
+    });
+
+    it.each(["PENDING", "RETRYING"])(
+      "ends an in-flight attempt span left open by a non-terminal invocation (%s)",
+      async (status) => {
+        // Attempt spans live only in spanMap, not spanStack, so a suspended
+        // attempt must still be ended here, not dropped when spanMap clears.
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({ id: "s1", type: "STEP", name: "my-step" }),
+        );
+        await plugin.onOperationAttemptStart(
+          makeAttemptInfo({
+            id: "s1",
+            type: "STEP",
+            name: "my-step",
+            attempt: 1,
+          }),
+        );
+
+        // Retain a live reference before spanMap is cleared, so we assert the
+        // span itself stops recording — not just that it reached the exporter.
+        const attemptSpanRef = (plugin as any).spanMap.get(
+          "attempt:s1:1",
+        ) as Span;
+        expect(attemptSpanRef).toBeDefined();
+        expect(attemptSpanRef.isRecording()).toBe(true);
+
+        // Suspend without onOperationAttemptEnd / onOperationEnd firing.
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: status as any }),
+        );
+
+        expect(attemptSpanRef.isRecording()).toBe(false);
+
+        const attemptSpan = findSpan("my-step attempt 1");
+        expect(attemptSpan).toBeDefined();
+        expect(
+          attemptSpan!.attributes["durable.attempt.outcome"],
+        ).toBeUndefined();
+      },
+    );
+
+    it.each(["WAIT", "CALLBACK"] as const)(
+      "gives a suspended %s and its later completion distinct exported identities",
+      async (type) => {
+        const name = `my-${type.toLowerCase()}`;
+
+        // Invocation 1: the operation starts and suspends.
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationStart(
+          makeOperationInfo({ id: "sus-1", type, name }),
+        );
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: "PENDING" as any }),
+        );
+
+        // Invocation 2: it resolves (cross-invocation continuation).
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            id: "sus-1",
+            type,
+            name,
+            status: "SUCCEEDED" as any,
+            isReplay: false,
+          }),
+        );
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+        );
+
+        // Partial and terminal segments must not share an identity, or the
+        // incomplete copy can overwrite the terminal one.
+        expectUniqueSpanIdentities();
+        expect(
+          getExportedSpans()
+            .filter((s) => s.name === name)
+            .some(
+              (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+            ),
+        ).toBe(true);
+      },
+    );
+
+    it("keeps exported identities unique for a STEP retried across three invocations", async () => {
+      // Regression guard: onOperationStart re-derives the deterministic ID on
+      // every replay, so ending those spans can emit duplicate identities.
+      for (let i = 1; i <= 3; i++) {
+        const isReplay = i > 1;
+        const base = { id: "op-1", type: "STEP", name: "retry-step", isReplay };
+
+        await plugin.onInvocationStart(
+          makeInvocationInfo({ isFirstInvocation: i === 1 }),
+        );
+        await plugin.onOperationStart(makeOperationInfo(base));
+        await plugin.onOperationAttemptStart(
+          makeAttemptInfo({ ...base, attempt: i }),
+        );
+        await plugin.onOperationAttemptEnd(
+          makeAttemptEndInfo({
+            ...base,
+            attempt: i,
+            outcome: (i === 3 ? "SUCCEEDED" : "FAILED") as any,
+          }),
+        );
+        if (i === 3) {
+          await plugin.onOperationEnd(
+            makeOperationEndInfo({
+              ...base,
+              isReplay: false,
+              status: "SUCCEEDED" as any,
+              attempt: 3,
+            }),
+          );
+        }
+        await plugin.onInvocationEnd(
+          makeInvocationEndInfo({
+            status: (i === 3 ? "SUCCEEDED" : "RETRYING") as any,
+          }),
+        );
+      }
+
+      expectUniqueSpanIdentities();
+      expect(
+        getExportedSpans()
+          .filter((s) => s.name === "retry-step")
+          .some(
+            (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+          ),
+      ).toBe(true);
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
@@ -3,18 +3,31 @@
  * skipping in the shared OTel plugin infrastructure (used by both
  * ExecutionOtelPlugin and InvocationOtelPlugin), driven by `providerSource`.
  */
-import { trace, context, propagation } from "@opentelemetry/api";
-import type { TracerProvider } from "@opentelemetry/api";
 import {
+  trace,
+  context,
+  propagation,
+  ROOT_CONTEXT,
+  TraceFlags,
+} from "@opentelemetry/api";
+import type { TracerProvider } from "@opentelemetry/api";
+import type { Sampler } from "@opentelemetry/sdk-trace-node";
+import type { Attributes } from "@opentelemetry/api";
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
   NodeTracerProvider,
   InMemorySpanExporter,
+  ParentBasedSampler,
+  SamplingDecision,
   SimpleSpanProcessor,
+  TraceIdRatioBasedSampler,
 } from "@opentelemetry/sdk-trace-node";
-import { createTracerProvider } from "../otel-plugin-provider";
 import {
-  ProviderSource,
-  resolveProviderSource,
-} from "../otel-plugin-config";
+  createTracerProvider,
+  resolveWorkflowRoot,
+} from "../otel-plugin-provider";
+import { ProviderSource, resolveProviderSource } from "../otel-plugin-config";
 import { registerStandaloneInstrumentations } from "../otel-plugin-instrumentations";
 
 // Save original env
@@ -246,7 +259,11 @@ describe("registerStandaloneInstrumentations", () => {
       const provider = new NodeTracerProvider();
 
       expect(() => {
-        registerStandaloneInstrumentations(provider, ProviderSource.AUTO_OTLP, {});
+        registerStandaloneInstrumentations(
+          provider,
+          ProviderSource.AUTO_OTLP,
+          {},
+        );
       }).not.toThrow();
 
       provider.shutdown();
@@ -347,3 +364,307 @@ describe("ExecutionOtelPlugin integration - provider resolution", () => {
     globalProvider.shutdown();
   });
 });
+
+describe("resolveWorkflowRoot", () => {
+  const rootFlags = (tracer: any, traceId: string) =>
+    resolveWorkflowRoot(
+      tracer,
+      traceId,
+      "b".repeat(16),
+      "Workflow",
+      "arn:x",
+    ).span.spanContext().traceFlags;
+
+  const TRACE_ID = "9c1c1a2b3d4e5f60718293a4b5c6d7e8";
+
+  function tracerFor(sampler: Sampler) {
+    const provider = new NodeTracerProvider({
+      sampler,
+      spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+    });
+    return { provider, tracer: provider.getTracer("t") };
+  }
+
+  it.each([
+    ["AlwaysOn", () => new AlwaysOnSampler(), TraceFlags.SAMPLED],
+    ["AlwaysOff", () => new AlwaysOffSampler(), TraceFlags.NONE],
+    ["ratio 1.0", () => new TraceIdRatioBasedSampler(1), TraceFlags.SAMPLED],
+    ["ratio 0.0", () => new TraceIdRatioBasedSampler(0), TraceFlags.NONE],
+    [
+      "ParentBased(AlwaysOff) — parentless root",
+      () => new ParentBasedSampler({ root: new AlwaysOffSampler() }),
+      TraceFlags.NONE,
+    ],
+  ])("returns the sampler's root decision for %s", (_n, make, expected) => {
+    const { provider, tracer } = tracerFor(make());
+    expect(rootFlags(tracer, TRACE_ID)).toBe(expected);
+    provider.shutdown();
+  });
+
+  // The whole point of the helper: reproduce what startSpan would have decided.
+  // If the SDK ever renames the internal `_sampler`, the fallback kicks in and
+  // this equivalence breaks — which is exactly what we want to be told about.
+  it.each([
+    ["AlwaysOn", () => new AlwaysOnSampler()],
+    ["AlwaysOff", () => new AlwaysOffSampler()],
+    ["ratio 0.01", () => new TraceIdRatioBasedSampler(0.01)],
+    [
+      "ParentBased(ratio 0.5)",
+      () => new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(0.5) }),
+    ],
+  ])("matches the flags a real root span gets from %s", (_n, make) => {
+    for (const traceId of [
+      TRACE_ID,
+      "1111111111111111aaaaaaaaaaaaaaaa",
+      "ffffffffffffffff0000000000000000",
+    ]) {
+      const { provider, tracer } = tracerFor(make());
+      (tracer as unknown as { _idGenerator: unknown })._idGenerator = {
+        generateTraceId: () => traceId,
+        generateSpanId: () => "b".repeat(16),
+      };
+
+      const real = tracer.startSpan("Workflow", {}, ROOT_CONTEXT);
+      const automatic = real.spanContext().traceFlags;
+      real.end();
+
+      expect(rootFlags(tracer, traceId)).toBe(automatic);
+      provider.shutdown();
+    }
+  });
+
+  it("falls back to SAMPLED when the tracer exposes no sampler", () => {
+    const noopTracer = trace.getTracer("noop"); // no-op API tracer
+    expect(rootFlags(noopTracer, TRACE_ID)).toBe(TraceFlags.SAMPLED);
+  });
+});
+
+/**
+ * The plugins hold the Workflow span identity as a synthetic, non-recording span
+ * context. Its flags must carry the provider's real sampling decision: asserting
+ * SAMPLED would export operation spans while the terminal root is dropped, and
+ * make enrichLogContext() report otelTraceSampled: true for dropped traces.
+ */
+describe.each([
+  [
+    "ExecutionOtelPlugin",
+    async () => (await import("../execution-plugin")).ExecutionOtelPlugin,
+  ],
+  [
+    "InvocationOtelPlugin",
+    async () => (await import("../invocation-plugin")).InvocationOtelPlugin,
+  ],
+])("%s honors an unsampled provider", (_name, importPlugin) => {
+  const invInfo = {
+    requestId: "req-1",
+    executionArn: "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1",
+    isFirstInvocation: true,
+    executionInput: {},
+    operations: {},
+    updatedOperations: {},
+  } as any;
+  const invEnd = { ...invInfo, status: "SUCCEEDED" } as any;
+
+  async function setup() {
+    const exporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider({
+      sampler: new ParentBasedSampler({ root: new AlwaysOffSampler() }),
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+    const Plugin = await importPlugin();
+    return {
+      exporter,
+      provider,
+      plugin: new Plugin({ providerSource: ProviderSource.GLOBAL }) as any,
+    };
+  }
+
+  it("marks the synthetic Workflow context unsampled and exports nothing", async () => {
+    const { exporter, provider, plugin } = await setup();
+
+    await plugin.onInvocationStart(invInfo);
+    expect(plugin.workflowSpan.spanContext().traceFlags).toBe(TraceFlags.NONE);
+
+    await plugin.onOperationStart({
+      id: "op-1",
+      type: "STEP",
+      name: "my-step",
+      isReplay: false,
+    });
+    await plugin.onOperationEnd({
+      id: "op-1",
+      type: "STEP",
+      name: "my-step",
+      isReplay: false,
+      status: "SUCCEEDED",
+    });
+    await plugin.onInvocationEnd(invEnd);
+
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
+    await provider.shutdown();
+  });
+
+  it("reports otelTraceSampled false from enrichLogContext", async () => {
+    const { provider, plugin } = await setup();
+
+    await plugin.onInvocationStart(invInfo);
+    const enriched = await plugin.wrapInvocation(invInfo, async () =>
+      plugin.enrichLogContext(),
+    );
+
+    expect(enriched?.otelTraceSampled).toBe(false);
+
+    await plugin.onInvocationEnd(invEnd);
+    await provider.shutdown();
+  });
+
+  it("still exports the root when the sampler says yes", async () => {
+    // Control, so the assertions above cannot pass vacuously.
+    const exporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider({
+      sampler: new ParentBasedSampler({ root: new AlwaysOnSampler() }),
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+    const Plugin = await importPlugin();
+    const plugin = new Plugin({
+      providerSource: ProviderSource.GLOBAL,
+    }) as any;
+
+    await plugin.onInvocationStart(invInfo);
+    expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+      TraceFlags.SAMPLED,
+    );
+    await plugin.onInvocationEnd(invEnd);
+
+    expect(
+      exporter.getFinishedSpans().filter((s) => s.name === "Workflow"),
+    ).toHaveLength(1);
+    await provider.shutdown();
+  });
+});
+
+/**
+ * The synthetic Workflow context and the terminal Workflow span must reach the
+ * SAME sampling decision. They are sampled at different times, so the inputs
+ * have to match (identical name + attributes, ROOT_CONTEXT, same traceId) and
+ * the result is cached and reused.
+ */
+describe.each([
+  [
+    "ExecutionOtelPlugin",
+    async () => (await import("../execution-plugin")).ExecutionOtelPlugin,
+  ],
+  [
+    "InvocationOtelPlugin",
+    async () => (await import("../invocation-plugin")).InvocationOtelPlugin,
+  ],
+])(
+  "%s sampling is consistent across both Workflow sampling points",
+  (_name, importPlugin) => {
+    const ARN = "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1";
+    const invInfo = {
+      requestId: "req-1",
+      executionArn: ARN,
+      isFirstInvocation: true,
+      executionInput: {},
+      operations: {},
+      updatedOperations: {},
+    } as any;
+    const invEnd = { ...invInfo, status: "SUCCEEDED" } as any;
+
+    /** Samples only spans carrying durable.execution.arn — and drops the rest. */
+    class ArnAttributeSampler implements Sampler {
+      public seen: Attributes[] = [];
+      shouldSample(
+        _ctx: unknown,
+        _traceId: string,
+        _name: string,
+        _kind: unknown,
+        attributes: Attributes,
+      ) {
+        this.seen.push({ ...attributes });
+        return {
+          decision: attributes["durable.execution.arn"]
+            ? SamplingDecision.RECORD_AND_SAMPLED
+            : SamplingDecision.NOT_RECORD,
+        };
+      }
+      toString() {
+        return "ArnAttributeSampler";
+      }
+    }
+
+    /** Samples the first root it sees, then drops everything after. */
+    class FirstOnlySampler implements Sampler {
+      public calls = 0;
+      shouldSample() {
+        this.calls += 1;
+        return {
+          decision:
+            this.calls === 1
+              ? SamplingDecision.RECORD_AND_SAMPLED
+              : SamplingDecision.NOT_RECORD,
+        };
+      }
+      toString() {
+        return "FirstOnlySampler";
+      }
+    }
+
+    async function run(sampler: Sampler) {
+      const exporter = new InMemorySpanExporter();
+      const provider = new NodeTracerProvider({
+        sampler,
+        spanProcessors: [new SimpleSpanProcessor(exporter)],
+      });
+      provider.register();
+      const Plugin = await importPlugin();
+      const plugin = new Plugin({
+        providerSource: ProviderSource.GLOBAL,
+      }) as any;
+
+      await plugin.onInvocationStart(invInfo);
+      const syntheticFlags = plugin.workflowSpan.spanContext().traceFlags;
+      await plugin.onInvocationEnd(invEnd);
+
+      const workflow = exporter
+        .getFinishedSpans()
+        .filter((s) => s.name === "Workflow");
+      await provider.shutdown();
+      return { syntheticFlags, workflow };
+    }
+
+    it("passes the Workflow attributes to an attribute-based sampler at both points", async () => {
+      const sampler = new ArnAttributeSampler();
+      const { syntheticFlags, workflow } = await run(sampler);
+
+      // Every root sampling call saw durable.execution.arn, so the sampler
+      // reached the same answer both times.
+      const rootCalls = sampler.seen.filter(
+        (a) => a["durable.execution.arn"] !== undefined,
+      );
+      expect(rootCalls.length).toBeGreaterThanOrEqual(1);
+      expect(syntheticFlags).toBe(TraceFlags.SAMPLED);
+      expect(workflow).toHaveLength(1);
+
+      // Status is stamped after creation, so it never skews the decision.
+      expect(workflow[0].attributes["durable.execution.status"]).toBe(
+        "SUCCEEDED",
+      );
+    });
+
+    it("does not export a Workflow root a stateful sampler would have dropped for children", async () => {
+      // The cached decision is what counts: if the first call said "drop", the
+      // terminal span is never created, so children and root agree.
+      const sampler = new FirstOnlySampler();
+      sampler.shouldSample(); // burn the one sampled decision before the plugin runs
+
+      const { syntheticFlags, workflow } = await run(sampler);
+
+      expect(syntheticFlags).toBe(TraceFlags.NONE);
+      expect(workflow).toHaveLength(0);
+    });
+  },
+);

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -9,12 +9,20 @@ import type {
   OperationChangeInfo,
 } from "@aws/durable-execution-sdk-js";
 import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
-import type { TracerProvider, Tracer, Span, Link } from "@opentelemetry/api";
+import type {
+  TracerProvider,
+  Tracer,
+  Span,
+  Link,
+  SpanContext,
+  TraceState,
+} from "@opentelemetry/api";
 import {
   context,
   trace,
   SpanKind,
   SpanStatusCode,
+  TraceFlags,
   ROOT_CONTEXT,
 } from "@opentelemetry/api";
 import {
@@ -26,7 +34,12 @@ import {
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
 import type { OtelPluginConfig } from "./otel-plugin-config";
-import { createTracerProvider, ProviderSource } from "./otel-plugin-provider";
+import {
+  createTracerProvider,
+  ProviderSource,
+  resolveWorkflowRoot,
+  WorkflowRoot,
+} from "./otel-plugin-provider";
 import { registerStandaloneInstrumentations } from "./otel-plugin-instrumentations";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
@@ -51,11 +64,15 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   private readonly tracerProvider: TracerProvider;
   private readonly tracer: Tracer;
 
-  // Per-invocation state
+  // Per-invocation state. workflowSpan is NON-RECORDING: it carries the
+  // deterministic identity for parenting/links only. The one recording
+  // Workflow_Span is created and ended at the terminal invocation.
   private workflowSpan: Span | undefined;
   private invocationSpan: Span | undefined;
   private spanMap: Map<string, Span>;
   private executionArn: string;
+  private executionStartTimestamp: Date | undefined;
+  private workflowRoot: WorkflowRoot | undefined;
 
   // Default provider mode
   private readonly providerSource: ProviderSource;
@@ -109,24 +126,24 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       this.idGenerator.setTraceId(derivedId);
     }
 
-    // 4. Derive the workflow span ID from execution ARN
-    const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
+    // 4. Remember the execution start to backdate the Workflow_Span. The
+    // now() fallback is taken HERE; at onInvocationEnd it would land after
+    // the span's own end time.
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
 
-    // 5. Set it as the next span ID so the tracer uses it for the Workflow_Span
-    this.idGenerator.setNextSpanId(workflowSpanId);
-
-    // 6. Create the Workflow_Span with deterministic ID (always as root — no parent)
-    this.workflowSpan = this.tracer.startSpan(
+    // 5. Resolve the Workflow_Span identity: a non-recording context until the
+    // terminal invocation, sampled once (see resolveWorkflowRoot).
+    this.workflowRoot = resolveWorkflowRoot(
+      this.tracer,
+      this.idGenerator.generateTraceId(),
+      deriveWorkflowSpanId(info.executionArn),
       this.workflowSpanName,
-      {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          "durable.execution.arn": info.executionArn,
-        },
-        startTime: info.executionStartTimestamp ?? new Date(),
-      },
-      ROOT_CONTEXT,
+      info.executionArn,
     );
+    this.workflowSpan = this.workflowRoot.span;
 
     // 7. Create Invocation_Span
     if (this.providerSource !== ProviderSource.GLOBAL) {
@@ -228,30 +245,44 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end();
     }
 
-    // 2. Handle Workflow_Span based on terminal status
-    if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-      // Terminal: set status attribute, map to span status, end (causes export).
-      // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-      // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-      // — those are collapsed into FAILED -> ERROR here.
-      if (this.workflowSpan) {
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end();
+    // 2. Terminal invocation ONLY: create and end the one real
+    // Workflow_Span, so a single span ever claims the deterministic
+    // (traceId, spanId). TIMED_OUT/STOPPED arrive as FAILED -> ERROR.
+    if (
+      this.workflowRoot?.sampled &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      this.idGenerator.setNextSpanId(this.workflowSpan!.spanContext().spanId);
+      const workflowSpan = this.tracer.startSpan(
+        this.workflowSpanName,
+        {
+          kind: SpanKind.INTERNAL,
+          attributes: this.workflowRoot.attributes,
+          startTime: this.executionStartTimestamp!,
+        },
+        ROOT_CONTEXT,
+      );
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
+      }
+      workflowSpan.end();
+    }
+
+    // 3. End every span still open — a suspended operation, or an attempt in
+    // flight. Status stays UNSET: no outcome was reached this invocation. A
+    // segment that resumes later is exported under its own unique ID linked
+    // back to this one, so ending here cannot duplicate an identity.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end();
       }
     }
-    // Non-terminal (PENDING/RETRYING): do NOT end workflowSpan — just drop the reference.
-    // Its status stays UNSET and the span is never exported (spans that are never
-    // .end()'d are never exported by the OTel SDK).
-
-    // 3. Discard open Operation_Spans without ending (they won't be exported)
 
     // 4. Always flush TracerProvider at invocation boundaries
     if ("forceFlush" in this.tracerProvider) {
@@ -272,6 +303,8 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.workflowSpan = undefined;
     this.invocationSpan = undefined;
     this.executionArn = "";
+    this.executionStartTimestamp = undefined;
+    this.workflowRoot = undefined;
   }
 
   /**
@@ -280,6 +313,17 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
    * Always links to the plugin-created Invocation_Span (this.invocationSpan),
    * which is created in both default-provider and non-default modes.
    */
+  /** Link context for a deterministic operation span ID in this trace. */
+  private deterministicLinkContext(spanId: string): SpanContext {
+    return {
+      traceId: this.idGenerator.generateTraceId(),
+      spanId,
+      traceFlags:
+        this.workflowSpan?.spanContext().traceFlags ?? TraceFlags.NONE,
+      traceState: this.workflowSpan?.spanContext().traceState,
+    };
+  }
+
   private buildInvocationLinks(): Link[] {
     if (this.invocationSpan) {
       return [{ context: this.invocationSpan.spanContext() }];
@@ -288,6 +332,14 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   }
 
   async onOperationStart(info: OperationInfo): Promise<void> {
+    // Same-invocation replay of an operation we already started (e.g. a step
+    // retried internally). Reuse the existing span rather than overwriting the
+    // map entry, which would orphan the first span un-ended. A genuine
+    // cross-invocation continuation has no span in the map and falls through.
+    if (info.isReplay && this.spanMap.has(info.id)) {
+      return;
+    }
+
     const deterministicSpanId = deriveSpanIdFromOperationId(
       info.id,
       this.executionArn,
@@ -318,10 +370,19 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       attributes["durable.operation.subtype"] = info.subType;
     }
 
-    const links = this.buildInvocationLinks();
+    // Only the first start claims the deterministic ID. A cross-invocation
+    // continuation gets a unique ID plus a link to it, because the earlier
+    // segment was already ended and exported under that ID.
+    const links = info.isReplay
+      ? [
+          { context: this.deterministicLinkContext(deterministicSpanId) },
+          ...this.buildInvocationLinks(),
+        ]
+      : this.buildInvocationLinks();
 
-    // Always use deterministic span ID regardless of replay status
-    this.idGenerator.setNextSpanId(deterministicSpanId);
+    if (!info.isReplay) {
+      this.idGenerator.setNextSpanId(deterministicSpanId);
+    }
     const span = this.tracer.startSpan(
       spanName,
       { attributes, startTime: info.startTimestamp, links },
@@ -419,9 +480,13 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         attributes["durable.attempt.number"] = info.attempt;
       }
 
-      const links = this.buildInvocationLinks();
+      // Completion of an operation started in an earlier invocation: unique ID
+      // plus a link to the deterministic ID that the earlier segment claimed.
+      const links = [
+        { context: this.deterministicLinkContext(deterministicSpanId) },
+        ...this.buildInvocationLinks(),
+      ];
 
-      this.idGenerator.setNextSpanId(deterministicSpanId);
       const span = this.tracer.startSpan(
         spanName,
         { attributes, startTime: info.startTimestamp, links },

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -15,12 +15,14 @@ import type {
   Span,
   SpanContext,
   Link,
+  TraceState,
 } from "@opentelemetry/api";
 import {
   context,
   trace,
   SpanKind,
   SpanStatusCode,
+  TraceFlags,
   ROOT_CONTEXT,
 } from "@opentelemetry/api";
 import { hrTime } from "@opentelemetry/core";
@@ -33,7 +35,11 @@ import {
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
 import type { OtelPluginConfig } from "./otel-plugin-config";
-import { createTracerProvider } from "./otel-plugin-provider";
+import {
+  createTracerProvider,
+  resolveWorkflowRoot,
+  WorkflowRoot,
+} from "./otel-plugin-provider";
 import { registerStandaloneInstrumentations } from "./otel-plugin-instrumentations";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
@@ -57,8 +63,12 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private spanMap: Map<string, Span> = new Map();
   private spanStack: Span[] = [];
   private invocationSpan: Span | undefined;
+  // NON-RECORDING: carries the deterministic identity for links only. The one
+  // recording Workflow span is created and ended at the terminal invocation.
   private workflowSpan: Span | undefined;
   private executionArn: string = "";
+  private executionStartTimestamp: Date | undefined;
+  private workflowRoot: WorkflowRoot | undefined;
 
   constructor(config?: OtelPluginConfig) {
     const instrumentationName =
@@ -112,20 +122,24 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     // once, at the terminal invocation (see onInvocationEnd). Emitting it only in
     // community-collector mode previously left the invocation view without a root
     // Workflow span under ADOT/X-Ray.
-    const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
-    this.idGenerator.setNextSpanId(workflowSpanId);
+    // Remember the execution start to backdate the Workflow span. The now()
+    // fallback is taken HERE; onInvocationEnd captures endTime first, so a
+    // fallback there would sit after it and give a negative duration.
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
 
-    this.workflowSpan = this.tracer.startSpan(
+    // Resolve the Workflow span identity: a non-recording context until the
+    // terminal invocation, sampled once (see resolveWorkflowRoot).
+    this.workflowRoot = resolveWorkflowRoot(
+      this.tracer,
+      this.idGenerator.generateTraceId(),
+      deriveWorkflowSpanId(info.executionArn),
       this.workflowSpanName,
-      {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          "durable.execution.arn": info.executionArn,
-        },
-        startTime: info.executionStartTimestamp ?? new Date(),
-      },
-      ROOT_CONTEXT,
+      info.executionArn,
     );
+    this.workflowSpan = this.workflowRoot.span;
 
     // 5. Create the invocation span, parented to the ACTIVE context. Under
     //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
@@ -172,6 +186,15 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       span.end(endTime);
     }
 
+    // 1b. End any Attempt_Spans still open. They live only in spanMap (not
+    // spanStack), so an in-flight attempt would otherwise be dropped un-ended.
+    // isRecording() skips spans the stack unwind above already ended.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end(endTime);
+      }
+    }
+
     // 2. End the invocation span if it exists
     if (this.invocationSpan) {
       this.invocationSpan.setAttribute(
@@ -198,27 +221,33 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end(endTime);
     }
 
-    // 3. Handle Workflow span based on terminal status. The Workflow span is
-    //    always created (both provider modes); it is finalized only on a
-    //    terminal invocation, and dropped un-exported while non-terminal.
-    if (this.workflowSpan) {
-      if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-        // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-        // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-        // — those are collapsed into FAILED -> ERROR here.
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end(endTime);
+    // 3. Terminal invocation ONLY: create and end the one real
+    // Workflow span, so a single span ever claims the deterministic
+    // (traceId, spanId). TIMED_OUT/STOPPED arrive as FAILED -> ERROR.
+    if (
+      this.workflowRoot?.sampled &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      this.idGenerator.setNextSpanId(this.workflowSpan!.spanContext().spanId);
+      const workflowSpan = this.tracer.startSpan(
+        this.workflowSpanName,
+        {
+          kind: SpanKind.INTERNAL,
+          attributes: this.workflowRoot.attributes,
+          startTime: this.executionStartTimestamp!,
+        },
+        ROOT_CONTEXT,
+      );
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      // Non-terminal (PENDING/RETRYING): do NOT end — status stays UNSET and the
-      // span is dropped without export
+      workflowSpan.end(endTime);
     }
 
     // 4. Force flush the tracer provider
@@ -238,6 +267,8 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.invocationSpan = undefined;
     this.workflowSpan = undefined;
     this.executionArn = "";
+    this.executionStartTimestamp = undefined;
+    this.workflowRoot = undefined;
   }
 
   async onOperationStart(info: OperationInfo): Promise<void> {
@@ -320,7 +351,13 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           // Workflow link (order-significant per the conformance contract).
           links: [
             {
-              context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
+              context: {
+                traceId,
+                spanId: deterministicSpanId,
+                traceFlags:
+                  this.workflowSpan?.spanContext().traceFlags ??
+                  TraceFlags.NONE,
+              },
             },
             ...this.workflowLinks(),
           ],
@@ -462,7 +499,13 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           // Workflow link (order-significant per the conformance contract).
           links: [
             {
-              context: { traceId, spanId: deterministicSpanId, traceFlags: 1 },
+              context: {
+                traceId,
+                spanId: deterministicSpanId,
+                traceFlags:
+                  this.workflowSpan?.spanContext().traceFlags ??
+                  TraceFlags.NONE,
+              },
             },
             ...this.workflowLinks(),
           ],

--- a/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
@@ -1,5 +1,17 @@
-import type { TracerProvider } from "@opentelemetry/api";
-import { propagation, trace } from "@opentelemetry/api";
+import type {
+  TracerProvider,
+  Tracer,
+  Span,
+  Attributes,
+  TraceState,
+} from "@opentelemetry/api";
+import {
+  propagation,
+  trace,
+  ROOT_CONTEXT,
+  SpanKind,
+  TraceFlags,
+} from "@opentelemetry/api";
 import {
   CompositePropagator,
   W3CTraceContextPropagator,
@@ -8,10 +20,12 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { AWSXRayPropagator } from "@opentelemetry/propagator-aws-xray";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import type { Sampler } from "@opentelemetry/sdk-trace-node";
 import {
   AlwaysOnSampler,
   BatchSpanProcessor,
   NodeTracerProvider,
+  SamplingDecision,
   TraceIdRatioBasedSampler,
 } from "@opentelemetry/sdk-trace-node";
 import type { OtelPluginConfig } from "./otel-plugin-config";
@@ -156,4 +170,77 @@ export function createTracerProvider(
   propagation.setGlobalPropagator(new CompositePropagator({ propagators }));
 
   return { tracerProvider, source };
+}
+
+/**
+ * The synthetic, non-recording stand-in for a durable execution's Workflow span,
+ * plus everything needed to create the one real span later.
+ *
+ * The Workflow span covers a whole execution, so only the terminal invocation
+ * can complete it. Until then its identity is carried by a non-recording
+ * context: a real span would have to be either abandoned un-ended (never
+ * exported) or ended every invocation (duplicate `(traceId, spanId)`).
+ *
+ * `attributes` is reused verbatim when the real span is created, so an
+ * attribute-based sampler sees identical inputs at both points. `sampled` is the
+ * decision reached here and is the only one honored, so a stateful sampler
+ * cannot drop the children and then export the root.
+ */
+export interface WorkflowRoot {
+  /** Non-recording span carrying the deterministic identity. */
+  span: Span;
+  /** Sampler inputs, reused when the real span is created. */
+  attributes: Attributes;
+  /** The provider's decision for this root. */
+  sampled: boolean;
+}
+
+/**
+ * Resolves the Workflow root identity and its sampling decision.
+ *
+ * The sampler is consulted through the SDK Tracer's internal `_sampler` (as this
+ * package already does for `_idGenerator`); if it is unavailable — a no-op or
+ * non-SDK Tracer — we fall back to sampled rather than dropping everything.
+ */
+export function resolveWorkflowRoot(
+  tracer: Tracer,
+  traceId: string,
+  spanId: string,
+  spanName: string,
+  executionArn: string,
+): WorkflowRoot {
+  const attributes: Attributes = { "durable.execution.arn": executionArn };
+  const sampler = (tracer as unknown as { _sampler?: Sampler })._sampler;
+
+  let sampled = true;
+  let traceState: TraceState | undefined;
+  if (sampler?.shouldSample) {
+    try {
+      // ROOT_CONTEXT: the Workflow span is parentless, so a ParentBased sampler
+      // correctly delegates to its root delegate.
+      const result = sampler.shouldSample(
+        ROOT_CONTEXT,
+        traceId,
+        spanName,
+        SpanKind.INTERNAL,
+        attributes,
+        [],
+      );
+      sampled = result.decision === SamplingDecision.RECORD_AND_SAMPLED;
+      traceState = result.traceState;
+    } catch {
+      sampled = true;
+    }
+  }
+
+  return {
+    span: trace.wrapSpanContext({
+      traceId,
+      spanId,
+      traceFlags: sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+      traceState,
+    }),
+    attributes,
+    sampled,
+  };
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/831

*Description of changes:*
Ends every recording span created by ExecutionOtelPlugin and InvocationOtelPlugin exactly once, including on PENDING/RETRYING (non-terminal) invocations.

Previously, the Workflow span (both plugins) and any open Operation/Attempt spans (suspended WAIT/CALLBACK, in-flight STEP attempts) were dropped without calling .end() when an invocation suspended rather than terminating. Spans that are never ended are never delivered to span processors/exporters, which breaks strict OTel compliance and can leak un-ended recording spans across warm Lambda invocations.

Fix: always end the Workflow span and any still-open Operation/Attempt spans in onInvocationEnd, regardless of terminal
status, using the same status-mapping already used for the Invocation span (PENDING -> OK, RETRYING -> UNSET). Cross-invocation correlation is unaffected since spans keep their deterministic IDs.

Tests updated to assert spans are ended/exported on PENDING/RETRYING instead of asserting they're dropped; added coverage for in-flight attempt spans left open by a suspending invocation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
