### PR TITLE
fix(sdk): return FAILED when replay validation detects non-determinism

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/non-deterministic-error/non-deterministic-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/non-deterministic-error/non-deterministic-error.ts
@@ -5,7 +5,7 @@ import { TerminationReason } from "../../termination-manager/types";
  * Error thrown when non-deterministic code is detected during replay
  */
 export class NonDeterministicExecutionError extends UnrecoverableExecutionError {
-  readonly terminationReason = TerminationReason.CUSTOM;
+  readonly terminationReason = TerminationReason.NON_DETERMINISM;
 
   constructor(message: string) {
     super(message);

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-class.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/termination-class.test.ts
@@ -1,0 +1,52 @@
+import {
+  TERMINATION_CLASS,
+  TerminationReason,
+  classifyTermination,
+} from "./types";
+
+describe("termination reason classification", () => {
+  it("classifies every reason in the enum", () => {
+    // The compiler already enforces this -- TERMINATION_CLASS is a
+    // Record<TerminationReason, ...>, so an unclassified reason fails to build. Asserted
+    // at runtime too because the enum is what the service and the SDK agree on, and a
+    // reason silently dropped from the map by a bad merge would otherwise fall to the
+    // "fault" default and quietly fail executions that were only suspending.
+    for (const reason of Object.values(TerminationReason)) {
+      expect(TERMINATION_CLASS[reason]).toBeDefined();
+    }
+    expect(Object.keys(TERMINATION_CLASS).sort()).toEqual(
+      Object.values(TerminationReason).sort(),
+    );
+  });
+
+  it.each([
+    TerminationReason.OPERATION_TERMINATED,
+    TerminationReason.WAIT_SCHEDULED,
+    TerminationReason.RETRY_SCHEDULED,
+    TerminationReason.RETRY_INTERRUPTED_STEP,
+    TerminationReason.CALLBACK_PENDING,
+  ])("treats %s as a suspend", (reason) => {
+    expect(classifyTermination(reason)).toBe("suspend");
+  });
+
+  it.each([
+    TerminationReason.CHECKPOINT_FAILED,
+    TerminationReason.SERDES_FAILED,
+    TerminationReason.CONTEXT_VALIDATION_ERROR,
+    TerminationReason.CONFIG_VALIDATION_ERROR,
+    TerminationReason.NON_DETERMINISM,
+    TerminationReason.CUSTOM,
+  ])("treats %s as a fault", (reason) => {
+    expect(classifyTermination(reason)).toBe("fault");
+  });
+
+  it("defaults to fault for a reason outside the enum", () => {
+    // Not reachable through the enum, but the value crosses a boundary where a plain
+    // string can arrive. Answering "suspend" for something unrecognised is the outcome
+    // being ruled out: it would report an execution as still progressing when nothing
+    // is pending.
+    expect(classifyTermination("SOMETHING_NEW" as TerminationReason)).toBe(
+      "fault",
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/termination-manager/types.ts
+++ b/packages/aws-durable-execution-sdk-js/src/termination-manager/types.ts
@@ -17,10 +17,66 @@ export enum TerminationReason {
   SERDES_FAILED = "SERDES_FAILED",
   CONTEXT_VALIDATION_ERROR = "CONTEXT_VALIDATION_ERROR",
   CONFIG_VALIDATION_ERROR = "CONFIG_VALIDATION_ERROR",
+  NON_DETERMINISM = "NON_DETERMINISM",
 
   // Custom reason
   CUSTOM = "CUSTOM",
 }
+
+/**
+ * Whether a termination means this invocation is done for now and the execution continues
+ * later, or that the execution has hit something it cannot continue past.
+ *
+ * A suspend is a wait, a scheduled retry, or a pending callback: the invocation answers
+ * PENDING and the service invokes again. A fault answers FAILED, carrying the error.
+ */
+export type TerminationClass = "suspend" | "fault";
+
+/**
+ * The class of every termination reason.
+ *
+ * Exhaustive by construction: `Record<TerminationReason, ...>` makes adding a reason
+ * without classifying it a compile error. That signal is the point of keeping this beside
+ * the enum -- a classification living in the consumer cannot tell anyone adding a reason
+ * here that they have left it unclassified, which is the very omission the fault default
+ * below exists to contain.
+ *
+ * CHECKPOINT_FAILED and SERDES_FAILED are faults, though in practice the invocation
+ * handles both before consulting this map: they rethrow, failing the invocation rather
+ * than the execution.
+ */
+export const TERMINATION_CLASS: Record<TerminationReason, TerminationClass> = {
+  [TerminationReason.OPERATION_TERMINATED]: "suspend",
+  [TerminationReason.RETRY_SCHEDULED]: "suspend",
+  [TerminationReason.RETRY_INTERRUPTED_STEP]: "suspend",
+  [TerminationReason.WAIT_SCHEDULED]: "suspend",
+  [TerminationReason.CALLBACK_PENDING]: "suspend",
+  [TerminationReason.CHECKPOINT_FAILED]: "fault",
+  [TerminationReason.SERDES_FAILED]: "fault",
+  [TerminationReason.CONTEXT_VALIDATION_ERROR]: "fault",
+  [TerminationReason.CONFIG_VALIDATION_ERROR]: "fault",
+  [TerminationReason.NON_DETERMINISM]: "fault",
+  // Deliberately unclassified in meaning: CUSTOM says nothing about whether the execution
+  // can continue, so it is treated as a fault. Reporting a fault that was really a suspend
+  // costs one failed execution; the reverse asks the service to retry something that can
+  // never progress, and hides the error while doing so.
+  [TerminationReason.CUSTOM]: "fault",
+};
+
+/**
+ * Classifies a termination reason, defaulting to `"fault"`.
+ *
+ * The default is not reachable through the enum -- the map above is exhaustive -- but is
+ * kept because `reason` crosses a boundary where a value outside the enum can arrive as a
+ * plain string, and answering PENDING for something unrecognised is the outcome worth
+ * ruling out.
+ */
+export const classifyTermination = (
+  reason: TerminationReason,
+): TerminationClass =>
+  (TERMINATION_CLASS as Partial<Record<TerminationReason, TerminationClass>>)[
+    reason
+  ] ?? "fault";
 
 export interface TerminationResponse {
   reason: TerminationReason;

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-failure.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-failure.composed.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Two ways a CHECKPOINT_FAILED termination arises, and what the invocation answers for
+ * each. A 5xx classifies as CheckpointUnrecoverableInvocationError: the invocation cannot
+ * continue but the execution can, so the correct outcome is to throw out of the handler and
+ * let the platform invoke again. Resolving instead -- with any status -- fails the
+ * execution for good.
+ *
+ * Reaching that outcome depends on the termination details carrying the error object,
+ * because runHandler's CHECKPOINT_FAILED branch does `throw result.error`. Which of the two
+ * callers terminates first therefore decides the outcome, and TerminationManager's
+ * isTerminated guard means the first one wins:
+ *
+ * - CheckpointManager's queue-processing catch already passed `error`, so a transport
+ *   failure was always handled correctly. The first test pins that; it is a regression
+ *   guard, not evidence for any recent change.
+ * - terminateForUnrecoverableError did not. It wins the race whenever an UnrecoverableError
+ *   classified CHECKPOINT_FAILED reaches step-handler's catch without the checkpoint queue
+ *   having failed -- step code throwing one itself. `throw result.error` then threw
+ *   `undefined`, the outer catch saw isUnrecoverableInvocationError(undefined) === false,
+ *   and the invocation resolved {Status: FAILED, Error: {ErrorMessage: "Unknown error"}}:
+ *   an execution permanently failed where it should have retried, with nothing naming the
+ *   cause. The second test pins the fix.
+ */
+
+import { withDurableExecution } from "../../with-durable-execution";
+import { DurableExecutionInvocationInputWithClient } from "../durable-execution-invocation-input/durable-execution-invocation-input";
+import { hashId } from "../step-id-utils/step-id-utils";
+import { DurableContext, DurableExecutionClient } from "../../types";
+import {
+  GetDurableExecutionStateResponse,
+  OperationStatus,
+  OperationType,
+  WireOperation,
+} from "../../types/wire";
+import { CheckpointUnrecoverableInvocationError } from "../../errors/checkpoint-errors/checkpoint-errors";
+import { Context } from "aws-lambda";
+
+const lambdaContext = {
+  awsRequestId: "request-1",
+  getRemainingTimeInMillis: () => 300_000,
+} as unknown as Context;
+
+/** A fresh execution: only the EXECUTION operation, so the step runs for the first time. */
+const freshExecutionState = (): WireOperation[] => [
+  {
+    Id: hashId("execution"),
+    Type: OperationType.EXECUTION,
+    Status: OperationStatus.STARTED,
+    StartTimestamp: new Date().toISOString(),
+    ExecutionDetails: { InputPayload: "{}" },
+  } as unknown as WireOperation,
+];
+
+const workingClient = (): DurableExecutionClient => ({
+  getExecutionState: async (): Promise<GetDurableExecutionStateResponse> => ({
+    Operations: [],
+    NextMarker: undefined,
+  }),
+  checkpoint: async () => ({
+    CheckpointToken: "token-2",
+    NewExecutionState: undefined,
+  }),
+});
+
+/** Rejects every checkpoint with an AWS-shaped 5xx, the shape CheckpointManager reads. */
+const failingClient = (): DurableExecutionClient => ({
+  ...workingClient(),
+  checkpoint: async () => {
+    throw Object.assign(new Error("Service Unavailable"), {
+      name: "ServiceException",
+      $metadata: { httpStatusCode: 503 },
+    });
+  },
+});
+
+const invoke = (
+  client: DurableExecutionClient,
+  handler: (event: unknown, context: DurableContext) => Promise<unknown>,
+): Promise<unknown> =>
+  withDurableExecution(handler)(
+    new DurableExecutionInvocationInputWithClient(
+      {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:repro:$LATEST",
+        CheckpointToken: "token-1",
+        InitialExecutionState: {
+          Operations: freshExecutionState(),
+          NextMarker: "",
+        },
+      },
+      client,
+    ),
+    lambdaContext,
+  );
+
+describe("CHECKPOINT_FAILED terminations", () => {
+  it("rethrows when the transport fails the checkpoint", async () => {
+    const invocation = invoke(
+      failingClient(),
+      async (_event, context: DurableContext) => {
+        await context.step("save-the-thing", async () => "done");
+        return "finished";
+      },
+    );
+
+    await expect(invocation).rejects.toThrow(/Checkpoint failed/);
+    await expect(invocation).rejects.toMatchObject({
+      isUnrecoverableInvocation: true,
+    });
+  });
+
+  it("rethrows when step code raises a checkpoint error itself", async () => {
+    // Nothing in the checkpoint queue fails here, so CheckpointManager never terminates and
+    // step-handler's catch is the first to do so. This is the path that resolved with
+    // "Unknown error" instead of throwing.
+    const invocation = invoke(
+      workingClient(),
+      async (_event, context: DurableContext) => {
+        await context.step("boom", async () => {
+          throw new CheckpointUnrecoverableInvocationError(
+            "thrown by step body",
+          );
+        });
+        return "finished";
+      },
+    );
+
+    await expect(invocation).rejects.toThrow(/thrown by step body/);
+    await expect(invocation).rejects.toMatchObject({
+      isUnrecoverableInvocation: true,
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-failure.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-failure.composed.test.ts
@@ -1,25 +1,12 @@
 /**
- * Two ways a CHECKPOINT_FAILED termination arises, and what the invocation answers for
- * each. A 5xx classifies as CheckpointUnrecoverableInvocationError: the invocation cannot
- * continue but the execution can, so the correct outcome is to throw out of the handler and
- * let the platform invoke again. Resolving instead -- with any status -- fails the
- * execution for good.
+ * A CHECKPOINT_FAILED termination has to throw out of the handler rather than resolve. A
+ * 5xx classifies as CheckpointUnrecoverableInvocationError -- the invocation cannot
+ * continue but the execution can -- so throwing is what gets it retried, and resolving with
+ * any status fails the execution for good.
  *
- * Reaching that outcome depends on the termination details carrying the error object,
- * because runHandler's CHECKPOINT_FAILED branch does `throw result.error`. Which of the two
- * callers terminates first therefore decides the outcome, and TerminationManager's
- * isTerminated guard means the first one wins:
- *
- * - CheckpointManager's queue-processing catch already passed `error`, so a transport
- *   failure was always handled correctly. The first test pins that; it is a regression
- *   guard, not evidence for any recent change.
- * - terminateForUnrecoverableError did not. It wins the race whenever an UnrecoverableError
- *   classified CHECKPOINT_FAILED reaches step-handler's catch without the checkpoint queue
- *   having failed -- step code throwing one itself. `throw result.error` then threw
- *   `undefined`, the outer catch saw isUnrecoverableInvocationError(undefined) === false,
- *   and the invocation resolved {Status: FAILED, Error: {ErrorMessage: "Unknown error"}}:
- *   an execution permanently failed where it should have retried, with nothing naming the
- *   cause. The second test pins the fix.
+ * Two callers can raise that termination, and TerminationManager's isTerminated guard means
+ * the first one wins. Which one it is decides whether runHandler's `throw result.error` has
+ * an error to throw, so there is a test per caller.
  */
 
 import { withDurableExecution } from "../../with-durable-execution";
@@ -65,7 +52,7 @@ const workingClient = (): DurableExecutionClient => ({
 /** Rejects every checkpoint with an AWS-shaped 5xx, the shape CheckpointManager reads. */
 const failingClient = (): DurableExecutionClient => ({
   ...workingClient(),
-  checkpoint: async () => {
+  checkpoint: async (): Promise<never> => {
     throw Object.assign(new Error("Service Unavailable"), {
       name: "ServiceException",
       $metadata: { httpStatusCode: 503 },
@@ -95,6 +82,8 @@ const invoke = (
 
 describe("CHECKPOINT_FAILED terminations", () => {
   it("rethrows when the transport fails the checkpoint", async () => {
+    // CheckpointManager's queue-processing catch has always carried the error, so this
+    // path was already correct: a regression guard rather than evidence for any change.
     const invocation = invoke(
       failingClient(),
       async (_event, context: DurableContext) => {
@@ -111,8 +100,11 @@ describe("CHECKPOINT_FAILED terminations", () => {
 
   it("rethrows when step code raises a checkpoint error itself", async () => {
     // Nothing in the checkpoint queue fails here, so CheckpointManager never terminates and
-    // step-handler's catch is the first to do so. This is the path that resolved with
-    // "Unknown error" instead of throwing.
+    // step-handler's catch gets there first, via terminateForUnrecoverableError. That call
+    // omitted the error, so `throw result.error` threw `undefined`, the outer catch read
+    // isUnrecoverableInvocationError(undefined) as false, and the invocation resolved
+    // `{Status: FAILED, Error: {ErrorMessage: "Unknown error"}}` -- an execution failed for
+    // good where it should have retried, with nothing naming the cause.
     const invocation = invoke(
       workingClient(),
       async (_event, context: DurableContext) => {

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Runs the real engine over a checkpoint history that does not match the code replaying
+ * it, and asserts the invocation reports the mismatch.
+ *
+ * This is the end-to-end shape of the fault a customer hits from a step name built at
+ * runtime -- `context.step("step-" + Date.now(), ...)` -- which produces a different name
+ * on every replay. The unit tests around `validateReplayConsistency` and the termination
+ * branch of `withDurableExecution` each cover one half; only running them together shows
+ * what the Lambda response actually says, which is the thing that was wrong: the SDK
+ * detected the mismatch, built a diagnostic for it, and then answered
+ * `{Status: "PENDING"}` with no error and no log line, asking the service to retry
+ * something that fails identically on every attempt. See
+ * https://github.com/aws/aws-durable-execution-sdk-js/issues/865.
+ */
+
+import { withDurableExecution } from "../../with-durable-execution";
+import { DurableExecutionInvocationInputWithClient } from "../durable-execution-invocation-input/durable-execution-invocation-input";
+import { hashId } from "../step-id-utils/step-id-utils";
+import {
+  DurableContext,
+  DurableExecutionClient,
+  InvocationStatus,
+  OperationSubType,
+} from "../../types";
+import {
+  CheckpointDurableExecutionRequest,
+  CheckpointDurableExecutionResponse,
+  GetDurableExecutionStateResponse,
+  OperationStatus,
+  OperationType,
+  WireOperation,
+} from "../../types/wire";
+import { Context } from "aws-lambda";
+
+const EXECUTION_ARN =
+  "arn:aws:lambda:us-east-1:123456789012:function:repro:$LATEST";
+
+const lambdaContext = {
+  awsRequestId: "request-1",
+  getRemainingTimeInMillis: () => 300_000,
+} as unknown as Context;
+
+/**
+ * Replay state for a single completed step, checkpointed under `checkpointedName`.
+ * `hashId("1")` is the id the engine derives for the first operation of the root context,
+ * so this is the checkpoint the handler's first `context.step` call will be matched
+ * against.
+ */
+const replayStateFor = (checkpointedName: string): WireOperation[] => [
+  {
+    Id: hashId("execution"),
+    Type: OperationType.EXECUTION,
+    Status: OperationStatus.STARTED,
+    StartTimestamp: new Date().toISOString(),
+    ExecutionDetails: { InputPayload: "{}" },
+  } as unknown as WireOperation,
+  {
+    Id: hashId("1"),
+    Type: OperationType.STEP,
+    SubType: OperationSubType.STEP,
+    Name: checkpointedName,
+    Status: OperationStatus.SUCCEEDED,
+    StartTimestamp: new Date().toISOString(),
+    StepDetails: { Result: JSON.stringify("checkpointed-result") },
+  } as unknown as WireOperation,
+];
+
+describe("non-deterministic replay reaches the invocation response", () => {
+  const checkpoints: CheckpointDurableExecutionRequest[] = [];
+
+  const client: DurableExecutionClient = {
+    getExecutionState: async (): Promise<GetDurableExecutionStateResponse> => ({
+      Operations: [],
+      NextMarker: undefined,
+    }),
+    checkpoint: async (
+      params: CheckpointDurableExecutionRequest,
+    ): Promise<CheckpointDurableExecutionResponse> => {
+      checkpoints.push(params);
+      return { CheckpointToken: "token-2", NewExecutionState: undefined };
+    },
+  };
+
+  const invoke = (
+    handler: (event: unknown, context: DurableContext) => Promise<unknown>,
+    checkpointedName: string,
+  ): Promise<unknown> =>
+    withDurableExecution(handler)(
+      new DurableExecutionInvocationInputWithClient(
+        {
+          DurableExecutionArn: EXECUTION_ARN,
+          CheckpointToken: "token-1",
+          InitialExecutionState: {
+            Operations: replayStateFor(checkpointedName),
+            NextMarker: "",
+          },
+        },
+        client,
+      ),
+      lambdaContext,
+    );
+
+  beforeEach(() => {
+    checkpoints.length = 0;
+  });
+
+  it("fails the invocation with the diagnostic when a step name changes on replay", async () => {
+    const stepBody = jest.fn();
+
+    const response = await invoke(async (_event, context: DurableContext) => {
+      await context.step("step-b", async () => {
+        stepBody();
+        return "fresh-result";
+      });
+      return "done";
+    }, "step-a");
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorType: "NonDeterministicExecutionError",
+        ErrorMessage: expect.stringContaining(
+          'Expected name "step-a", but got "step-b"',
+        ),
+      }),
+    });
+
+    // Nothing is checkpointed against a history the code no longer agrees with. The step
+    // body not running is not evidence of anything this change does: the checkpoint is
+    // already SUCCEEDED, so the replay path returns the cached result rather than
+    // executing. It is asserted only to pin that this scenario stays a pure replay.
+    expect(stepBody).not.toHaveBeenCalled();
+    expect(checkpoints).toEqual([]);
+  });
+
+  it("succeeds on the same history when the step name is stable", async () => {
+    // The control: the failure above is caused by the name divergence and nothing else
+    // about this harness.
+    const stepBody = jest.fn();
+
+    const response = await invoke(async (_event, context: DurableContext) => {
+      const result = await context.step("step-a", async () => {
+        stepBody();
+        return "fresh-result";
+      });
+      return result;
+    }, "step-a");
+
+    expect(response).toEqual({
+      Status: InvocationStatus.SUCCEEDED,
+      Result: JSON.stringify("checkpointed-result"),
+    });
+    expect(stepBody).not.toHaveBeenCalled(); // replayed from the checkpoint
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/replay-validation/replay-validation.composed.test.ts
@@ -105,13 +105,8 @@ describe("non-deterministic replay reaches the invocation response", () => {
   });
 
   it("fails the invocation with the diagnostic when a step name changes on replay", async () => {
-    const stepBody = jest.fn();
-
     const response = await invoke(async (_event, context: DurableContext) => {
-      await context.step("step-b", async () => {
-        stepBody();
-        return "fresh-result";
-      });
+      await context.step("step-b", async () => "fresh-result");
       return "done";
     }, "step-a");
 
@@ -125,11 +120,6 @@ describe("non-deterministic replay reaches the invocation response", () => {
       }),
     });
 
-    // Nothing is checkpointed against a history the code no longer agrees with. The step
-    // body not running is not evidence of anything this change does: the checkpoint is
-    // already SUCCEEDED, so the replay path returns the cached result rather than
-    // executing. It is asserted only to pin that this scenario stays a pure replay.
-    expect(stepBody).not.toHaveBeenCalled();
     expect(checkpoints).toEqual([]);
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-deferral.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-deferral.test.ts
@@ -31,6 +31,7 @@ describe("terminateForUnrecoverableError", () => {
     expect(mockContext.terminationManager.terminate).toHaveBeenCalledWith({
       reason: TerminationReason.CUSTOM,
       message: "Unrecoverable error in step test-step: Test error",
+      error,
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.test.ts
@@ -34,6 +34,9 @@ describe("termination helpers", () => {
         reason: TerminationReason.CUSTOM,
         message:
           "Unrecoverable error in step test-step: Test unrecoverable error",
+        // The error itself, not only its message: invocation-level handling
+        // reports it to plugins and serializes it into the Lambda response.
+        error: mockError,
       });
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/termination-helper/termination-helper.ts
@@ -3,6 +3,14 @@ import { UnrecoverableError } from "../../errors/unrecoverable-error/unrecoverab
 
 /**
  * Terminates execution for unrecoverable errors and returns a never-resolving promise
+ *
+ * The error itself is carried on the termination details, not just its message: the
+ * invocation-level handling in `with-durable-execution.ts` reports the error to
+ * plugins and serializes it into the Lambda response, and both need the concrete
+ * error (its `name`, and its stack when stack storage is enabled) rather than a
+ * flattened string. `CHECKPOINT_FAILED` goes further and rethrows the carried error
+ * to fail the invocation, so omitting it there would rethrow `undefined`.
+ *
  * @param context - The execution context containing the termination manager
  * @param error - The unrecoverable error that caused termination
  * @param stepIdentifier - The step name or ID for error messaging
@@ -16,6 +24,7 @@ export function terminateForUnrecoverableError<T>(
   context.terminationManager.terminate({
     reason: error.terminationReason,
     message: `Unrecoverable error in step ${stepIdentifier}: ${error.message}`,
+    error,
   });
 
   return new Promise<T>(() => {}); // Never-resolving promise

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution-queue-completion.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution-queue-completion.test.ts
@@ -5,6 +5,7 @@ import { Context } from "aws-lambda";
 import { DurableExecutionInvocationInput } from "./types";
 import { log } from "./utils/logger/logger";
 import { CheckpointManager } from "./utils/checkpoint/checkpoint-manager";
+import { TerminationReason } from "./termination-manager/types";
 
 // Mock dependencies
 jest.mock("./context/execution-context/execution-context");
@@ -92,7 +93,8 @@ describe("withDurableExecution Queue Completion", () => {
 
     // Mock termination promise to resolve immediately
     mockTerminationManager.getTerminationPromise.mockResolvedValue({
-      reason: "TIMEOUT",
+      reason: TerminationReason.WAIT_SCHEDULED,
+      message: "Wait scheduled",
     });
 
     const wrappedHandler = withDurableExecution(mockHandler);

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -15,6 +15,8 @@ import {
 import { TEST_CONSTANTS } from "./testing/test-constants";
 import { loadConfiguredPlugins } from "./utils/plugin/plugin-loader";
 import { PluginLoadError } from "./errors/plugin-load-error/plugin-load-error";
+import { TerminationReason } from "./termination-manager/types";
+import { NonDeterministicExecutionError } from "./errors/non-deterministic-error/non-deterministic-error";
 
 jest.mock("./context/execution-context/execution-context");
 jest.mock("./context/durable-context/durable-context");
@@ -496,4 +498,56 @@ describe("onInvocationEnd receives correct InvocationEndInfo on failure", () => 
       expect(endInfo.executionResult).toBeUndefined();
     },
   );
+});
+
+describe("onInvocationEnd reflects the class of a termination", () => {
+  // PluginInvocationStatus is public surface, so which status a termination reports is
+  // part of the contract. A fault previously reached plugins as PENDING with no error,
+  // because every reason without an explicit branch fell through to the suspend handling.
+  const runWithTermination = async (
+    reason: TerminationReason,
+    details: { message: string; error?: Error },
+  ): Promise<Record<string, unknown>> => {
+    const plugin: jest.Mocked<DurableInstrumentationPlugin> = {
+      onInvocationStart: jest.fn(),
+      onInvocationEnd: jest.fn(),
+    };
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason,
+      ...details,
+    });
+
+    const handler = withDurableExecution(
+      jest.fn().mockReturnValue(new Promise(() => {})), // never resolves
+      { plugins: [plugin] },
+    );
+    await handler(mockEvent, mockContext);
+
+    expect(plugin.onInvocationEnd).toHaveBeenCalledTimes(1);
+    return (plugin.onInvocationEnd as jest.Mock).mock.calls[0][0];
+  };
+
+  it("reports FAILED with the error for NON_DETERMINISM", async () => {
+    const error = new NonDeterministicExecutionError(
+      'Operation name mismatch for step "1"',
+    );
+    const endInfo = await runWithTermination(
+      TerminationReason.NON_DETERMINISM,
+      { message: error.message, error },
+    );
+
+    expect(endInfo.status).toBe(PluginInvocationStatus.FAILED);
+    expect(endInfo.executionError).toBe(error);
+    expect(endInfo.executionResult).toBeUndefined();
+  });
+
+  it("reports PENDING with no error for a suspend", async () => {
+    const endInfo = await runWithTermination(TerminationReason.WAIT_SCHEDULED, {
+      message: "Wait scheduled",
+    });
+
+    expect(endInfo.status).toBe(PluginInvocationStatus.PENDING);
+    expect(endInfo.executionError).toBeUndefined();
+    expect(endInfo.executionResult).toBeUndefined();
+  });
 });

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -2,6 +2,7 @@ import { withDurableExecution } from "./with-durable-execution";
 import { initializeExecutionContext } from "./context/execution-context/execution-context";
 import { createDurableContext } from "./context/durable-context/durable-context";
 import { CheckpointUnrecoverableInvocationError } from "./errors/checkpoint-errors/checkpoint-errors";
+import { NonDeterministicExecutionError } from "./errors/non-deterministic-error/non-deterministic-error";
 import {
   UnrecoverableInvocationError,
   UnrecoverableExecutionError,
@@ -252,11 +253,94 @@ describe("withDurableExecution", () => {
     );
   });
 
-  it("should return PENDING response for non-checkpoint termination", async () => {
+  it("should return FAILED response for CONTEXT_VALIDATION_ERROR reason", async () => {
+    // Using a parent or sibling context inside runInChildContext: deterministic and
+    // permanent, so the execution fails rather than being reported as still pending.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    const contextError = new Error(
+      'Context usage error in "child": You are using a parent or sibling context',
+    );
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CONTEXT_VALIDATION_ERROR,
+      message: contextError.message,
+      error: contextError,
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({ ErrorMessage: contextError.message }),
+    });
+  });
+
+  it("should return FAILED response carrying the error for CUSTOM reason", async () => {
+    // CUSTOM is how replay validation reports non-deterministic workflow code. It used
+    // to fall through to the generic handling and answer PENDING, which asked the
+    // service to retry an error that reproduces on every replay and hid the diagnostic
+    // from the customer entirely -- until the execution eventually failed with
+    // "Cannot return PENDING status with no pending operations" instead.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    const nonDeterminismError = new NonDeterministicExecutionError(
+      'Non-deterministic execution detected: Operation name mismatch for step "1". ' +
+        'Expected name "step-a", but got "step-b".',
+    );
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CUSTOM,
+      message: `Unrecoverable error in step 1: ${nonDeterminismError.message}`,
+      error: nonDeterminismError,
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorType: "NonDeterministicExecutionError",
+        ErrorMessage: nonDeterminismError.message,
+      }),
+    });
+  });
+
+  it("should return FAILED for a termination reason with no explicit branch", async () => {
+    // Fail closed: a reason added later without being classified as a suspend must not
+    // inherit PENDING by default, because PENDING claims the execution is progressing.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: "SOME_FUTURE_REASON" as TerminationReason,
+      message: "something the SDK does not classify yet",
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorMessage: "something the SDK does not classify yet",
+      }),
+    });
+  });
+
+  it.each([
+    TerminationReason.OPERATION_TERMINATED,
+    TerminationReason.WAIT_SCHEDULED,
+    TerminationReason.RETRY_SCHEDULED,
+    TerminationReason.RETRY_INTERRUPTED_STEP,
+    TerminationReason.CALLBACK_PENDING,
+  ])("should return PENDING response for %s termination", async (reason) => {
     // Setup
     const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
     mockTerminationManager.getTerminationPromise.mockResolvedValue({
-      reason: TerminationReason.OPERATION_TERMINATED,
+      reason,
       message: "Operation terminated",
     });
 

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -277,19 +277,19 @@ describe("withDurableExecution", () => {
     });
   });
 
-  it("should return FAILED response carrying the error for CUSTOM reason", async () => {
-    // CUSTOM is how replay validation reports non-deterministic workflow code. It used
-    // to fall through to the generic handling and answer PENDING, which asked the
-    // service to retry an error that reproduces on every replay and hid the diagnostic
-    // from the customer entirely -- until the execution eventually failed with
-    // "Cannot return PENDING status with no pending operations" instead.
+  it("should return FAILED response carrying the error for NON_DETERMINISM reason", async () => {
+    // How replay validation reports non-deterministic workflow code. It used to fall
+    // through to the generic handling and answer PENDING, which asked the service to
+    // retry an error that reproduces on every replay and hid the diagnostic from the
+    // customer entirely -- until the execution eventually failed with "Cannot return
+    // PENDING status with no pending operations" instead.
     const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
     const nonDeterminismError = new NonDeterministicExecutionError(
       'Non-deterministic execution detected: Operation name mismatch for step "1". ' +
         'Expected name "step-a", but got "step-b".',
     );
     mockTerminationManager.getTerminationPromise.mockResolvedValue({
-      reason: TerminationReason.CUSTOM,
+      reason: TerminationReason.NON_DETERMINISM,
       message: `Unrecoverable error in step 1: ${nonDeterminismError.message}`,
       error: nonDeterminismError,
     });
@@ -304,6 +304,30 @@ describe("withDurableExecution", () => {
       Error: expect.objectContaining({
         ErrorType: "NonDeterministicExecutionError",
         ErrorMessage: nonDeterminismError.message,
+      }),
+    });
+  });
+
+  it("should return FAILED response for CUSTOM reason", async () => {
+    // CUSTOM says nothing about whether the execution can continue, so it is treated as a
+    // fault. Pinned separately from NON_DETERMINISM above: that reason exists precisely so
+    // non-determinism no longer relies on CUSTOM's default, and this asserts the default
+    // itself did not change with it.
+    const mockHandler = jest.fn().mockReturnValue(new Promise(() => {})); // Never resolves
+    mockTerminationManager.getTerminationPromise.mockResolvedValue({
+      reason: TerminationReason.CUSTOM,
+      message: "terminated for a reason the SDK does not classify",
+    });
+
+    const response = await withDurableExecution(mockHandler)(
+      mockEvent,
+      mockContext,
+    );
+
+    expect(response).toEqual({
+      Status: InvocationStatus.FAILED,
+      Error: expect.objectContaining({
+        ErrorMessage: "terminated for a reason the SDK does not classify",
       }),
     });
   });

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -8,7 +8,10 @@ import { initializeExecutionContext } from "./context/execution-context/executio
 import { SerdesFailedError } from "./errors/serdes-errors/serdes-errors";
 import { isUnrecoverableInvocationError } from "./errors/unrecoverable-error/unrecoverable-error";
 import { isNonRetryableCustomerError } from "./errors/non-retryable-errors";
-import { TerminationReason } from "./termination-manager/types";
+import {
+  TerminationReason,
+  classifyTermination,
+} from "./termination-manager/types";
 import { resolveRootPreserveChildDepth } from "./utils/child-operations-depth/child-operations-depth";
 import {
   validateDurableExecutionConfig,
@@ -49,32 +52,6 @@ import {
 
 // Lambda response size limit is 6MB
 const LAMBDA_RESPONSE_SIZE_LIMIT = 6 * 1024 * 1024 - 50; // 6MB in bytes, minus 50 bytes for envelope
-
-/**
- * Termination reasons that mean "this invocation is done for now, the execution
- * continues later" -- a wait, a scheduled retry, or a pending callback. These are
- * the only reasons that may answer PENDING, which tells the service to keep the
- * execution alive and invoke again.
- *
- * Everything else is a fault, and the default for an unlisted reason is FAILED.
- * The list is an allowlist rather than a denylist deliberately: a reason added
- * later without a corresponding branch here then fails closed with its error
- * reported, instead of silently claiming the execution is still progressing.
- * Answering PENDING for a deterministic, permanent fault is worse than useless --
- * every replay reproduces it, the error never reaches the customer, and once no
- * operation is actually pending the service rejects the response outright
- * ("Cannot return PENDING status with no pending operations").
- *
- * CHECKPOINT_FAILED and SERDES_FAILED are absent because they are handled before
- * this point: both rethrow, which fails the invocation rather than the execution.
- */
-const SUSPEND_TERMINATION_REASONS: ReadonlySet<TerminationReason> = new Set([
-  TerminationReason.OPERATION_TERMINATED,
-  TerminationReason.WAIT_SCHEDULED,
-  TerminationReason.RETRY_SCHEDULED,
-  TerminationReason.RETRY_INTERRUPTED_STEP,
-  TerminationReason.CALLBACK_PENDING,
-]);
 
 async function runHandler<
   Input,
@@ -270,11 +247,11 @@ async function runHandler<
           throw new SerdesFailedError(result.message);
         }
 
-        // Every remaining termination reason is decided here. A suspend answers
-        // PENDING; anything else is a fault and answers FAILED with the error the
-        // terminating code carried (see SUSPEND_TERMINATION_REASONS).
+        // Every remaining termination reason is decided by its class: a suspend means the
+        // execution continues later and answers PENDING, a fault answers FAILED carrying
+        // the error. See TERMINATION_CLASS for what each reason is and why.
         if (resultType === "termination") {
-          if (SUSPEND_TERMINATION_REASONS.has(result.reason)) {
+          if (classifyTermination(result.reason) === "suspend") {
             log("🛑", "Returning termination response", {
               reason: result.reason,
             });
@@ -293,12 +270,6 @@ async function runHandler<
             };
           }
 
-          // Deterministic, non-retryable faults: an invalid maxConcurrency or
-          // completionConfig (CONFIG_VALIDATION_ERROR), use of a parent or sibling
-          // context inside runInChildContext (CONTEXT_VALIDATION_ERROR), and
-          // non-deterministic workflow code detected during replay (CUSTOM, raised
-          // by validateReplayConsistency). Retrying reproduces all of them, so the
-          // execution fails now and the diagnostic reaches the customer.
           const error = result.error ?? new Error(result.message);
           log(
             "🛑",

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -50,6 +50,32 @@ import {
 // Lambda response size limit is 6MB
 const LAMBDA_RESPONSE_SIZE_LIMIT = 6 * 1024 * 1024 - 50; // 6MB in bytes, minus 50 bytes for envelope
 
+/**
+ * Termination reasons that mean "this invocation is done for now, the execution
+ * continues later" -- a wait, a scheduled retry, or a pending callback. These are
+ * the only reasons that may answer PENDING, which tells the service to keep the
+ * execution alive and invoke again.
+ *
+ * Everything else is a fault, and the default for an unlisted reason is FAILED.
+ * The list is an allowlist rather than a denylist deliberately: a reason added
+ * later without a corresponding branch here then fails closed with its error
+ * reported, instead of silently claiming the execution is still progressing.
+ * Answering PENDING for a deterministic, permanent fault is worse than useless --
+ * every replay reproduces it, the error never reaches the customer, and once no
+ * operation is actually pending the service rejects the response outright
+ * ("Cannot return PENDING status with no pending operations").
+ *
+ * CHECKPOINT_FAILED and SERDES_FAILED are absent because they are handled before
+ * this point: both rethrow, which fails the invocation rather than the execution.
+ */
+const SUSPEND_TERMINATION_REASONS: ReadonlySet<TerminationReason> = new Set([
+  TerminationReason.OPERATION_TERMINATED,
+  TerminationReason.WAIT_SCHEDULED,
+  TerminationReason.RETRY_SCHEDULED,
+  TerminationReason.RETRY_INTERRUPTED_STEP,
+  TerminationReason.CALLBACK_PENDING,
+]);
+
 async function runHandler<
   Input,
   Output,
@@ -244,72 +270,57 @@ async function runHandler<
           throw new SerdesFailedError(result.message);
         }
 
-        // If termination was due to context validation error, return FAILED
-        if (
-          resultType === "termination" &&
-          result.reason === TerminationReason.CONTEXT_VALIDATION_ERROR
-        ) {
-          log("🛑", "Context validation error - returning FAILED status");
-          const response = {
-            Status: InvocationStatus.FAILED,
-            Error: createErrorObjectFromError(
-              result.error || new Error(result.message),
-            ),
-          };
-          await plugin.onInvocationEnd?.({
-            ...invocationBaseInfo,
-            status: PluginInvocationStatus.FAILED,
-            executionInput: customerHandlerEvent,
-            executionError: result.error || new Error(result.message),
-            executionResult: undefined,
-            operations: toOperationInfoMap(executionContext._stepData),
-          });
-          return response;
-        }
-
-        // If termination was due to a config validation error (e.g. an
-        // invalid maxConcurrency or a mutually-exclusive completionConfig),
-        // return FAILED. This is a deterministic, non-retryable caller
-        // mistake -- same category as CONTEXT_VALIDATION_ERROR above, not a
-        // suspend/pause, so it must not fall through to the generic
-        // termination handling below (which returns PENDING).
-        if (
-          resultType === "termination" &&
-          result.reason === TerminationReason.CONFIG_VALIDATION_ERROR
-        ) {
-          log("🛑", "Config validation error - returning FAILED status");
-          const response = {
-            Status: InvocationStatus.FAILED,
-            Error: createErrorObjectFromError(
-              result.error || new Error(result.message),
-            ),
-          };
-          await plugin.onInvocationEnd?.({
-            ...invocationBaseInfo,
-            status: PluginInvocationStatus.FAILED,
-            executionInput: customerHandlerEvent,
-            executionError: result.error || new Error(result.message),
-            executionResult: undefined,
-            operations: toOperationInfoMap(executionContext._stepData),
-          });
-          return response;
-        }
-
+        // Every remaining termination reason is decided here. A suspend answers
+        // PENDING; anything else is a fault and answers FAILED with the error the
+        // terminating code carried (see SUSPEND_TERMINATION_REASONS).
         if (resultType === "termination") {
-          log("🛑", "Returning termination response");
+          if (SUSPEND_TERMINATION_REASONS.has(result.reason)) {
+            log("🛑", "Returning termination response", {
+              reason: result.reason,
+            });
 
+            await plugin.onInvocationEnd?.({
+              ...invocationBaseInfo,
+              status: PluginInvocationStatus.PENDING,
+              executionInput: customerHandlerEvent,
+              executionResult: undefined,
+              executionError: undefined,
+              operations: toOperationInfoMap(executionContext._stepData),
+            });
+
+            return {
+              Status: InvocationStatus.PENDING,
+            };
+          }
+
+          // Deterministic, non-retryable faults: an invalid maxConcurrency or
+          // completionConfig (CONFIG_VALIDATION_ERROR), use of a parent or sibling
+          // context inside runInChildContext (CONTEXT_VALIDATION_ERROR), and
+          // non-deterministic workflow code detected during replay (CUSTOM, raised
+          // by validateReplayConsistency). Retrying reproduces all of them, so the
+          // execution fails now and the diagnostic reaches the customer.
+          const error = result.error ?? new Error(result.message);
+          log(
+            "🛑",
+            `Terminated with ${result.reason} - returning FAILED status`,
+            {
+              message: result.message,
+            },
+          );
+
+          const response = {
+            Status: InvocationStatus.FAILED,
+            Error: createErrorObjectFromError(error),
+          };
           await plugin.onInvocationEnd?.({
             ...invocationBaseInfo,
-            status: PluginInvocationStatus.PENDING,
+            status: PluginInvocationStatus.FAILED,
             executionInput: customerHandlerEvent,
+            executionError: error,
             executionResult: undefined,
-            executionError: undefined,
             operations: toOperationInfoMap(executionContext._stepData),
           });
-
-          return {
-            Status: InvocationStatus.PENDING,
-          };
+          return response;
         }
 
         log("✅", "Returning normal completion response");


### PR DESCRIPTION
Replay validation raises NonDeterministicExecutionError, the only production error carrying TerminationReason.CUSTOM. runHandler had no branch for CUSTOM, so it fell through to the catch-all and answered {Status: "PENDING"} with no error and no log line. PENDING asks the service to keep the execution alive and invoke again, but the fault is deterministic and permanent: every replay reproduces it, the diagnostic the SDK had already built never reached the customer, and once nothing was actually pending the service rejected the response outright with "Cannot return PENDING status with no pending operations".

Invert the termination branch rather than add a third near-identical case. Suspend reasons are now an allowlist (OPERATION_TERMINATED, WAIT_SCHEDULED, RETRY_SCHEDULED, RETRY_INTERRUPTED_STEP, CALLBACK_PENDING) and every other reason answers FAILED with the carried error, so a reason added later without a branch here fails closed instead of silently claiming the execution is still progressing. This also subsumes the CONTEXT_VALIDATION_ERROR and CONFIG_VALIDATION_ERROR branches, which were copies of each other. CHECKPOINT_FAILED and SERDES_FAILED still rethrow ahead of it, unchanged.

terminateForUnrecoverableError now carries the error object, not only its message, so ErrorType reaches the customer as NonDeterministicExecutionError rather than a bare Error. This also fixes a latent bug on the CHECKPOINT_FAILED path: runHandler does `throw result.error`, which threw undefined whenever the termination came from terminateForUnrecoverableError rather than from CheckpointManager.

Tests: a composed test runs the real engine over a history checkpointed as "step-a" while the handler replays "step-b", and asserts FAILED carrying the diagnostic, with a stable-name control case. Pinned against the unfixed source it returns {Status: "PENDING"}, reproducing the report. Unit coverage added for CUSTOM -> FAILED with the type preserved, CONTEXT_VALIDATION_ERROR -> FAILED (previously untested), an unclassified reason failing closed, and all five suspend reasons -> PENDING; only OPERATION_TERMINATED was covered before.

This is the status half of #865. Item 3 of that issue -- validateReplayConsistency discarding its never-resolving promise, which lets handler code keep running against checkpoint data known to belong to a different operation -- is a separate defect with a wider blast radius, and follows in its own change.

This changes observable invocation status for a public failure mode, so it looks like a candidate for a conformance test in
https://github.com/aws/aws-durable-execution-conformance-tests.

Refs #865