### PR TITLE
fix(examples): pin Managed Instances runtime to unblock capacity provider tests

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -22,6 +22,8 @@ import {
   State,
   LastUpdateStatusReasonCode,
   PutFunctionScalingConfigCommand,
+  PutRuntimeManagementConfigCommand,
+  UpdateRuntimeOn,
   CreateFunctionCommandInput,
 } from "@aws-sdk/client-lambda";
 import { ExamplesWithConfig } from "../src/types";
@@ -35,6 +37,27 @@ import {
 
 const DEBUG = false;
 const INTEGRATION_TEST_LOG_RETENTION_DAYS = 7;
+
+// TEMPORARY WORKAROUND — pin the Managed Instances runtime.
+//
+// The managed-instances durable runtime nodejs:24.DurableFunction.v33 has no outbound
+// network connectivity from the execution sandbox: DNS resolves, but TCP/TLS to every AWS
+// service endpoint (lambda, sqs, sts) black-holes. The durable SDK's first checkpoint
+// therefore never returns — `client.send(CheckpointDurableExecutionCommand)` neither
+// resolves nor rejects — and the execution dies at its ExecutionTimeout. This surfaces as
+// `capacity-provider-tests` failing with `getOperations()` returning [].
+//
+// Runtime v29 is unaffected. Pinning it restores connectivity (verified in us-west-2:
+// TCP to the Lambda endpoint 1ms, checkpoint round trip 102ms, execution succeeds in ~1s).
+// Only functions on a capacity provider are affected; on-demand functions are fine.
+//
+// Remove this block, and the PutRuntimeManagementConfig call below, once Lambda ships a
+// fixed managed-instances runtime. Pinning opts these functions out of automatic runtime
+// patching, so it must not outlive the underlying fix.
+const PINNED_CAPACITY_PROVIDER_RUNTIME_ARNS: Record<string, string> = {
+  "us-west-2":
+    "arn:aws:lambda:us-west-2::runtime:33c885f25b2bbcf5fe2728c23ed25a2d438e49c5d08c29476328b3a18e0ca9d1",
+};
 
 // ADOT Layer ARN mapping for X-Ray E2E test
 // Format: arn:aws:lambda:${region}:615299751070:layer:AWSOpenTelemetryDistroJs:<version>
@@ -352,6 +375,47 @@ async function ensureLogGroupRetention(functionName: string): Promise<void> {
       retentionInDays: INTEGRATION_TEST_LOG_RETENTION_DAYS,
     }),
   );
