### PR TITLE
docs: add conformance status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # AWS Durable Execution SDKs for JavaScript
 
 [![Build](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/build.yml/badge.svg)](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/build.yml)
+[![Core Conformance](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/conformance-tests.yml/badge.svg)](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/conformance-tests.yml)
+[![OpenTelemetry Conformance](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/opentelemetry-conformance-tests.yml/badge.svg)](https://github.com/aws/aws-durable-execution-sdk-js/actions/workflows/opentelemetry-conformance-tests.yml)
 [![NPM Version](https://img.shields.io/npm/v/@aws/durable-execution-sdk-js)](https://www.npmjs.com/package/@aws/durable-execution-sdk-js)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/aws/aws-durable-execution-sdk-js/badge)](https://scorecard.dev/viewer/?uri=github.com/aws/aws-durable-execution-sdk-js)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Depends on #836.

### Issue Link, if available

#836

### Description

Adds README status badges for the core and OpenTelemetry conformance test workflows. The OpenTelemetry badge targets `.github/workflows/opentelemetry-conformance-tests.yml`, which is introduced by #836 and will begin reporting status after that PR merges.

### Demo/Screenshots

Not applicable. The change adds status badges to the README header.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Not applicable for a documentation-only change.

#### Integration Tests

Not applicable for a documentation-only change.

#### Examples

Not applicable.

Validated with `git diff --check`, confirmed the core workflow is active on `main`, and confirmed the OpenTelemetry workflow path exists in #836.