### PR TITLE
fix(otel): end spans on non-terminal invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **otel**: the OTel plugins no longer leave recording spans un-ended on non-terminal
+  (`PENDING`/`RETRYING`) invocations, and no longer export two spans sharing one
+  `(traceId, spanId)`. The Workflow span identity is now carried as a non-recording span
+  context while the execution is in flight, and the single recording Workflow span is created
+  and ended once, at the terminal invocation, backdated to the execution start. In-flight
+  attempt spans and suspended operation spans are ended at invocation cleanup; a later
+  invocation that resumes an operation exports it under its own ID rather than reusing the
+  deterministic one. The non-recording context carries the provider's own sampling decision,
+  so operations are sampled consistently with the eventual root and `enrichLogContext()` no
+  longer reports `otelTraceSampled: true` for dropped traces. Fixes
+  [#831](https://github.com/aws/aws-durable-execution-sdk-js/issues/831).
+
 - `waitForCondition` no longer discards checkpointed state when a custom serdes fails to
   deserialize it on a resumed invocation. Previously the restore path caught the
   deserialization error and silently fell back to `initialState`, so the condition loop

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -250,12 +250,14 @@ to the execution ARN alone. It never substitutes the current time in the hash.
 The Workflow span itself uses the durable execution start timestamp when
 available and the current time otherwise.
 
-The plugins create the same Workflow span identity on each invocation, but end
-and export it only when the execution reaches `SUCCEEDED` or `FAILED`.
-Workflow spans created for `PENDING` or `RETRYING` invocations are left unended
-and are therefore not exported. This produces one exported Workflow root for
-the durable execution while allowing intermediate invocation spans to export
-normally.
+The plugins carry the same Workflow span identity on each invocation as a
+non-recording span context, and create the single recording Workflow span only
+when the execution reaches `SUCCEEDED` or `FAILED`, backdated to the execution
+start. `PENDING` and `RETRYING` invocations create no recording Workflow span,
+so none is ever left unended, and exactly one Workflow root is exported for the
+durable execution while intermediate invocation spans export normally. The
+non-recording context carries the provider's own sampling decision, so
+operations under it are sampled consistently with the eventual root.
 
 Each durable execution has its own Workflow trace. Parent and target executions
 in a chained invoke therefore remain separate roots even when their Invocation

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/otel-plugin-provider-resolution.test.ts
@@ -1,12 +1,20 @@
-import { context, propagation, trace } from "@opentelemetry/api";
+import { context, propagation, trace, ROOT_CONTEXT } from "@opentelemetry/api";
+import { TraceFlags } from "@opentelemetry/api";
 import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
   InMemorySpanExporter,
   NodeTracerProvider,
+  ParentBasedSampler,
   SimpleSpanProcessor,
+  TraceIdRatioBasedSampler,
 } from "@opentelemetry/sdk-trace-node";
-import type { IdGenerator } from "@opentelemetry/sdk-trace-node";
+import type { IdGenerator, Sampler } from "@opentelemetry/sdk-trace-node";
 import { DeterministicIdGenerator } from "../deterministic-id-generator";
