### PR TITLE
ci: run conformance tests on pushes to main

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -7,6 +7,8 @@ name: Conformance Tests
 # job, so adding a suite only requires shipping its template + handlers.
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
Adds a `push` trigger for the `main` branch to the Conformance Tests workflow. The full-integration conformance run (build handlers -> deploy/invoke/validate one SAM stack per suite) will now also execute after commits land on `main`, not only on pull requests.

## Change
Under `on:`, a `push: { branches: [main] }` trigger is added immediately before the existing `pull_request` trigger:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
    paths:
      ...
```

## Notes
- The existing `pull_request` trigger and its `paths` filters are unchanged — PR runs still fire only when the SDK, conformance-tests package, or this workflow file changes.
- The new `push` trigger intentionally has no path filter, so every commit merged to `main` runs the conformance suite as a post-merge safety net.
- `workflow_dispatch` and all job definitions are untouched.

Validated locally: YAML parses cleanly and `on` resolves to `push`, `pull_request`, and `workflow_dispatch`.