### PR TITLE
fix(sdk): fail the execution when replay validation detects non-determinism

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/callback-handler/callback.ts
@@ -81,7 +81,7 @@ export const createCallback = (
       let stepData = context.getStepData(stepId);
 
       // Validate replay consistency
-      validateReplayConsistency(
+      const replayMismatch = validateReplayConsistency(
         stepId,
         {
           type: OperationType.CALLBACK,
@@ -91,6 +91,7 @@ export const createCallback = (
         stepData,
         context,
       );
+      if (replayMismatch) return replayMismatch;
 
       // Check if already completed
       if (stepData?.Status === OperationStatus.SUCCEEDED) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/invoke-handler/invoke-handler.ts
@@ -94,7 +94,7 @@ export const createInvokeHandler = (
       let stepData = context.getStepData(stepId);
 
       // Validate replay consistency
-      validateReplayConsistency(
+      const replayMismatch = validateReplayConsistency(
         stepId,
         {
           type: OperationType.CHAINED_INVOKE,
@@ -104,6 +104,7 @@ export const createInvokeHandler = (
         stepData,
         context,
       );
+      if (replayMismatch) return replayMismatch;
 
       // Check if already completed
       if (stepData?.Status === OperationStatus.SUCCEEDED) {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-composed.test.ts
@@ -7,6 +7,7 @@ import {
   DurableContext,
   DurableExecutionMode,
   DurableLogger,
+  OperationSubType,
 } from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import {
@@ -429,6 +430,8 @@ describe("Run In Child Context Integration Tests", () => {
       [hashId("1")]: {
         Id: "1",
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Name: "test-replay-child-context",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.test.ts
@@ -487,6 +487,8 @@ describe("Run In Child Context Handler", () => {
     stepData[hashId(TEST_CONSTANTS.CHILD_CONTEXT_ID)] = {
       Id: TEST_CONSTANTS.CHILD_CONTEXT_ID,
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: TEST_CONSTANTS.CHILD_CONTEXT_NAME,
       StartTimestamp: new Date(),
       Status: OperationStatus.SUCCEEDED,
       ContextDetails: {
@@ -655,9 +657,10 @@ describe("Run In Child Context Handler", () => {
       [hashId(TEST_CONSTANTS.CHILD_CONTEXT_ID)]: {
         Id: TEST_CONSTANTS.CHILD_CONTEXT_ID,
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
         StartTimestamp: new Date(),
         Status: OperationStatus.STARTED,
-        name: TEST_CONSTANTS.CHILD_CONTEXT_NAME,
+        Name: TEST_CONSTANTS.CHILD_CONTEXT_NAME,
       },
     } as any;
 
@@ -884,6 +887,8 @@ describe("runInChildContext with custom serdes", () => {
       [hashId("test-step-id")]: {
         Id: "test-step-id",
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Name: "test-child-with-serdes",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {
@@ -917,6 +922,8 @@ describe("runInChildContext with custom serdes", () => {
     stepData[hashId("test-step-id")] = {
       Id: "test-step-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       StartTimestamp: new Date(),
       Status: OperationStatus.FAILED,
       ContextDetails: {
@@ -941,6 +948,8 @@ describe("runInChildContext with custom serdes", () => {
     stepData[hashId("test-step-id")] = {
       Id: "test-step-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       StartTimestamp: new Date(),
       Status: OperationStatus.FAILED,
       ContextDetails: {}, // No Error field (legacy data)
@@ -1046,6 +1055,8 @@ describe("runWithContext Integration", () => {
     mockExecutionContext._stepData[hashId("child-context-id")] = {
       Id: "child-context-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       Status: OperationStatus.SUCCEEDED,
       ContextDetails: {
         Result: '"cached-result"',
@@ -1067,6 +1078,8 @@ describe("runWithContext Integration", () => {
     mockExecutionContext._stepData[hashId("child-context-id")] = {
       Id: "child-context-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       Status: OperationStatus.SUCCEEDED,
       ContextDetails: {
         Result: '"original-result"',
@@ -1095,6 +1108,8 @@ describe("runWithContext Integration", () => {
     mockExecutionContext._stepData[hashId("child-context-id")] = {
       Id: "child-context-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       Status: OperationStatus.FAILED,
       ContextDetails: {
         Error: createErrorObjectFromError(new Error("Previous failure")),
@@ -1142,6 +1157,8 @@ describe("runWithContext Integration", () => {
     mockExecutionContext._stepData[hashId("child-context-id")] = {
       Id: "child-context-id",
       Type: OperationType.CONTEXT,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Name: "test-child",
       Status: OperationStatus.SUCCEEDED,
       ContextDetails: {
         ReplayChildren: true,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-handler.ts
@@ -107,22 +107,6 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
       name,
     });
 
-    const stepData = context.getStepData(entityId);
-
-    // Validate replay consistency
-    validateReplayConsistency(
-      entityId,
-      {
-        type: OperationType.CONTEXT,
-        name,
-        subType:
-          (options?.subType as OperationSubType) ||
-          OperationSubType.RUN_IN_CHILD_CONTEXT,
-      },
-      stepData,
-      context,
-    );
-
     // Two-phase execution: Phase 1 starts immediately, Phase 2 returns result when awaited
     let phase1Result: T | undefined;
     let phase1Error: unknown;
@@ -130,6 +114,25 @@ export const createRunInChildContextHandler = <Logger extends DurableLogger>(
     // Phase 1: Start execution immediately and capture result/error
     const phase1Promise = (async (): Promise<T> => {
       const currentStepData = context.getStepData(entityId);
+
+      // Validate replay consistency. This lives inside phase 1, unlike the other
+      // handlers where it precedes one: the halt promise has to be returned to
+      // something that stops on it, and the enclosing function must hand back a
+      // DurablePromise. Phase 1 runs synchronously up to its first await, so the
+      // check still happens as early as it did before.
+      const replayMismatch = validateReplayConsistency(
+        entityId,
+        {
+          type: OperationType.CONTEXT,
+          name,
+          subType:
+            (options?.subType as OperationSubType) ||
+            OperationSubType.RUN_IN_CHILD_CONTEXT,
+        },
+        currentStepData,
+        context,
+      );
+      if (replayMismatch) return replayMismatch;
 
       // If already completed, return cached result
       if (

--- a/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/run-in-child-context-handler/run-in-child-context-serdes.composed.test.ts
@@ -7,6 +7,7 @@ import {
   DurableContext,
   DurableExecutionMode,
   DurableLogger,
+  OperationSubType,
 } from "../../types";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import {
@@ -199,6 +200,8 @@ describe("runInChildContext serdes round-trip", () => {
       [hashId("1")]: {
         Id: "1",
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Name: "serdes-child",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {
@@ -235,6 +238,8 @@ describe("runInChildContext serdes round-trip", () => {
       [hashId("1")]: {
         Id: "1",
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Name: "serdes-child",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {
@@ -272,6 +277,8 @@ describe("runInChildContext serdes round-trip", () => {
       [hashId("1")]: {
         Id: "1",
         Type: OperationType.CONTEXT,
+        SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+        Name: "large-child",
         StartTimestamp: new Date(),
         Status: OperationStatus.SUCCEEDED,
         ContextDetails: {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -89,12 +89,13 @@ export const createStepHandler = <Logger extends DurableLogger>(
     const phase1Promise = (async (): Promise<T> => {
       let stepData = context.getStepData(stepId);
 
-      validateReplayConsistency(
+      const replayMismatch = validateReplayConsistency(
         stepId,
         { type: OperationType.STEP, name, subType: OperationSubType.STEP },
         stepData,
         context,
       );
+      if (replayMismatch) return replayMismatch;
 
       const opInfo = {
         id: hashId(stepId),

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-handler/wait-handler.ts
@@ -65,7 +65,7 @@ export const createWaitHandler = (
       let stepData = context.getStepData(stepId);
 
       // Validate replay consistency
-      validateReplayConsistency(
+      const replayMismatch = validateReplayConsistency(
         stepId,
         {
           type: OperationType.WAIT,
@@ -75,6 +75,7 @@ export const createWaitHandler = (
         stepData,
         context,
       );
+      if (replayMismatch) return replayMismatch;
 
       // Check if already completed
       if (stepData?.Status === OperationStatus.SUCCEEDED) {

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Runs the real engine over a checkpoint history that does not match the code replaying
+ * it, and asserts the invocation reports the mismatch.
+ *
+ * This is the end-to-end shape of the fault a customer hits from a step name built at
+ * runtime -- `context.step("step-" + Date.now(), ...)` -- which produces a different name
+ * on every replay. The unit tests around `validateReplayConsistency` and the termination
+ * branch of `withDurableExecution` each cover one half; only running them together shows
+ * what the Lambda response actually says, which is the thing that was wrong: the SDK
+ * detected the mismatch, built a diagnostic for it, and then answered
+ * `{Status: "PENDING"}` with no error and no log line, asking the service to retry
+ * something that fails identically on every attempt. See
+ * https://github.com/aws/aws-durable-execution-sdk-js/issues/865.
+ */
+
+import { withDurableExecution } from "../../with-durable-execution";
+import { DurableExecutionInvocationInputWithClient } from "../durable-execution-invocation-input/durable-execution-invocation-input";
+import { hashId } from "../step-id-utils/step-id-utils";
+import {
+  DurableContext,
+  DurableExecutionClient,
+  InvocationStatus,
+  OperationSubType,
+} from "../../types";
+import {
+  CheckpointDurableExecutionRequest,
+  CheckpointDurableExecutionResponse,
+  GetDurableExecutionStateResponse,
+  OperationStatus,
+  OperationType,
+  WireOperation,
+} from "../../types/wire";
+import { Context } from "aws-lambda";
+
+const EXECUTION_ARN =
+  "arn:aws:lambda:us-east-1:123456789012:function:repro:$LATEST";
+
+const lambdaContext = {
+  awsRequestId: "request-1",
+  getRemainingTimeInMillis: () => 300_000,
+} as unknown as Context;
+
+/**
+ * Replay state for a single completed step, checkpointed under `checkpointedName`.
+ * `hashId("1")` is the id the engine derives for the first operation of the root context,
+ * so this is the checkpoint the handler's first `context.step` call will be matched
+ * against.
+ */
+const replayStateFor = (checkpointedName: string): WireOperation[] => [
+  {
+    Id: hashId("execution"),
+    Type: OperationType.EXECUTION,
+    Status: OperationStatus.STARTED,
+    StartTimestamp: new Date().toISOString(),
+    ExecutionDetails: { InputPayload: "{}" },
+  } as unknown as WireOperation,
+  {
+    Id: hashId("1"),
+    Type: OperationType.STEP,
+    SubType: OperationSubType.STEP,
+    Name: checkpointedName,
+    Status: OperationStatus.SUCCEEDED,
+    StartTimestamp: new Date().toISOString(),
+    StepDetails: { Result: JSON.stringify("checkpointed-result") },
+  } as unknown as WireOperation,
+];
+
+describe("non-deterministic replay reaches the invocation response", () => {
+  const checkpoints: CheckpointDurableExecutionRequest[] = [];
+
+  const client: DurableExecutionClient = {
+    getExecutionState: async (): Promise<GetDurableExecutionStateResponse> => ({
+      Operations: [],
+      NextMarker: undefined,
+    }),
+    checkpoint: async (
+      params: CheckpointDurableExecutionRequest,
+    ): Promise<CheckpointDurableExecutionResponse> => {
+      checkpoints.push(params);
+      return { CheckpointToken: "token-2", NewExecutionState: undefined };
+    },
+  };
+
+  const invoke = (
+    handler: (event: unknown, context: DurableContext) => Promise<unknown>,
+    checkpointedName: string,
+  ): Promise<unknown> =>
+    withDurableExecution(handler)(
+      new DurableExecutionInvocationInputWithClient(
+        {
+          DurableExecutionArn: EXECUTION_ARN,
+          CheckpointToken: "token-1",
+          InitialExecutionState: {
+            Operations: replayStateFor(checkpointedName),
+            NextMarker: "",
+          },
+        },
+        client,
+      ),
+      lambdaContext,
+    );
+
+  beforeEach(() => {
+    checkpoints.length = 0;
+  });
+
+  it("fails the invocation with the diagnostic when a step name changes on replay", async () => {
+    const stepBody = jest.fn();
+
+    const response = await invoke(async (_event, context: DurableContext) => {
+      await context.step("step-b", async () => {
+        stepBody();
+        return "fresh-result";
+      });
+      return "done";
+    }, "step-a");
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorType: "NonDeterministicExecutionError",
+        ErrorMessage: expect.stringContaining(
+          'Expected name "step-a", but got "step-b"',
+        ),
+      }),
+    });
+
+    // The mismatch halts the handler where it was found: nothing after the offending
+    // operation runs, so the step body cannot fire for its side effects and no
+    // checkpoint is written against a history the code no longer agrees with.
+    expect(stepBody).not.toHaveBeenCalled();
+    expect(checkpoints).toEqual([]);
+  });
+
+  it("succeeds on the same history when the step name is stable", async () => {
+    // The control: the failure above is caused by the name divergence and nothing else
+    // about this harness.
+    const stepBody = jest.fn();
+
+    const response = await invoke(async (_event, context: DurableContext) => {
+      const result = await context.step("step-a", async () => {
+        stepBody();
+        return "fresh-result";
+      });
+      return result;
+    }, "step-a");
+
+    expect(response).toEqual({
+      Status: InvocationStatus.SUCCEEDED,
+      Result: JSON.stringify("checkpointed-result"),
+    });
+    expect(stepBody).not.toHaveBeenCalled(); // replayed from the checkpoint
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.test.ts
@@ -13,7 +13,7 @@ describe("validateReplayConsistency", () => {
   });
 
   it("should not validate when checkpoint data is undefined", () => {
-    validateReplayConsistency(
+    const result = validateReplayConsistency(
       "step1",
       {
         type: OperationType.STEP,
@@ -25,6 +25,7 @@ describe("validateReplayConsistency", () => {
     );
 
     expect(terminateForUnrecoverableError).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 
   it("should pass validation when all fields match", () => {
@@ -37,7 +38,7 @@ describe("validateReplayConsistency", () => {
       Status: "SUCCEEDED",
     };
 
-    validateReplayConsistency(
+    const result = validateReplayConsistency(
       "step1",
       {
         type: OperationType.STEP,
@@ -49,6 +50,7 @@ describe("validateReplayConsistency", () => {
     );
 
     expect(terminateForUnrecoverableError).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 
   it("should pass validation when name is undefined in both", () => {
@@ -190,6 +192,74 @@ describe("validateReplayConsistency", () => {
       mockContext,
       expect.objectContaining({
         message: expect.stringContaining("Operation subtype mismatch"),
+      }),
+      "step1",
+    );
+  });
+
+  it("should hand back the halt promise so the caller stops on a mismatch", async () => {
+    // The caller must be able to stop. Reporting the mismatch is not enough on its
+    // own: termination resolves asynchronously, and until it does, a caller that
+    // carried on would act on checkpoint data belonging to a different operation --
+    // deserializing another step's result, or re-running a step body for its side
+    // effects.
+    const haltPromise = new Promise<never>(() => {});
+    (terminateForUnrecoverableError as jest.Mock).mockReturnValue(haltPromise);
+
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "step-a",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    const result = validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.STEP,
+        name: "step-b",
+        subType: OperationSubType.STEP,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(result).toBe(haltPromise);
+    await expect(
+      Promise.race([result, Promise.resolve("still-pending")]),
+    ).resolves.toBe("still-pending");
+  });
+
+  it("should report only the first mismatch it finds", () => {
+    // Type is checked first; the name and subtype comparisons that follow describe the
+    // same divergence, so reporting them as well would add nothing.
+    const checkpointData: Operation = {
+      Id: "step1",
+      Type: OperationType.STEP,
+      Name: "step-a",
+      SubType: OperationSubType.STEP,
+      StartTimestamp: new Date(),
+      Status: "SUCCEEDED",
+    };
+
+    validateReplayConsistency(
+      "step1",
+      {
+        type: OperationType.WAIT,
+        name: "step-b",
+        subType: OperationSubType.WAIT,
+      },
+      checkpointData,
+      mockContext,
+    );
+
+    expect(terminateForUnrecoverableError).toHaveBeenCalledTimes(1);
+    expect(terminateForUnrecoverableError).toHaveBeenCalledWith(
+      mockContext,
+      expect.objectContaining({
+        message: expect.stringContaining("Operation type mismatch"),
       }),
       "step1",
     );

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.ts
@@ -3,6 +3,21 @@ import { OperationSubType, ExecutionContext } from "../../types";
 import { terminateForUnrecoverableError } from "../termination-helper/termination-helper";
 import { NonDeterministicExecutionError } from "../../errors/non-deterministic-error/non-deterministic-error";
 
+/**
+ * Checks that an operation about to be replayed is the same operation that was
+ * checkpointed at this position. A mismatch means the workflow took a different
+ * path than it did on the invocation that produced the checkpoint, so the
+ * checkpoint at hand belongs to a different operation and nothing after this point
+ * can be trusted.
+ *
+ * @returns `undefined` when the operation matches its checkpoint. On a mismatch the
+ *   execution has already been terminated and a never-resolving promise is returned:
+ *   the caller MUST return or await it, so that handler code stops instead of racing
+ *   the termination while acting on checkpoint data known to be the wrong operation's
+ *   (deserializing another step's result, or re-running a step body for its side
+ *   effects). Termination is what turns this into a FAILED invocation carrying the
+ *   diagnostic below; the promise only stops the caller from continuing meanwhile.
+ */
 export const validateReplayConsistency = (
   stepId: string,
   currentOperation: {
@@ -12,10 +27,10 @@ export const validateReplayConsistency = (
   },
   checkpointData: Operation | undefined,
   context: ExecutionContext,
-): void => {
+): Promise<never> | undefined => {
   // Skip validation if no checkpoint data exists or if Type is undefined (first execution)
   if (!checkpointData || !checkpointData.Type) {
-    return;
+    return undefined;
   }
 
   // Validate operation type
@@ -25,7 +40,7 @@ export const validateReplayConsistency = (
         `Expected type "${checkpointData.Type}", but got "${currentOperation.type}". ` +
         `This indicates non-deterministic control flow in your workflow code.`,
     );
-    terminateForUnrecoverableError(context, error, stepId);
+    return terminateForUnrecoverableError(context, error, stepId);
   }
 
   // Validate operation name (including undefined)
@@ -35,7 +50,7 @@ export const validateReplayConsistency = (
         `Expected name "${checkpointData.Name ?? "undefined"}", but got "${currentOperation.name ?? "undefined"}". ` +
         `This indicates non-deterministic control flow in your workflow code.`,
     );
-    terminateForUnrecoverableError(context, error, stepId);
+    return terminateForUnrecoverableError(context, error, stepId);
   }
 
   // Validate operation subtype
@@ -45,6 +60,8 @@ export const validateReplayConsistency = (
         `Expected subtype "${checkpointData.SubType}", but got "${currentOperation.subType}". ` +
         `This indicates non-deterministic control flow in your workflow code.`,
     );
-    terminateForUnrecoverableError(context, error, stepId);
+    return terminateForUnrecoverableError(context, error, stepId);
   }
+
+  return undefined;
 };

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-deferral.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-deferral.test.ts
@@ -31,6 +31,7 @@ describe("terminateForUnrecoverableError", () => {
     expect(mockContext.terminationManager.terminate).toHaveBeenCalledWith({
       reason: TerminationReason.CUSTOM,
       message: "Unrecoverable error in step test-step: Test error",
+      error,
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
@@ -34,6 +34,9 @@ describe("termination helpers", () => {
         reason: TerminationReason.CUSTOM,
         message:
           "Unrecoverable error in step test-step: Test unrecoverable error",
+        // The error itself, not only its message: invocation-level handling
+        // reports it to plugins and serializes it into the Lambda response.
+        error: mockError,
       });
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
@@ -3,6 +3,14 @@ import { UnrecoverableError } from "../../errors/unrecoverable-error/unrecoverab
 
 /**
  * Terminates execution for unrecoverable errors and returns a never-resolving promise
+ *
+ * The error itself is carried on the termination details, not just its message: the
+ * invocation-level handling in `with-durable-execution.ts` reports the error to
+ * plugins and serializes it into the Lambda response, and both need the concrete
+ * error (its `name`, and its stack when stack storage is enabled) rather than a
+ * flattened string. `CHECKPOINT_FAILED` goes further and rethrows the carried error
+ * to fail the invocation, so omitting it there would rethrow `undefined`.
+ *
  * @param context - The execution context containing the termination manager
  * @param error - The unrecoverable error that caused termination
  * @param stepIdentifier - The step name or ID for error messaging
@@ -16,6 +24,7 @@ export function terminateForUnrecoverableError<T>(
   context.terminationManager.terminate({
     reason: error.terminationReason,
     message: `Unrecoverable error in step ${stepIdentifier}: ${error.message}`,
+    error,
   });
 
   return new Promise<T>(() => {}); // Never-resolving promise

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution-queue-completion.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution-queue-completion.test.ts
@@ -5,6 +5,7 @@ import { Context } from "aws-lambda";
 import { DurableExecutionInvocationInput } from "./types";
 import { log } from "./utils/logger/logger";
 import { CheckpointManager } from "./utils/checkpoint/checkpoint-manager";
+import { TerminationReason } from "./termination-manager/types";
 
 // Mock dependencies
 jest.mock("./context/execution-context/execution-context");
@@ -92,7 +93,8 @@ describe("withDurableExecution Queue Completion", () => {
 
     // Mock termination promise to resolve immediately
     mockTerminationManager.getTerminationPromise.mockResolvedValue({
-      reason: "TIMEOUT",
+      reason: TerminationReason.WAIT_SCHEDULED,
+      message: "Wait scheduled",
     });
 
     const wrappedHandler = withDurableExecution(mockHandler);

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -2,6 +2,7 @@ import { withDurableExecution } from "./with-durable-execution";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { createDurableContext } from "./context/durable-context/durable-context";
 import { CheckpointUnrecoverableInvocationError } from "./errors/checkpoint-errors/checkpoint-errors";
+import { NonDeterministicExecutionError } from "./errors/non-deterministic-error/non-deterministic-error";
 import {
   UnrecoverableInvocationError,
   UnrecoverableExecutionError,
@@ -252,11 +253,94 @@ describe("withDurableExecution", () => {
     );
   });
 
-  it("should return PENDING response for non-checkpoint termination", async () => {
+  it("should return FAILED response for CONTEXT_VALIDATION_ERROR reason", async () => {
+    // Using a parent or sibling context inside runInChildContext: deterministic and
+    // permanent, so the execution fails rather than being reported as still pending.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    const contextError = new Error(
+      'Context usage error in "child": You are using a parent or sibling context',
+    );
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CONTEXT_VALIDATION_ERROR,
+      message: contextError.message,
+      error: contextError,
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({ ErrorMessage: contextError.message }),
+    });
+  });
+
+  it("should return FAILED response carrying the error for CUSTOM reason", async () => {
+    // CUSTOM is how replay validation reports non-deterministic workflow code. It used
+    // to fall through to the generic handling and answer PENDING, which asked the
+    // service to retry an error that reproduces on every replay and hid the diagnostic
+    // from the customer entirely -- until the execution eventually failed with
+    // "Cannot return PENDING status with no pending operations" instead.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    const nonDeterminismError = new NonDeterministicExecutionError(
+      'Non-deterministic execution detected: Operation name mismatch for step "1". ' +
+        'Expected name "step-a", but got "step-b".',
+    );
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CUSTOM,
+      message: `Unrecoverable error in step 1: ${nonDeterminismError.message}`,
+      error: nonDeterminismError,
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorType: "NonDeterministicExecutionError",
+        ErrorMessage: nonDeterminismError.message,
+      }),
+    });
+  });
+
+  it("should return FAILED for a termination reason with no explicit branch", async () => {
+    // Fail closed: a reason added later without being classified as a suspend must not
+    // inherit PENDING by default, because PENDING claims the execution is progressing.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: "SOME_FUTURE_REASON" as TerminationReason,
+      message: "something the SDK does not classify yet",
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorMessage: "something the SDK does not classify yet",
+      }),
+    });
+  });
+
+  it.each([
+    TerminationReason.OPERATION_TERMINATED,
+    TerminationReason.WAIT_SCHEDULED,
+    TerminationReason.RETRY_SCHEDULED,
+    TerminationReason.RETRY_INTERRUPTED_STEP,
+    TerminationReason.CALLBACK_PENDING,
+  ])("should return PENDING response for %s termination", async (reason) => {
     // Setup
     const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
     mockTerminationManager.getTerminationPromise.mockResolvedValue({
-      reason: TerminationReason.OPERATION_TERMINATED,
+      reason,
       message: "Operation terminated",
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -50,6 +50,32 @@ import {
 // Lambda response size limit is 6MB
 const LAMBDA_RESPONSE_SIZE_LIMIT = 6 * 1024 * 1024 - 50; // 6MB in bytes, minus 50 bytes for envelope
 
+/**
+ * Termination reasons that mean "this invocation is done for now, the execution
+ * continues later" -- a wait, a scheduled retry, or a pending callback. These are
+ * the only reasons that may answer PENDING, which tells the service to keep the
+ * execution alive and invoke again.
+ *
+ * Everything else is a fault, and the default for an unlisted reason is FAILED.
+ * The list is an allowlist rather than a denylist deliberately: a reason added
+ * later without a corresponding branch here then fails closed with its error
+ * reported, instead of silently claiming the execution is still progressing.
+ * Answering PENDING for a deterministic, permanent fault is worse than useless --
+ * every replay reproduces it, the error never reaches the customer, and once no
+ * operation is actually pending the service rejects the response outright
+ * ("Cannot return PENDING status with no pending operations").
+ *
+ * CHECKPOINT_FAILED and SERDES_FAILED are absent because they are handled before
+ * this point: both rethrow, which fails the invocation rather than the execution.
+ */
+const SUSPEND_TERMINATION_REASONS: ReadonlySet<TerminationReason> = new Set([
+  TerminationReason.OPERATION_TERMINATED,
+  TerminationReason.WAIT_SCHEDULED,
+  TerminationReason.RETRY_SCHEDULED,
+  TerminationReason.RETRY_INTERRUPTED_STEP,
+  TerminationReason.CALLBACK_PENDING,
+]);
+
 async function runHandler<
   Input,
   Output,
@@ -244,72 +270,57 @@ async function runHandler<
           throw new SerdesFailedError(result.message);
         }
 
-        // If termination was due to context validation error, return FAILED
-        if (
-          resultType === "termination" &&
-          result.reason === TerminationReason.CONTEXT_VALIDATION_ERROR
-        ) {
-          log("🛑", "Context validation error - returning FAILED status");
-          const response = {
-            Status: InvocationStatus.FAILED,
-            Error: createErrorObjectFromError(
-              result.error || new Error(result.message),
-            ),
-          };
-          await plugin.onInvocationEnd?.({
-            ...invocationBaseInfo,
-            status: PluginInvocationStatus.FAILED,
-            executionInput: customerHandlerEvent,
-            executionError: result.error || new Error(result.message),
-            executionResult: undefined,
-            operations: toOperationInfoMap(executionContext._stepData),
-          });
-          return response;
-        }
-
-        // If termination was due to a config validation error (e.g. an
-        // invalid maxConcurrency or a mutually-exclusive completionConfig),
-        // return FAILED. This is a deterministic, non-retryable caller
-        // mistake -- same category as CONTEXT_VALIDATION_ERROR above, not a
-        // suspend/pause, so it must not fall through to the generic
-        // termination handling below (which returns PENDING).
-        if (
-          resultType === "termination" &&
-          result.reason === TerminationReason.CONFIG_VALIDATION_ERROR
-        ) {
-          log("🛑", "Config validation error - returning FAILED status");
-          const response = {
-            Status: InvocationStatus.FAILED,
-            Error: createErrorObjectFromError(
-              result.error || new Error(result.message),
-            ),
-          };
-          await plugin.onInvocationEnd?.({
-            ...invocationBaseInfo,
-            status: PluginInvocationStatus.FAILED,
-            executionInput: customerHandlerEvent,
-            executionError: result.error || new Error(result.message),
-            executionResult: undefined,
-            operations: toOperationInfoMap(executionContext._stepData),
-          });
-          return response;
-        }
-
+        // Every remaining termination reason is decided here. A suspend answers
+        // PENDING; anything else is a fault and answers FAILED with the error the
+        // terminating code carried (see SUSPEND_TERMINATION_REASONS).
         if (resultType === "termination") {
-          log("🛑", "Returning termination response");
+          if (SUSPEND_TERMINATION_REASONS.has(result.reason)) {
+            log("🛑", "Returning termination response", {
+              reason: result.reason,
+            });
 
+            await plugin.onInvocationEnd?.({
+              ...invocationBaseInfo,
+              status: PluginInvocationStatus.PENDING,
+              executionInput: customerHandlerEvent,
+              executionResult: undefined,
+              executionError: undefined,
+              operations: toOperationInfoMap(executionContext._stepData),
+            });
+
+            return {
+              Status: InvocationStatus.PENDING,
+            };
+          }
+
+          // Deterministic, non-retryable faults: an invalid maxConcurrency or
+          // completionConfig (CONFIG_VALIDATION_ERROR), use of a parent or sibling
+          // context inside runInChildContext (CONTEXT_VALIDATION_ERROR), and
+          // non-deterministic workflow code detected during replay (CUSTOM, raised
+          // by validateReplayConsistency). Retrying reproduces all of them, so the
+          // execution fails now and the diagnostic reaches the customer.
+          const error = result.error ?? new Error(result.message);
+          log(
+            "🛑",
+            `Terminated with ${result.reason} - returning FAILED status`,
+            {
+              message: result.message,
+            },
+          );
+
+          const response = {
+            Status: InvocationStatus.FAILED,
+            Error: createErrorObjectFromError(error),
+          };
           await plugin.onInvocationEnd?.({
             ...invocationBaseInfo,
-            status: PluginInvocationStatus.PENDING,
+            status: PluginInvocationStatus.FAILED,
             executionInput: customerHandlerEvent,
+            executionError: error,
             executionResult: undefined,
-            executionError: undefined,
             operations: toOperationInfoMap(executionContext._stepData),
           });
-
-          return {
-            Status: InvocationStatus.PENDING,
-          };
+          return response;
         }
 
         log("✅", "Returning normal completion response");


### PR DESCRIPTION
Replay validation raises NonDeterministicExecutionError, the only production error carrying TerminationReason.CUSTOM. runHandler had no branch for CUSTOM, so it fell through to the catch-all and answered {Status: "PENDING"} with no error and no log line. PENDING asks the service to keep the execution alive and invoke again, but the fault is deterministic and permanent: every replay reproduces it, the diagnostic the SDK had already built never reached the customer, and once nothing was actually pending the service rejected the response outright with "Cannot return PENDING status with no pending operations".

Invert the termination branch instead of adding a CUSTOM case. Suspend reasons are now an allowlist (OPERATION_TERMINATED, WAIT_SCHEDULED, RETRY_SCHEDULED, RETRY_INTERRUPTED_STEP, CALLBACK_PENDING) and everything else answers FAILED with the carried error, so a reason added later without a branch here fails closed rather than silently claiming progress. This subsumes the CONTEXT_VALIDATION_ERROR and CONFIG_VALIDATION_ERROR branches, which were duplicates of each other. CHECKPOINT_FAILED and SERDES_FAILED still rethrow ahead of it.

terminateForUnrecoverableError now carries the error, not only its message, so ErrorType survives as NonDeterministicExecutionError. This also fixes a latent bug on the CHECKPOINT_FAILED path: runHandler does `throw result.error`, which threw undefined whenever termination came from terminateForUnrecoverableError rather than from CheckpointManager.

validateReplayConsistency returns its never-resolving halt promise instead of discarding it, and the five call sites return it. Reporting the mismatch was not enough on its own: termination resolves asynchronously, so handler code kept running against checkpoint data known to belong to a different operation, which could deserialize another step's result or re-run a step body for its side effects. The function stays synchronous so the matching path adds no microtask and operation ordering is unchanged. In run-in-child-context the check moved inside the phase-1 IIFE, since the enclosing function must return a DurablePromise; phase 1 runs synchronously to its first await, so the check still happens as early as before.

Halting exposed 13 child-context tests whose fixtures declared Type: CONTEXT but omitted Name and SubType, which a real checkpoint always carries -- the handler's own START checkpoint writes both. Those fixtures were already tripping replay validation; the silent termination is why nobody noticed, the same class of failure this change fixes. One had a lowercase `name:` typo. The fixtures are completed rather than the check weakened.

Tests: a composed test runs the real engine over a history checkpointed as "step-a" while the handler replays "step-b" and asserts FAILED with the diagnostic, that the step body never runs, and that no checkpoint is written, with a stable-name control case. Pinned against the unfixed source it returns
{Status: "PENDING"}, reproducing the report. Unit coverage added for CUSTOM ->
FAILED with the type preserved, CONTEXT_VALIDATION_ERROR -> FAILED (previously untested), an unclassified reason failing closed, and all five suspend reasons -> PENDING; only OPERATION_TERMINATED was covered before.

This changes observable invocation status for a public failure mode, so it looks like a candidate for a conformance test in
https://github.com/aws/aws-durable-execution-conformance-tests.

Fixes #865
