### PR TITLE
feat(otel): add context extractor types and root-id helpers

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/context-extractors.test.ts
@@ -2,6 +2,9 @@ import type { InvocationInfo } from "@aws/durable-execution-sdk-js";
 import {
   xRayContextExtractor,
   w3cClientContextExtractor,
+  resolveSampling,
+  hasCompleteRemoteParent,
+  hasValidTraceId,
 } from "../context-extractors";
 
 const baseInfo: InvocationInfo = {
@@ -39,6 +42,7 @@ describe("xRayContextExtractor", () => {
     expect(result).toEqual({
       traceId: "5759e988bd862e3fe1be46a994272793",
       parentSpanId: "53995c3f42cd8ad8",
+      sampling: "SAMPLED",
     });
   });
 
@@ -50,6 +54,49 @@ describe("xRayContextExtractor", () => {
     expect(result).toEqual({
       traceId: "5759e988bd862e3fe1be46a994272793",
       parentSpanId: undefined,
+      sampling: "SAMPLED",
+    });
+  });
+
+  it("maps Sampled=0 to NOT_SAMPLED", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=0";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result?.sampling).toBe("NOT_SAMPLED");
+  });
+
+  it("maps a missing Sampled field to UNDECIDED", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result?.sampling).toBe("UNDECIDED");
+  });
+
+  it("maps an unusable Sampled value to UNDECIDED", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=?";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result?.sampling).toBe("UNDECIDED");
+  });
+
+  it("returns undefined for an all-zero Root (well-formed but invalid)", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-00000000-000000000000000000000000;Parent=53995c3f42cd8ad8;Sampled=1";
+    expect(xRayContextExtractor(baseInfo)).toBeUndefined();
+  });
+
+  it("treats an all-zero Parent as absent, keeping the valid Root", () => {
+    process.env._X_AMZN_TRACE_ID =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=0000000000000000;Sampled=1";
+
+    const result = xRayContextExtractor(baseInfo);
+    expect(result).toEqual({
+      traceId: "5759e988bd862e3fe1be46a994272793",
+      parentSpanId: undefined,
+      sampling: "SAMPLED",
     });
   });
 
@@ -82,6 +129,7 @@ describe("xRayContextExtractor", () => {
     expect(result).toEqual({
       traceId: "5759e988bd862e3fe1be46a994272793",
       parentSpanId: "53995c3f42cd8ad8",
+      sampling: "SAMPLED",
     });
   });
 
@@ -93,6 +141,7 @@ describe("xRayContextExtractor", () => {
     expect(result).toEqual({
       traceId: "5759e988bd862e3fe1be46a994272793",
       parentSpanId: undefined,
+      sampling: "SAMPLED",
     });
   });
 });
@@ -141,6 +190,7 @@ describe("w3cClientContextExtractor", () => {
       traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
       parentSpanId: "00f067aa0ba902b7",
       traceFlags: 1,
+      sampling: "SAMPLED",
     });
   });
 
