### PR TITLE
test(examples): keep execution X-Ray e2e local

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.ts
@@ -104,7 +104,7 @@ export const config: ExampleConfig = {
     ExecutionTimeout: 120,
     RetentionPeriodInDays: 7,
   },
-  excludeRuntimes: ["24.x"],
+  localOnly: true,
 };
 
 export const handler = withDurableExecution(


### PR DESCRIPTION
## Summary
- exclude the community collector Execution/X-Ray example from cloud integration deployment and tests
- retain its local Jest span-topology coverage
- rely on the OTel conformance Execution suite for deployed backend validation

The Invocation counterpart was handled by #848. Conformance covers both plugin views across success, wait/resume, retry, and child-context scenarios, with X-Ray and community collector backends.

## Testing
- generated the examples catalog and verified both community collector X-Ray examples are filtered from Node 22 and Node 24 integration selection
- `jest --config packages/aws-durable-execution-sdk-js-examples/jest.config.js packages/aws-durable-execution-sdk-js-examples/src/examples/otel/community-collector-execution-xray-e2e/otel-community-collector-execution-xray-e2e.test.ts --runInBand`
- Prettier check on both example configuration files