+}
+
+/**
+ * TEMPORARY WORKAROUND. Pins the runtime version for a function that
+ * runs on a Managed Instances capacity provider, so it does not pick up the broken
+ * nodejs:24.DurableFunction.v33 runtime. See PINNED_CAPACITY_PROVIDER_RUNTIME_ARNS.
+ *
+ * No-op in regions without a known-good pinned ARN — runtime ARNs are region-scoped, and
+ * only us-west-2 has been verified. Failures are logged but not fatal: an unpinned function
+ * still deploys, and failing the deploy here would be worse than letting the test report
+ * the real symptom.
+ */
+async function pinCapacityProviderRuntime(
+  lambdaClient: LambdaClient,
+  functionName: string,
+  region: string,
+): Promise<void> {
+  const runtimeVersionArn = PINNED_CAPACITY_PROVIDER_RUNTIME_ARNS[region];
+  if (!runtimeVersionArn) {
+    console.log(
+      `No pinned Managed Instances runtime configured for ${region}; using the default runtime`,
+    );
+    return;
+  }
+
+  console.log(`Pinning Managed Instances runtime to ${runtimeVersionArn}`);
+  try {
+    await lambdaClient.send(
+      new PutRuntimeManagementConfigCommand({
+        FunctionName: functionName,
+        UpdateRuntimeOn: UpdateRuntimeOn.Manual,
+        RuntimeVersionArn: runtimeVersionArn,
+      }),
+    );
+    console.log("Runtime pinned successfully");
+  } catch (error) {
+    console.error(
+      `Failed to pin Managed Instances runtime for ${functionName}:`,
+      error,
+    );
+  }
 }
 
 async function createFunction(
@@ -710,6 +774,15 @@ async function main(): Promise<void> {
         }
 
         if (useCapacityProvider) {
+          // Must happen before PublishVersion: the published version snapshots the
+          // function's runtime management config, so pinning afterwards has no effect on
+          // the version that actually serves invocations.
+          await pinCapacityProviderRuntime(
+            lambdaClient,
+            functionName,
+            env.AWS_REGION,
+          );
+
           for (let attempts = 1; attempts <= 2; attempts++) {
             console.log(
               "Publishing LATEST_PUBLISHED for function with capacity provider",

--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -402,12 +402,20 @@ async function pinCapacityProviderRuntime(
 
   console.log(`Pinning Managed Instances runtime to ${runtimeVersionArn}`);
   try {
-    await lambdaClient.send(
-      new PutRuntimeManagementConfigCommand({
-        FunctionName: functionName,
-        UpdateRuntimeOn: UpdateRuntimeOn.Manual,
-        RuntimeVersionArn: runtimeVersionArn,
-      }),
+    // PutRuntimeManagementConfig rejects a function that is still Pending/Creating with
+    // ResourceConflictException, and CreateFunction returns well before a capacity-provider
+    // function reaches Active (typically 90s+, since Lambda launches three instances for AZ
+    // resiliency first). Retry on conflict with the same budget the publish call below uses.
+    await retryOnConflict(
+      () =>
+        lambdaClient.send(
+          new PutRuntimeManagementConfigCommand({
+            FunctionName: functionName,
+            UpdateRuntimeOn: UpdateRuntimeOn.Manual,
+            RuntimeVersionArn: runtimeVersionArn,
+          }),
+        ),
+      180,
     );
     console.log("Runtime pinned successfully");
   } catch (error) {

--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -418,6 +418,33 @@ async function pinCapacityProviderRuntime(
       180,
     );
     console.log("Runtime pinned successfully");
+
+    // PutRuntimeManagementConfig starts an update. Publishing while that update is in
+    // flight fails with "An update is in progress for resource ...", which the caller's
+    // outer retry turns into a re-run of CreateFunction and then an unrecoverable
+    // "Function already exist". Wait for the function to settle before returning.
+    await runWithRetry(
+      () => getCurrentConfiguration(lambdaClient, functionName),
+      (config) => {
+        if (
+          config.LastUpdateStatus === LastUpdateStatus.Failed ||
+          config.State === State.Failed
+        ) {
+          throw new Error(
+            `Function ${functionName} failed to settle after pinning the runtime. ` +
+              `${config.LastUpdateStatusReason ?? config.StateReason}`,
+          );
+        }
+        if (config.LastUpdateStatus === LastUpdateStatus.InProgress) {
+          return {
+            shouldRetry: true,
+            reason: `Runtime pin update is ${config.LastUpdateStatus}`,
+          };
+        }
+        return { shouldRetry: false, reason: "Runtime pin update completed" };
+      },
+      300,
+    );
   } catch (error) {
     console.error(
       `Failed to pin Managed Instances runtime for ${functionName}:`,


### PR DESCRIPTION
## Summary

`capacity-provider-tests` has failed on every PR since 2026-08-21. `step-basic` asserts one operation and receives `[]`, because the durable execution times out after 60s having recorded nothing.

The cause is the Managed Instances runtime, not our code, our VPC, or the SDK. Runtime `nodejs:24.DurableFunction.v33` has no outbound network connectivity from the execution sandbox: DNS resolves, but TCP/TLS to every AWS service endpoint black-holes. The SDK's first checkpoint therefore never completes — `client.send(CheckpointDurableExecutionCommand)` neither resolves nor rejects, so the `catch` that logs `CheckpointDurableExecution failed` never fires — and the execution dies at its `ExecutionTimeout`.

This PR pins capacity-provider functions to runtime `v29`, which is unaffected.

## Evidence

Same function, same capacity provider, same VPC, same SDK, us-west-2. Only the runtime differs.

Runtime `v33` (auto):

```
NET_TCP  <lambda-endpoint>:443 -> TIMEOUT
Creating checkpoint batch
(59.5s gap)
platform.report status=timeout
```

Runtime `v29` (pinned):

```
initStart runtimeVersion=nodejs:24.DurableFunction.v29
NET_TCP  18.246.196.22:443 -> ok 1ms
Creating checkpoint batch
Updating stepData from checkpoint response   (102ms round trip)
AFTER_STEP step completed
platform.report status=success
```

## What this is not

Each of these was proposed and then tested during the investigation:

- **Not VPC egress.** Reproduces with a public subnet + internet gateway (instances do get public IPs), with a private subnet + NAT gateway, and with a Lambda interface VPC endpoint — all three options in the [Managed Instances networking docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances-networking.html).
- **Not durable-specific.** A plain non-durable function on the same capacity provider cannot complete a TLS handshake to `lambda`, `sqs` or `sts`, and any AWS SDK call from it hangs without settling.
- **Not regional infrastructure.** On-demand functions in the same region and account reach `sts:GetCallerIdentity` in ~30ms. Only managed-instances functions are affected.
- **Not the SDK version.** Reproduced identically on `2.1.0`, `2.2.0` and `2.3.0`.
- **Not IAM.** The same execution role runs durable functions successfully off Managed Instances.

## Implementation notes

- The pin is applied **before** `PublishVersion`, because the published version snapshots the runtime management config. Pinning afterwards has no effect on the version that serves invocations.
- Scoped to `us-west-2` only. Runtime ARNs are region-scoped and only us-west-2 is verified; other regions log a message and use the default runtime.
- A failure to pin is logged but not fatal, so the deploy still succeeds and the test reports the real symptom rather than a setup error.

## Testing

- Verified live in AWS: pinning turns a 60s timeout into a ~1s success on a Managed Instances capacity provider in us-west-2. That is how the fix was found.
- `prettier --check` clean. `tsc --noEmit` reports 0 errors in `deploy-lambda.ts` and the same pre-existing error count as `main` (437, from unbuilt workspace deps).
- Not smoke-tested via the CLI locally: `npm run build -w packages/aws-durable-execution-sdk-js-examples` fails on a pre-existing `generate-examples` / `dist/examples-catalog.js` bootstrap issue that reproduces unchanged on `main`. CI exercises this path, so `capacity-provider-tests` passing on this PR is the real confirmation.

## Follow-ups (not in this PR)

- **Revert once Lambda ships a fixed runtime.** Pinning opts these functions out of automatic runtime patching and must not outlive the underlying fix. An AWS-side investigation is tracked internally.
- The capacity provider pins a single instance type (`m6g.large`), and provider logs show `InsufficientInstanceCapacity` retries in us-west-2c before succeeding in us-west-2b. Allowing more ARM types would make CI sturdier.
- Capacity is not released promptly after function deletion: `CreateFunction` can fail with `CapacityProviderScalingLimitExceeded` with zero instances running. Both providers are at `maxVCpuCount: 12` while shared across every PR run.