@@ -159,6 +209,7 @@ describe("w3cClientContextExtractor", () => {
 
     const result = w3cClientContextExtractor(info);
     expect(result?.traceFlags).toBe(0);
+    expect(result?.sampling).toBe("NOT_SAMPLED");
   });
 
   it("returns undefined for traceparent with wrong number of parts", () => {
@@ -236,5 +287,171 @@ describe("w3cClientContextExtractor", () => {
     } as unknown as InvocationInfo;
 
     expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for traceparent with malformed flags (not 2 hex chars)", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-zz",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for an all-zero traceId (well-formed but invalid)", () => {
+    // An all-zero trace ID is 32 hex chars but invalid per the W3C spec. It must
+    // be rejected so its sampled bit is not treated as authoritative when the
+    // resolver falls back to the ARN-derived trace.
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+
+  it("returns undefined for an all-zero parentId (well-formed but invalid)", () => {
+    const info = {
+      ...baseInfo,
+      context: {
+        clientContext: {
+          custom: {
+            traceparent:
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+          },
+        },
+      },
+    } as unknown as InvocationInfo;
+
+    expect(w3cClientContextExtractor(info)).toBeUndefined();
+  });
+});
+
+const VALID_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const VALID_SPAN_ID = "00f067aa0ba902b7";
+const ALL_ZERO_TRACE_ID = "0".repeat(32);
+const ALL_ZERO_SPAN_ID = "0".repeat(16);
+
+describe("resolveSampling", () => {
+  it("prefers an explicit SAMPLED value over traceFlags", () => {
+    expect(resolveSampling({ sampling: "SAMPLED", traceFlags: 0 })).toBe(
+      "SAMPLED",
+    );
+  });
+
+  it("prefers an explicit NOT_SAMPLED value over traceFlags", () => {
+    expect(resolveSampling({ sampling: "NOT_SAMPLED", traceFlags: 1 })).toBe(
+      "NOT_SAMPLED",
+    );
+  });
+
+  it("returns an explicit UNDECIDED value as-is", () => {
+    expect(resolveSampling({ sampling: "UNDECIDED", traceFlags: 1 })).toBe(
+      "UNDECIDED",
+    );
+  });
+
+  it("derives SAMPLED from the traceFlags sampled bit when sampling is absent", () => {
+    expect(resolveSampling({ traceFlags: 1 })).toBe("SAMPLED");
+  });
+
+  it("derives NOT_SAMPLED from a clear traceFlags sampled bit", () => {
+    expect(resolveSampling({ traceFlags: 0 })).toBe("NOT_SAMPLED");
+  });
+
+  it("reads only the low sampled bit of traceFlags", () => {
+    // 0b10 has the sampled (low) bit clear.
+    expect(resolveSampling({ traceFlags: 2 })).toBe("NOT_SAMPLED");
+    // 0b11 has the sampled (low) bit set.
+    expect(resolveSampling({ traceFlags: 3 })).toBe("SAMPLED");
+  });
+
+  it("returns UNDECIDED when neither sampling nor traceFlags is provided", () => {
+    expect(resolveSampling({})).toBe("UNDECIDED");
+  });
+});
+
+describe("hasCompleteRemoteParent", () => {
+  it("is true for a context with valid trace and parent IDs", () => {
+    expect(
+      hasCompleteRemoteParent({
+        traceId: VALID_TRACE_ID,
+        parentSpanId: VALID_SPAN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the context is undefined", () => {
+    expect(hasCompleteRemoteParent(undefined)).toBe(false);
+  });
+
+  it("is false when the parent span ID is missing", () => {
+    expect(
+      hasCompleteRemoteParent({
+        traceId: VALID_TRACE_ID,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for an all-zero (invalid) trace ID", () => {
+    expect(
+      hasCompleteRemoteParent({
+        traceId: ALL_ZERO_TRACE_ID,
+        parentSpanId: VALID_SPAN_ID,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for an all-zero (invalid) parent span ID", () => {
+    expect(
+      hasCompleteRemoteParent({
+        traceId: VALID_TRACE_ID,
+        parentSpanId: ALL_ZERO_SPAN_ID,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("hasValidTraceId", () => {
+  it("is true for a context with a valid trace ID", () => {
+    expect(
+      hasValidTraceId({
+        traceId: VALID_TRACE_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not require a parent span ID", () => {
+    expect(
+      hasValidTraceId({
+        traceId: VALID_TRACE_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the context is undefined", () => {
+    expect(hasValidTraceId(undefined)).toBe(false);
+  });
+
+  it("is false for an all-zero (invalid) trace ID", () => {
+    expect(
+      hasValidTraceId({
+        traceId: ALL_ZERO_TRACE_ID,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/deterministic-id-generator.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/deterministic-id-generator.test.ts
@@ -4,6 +4,7 @@ import {
   deriveTraceIdFromArn,
   deriveSpanIdFromOperationId,
   deriveWorkflowSpanId,
+  deriveExecutionRootSpanId,
 } from "../deterministic-id-generator";
 import * as fc from "fast-check";
 
@@ -375,5 +376,44 @@ describe("deriveWorkflowSpanId", () => {
     const workflowSpanId = deriveWorkflowSpanId(TEST_ARN);
     const opSpanId = deriveSpanIdFromOperationId(TEST_ARN, TEST_ARN);
     expect(workflowSpanId).not.toBe(opSpanId);
+  });
+});
+
+describe("deriveExecutionRootSpanId", () => {
+  const TEST_ARN =
+    "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123";
+
+  it("produces a 16-char lowercase hex string", () => {
+    expect(deriveExecutionRootSpanId(TEST_ARN)).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is deterministic (same input always produces same output)", () => {
+    expect(deriveExecutionRootSpanId(TEST_ARN)).toBe(
+      deriveExecutionRootSpanId(TEST_ARN),
+    );
+  });
+
+  it("produces different results for different ARNs", () => {
+    expect(deriveExecutionRootSpanId(`${TEST_ARN}-a`)).not.toBe(
+      deriveExecutionRootSpanId(`${TEST_ARN}-b`),
+    );
+  });
+
+  it("throws an Error for an empty string", () => {
+    expect(() => deriveExecutionRootSpanId("")).toThrow(
+      "Execution ARN must be non-empty",
+    );
+  });
+
+  it("never returns all-zeros", () => {
+    expect(deriveExecutionRootSpanId(TEST_ARN)).not.toBe("0000000000000000");
+  });
+
+  it("uses a distinct namespace from the Workflow and operation span IDs", () => {
+    // The "execution-root:" salt must not collide with "workflow:" or the
+    // operation span ID for the same ARN, since all three share the trace.
+    const rootId = deriveExecutionRootSpanId(TEST_ARN);
+    expect(rootId).not.toBe(deriveWorkflowSpanId(TEST_ARN));
+    expect(rootId).not.toBe(deriveSpanIdFromOperationId(TEST_ARN, TEST_ARN));
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
@@ -1,15 +1,115 @@
 import type { InvocationInfo } from "@aws/durable-execution-sdk-js";
 
 /**
+ * The upstream sampling decision carried by a propagated context.
+ *
+ * Tri-state so that "no usable decision" is distinct from an explicit
+ * "do not sample". Extractors use `SAMPLED` / `NOT_SAMPLED` only for explicit
+ * upstream values (for example X-Ray `Sampled=1` / `Sampled=0`, or a W3C
+ * `traceparent` sampled bit); anything absent or unusable is `UNDECIDED`, which
+ * lets the configured sampler decide.
+ */
+export type Sampling = "SAMPLED" | "NOT_SAMPLED" | "UNDECIDED";
+
+/**
  * Result type returned by context extractors.
+ *
+ * `sampling` is the tri-state upstream decision. `traceFlags` is retained for
+ * backward compatibility with custom extractors: when `sampling` is omitted it
+ * is derived from `traceFlags` (sampled bit set -> `SAMPLED`, clear ->
+ * `NOT_SAMPLED`), and when neither is provided the decision is `UNDECIDED`.
+ *
+ * The resolver adopts the trace ID and parent span ID only when they are valid
+ * (well-formed, non-zero); an extractor that cannot supply a usable value
+ * returns `undefined` for it so the resolver falls back to a deterministic
+ * ARN-derived trace and synthetic root.
  */
 export type ContextExtractorResult =
   | {
       traceId: string;
       parentSpanId?: string;
       traceFlags?: number;
+      sampling?: Sampling;
     }
   | undefined;
+
+const OTEL_TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+const OTEL_SPAN_ID_PATTERN = /^[0-9a-f]{16}$/;
+const ALL_ZERO_TRACE_ID = "0".repeat(32);
+const ALL_ZERO_SPAN_ID = "0".repeat(16);
+
+/**
+ * True when `traceId` is a well-formed, non-zero 32-char hex OTel trace ID.
+ *
+ * Validity is stricter than a format match: an all-zero ID is well-formed hex
+ * but invalid, and anchoring an execution on it would split the trace.
+ */
+export function isValidTraceId(traceId: string | undefined): traceId is string {
+  return (
+    traceId != null &&
+    OTEL_TRACE_ID_PATTERN.test(traceId) &&
+    traceId !== ALL_ZERO_TRACE_ID
+  );
+}
+
+/**
+ * True when `spanId` is a well-formed, non-zero 16-char hex OTel span ID.
+ */
+export function isValidSpanId(spanId: string | undefined): spanId is string {
+  return (
+    spanId != null &&
+    OTEL_SPAN_ID_PATTERN.test(spanId) &&
+    spanId !== ALL_ZERO_SPAN_ID
+  );
+}
+
+/**
+ * Resolves the tri-state sampling decision for an extracted context.
+ *
+ * Prefers an explicit `sampling` value; otherwise derives from `traceFlags`
+ * when present; otherwise `UNDECIDED`.
+ */
+export function resolveSampling(extracted: {
+  traceFlags?: number;
+  sampling?: Sampling;
+}): Sampling {
+  if (extracted.sampling) {
+    return extracted.sampling;
+  }
+  if (extracted.traceFlags != null) {
+    return (extracted.traceFlags & 1) !== 0 ? "SAMPLED" : "NOT_SAMPLED";
+  }
+  return "UNDECIDED";
+}
+
+/**
+ * True when the extracted context carries a complete remote parent: a valid
+ * trace ID and a valid parent span ID, so it can serve as a remote parent.
+ */
+export function hasCompleteRemoteParent(
+  extracted: ContextExtractorResult,
+): extracted is {
+  traceId: string;
+  parentSpanId: string;
+} & NonNullable<ContextExtractorResult> {
+  return (
+    extracted != null &&
+    isValidTraceId(extracted.traceId) &&
+    isValidSpanId(extracted.parentSpanId)
+  );
+}
+
+/**
+ * True when the extracted context carries a valid (well-formed, non-zero) trace
+ * ID that the resolver can anchor the durable execution trace on.
+ */
+export function hasValidTraceId(
+  extracted: ContextExtractorResult,
+): extracted is {
+  traceId: string;
+} & NonNullable<ContextExtractorResult> {
+  return extracted != null && isValidTraceId(extracted.traceId);
+}
 
 /**
  * A function that extracts upstream trace context from the invocation environment.
@@ -27,8 +127,14 @@ export type ContextExtractor = (info: InvocationInfo) => ContextExtractorResult;
  *
  * - Extract Root value, strip "1-" prefix and all "-" to get 32-char hex traceId
  * - Extract Parent value for parentSpanId (16-char hex)
+ * - Extract Sampled: `1` -> SAMPLED, `0` -> NOT_SAMPLED, anything else undecided
  *
- * Returns undefined when _X_AMZN_TRACE_ID is missing or malformed.
+ * `Root`, `Parent`, and `Sampled` are parsed independently: only `Sampled=1`
+ * and `Sampled=0` are authoritative, and an all-zero Root or Parent is rejected
+ * as invalid (it is well-formed hex but not a usable ID). A valid Root with no
+ * usable Parent is still returned (the trace ID is usable on its own).
+ *
+ * Returns undefined when _X_AMZN_TRACE_ID is missing or has no valid Root.
  */
 export function xRayContextExtractor(
   _info: InvocationInfo,
@@ -59,18 +165,29 @@ export function xRayContextExtractor(
   const rootValue = root.startsWith("1-") ? root.slice(2) : root;
   const traceId = rootValue.replace(/-/g, "").toLowerCase();
 
-  // Validate: must be exactly 32 hex characters
-  if (!/^[0-9a-f]{32}$/.test(traceId)) {
+  // Reject a missing, malformed, or all-zero Root: it is not a usable trace ID.
+  if (!isValidTraceId(traceId)) {
     return undefined;
   }
 
+  // Parent is a 16-char hex span ID; reject an all-zero Parent the same way,
+  // and treat an unusable Parent as absent while keeping the valid Root.
   const parent = fields.get("Parent");
   let parentSpanId: string | undefined;
-  if (parent && /^[0-9a-f]{16}$/.test(parent.toLowerCase())) {
+  if (parent && isValidSpanId(parent.toLowerCase())) {
     parentSpanId = parent.toLowerCase();
   }
 
-  return { traceId, parentSpanId };
+  // Only Sampled=1 and Sampled=0 are authoritative; anything else is undecided.
+  const sampledField = fields.get("Sampled");
+  const sampling: Sampling =
+    sampledField === "1"
+      ? "SAMPLED"
+      : sampledField === "0"
+        ? "NOT_SAMPLED"
+        : "UNDECIDED";
+
+  return { traceId, parentSpanId, sampling };
 }
 
 /**
@@ -133,13 +250,12 @@ function parseW3CTraceparent(traceparent: string): ContextExtractorResult {
     return undefined;
   }
 
-  // TraceId must be 32 hex chars
-  if (!/^[0-9a-f]{32}$/.test(traceId)) {
-    return undefined;
-  }
-
-  // ParentId must be 16 hex chars
-  if (!/^[0-9a-f]{16}$/.test(parentId)) {
+  // TraceId and ParentId must be well-formed AND non-zero. An all-zero trace or
+  // parent ID is syntactically 32/16 hex chars but invalid per the W3C spec;
+  // accepting it would let a malformed traceparent's sampled bit force or
+  // suppress sampling even though the resolver rejects the trace ID and falls
+  // back to the ARN-derived trace.
+  if (!isValidTraceId(traceId) || !isValidSpanId(parentId)) {
     return undefined;
   }
 
@@ -150,9 +266,14 @@ function parseW3CTraceparent(traceparent: string): ContextExtractorResult {
 
   const traceFlags = parseInt(flags, 16);
 
+  // W3C traceparent carries an explicit sampled bit, so the decision is never
+  // UNDECIDED.
+  const sampling: Sampling = (traceFlags & 1) !== 0 ? "SAMPLED" : "NOT_SAMPLED";
+
   return {
     traceId,
     parentSpanId: parentId,
     traceFlags,
+    sampling,
   };
 }

--- a/packages/aws-durable-execution-sdk-js-otel/src/deterministic-id-generator.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/deterministic-id-generator.ts
@@ -169,3 +169,35 @@ export function deriveWorkflowSpanId(executionArn: string): string {
 
   return spanId;
 }
+
+/**
+ * Derive a deterministic span ID for the synthetic execution root from an
+ * execution ARN. Hashes `"execution-root:" + executionArn` with SHA-256 and
+ * truncates to the first 16 lowercase hex characters.
+ *
+ * The `"execution-root:"` prefix is a distinct namespace from
+ * `deriveWorkflowSpanId` (`"workflow:"`) and `deriveSpanIdFromOperationId`
+ * (`"<arn>:<opId>"`), so the synthetic root never collides with the Workflow or
+ * operation spans that share the execution trace. Stable across reinvocations
+ * so the same synthetic root is the common ancestor every invocation.
+ *
+ * @param executionArn - The execution ARN string (must be non-empty)
+ * @returns A 16-char lowercase hex string, never equal to "0000000000000000"
+ * @throws Error if the execution ARN is an empty string
+ */
+export function deriveExecutionRootSpanId(executionArn: string): string {
+  if (executionArn === "") {
+    throw new Error("Execution ARN must be non-empty");
+  }
+
+  const spanId = createHash("sha256")
+    .update("execution-root:" + executionArn)
+    .digest("hex")
+    .slice(0, 16);
+
+  if (spanId === "0000000000000000") {
+    return "0000000000000001";
+  }
+
+  return spanId;
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-durable-execution-sdk-js/issues/854

*Description of changes:*
- First PR in the stack for reparenting durable OTel spans onto one shared execution trace. 
- Adds the leaf building blocks the later PRs consume: extractor types (Sampling, ContextExtractorResult) and classification helpers (resolveSampling, hasCompleteRemoteParent, hasExecutionStableTraceId) in context-extractors.ts, plus the deterministic deriveExecutionRootSpanId root-id helper for the synthetic execution root. 
- Next in stack: the trace resolver plus DurableSampler, which is where these helpers first get wired in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.