### PR TITLE
test(examples): keep invocation X-Ray e2e local

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.ts
@@ -104,7 +104,7 @@ export const config: ExampleConfig = {
     ExecutionTimeout: 120,
     RetentionPeriodInDays: 7,
   },
-  excludeRuntimes: ["24.x"],
+  localOnly: true,
 };
 
 export const handler = withDurableExecution(


### PR DESCRIPTION
## Summary
- exclude the community collector Invocation/X-Ray example from cloud integration deployment and tests
- retain its local Jest coverage
- rely on OTel conformance tests for cloud trace-topology validation

## Testing
- generated the examples catalog and verified the example is filtered from the Node 22 integration selection
- `jest --config packages/aws-durable-execution-sdk-js-examples/jest.config.js packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-invocation-xray-e2e/otel-community-collector-invocation-xray-e2e.test.ts --runInBand`
- Prettier check on the changed file