-import { createTracerProvider } from "../otel-plugin-provider";
+import {
+  createTracerProvider,
+  resolveWorkflowRoot,
+} from "../otel-plugin-provider";
 
 beforeEach(() => {
   trace.disable();
@@ -176,5 +184,95 @@ describe("ExecutionOtelPlugin provider resolution", () => {
     );
 
     await globalProvider.shutdown();
+  });
+});
+
+describe("resolveWorkflowRoot", () => {
+  const TRACE_ID = "9c1c1a2b3d4e5f60718293a4b5c6d7e8";
+  const SPAN_ID = "b1b2b3b4b5b6b7b8";
+  const ARN = "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1";
+
+  function tracerFor(sampler: Sampler) {
+    const provider = new NodeTracerProvider({
+      sampler,
+      spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+    });
+    return { provider, tracer: provider.getTracer("t") };
+  }
+
+  it.each([
+    ["AlwaysOn", () => new AlwaysOnSampler(), TraceFlags.SAMPLED],
+    ["AlwaysOff", () => new AlwaysOffSampler(), TraceFlags.NONE],
+    ["ratio 1.0", () => new TraceIdRatioBasedSampler(1), TraceFlags.SAMPLED],
+    ["ratio 0.0", () => new TraceIdRatioBasedSampler(0), TraceFlags.NONE],
+    [
+      "ParentBased(AlwaysOff) — parentless root",
+      () => new ParentBasedSampler({ root: new AlwaysOffSampler() }),
+      TraceFlags.NONE,
+    ],
+  ])("carries the sampler's root decision for %s", (_n, make, expected) => {
+    const { provider, tracer } = tracerFor(make());
+    const root = resolveWorkflowRoot(
+      tracer,
+      TRACE_ID,
+      SPAN_ID,
+      "Workflow",
+      ARN,
+    );
+    expect(root.span.spanContext().traceFlags).toBe(expected);
+    expect(root.sampled).toBe(expected === TraceFlags.SAMPLED);
+    expect(root.attributes).toEqual({ "durable.execution.arn": ARN });
+    void provider.shutdown();
+  });
+
+  // The whole point: reproduce what a real root startSpan would have decided.
+  // If the SDK ever renames the internal `_sampler`, the fallback engages and
+  // this equivalence breaks — which is exactly what we want to be told about.
+  it.each([
+    ["AlwaysOn", () => new AlwaysOnSampler()],
+    ["AlwaysOff", () => new AlwaysOffSampler()],
+    ["ratio 0.01", () => new TraceIdRatioBasedSampler(0.01)],
+    [
+      "ParentBased(ratio 0.5)",
+      () => new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(0.5) }),
+    ],
+  ])("matches the flags a real root span gets from %s", (_n, make) => {
+    for (const traceId of [
+      TRACE_ID,
+      "1111111111111111aaaaaaaaaaaaaaaa",
+      "ffffffffffffffff0000000000000000",
+    ]) {
+      const { provider, tracer } = tracerFor(make());
+      (tracer as unknown as { _idGenerator: unknown })._idGenerator = {
+        generateTraceId: () => traceId,
+        generateSpanId: () => SPAN_ID,
+      };
+      const real = tracer.startSpan("Workflow", {}, ROOT_CONTEXT);
+      const automatic = real.spanContext().traceFlags;
+      real.end();
+
+      const root = resolveWorkflowRoot(
+        tracer,
+        traceId,
+        SPAN_ID,
+        "Workflow",
+        ARN,
+      );
+      expect(root.span.spanContext().traceFlags).toBe(automatic);
+      void provider.shutdown();
+    }
+  });
+
+  it("falls back to sampled when the tracer exposes no sampler", () => {
+    const noopTracer = trace.getTracer("noop"); // no-op API tracer
+    const root = resolveWorkflowRoot(
+      noopTracer,
+      TRACE_ID,
+      SPAN_ID,
+      "Workflow",
+      ARN,
+    );
+    expect(root.span.spanContext().traceFlags).toBe(TraceFlags.SAMPLED);
+    expect(root.sampled).toBe(true);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle-831.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle-831.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Regression coverage for issue #831: every recording span must be ended
+ * exactly once, including on non-terminal (PENDING/RETRYING) invocations, and
+ * no two exported spans may share a `(traceId, spanId)`.
+ *
+ * These run against BOTH plugins through the globally-registered provider,
+ * matching the integration-test harness.
+ */
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  ParentBasedSampler,
+  SamplingDecision,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import type { ReadableSpan, Sampler } from "@opentelemetry/sdk-trace-node";
+import { context, propagation, trace, TraceFlags } from "@opentelemetry/api";
+import type { Attributes, Span } from "@opentelemetry/api";
+import type {
+  InvocationInfo,
+  InvocationEndInfo,
+  OperationInfo,
+  OperationEndInfo,
+  AttemptInfo,
+} from "@aws/durable-execution-sdk-js";
+import { ExecutionOtelPlugin } from "../execution-plugin";
+import { InvocationOtelPlugin } from "../invocation-plugin";
+
+const ARN = "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1";
+
+function makeInvocationInfo(o?: Partial<InvocationInfo>): InvocationInfo {
+  return {
+    requestId: "req-1",
+    executionArn: ARN,
+    isFirstInvocation: true,
+    executionInput: {},
+    operations: {},
+    updatedOperations: {},
+    ...o,
+  };
+}
+
+function makeInvocationEndInfo(
+  o?: Partial<InvocationEndInfo>,
+): InvocationEndInfo {
+  return {
+    requestId: "req-1",
+    executionArn: ARN,
+    executionInput: {},
+    operations: {},
+    status: "SUCCEEDED" as any,
+    ...o,
+  };
+}
+
+function makeOperationInfo(o?: Partial<OperationInfo>): OperationInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, ...o };
+}
+
+function makeOperationEndInfo(o?: Partial<OperationEndInfo>): OperationEndInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, ...o };
+}
+
+function makeAttemptInfo(o?: Partial<AttemptInfo>): AttemptInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, attempt: 1, ...o };
+}
+
+/** Exported identities appearing more than once, as `traceId:spanId`. */
+function duplicateIdentities(exporter: InMemorySpanExporter): string[] {
+  const counts = new Map<string, number>();
+  for (const s of exporter.getFinishedSpans()) {
+    const k = `${s.spanContext().traceId}:${s.spanContext().spanId}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
+}
+
+function named(exporter: InMemorySpanExporter, name: string): ReadableSpan[] {
+  return exporter.getFinishedSpans().filter((s) => s.name === name);
+}
+
+const PLUGINS = [
+  ["ExecutionOtelPlugin", () => new ExecutionOtelPlugin({})],
+  ["InvocationOtelPlugin", () => new InvocationOtelPlugin({})],
+] as const;
+
+describe.each(PLUGINS)("%s span lifecycle (#831)", (_name, makePlugin) => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  function register(sampler?: Sampler) {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      ...(sampler ? { sampler } : {}),
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  }
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it.each(["PENDING", "RETRYING"])(
+    "leaves no recording Workflow span on non-terminal status %s",
+    async (status) => {
+      register();
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const workflowRef = plugin.workflowSpan as Span;
+      expect(workflowRef.isRecording()).toBe(false); // non-recording identity
+
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: status as any }),
+      );
+
+      expect(workflowRef.isRecording()).toBe(false);
+      expect(named(exporter, "Workflow")).toHaveLength(0);
+    },
+  );
+
+  it("exports exactly one Workflow span across a suspend/resume pair", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    // Invocation 1 suspends.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    // Invocation 2 (same ARN) completes.
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    const workflow = named(exporter, "Workflow");
+    expect(workflow).toHaveLength(1);
+    expect(workflow[0].attributes["durable.execution.status"]).toBe(
+      "SUCCEEDED",
+    );
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+
+  it("ends an in-flight attempt span left open by a non-terminal invocation", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(makeOperationInfo({ name: "retry-step" }));
+    await plugin.onOperationAttemptStart(
+      makeAttemptInfo({ name: "retry-step", attempt: 1 }),
+    );
+
+    // Retain the attempt span reference before spanMap is cleared.
+    const spanMap = plugin.spanMap as Map<string, Span>;
+    const attemptRef = [...spanMap.entries()].find(([k]) =>
+      k.includes("attempt"),
+    )?.[1];
+    expect(attemptRef?.isRecording()).toBe(true);
+
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    expect(attemptRef?.isRecording()).toBe(false);
+    const attempt = named(exporter, "retry-step attempt 1");
+    expect(attempt).toHaveLength(1);
+    // No outcome: the attempt never completed this invocation.
+    expect(attempt[0].attributes["durable.attempt.outcome"]).toBeUndefined();
+  });
+
+  it("gives a suspended WAIT and its later completion distinct identities", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    // Invocation 1: WAIT starts, then the invocation suspends.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({ id: "w1", type: "WAIT" as any, name: "my-wait" }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    // Invocation 2: WAIT resolves (cross-invocation completion).
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "w1",
+        type: "WAIT" as any,
+        name: "my-wait",
+        status: "SUCCEEDED" as any,
+      }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    expect(duplicateIdentities(exporter)).toEqual([]);
+    expect(
+      named(exporter, "my-wait").some(
+        (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps identities unique for a STEP retried across three invocations", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    for (let i = 1; i <= 3; i++) {
+      const base = {
+        id: "s1",
+        type: "STEP" as any,
+        name: "retry-step",
+        isReplay: i > 1,
+      };
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ isFirstInvocation: i === 1 }),
+      );
+      await plugin.onOperationStart(makeOperationInfo(base));
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({ ...base, attempt: i }),
+      );
+      await plugin.onOperationAttemptEnd({
+        ...base,
+        attempt: i,
+        outcome: (i === 3 ? "SUCCEEDED" : "FAILED") as any,
+      });
+      if (i === 3) {
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            ...base,
+            isReplay: false,
+            status: "SUCCEEDED" as any,
+            attempt: 3,
+          }),
+        );
+      }
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: (i === 3 ? "SUCCEEDED" : "RETRYING") as any,
+        }),
+      );
+    }
+
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+
+  it("keeps a non-negative Workflow duration when executionStartTimestamp is omitted", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ executionStartTimestamp: undefined }),
+    );
+    // A real gap so a late fallback would be measurable (Date is ms-truncated).
+    await new Promise((r) => setTimeout(r, 15));
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({
+        status: "SUCCEEDED" as any,
+        executionStartTimestamp: undefined,
+      }),
+    );
+
+    const workflow = named(exporter, "Workflow")[0];
+    const invocation = named(exporter, "Invocation")[0];
+    expect(workflow).toBeDefined();
+    expect(invocation).toBeDefined();
+    // The Workflow span must contain the invocation it covers; a late fallback
+    // would start it after the invocation span began.
+    const cmp = (a: ReadableSpan["startTime"], b: ReadableSpan["startTime"]) =>
+      a[0] - b[0] || a[1] - b[1];
+    expect(cmp(workflow.startTime, invocation.startTime)).toBeLessThanOrEqual(
+      0,
+    );
+    expect(cmp(workflow.endTime, workflow.startTime)).toBeGreaterThanOrEqual(0);
+  });
+
+  describe("sampling", () => {
+    it("marks the Workflow context unsampled and exports nothing under an unsampled provider", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOffSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.NONE,
+      );
+
+      await plugin.onOperationStart(makeOperationInfo());
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      expect(exporter.getFinishedSpans()).toHaveLength(0);
+    });
+
+    it("reports otelTraceSampled false from enrichLogContext under an unsampled provider", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOffSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const enriched = await plugin.wrapInvocation(
+        makeInvocationInfo(),
+        async () => plugin.enrichLogContext(),
+      );
+      expect(enriched?.otelTraceSampled).toBe(false);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("exports the Workflow root under a sampled provider (control)", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOnSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.SAMPLED,
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      expect(named(exporter, "Workflow")).toHaveLength(1);
+    });
+
+    it("passes the Workflow attributes to an attribute-based sampler", async () => {
+      const seen: Attributes[] = [];
+      const sampler: Sampler = {
+        shouldSample: (_c, _t, _n, _k, attributes) => {
+          seen.push({ ...attributes });
+          return {
+            decision: attributes["durable.execution.arn"]
+              ? SamplingDecision.RECORD_AND_SAMPLED
+              : SamplingDecision.NOT_RECORD,
+          };
+        },
+        toString: () => "ArnAttributeSampler",
+      };
+      register(sampler);
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      // Every root sampling call saw durable.execution.arn, so the synthetic
+      // context and the real span reach the same decision.
+      const rootCalls = seen.filter(
+        (a) => a["durable.execution.arn"] !== undefined,
+      );
+      expect(rootCalls.length).toBeGreaterThanOrEqual(1);
+      expect(named(exporter, "Workflow")).toHaveLength(1);
+    });
+
+    it("does not export a Workflow root a stateful sampler dropped for children", async () => {
+      let calls = 0;
+      const sampler: Sampler = {
+        // Samples the first root it sees, drops everything after.
+        shouldSample: () => {
+          calls += 1;
+          return {
+            decision:
+              calls === 1
+                ? SamplingDecision.RECORD_AND_SAMPLED
+                : SamplingDecision.NOT_RECORD,
+          };
+        },
+        toString: () => "FirstOnlySampler",
+      };
+      sampler.shouldSample(null as any, "", "", 0 as any, {}, []); // burn the one sampled decision before the plugin runs
+      register(sampler);
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.NONE,
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      expect(named(exporter, "Workflow")).toHaveLength(0);
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -28,7 +28,11 @@ import {
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
 import type { OtelPluginConfig } from "./otel-plugin-config";
-import { createTracerProvider } from "./otel-plugin-provider";
+import type { WorkflowRoot } from "./otel-plugin-provider";
+import {
+  createTracerProvider,
+  resolveWorkflowRoot,
+} from "./otel-plugin-provider";
 import { tryInstallGlobalIdGenerator } from "./global-id-generator";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
@@ -50,12 +54,16 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   private tracer: Tracer;
   private readonly instrumentationName: string;
 
-  // Per-invocation state
+  // Per-invocation state. workflowSpan is a NON-RECORDING context carrying the
+  // deterministic Workflow identity for parenting/links; the one real span is
+  // created and ended only at the terminal invocation (see onInvocationEnd).
   private workflowSpan: Span | undefined;
+  private workflowRoot: WorkflowRoot | undefined;
   private invocationSpan: Span | undefined;
   private spanMap: Map<string, Span>;
   private executionArn: string;
   private executionTraceId: string;
+  private executionStartTimestamp: Date | undefined;
 
   private readonly usesGlobalProvider: boolean;
   private globalIdGeneratorInstalled: boolean;
@@ -122,29 +130,29 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       info.executionStartTimestamp,
     );
 
-    // 4. Derive the workflow span ID from execution ARN
-    const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
+    // 4. Remember the execution start to backdate the terminal Workflow_Span.
+    // The now() fallback is taken HERE; at onInvocationEnd it would land after
+    // the span's own end time.
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
 
-    // 5. Create the Workflow_Span with deterministic IDs. The override is
-    // scoped to this single startSpan call.
-    this.workflowSpan = this.idGenerator.withIds(
-      {
-        traceId: this.executionTraceId,
-        spanId: workflowSpanId,
-      },
-      () =>
-        this.tracer.startSpan(
-          this.workflowSpanName,
-          {
-            kind: SpanKind.INTERNAL,
-            attributes: {
-              "durable.execution.arn": info.executionArn,
-            },
-            startTime: info.executionStartTimestamp ?? new Date(),
-          },
-          ROOT_CONTEXT,
-        ),
+    // 5. Resolve the Workflow_Span identity as a NON-RECORDING context. A whole
+    // execution spans many invocations, so only the terminal one can complete
+    // the real span; carrying a real recording span across invocations would
+    // leak it un-ended, and ending one per invocation would export duplicate
+    // (traceId, spanId). Sampling is resolved once here (see resolveWorkflowRoot)
+    // and reused for the terminal span.
+    const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
+    this.workflowRoot = resolveWorkflowRoot(
+      this.tracer,
+      this.executionTraceId,
+      workflowSpanId,
+      this.workflowSpanName,
+      info.executionArn,
     );
+    this.workflowSpan = this.workflowRoot.span;
 
     // 6. Create Invocation_Span in the ambient Lambda trace. When no OTel span
     // is active, fall back to the extracted upstream parent, or create a root if
@@ -256,30 +264,52 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end();
     }
 
-    // 2. Handle Workflow_Span based on terminal status
-    if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-      // Terminal: set status attribute, map to span status, end (causes export).
-      // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-      // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-      // — those are collapsed into FAILED -> ERROR here.
-      if (this.workflowSpan) {
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end();
+    // 2. Terminal invocation ONLY: create and end the one real Workflow_Span,
+    // so a single span ever claims the deterministic (traceId, spanId). Skipped
+    // when the cached decision was "drop", so a stateful sampler cannot export a
+    // root whose children were dropped. Attributes match resolveWorkflowRoot.
+    // TIMED_OUT/STOPPED arrive as FAILED -> ERROR.
+    if (
+      this.workflowRoot?.sampled &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      const workflowSpanId = deriveWorkflowSpanId(this.executionArn);
+      const workflowSpan = this.idGenerator.withIds(
+        { traceId: this.executionTraceId, spanId: workflowSpanId },
+        () =>
+          this.tracer.startSpan(
+            this.workflowSpanName,
+            {
+              kind: SpanKind.INTERNAL,
+              attributes: this.workflowRoot!.attributes,
+              startTime: this.executionStartTimestamp!,
+            },
+            ROOT_CONTEXT,
+          ),
+      );
+      // Set status after creation so the sampler saw the same attributes.
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
+      }
+      workflowSpan.end();
+    }
+
+    // 3. End every span still open — a suspended operation, or an attempt in
+    // flight. Status stays UNSET: no terminal outcome was reached this
+    // invocation. A segment that resumes later is exported under its own random
+    // ID (see onOperationStart / onOperationEnd), so ending here cannot
+    // duplicate an identity.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end();
       }
     }
-    // Non-terminal (PENDING/RETRYING): do NOT end workflowSpan — just drop the reference.
-    // Its status stays UNSET and the span is never exported (spans that are never
-    // .end()'d are never exported by the OTel SDK).
-
-    // 3. Discard open Operation_Spans without ending (they won't be exported)
 
     // 4. Always flush TracerProvider at invocation boundaries
     if ("forceFlush" in this.tracerProvider) {
@@ -326,9 +356,11 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   private resetInvocationState(): void {
     this.spanMap.clear();
     this.workflowSpan = undefined;
+    this.workflowRoot = undefined;
     this.invocationSpan = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionStartTimestamp = undefined;
     this.tracingEnabled = false;
   }
 
@@ -347,6 +379,14 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
   async onOperationStart(info: OperationInfo): Promise<void> {
     if (!this.tracingEnabled) {
+      return;
+    }
+
+    // Same-invocation replay of an operation we already started (e.g. a step
+    // retried internally). Reuse the existing span rather than overwriting the
+    // map entry, which would orphan the first span un-ended. A genuine
+    // cross-invocation continuation has no span in the map and falls through.
+    if (info.isReplay && this.spanMap.has(info.id)) {
       return;
     }
 
@@ -382,19 +422,28 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
     const links = this.buildInvocationLinks();
 
-    // Always use a deterministic span ID regardless of replay status.
-    const span = this.idGenerator.withIds(
-      {
-        traceId: this.executionTraceId,
-        spanId: deterministicSpanId,
-      },
-      () =>
-        this.tracer.startSpan(
+    // The first start claims the deterministic ID. A cross-invocation replay
+    // gets a random ID: the earlier segment was ended and exported under the
+    // deterministic ID, so reusing it would emit a duplicate identity.
+    // Correlation is preserved via the shared execution trace and links.
+    const span = info.isReplay
+      ? this.tracer.startSpan(
           spanName,
           { attributes, startTime: info.startTimestamp, links },
           parentContext,
-        ),
-    );
+        )
+      : this.idGenerator.withIds(
+          {
+            traceId: this.executionTraceId,
+            spanId: deterministicSpanId,
+          },
+          () =>
+            this.tracer.startSpan(
+              spanName,
+              { attributes, startTime: info.startTimestamp, links },
+              parentContext,
+            ),
+        );
 
     if (span) {
       this.spanMap.set(info.id, span);
@@ -418,11 +467,6 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     if (!this.tracingEnabled) {
       return;
     }
-
-    const deterministicSpanId = deriveSpanIdFromOperationId(
-      info.id,
-      this.executionArn,
-    );
 
     if (this.spanMap.has(info.id)) {
       // Operation was started in this invocation
@@ -497,17 +541,15 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
       const links = this.buildInvocationLinks();
 
-      const span = this.idGenerator.withIds(
-        {
-          traceId: this.executionTraceId,
-          spanId: deterministicSpanId,
-        },
-        () =>
-          this.tracer.startSpan(
-            spanName,
-            { attributes, startTime: info.startTimestamp, links },
-            parentContext,
-          ),
+      // Completion of an operation started in an earlier invocation. Use a
+      // random ID: the partial segment was already ended and exported under the
+      // deterministic ID at that invocation's cleanup, so reusing it would emit
+      // a duplicate identity. Correlation is preserved via the shared execution
+      // trace and links.
+      const span = this.tracer.startSpan(
+        spanName,
+        { attributes, startTime: info.startTimestamp, links },
+        parentContext,
       );
 
       if (info.error) {

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -35,7 +35,11 @@ import {
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
 import type { OtelPluginConfig } from "./otel-plugin-config";
-import { createTracerProvider } from "./otel-plugin-provider";
+import type { WorkflowRoot } from "./otel-plugin-provider";
+import {
+  createTracerProvider,
+  resolveWorkflowRoot,
+} from "./otel-plugin-provider";
 import { tryInstallGlobalIdGenerator } from "./global-id-generator";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
@@ -63,9 +67,14 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private spanMap: Map<string, Span> = new Map();
   private spanStack: Span[] = [];
   private invocationSpan: Span | undefined;
+  // workflowSpan is a NON-RECORDING context carrying the deterministic Workflow
+  // identity for links; the one real span is created and ended only at the
+  // terminal invocation (see onInvocationEnd).
   private workflowSpan: Span | undefined;
+  private workflowRoot: WorkflowRoot | undefined;
   private executionArn: string = "";
   private executionTraceId: string = "";
+  private executionStartTimestamp: Date | undefined;
 
   constructor(config?: OtelPluginConfig) {
     const instrumentationName =
@@ -116,36 +125,34 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       info.executionStartTimestamp,
     );
 
-    // 4. Create the Workflow root span.
+    // 3b. Remember the execution start to backdate the terminal Workflow span.
+    // The now() fallback is taken HERE; at onInvocationEnd it would land after
+    // the span's own end time.
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
+
+    // 4. Resolve the Workflow span identity as a NON-RECORDING context.
     //
-    // The Workflow span is the parentless root of the execution-scoped trace and
-    // is emitted in BOTH provider modes (default/ADOT and owned/community
-    // collector), matching ExecutionOtelPlugin and the Python/Java reference
-    // plugins. It is keyed to a deterministic span ID derived from the execution
-    // ARN so every invocation of the same durable execution shares one root, and
-    // it is finalized (stamped with a terminal execution status and ended) only
-    // once, at the terminal invocation (see onInvocationEnd). Emitting it only in
-    // community-collector mode previously left the invocation view without a root
-    // Workflow span under ADOT/X-Ray.
+    // The Workflow span is the parentless root of the execution-scoped trace,
+    // spanning many invocations, so only the terminal one can complete it.
+    // Carrying a real recording span across invocations would leak it un-ended
+    // (issue #831); ending one per invocation would export duplicate
+    // (traceId, spanId). Its identity is keyed to a deterministic span ID so
+    // every invocation shares one root, and operation/attempt spans link to it
+    // (see workflowLinks). The single real span is created and ended once, at
+    // the terminal invocation (see onInvocationEnd). Sampling is resolved once
+    // here (see resolveWorkflowRoot) and reused for the terminal span.
     const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
-    this.workflowSpan = this.idGenerator.withIds(
-      {
-        traceId: this.executionTraceId,
-        spanId: workflowSpanId,
-      },
-      () =>
-        this.tracer.startSpan(
-          this.workflowSpanName,
-          {
-            kind: SpanKind.INTERNAL,
-            attributes: {
-              "durable.execution.arn": info.executionArn,
-            },
-            startTime: info.executionStartTimestamp ?? new Date(),
-          },
-          ROOT_CONTEXT,
-        ),
+    this.workflowRoot = resolveWorkflowRoot(
+      this.tracer,
+      this.executionTraceId,
+      workflowSpanId,
+      this.workflowSpanName,
+      info.executionArn,
     );
+    this.workflowSpan = this.workflowRoot.span;
 
     // 5. Create the invocation span in the ambient Lambda trace. Under
     //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
@@ -219,6 +226,15 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       span.end(endTime);
     }
 
+    // 1b. End any span still open. Attempt spans live only in spanMap (not the
+    // stack), so an attempt in flight when the invocation ends would otherwise
+    // leak un-ended. isRecording() skips spans already ended by the unwind.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end(endTime);
+      }
+    }
+
     // 2. End the invocation span if it exists
     if (this.invocationSpan) {
       this.invocationSpan.setAttribute(
@@ -245,27 +261,40 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end(endTime);
     }
 
-    // 3. Handle Workflow span based on terminal status. The Workflow span is
-    //    always created (both provider modes); it is finalized only on a
-    //    terminal invocation, and dropped un-exported while non-terminal.
-    if (this.workflowSpan) {
-      if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-        // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-        // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-        // — those are collapsed into FAILED -> ERROR here.
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end(endTime);
+    // 3. Terminal invocation ONLY: create and end the one real Workflow span,
+    //    so a single span ever claims the deterministic (traceId, spanId).
+    //    Skipped when the cached decision was "drop", so a stateful sampler
+    //    cannot export a root whose children were dropped. Attributes match
+    //    resolveWorkflowRoot. TIMED_OUT/STOPPED arrive as FAILED -> ERROR.
+    if (
+      this.workflowRoot?.sampled &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      const workflowSpanId = deriveWorkflowSpanId(this.executionArn);
+      const workflowSpan = this.idGenerator.withIds(
+        { traceId: this.executionTraceId, spanId: workflowSpanId },
+        () =>
+          this.tracer.startSpan(
+            this.workflowSpanName,
+            {
+              kind: SpanKind.INTERNAL,
+              attributes: this.workflowRoot!.attributes,
+              startTime: this.executionStartTimestamp!,
+            },
+            ROOT_CONTEXT,
+          ),
+      );
+      // Set status after creation so the sampler saw the same attributes.
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      // Non-terminal (PENDING/RETRYING): do NOT end — status stays UNSET and the
-      // span is dropped without export
+      workflowSpan.end(endTime);
     }
 
     // 4. Force flush the tracer provider
@@ -312,8 +341,10 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.spanStack = [];
     this.invocationSpan = undefined;
     this.workflowSpan = undefined;
+    this.workflowRoot = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionStartTimestamp = undefined;
     this.tracingEnabled = false;
   }
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-provider.ts
@@ -1,5 +1,13 @@
-import type { TracerProvider } from "@opentelemetry/api";
-import { trace } from "@opentelemetry/api";
+import type {
+  TracerProvider,
+  Tracer,
+  Span,
+  Attributes,
+  TraceState,
+} from "@opentelemetry/api";
+import { trace, ROOT_CONTEXT, SpanKind, TraceFlags } from "@opentelemetry/api";
+import type { Sampler } from "@opentelemetry/sdk-trace-node";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-node";
 import { DeterministicIdGenerator } from "./deterministic-id-generator";
 import type {
   IdGeneratorFactory,
@@ -42,5 +50,78 @@ export function createTracerProvider(
   return {
     tracerProvider: trace.getTracerProvider(),
     usesGlobalProvider: true,
+  };
+}
+
+/**
+ * The synthetic, non-recording stand-in for a durable execution's Workflow span,
+ * plus everything needed to create the one real span later.
+ *
+ * The Workflow span covers a whole execution, so only the terminal invocation
+ * can complete it. Until then its identity is carried by a non-recording
+ * context: a real span would have to be either abandoned un-ended (never
+ * exported) or ended every invocation (duplicate `(traceId, spanId)`).
+ *
+ * `attributes` is reused verbatim when the real span is created, so an
+ * attribute-based sampler sees identical inputs at both points. `sampled` is the
+ * decision reached here and is the only one honored, so a stateful sampler
+ * cannot drop the children and then export the root.
+ */
+export interface WorkflowRoot {
+  /** Non-recording span carrying the deterministic identity. */
+  span: Span;
+  /** Sampler inputs, reused when the real span is created. */
+  attributes: Attributes;
+  /** The provider's decision for this root. */
+  sampled: boolean;
+}
+
+/**
+ * Resolves the Workflow root identity and its sampling decision.
+ *
+ * The sampler is consulted through the SDK Tracer's internal `_sampler` (as this
+ * package already does for `_idGenerator`); if it is unavailable — a no-op or
+ * non-SDK Tracer — we fall back to sampled rather than dropping everything.
+ */
+export function resolveWorkflowRoot(
+  tracer: Tracer,
+  traceId: string,
+  spanId: string,
+  spanName: string,
+  executionArn: string,
+): WorkflowRoot {
+  const attributes: Attributes = { "durable.execution.arn": executionArn };
+  const sampler = (tracer as unknown as { _sampler?: Sampler })._sampler;
+
+  let sampled = true;
+  let traceState: TraceState | undefined;
+  if (sampler?.shouldSample) {
+    try {
+      // ROOT_CONTEXT: the Workflow span is parentless, so a ParentBased sampler
+      // correctly delegates to its root delegate.
+      const result = sampler.shouldSample(
+        ROOT_CONTEXT,
+        traceId,
+        spanName,
+        SpanKind.INTERNAL,
+        attributes,
+        [],
+      );
+      sampled = result.decision === SamplingDecision.RECORD_AND_SAMPLED;
+      traceState = result.traceState;
+    } catch {
+      sampled = true;
+    }
+  }
+
+  return {
+    span: trace.wrapSpanContext({
+      traceId,
+      spanId,
+      traceFlags: sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+      traceState,
+    }),
+    attributes,
+    sampled,
   };
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-js/issues/831

*Description of changes:*
Both OTel plugins created a recording Workflow span at invocation start and dropped it un-ended on non-terminal (PENDING/RETRYING) invocations. An un-ended span is never delivered to span processors, so it leaked across warm Lambda invocations and was never exported. In-flight attempt spans (and, in ExecutionOtelPlugin, suspended operation spans) were also left un-ended.

Carry the Workflow span identity as a non-recording span context while the execution is in flight, and create the single recording Workflow span once, at the terminal invocation, backdated to the execution start. End in-flight attempt and suspended operation spans at invocation cleanup; a later invocation that resumes an operation exports it under its own ID rather than reusing the deterministic one, so no two exported spans share a (traceId, spanId). Resolve the non-recording context's sampling decision from the provider's own sampler (resolveWorkflowRoot) so operations are sampled consistently with the eventual root and enrichLogContext() reports the true sampling flag.

Also fixes a latent bug in ExecutionOtelPlugin where onOperationStart firing twice for one operation (internal retry) overwrote the span map and orphaned the first span.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
