### PR TITLE
fix(sdk): surface checkpoint failure raised after the handler resolves

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-batch-failure-end-to-end.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-batch-failure-end-to-end.composed.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The handler-wins path: the customer handler returns normally while a checkpoint
+ * is still queued, and that checkpoint's batch then fails during the drain.
+ *
+ * run-in-child-context-handler does not await its terminal SUCCEED checkpoint, so
+ * `await context.runInChildContext(...)` hands the value back to the handler with
+ * that checkpoint still in the queue. The handler returns, wins the race against
+ * the termination promise, and only then does the drain fail. Nothing is left
+ * awaiting the termination promise at that point, so before the fix this reported
+ * SUCCEEDED for state that was never persisted -- and because a result was being
+ * returned, there was no subsequent invocation to retry it.
+ *
+ * Real withDurableExecution and real CheckpointManager; only the transport is
+ * faked, and it fails only after the handler's work is done.
+ */
+
+import { withDurableExecution } from "../../with-durable-execution";
+import { DurableExecutionInvocationInputWithClient } from "../durable-execution-invocation-input/durable-execution-invocation-input";
+import { hashId } from "../step-id-utils/step-id-utils";
+import { DurableContext, DurableExecutionClient } from "../../types";
+import {
+  CheckpointDurableExecutionResponse,
+  GetDurableExecutionStateResponse,
+  OperationStatus,
+  OperationType,
+  WireOperation,
+} from "../../types/wire";
+import { Context } from "aws-lambda";
+
+const lambdaContext = {
+  awsRequestId: "request-1",
+  getRemainingTimeInMillis: () => 300_000,
+} as unknown as Context;
+
+/** A fresh execution: only the EXECUTION operation, so the child runs for the first time. */
+const freshExecutionState = (): WireOperation[] => [
+  {
+    Id: hashId("execution"),
+    Type: OperationType.EXECUTION,
+    Status: OperationStatus.STARTED,
+    StartTimestamp: new Date().toISOString(),
+    ExecutionDetails: { InputPayload: "{}" },
+  } as unknown as WireOperation,
+];
+
+/**
+ * Succeeds until `failFrom` is flipped, then rejects with an AWS-shaped 5xx --
+ * a transient backend error, classified as CheckpointUnrecoverableInvocationError.
+ */
+const clientFailingAfterHandler = (
+  shouldFail: () => boolean,
+  onCall: () => void,
+): DurableExecutionClient => ({
+  getExecutionState: async (): Promise<GetDurableExecutionStateResponse> => ({
+    Operations: [],
+    NextMarker: undefined,
+  }),
+  checkpoint: async (): Promise<CheckpointDurableExecutionResponse> => {
+    onCall();
+
+    if (shouldFail()) {
+      throw Object.assign(new Error("Service Unavailable"), {
+        name: "ServiceException",
+        $metadata: { httpStatusCode: 503 },
+      });
+    }
+
+    return {
+      CheckpointToken: "token-2",
+      NewExecutionState: undefined,
+    } as unknown as CheckpointDurableExecutionResponse;
+  },
+});
+
+const invoke = (
+  client: DurableExecutionClient,
+  handler: (event: unknown, context: DurableContext) => Promise<unknown>,
+): Promise<unknown> =>
+  withDurableExecution(handler)(
+    new DurableExecutionInvocationInputWithClient(
+      {
+        DurableExecutionArn:
+          "arn:aws:lambda:us-east-1:123456789012:function:repro:$LATEST",
+        CheckpointToken: "token-1",
+        InitialExecutionState: {
+          Operations: freshExecutionState(),
+          NextMarker: "",
+        },
+      },
+      client,
+    ),
+    lambdaContext,
+  );
+
+describe("checkpoint failure after the handler resolves", () => {
+  it("throws instead of reporting SUCCEEDED for a discarded checkpoint", async () => {
+    let handlerDone = false;
+    let checkpointCalls = 0;
+
+    const client = clientFailingAfterHandler(
+      () => handlerDone,
+      () => {
+        checkpointCalls += 1;
+      },
+    );
+
+    const invocation = invoke(
+      client,
+      async (_event, context: DurableContext) => {
+        // The child context's terminal SUCCEED checkpoint is enqueued but not
+        // awaited, so it is still outstanding when this handler returns.
+        await context.runInChildContext("child", async () => "child-done");
+
+        handlerDone = true;
+        return "finished";
+      },
+    );
+
+    // Before the fix this resolved {"Status":"SUCCEEDED","Result":"\"finished\""}.
+    await expect(invocation).rejects.toThrow(/Checkpoint failed/);
+    await expect(invocation).rejects.toMatchObject({
+      isUnrecoverableInvocation: true,
+    });
+
+    // Guards the setup rather than the fix: if the transport were never reached
+    // after the handler finished, the test would pass for the wrong reason.
+    expect(checkpointCalls).toBeGreaterThan(0);
+  });
+
+  it("still reports SUCCEEDED when the drain succeeds", async () => {
+    let checkpointCalls = 0;
+
+    const client = clientFailingAfterHandler(
+      () => false,
+      () => {
+        checkpointCalls += 1;
+      },
+    );
+
+    const result = await invoke(
+      client,
+      async (_event, context: DurableContext) => {
+        await context.runInChildContext("child", async () => "child-done");
+        return "finished";
+      },
+    );
+
+    expect(result).toMatchObject({ Status: "SUCCEEDED" });
+    expect(checkpointCalls).toBeGreaterThan(0);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-batch-failure.composed.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-batch-failure.composed.test.ts
@@ -1,0 +1,122 @@
+import { createTestCheckpointManager } from "../../testing/create-test-checkpoint-manager";
+import { CheckpointManager } from "./checkpoint-manager";
+import { CheckpointUnrecoverableInvocationError } from "../../errors/checkpoint-errors/checkpoint-errors";
+import { DurableLogger, ExecutionContext, OperationSubType } from "../../types";
+import { OperationAction, OperationType } from "../../types/wire";
+import { TerminationManager } from "../../termination-manager/termination-manager";
+import { TerminationReason } from "../../termination-manager/types";
+import { createMockExecutionContext } from "../../testing/mock-context";
+import { TEST_CONSTANTS } from "../../testing/test-constants";
+import { EventEmitter } from "events";
+import { createDefaultLogger } from "../logger/default-logger";
+import {
+  DurableExecutionClientError,
+  DurableExecutionClientErrorScope,
+} from "../../errors/durable-execution-client-error/durable-execution-client-error";
+
+jest.mock("../logger/logger", () => ({
+  log: jest.fn(),
+}));
+
+/**
+ * Composed: real CheckpointManager and real TerminationManager, with only the
+ * transport faked.
+ *
+ * These pin the contract `withDurableExecution` relies on when the handler wins
+ * the race and a checkpoint batch then fails while the queue is drained. That
+ * path cannot learn about the failure from `waitForQueueCompletion()`, which
+ * resolves either way, so it reads `getBatchFailure()`. Whether that read sees
+ * anything depends on ordering inside `processQueue`'s catch, exercised here
+ * with the real objects rather than a mock.
+ */
+describe("Checkpoint drain failure (composed)", () => {
+  let terminationManager: TerminationManager;
+  let context: ExecutionContext;
+  let logger: DurableLogger;
+  let emitter: EventEmitter;
+  let checkpointManager: CheckpointManager;
+
+  const transportError = new DurableExecutionClientError(
+    "backend unavailable",
+    {
+      scope: DurableExecutionClientErrorScope.INVOCATION,
+    },
+  );
+
+  const enqueueTerminalCheckpoint = (stepId: string): void => {
+    // Not awaited, mirroring how run-in-child-context-handler enqueues its
+    // terminal checkpoint: the value is handed back to the handler while this
+    // checkpoint is still queued.
+    void checkpointManager.checkpoint(stepId, {
+      Id: stepId,
+      Action: OperationAction.SUCCEED,
+      SubType: OperationSubType.RUN_IN_CHILD_CONTEXT,
+      Type: OperationType.CONTEXT,
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    emitter = new EventEmitter();
+
+    terminationManager = new TerminationManager();
+
+    context = createMockExecutionContext({
+      durableExecutionArn: "test-durable-execution-arn",
+      durableExecutionClient: {
+        checkpoint: jest.fn().mockRejectedValue(transportError),
+      } as unknown as ExecutionContext["durableExecutionClient"],
+      terminationManager,
+    });
+
+    logger = createDefaultLogger(context);
+    checkpointManager = createTestCheckpointManager(
+      context,
+      TEST_CONSTANTS.CHECKPOINT_TOKEN,
+      emitter,
+      logger,
+    );
+  });
+
+  it("reports nothing when no batch has failed", () => {
+    expect(checkpointManager.getBatchFailure()).toBeUndefined();
+  });
+
+  it("has recorded the classified failure by the time the drain's await resumes", async () => {
+    enqueueTerminalCheckpoint("child-context-1");
+
+    // The waiter is resolved rather than rejected, so awaiting it looks like an
+    // ordinary completion; getBatchFailure() is what distinguishes the two.
+    await expect(
+      checkpointManager.waitForQueueCompletion(),
+    ).resolves.toBeUndefined();
+
+    const failure = checkpointManager.getBatchFailure();
+
+    expect(failure).toBeInstanceOf(CheckpointUnrecoverableInvocationError);
+    expect(failure?.message).toContain("backend unavailable");
+  });
+
+  it("reports the batch failure even when something else terminated first", async () => {
+    // Why the failure is recorded on the CheckpointManager rather than read back
+    // from the TerminationManager: terminate() early-returns once isTerminated is
+    // set, so an earlier termination like this one would hide the
+    // CHECKPOINT_FAILED that follows.
+    //
+    // The termination is raised directly to isolate that semantics. A real
+    // suspend-class termination could not coexist with a batch still to drain:
+    // executeTermination gates on shouldTerminate(), which requires an idle
+    // queue.
+    terminationManager.terminate({
+      reason: TerminationReason.WAIT_SCHEDULED,
+      message: "Wait scheduled",
+    });
+
+    enqueueTerminalCheckpoint("child-context-1");
+    await checkpointManager.waitForQueueCompletion();
+
+    expect(checkpointManager.getBatchFailure()).toBeInstanceOf(
+      CheckpointUnrecoverableInvocationError,
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -72,6 +72,16 @@ export class CheckpointManager implements Checkpoint {
     reject: (error: Error) => void;
   }> = [];
   private queueCompletionResolver: (() => void) | null = null;
+  /**
+   * The classified error from a checkpoint batch that failed, if one did.
+   *
+   * Neither {@link waitForQueueCompletion}, which only ever resolves, nor the
+   * TerminationManager, whose `isTerminated` guard keeps only the first
+   * termination raised, reports this reliably.
+   */
+  private batchFailure?:
+    | CheckpointUnrecoverableInvocationError
+    | CheckpointUnrecoverableExecutionError;
   private readonly MAX_PAYLOAD_SIZE = 750 * 1024; // 750KB in bytes
   private readonly MAX_ITEMS_IN_BATCH = 250;
   private isTerminating = false;
@@ -442,6 +452,14 @@ export class CheckpointManager implements Checkpoint {
 
       const checkpointError = this.classifyCheckpointError(error);
 
+      // Assigned synchronously within this block, before clearQueue() resolves
+      // anyone inside waitForQueueCompletion(). Awaiting anything ahead of this
+      // point would let such a caller resume while the failure is still
+      // unreadable, and report success. The relative order of these two
+      // statements does not matter -- the waiter resumes in a microtask, after
+      // this block finishes -- but an await between them would.
+      this.batchFailure = checkpointError;
+
       // Clear remaining queue silently - we're terminating
       this.clearQueue();
 
@@ -467,6 +485,19 @@ export class CheckpointManager implements Checkpoint {
         }
       }
     }
+  }
+
+  /**
+   * The classified error from a checkpoint batch that failed during this
+   * invocation, or `undefined` if none did. A caller that awaited
+   * {@link waitForQueueCompletion} needs this to tell a completed drain from a
+   * failed one, since that await resolves either way.
+   */
+  getBatchFailure():
+    | CheckpointUnrecoverableInvocationError
+    | CheckpointUnrecoverableExecutionError
+    | undefined {
+    return this.batchFailure;
   }
 
   private notifyQueueCompletion(): void {

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.plugin.test.ts
@@ -76,6 +76,7 @@ beforeEach(() => {
     setTerminating: jest.fn(),
     dispose: jest.fn(),
     waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+    getBatchFailure: jest.fn().mockReturnValue(undefined),
   }));
   mockTerminationManager.getTerminationPromise.mockReturnValue(
     new Promise(() => {}),

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.test.ts
@@ -83,6 +83,7 @@ describe("withDurableExecution", () => {
       setTerminating: jest.fn(),
       dispose: jest.fn(),
       waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+      getBatchFailure: jest.fn().mockReturnValue(undefined),
     }));
 
     // Reset termination manager mock behavior
@@ -102,6 +103,7 @@ describe("withDurableExecution", () => {
       setTerminating: jest.fn(),
       dispose,
       waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+      getBatchFailure: jest.fn().mockReturnValue(undefined),
     }));
     mockTerminationManager.getTerminationPromise.mockReturnValue(
       new Promise(() => {}),
@@ -122,6 +124,7 @@ describe("withDurableExecution", () => {
       setTerminating: jest.fn(),
       dispose,
       waitForQueueCompletion: jest.fn().mockResolvedValue(undefined),
+      getBatchFailure: jest.fn().mockReturnValue(undefined),
     }));
     mockTerminationManager.getTerminationPromise.mockReturnValue(
       new Promise(() => {}),
@@ -559,6 +562,7 @@ describe("withDurableExecution", () => {
       checkpoint: jest.fn().mockRejectedValue(checkpointError),
       setTerminating: jest.fn(),
       dispose: jest.fn(),
+      getBatchFailure: jest.fn().mockReturnValue(undefined),
     }));
 
     mockTerminationManager.getTerminationPromise.mockReturnValue(
@@ -850,5 +854,66 @@ describe("withDurableExecution", () => {
     })(mockEvent, mockContext);
 
     expect(initializeExecutionContext).toHaveBeenCalled();
+  });
+  it("throws the drain failure when the handler resolved before the batch failed", async () => {
+    // The handler resolves first, so it wins the race and `resultType` is
+    // "handler". A checkpoint batch then fails during waitForQueueCompletion():
+    // processQueue records the classified error, discards the queue and raises
+    // terminate(CHECKPOINT_FAILED). The waiter still resolves -- it is only ever
+    // resolved -- so nothing throws, and the termination promise has no observer
+    // left. Without reading getBatchFailure() this returned SUCCEEDED for an
+    // operation whose checkpoint was never persisted.
+    //
+    // checkpoint-batch-failure-end-to-end.composed.test.ts covers the same path
+    // through the public API with a real CheckpointManager; this pins the wiring.
+    const mockHandler = jest.fn().mockResolvedValue({ ok: true });
+
+    const batchFailure = new CheckpointUnrecoverableInvocationError(
+      "Checkpoint failed after handler resolved",
+    );
+
+    // Never resolves: the handler wins the race.
+    mockTerminationManager.getTerminationPromise.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const getBatchFailure = jest.fn().mockReturnValue(undefined);
+
+    (CheckpointManager as unknown as jest.Mock).mockImplementation(() => ({
+      checkpoint: jest.fn().mockResolvedValue(undefined),
+      setTerminating: jest.fn(),
+      dispose: jest.fn(),
+      waitForQueueCompletion: jest.fn().mockImplementation(async () => {
+        // The batch failed: the classified error is recorded before the waiter
+        // is notified, and the drain still resolves rather than rejecting.
+        getBatchFailure.mockReturnValue(batchFailure);
+        return undefined;
+      }),
+      getBatchFailure,
+    }));
+
+    const wrappedHandler = withDurableExecution(mockHandler);
+
+    await expect(wrappedHandler(mockEvent, mockContext)).rejects.toThrow(
+      CheckpointUnrecoverableInvocationError,
+    );
+  });
+
+  it("returns the handler result when the drain reported no failure", async () => {
+    // The negative case for the check above: getBatchFailure() answering
+    // undefined must leave a successful invocation untouched.
+    const mockHandler = jest.fn().mockResolvedValue({ ok: true });
+
+    mockTerminationManager.getTerminationPromise.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const wrappedHandler = withDurableExecution(mockHandler);
+    const response = await wrappedHandler(mockEvent, mockContext);
+
+    expect(response).toEqual({
+      Status: InvocationStatus.SUCCEEDED,
+      Result: JSON.stringify({ ok: true }),
+    });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -228,6 +228,28 @@ async function runHandler<
           log("⚠️", "Error waiting for checkpoint completion:", error);
         }
 
+        // waitForQueueCompletion() resolves whether the drain succeeded or
+        // failed: on failure processQueue's catch resolves the waiter via
+        // clearQueue(), and the CHECKPOINT_FAILED termination it raises lands
+        // after Promise.race has settled, so on this path nothing observes it.
+        // Reachable from ordinary awaited code -- run-in-child-context-handler
+        // does not await its terminal checkpoint -- and reports success for a
+        // checkpoint that was discarded, with no later invocation to retry it.
+        //
+        // Only this path needs the check: a suspend-class termination cannot
+        // leave a batch to drain, since shouldTerminate() requires an idle
+        // queue, and a fault-class one already returns FAILED carrying its own
+        // error.
+        if (resultType === "handler") {
+          const batchFailure =
+            durableExecution.checkpointManager.getBatchFailure();
+
+          if (batchFailure) {
+            log("🛑", "Checkpoint batch failed - handling termination");
+            throw batchFailure;
+          }
+        }
+
         // If termination was due to checkpoint failure, throw the appropriate error
         if (
           resultType === "termination" &&


### PR DESCRIPTION
A checkpoint batch that fails while `runHandler` drains the checkpoint
queue was silently dropped when the handler had already won the race, and
the invocation returned SUCCEEDED for an operation whose checkpoint was
classified as failed and then discarded.

Neither channel out of that drain reports the failure. On the failure path
`processQueue`'s catch calls `clearQueue()`, which notifies the queue-
completion waiter, so the `try/catch` around `waitForQueueCompletion()`
sees an ordinary completion -- the waiter captures only `resolve` and is
never rejected. (The later `notifyQueueCompletion()` in `finally` is a
no-op by then, since the resolver has already been nulled.) The other
signal, `terminate({ reason: CHECKPOINT_FAILED })`, is raised after
`Promise.race` has settled: when the handler won it, nothing is awaiting
the termination promise, so the resolution has no observer, and every
branch that follows was gated on `resultType === "termination"`.

Because a result is being returned there is no subsequent invocation, so
the discarded checkpoint is never retried, contrary to the "will be
retried on next invocation" reasoning at the sibling drain sites.

Reachable from ordinary awaited code: run-in-child-context-handler is the
only handler that does not await its terminal checkpoint (SUCCEED and FAIL
are both fire-and-forget), so `await context.runInChildContext(...)` as
the last operation returns to the handler with that checkpoint still
queued. The end-to-end composed test added here is exactly that -- a plain
handler and a plain 503 -- and on main it resolves
`{"Status":"SUCCEEDED","Result":"\"finished\""}`.

Record the classified error on CheckpointManager, which already has it in
that catch, and expose `getBatchFailure()`. The caller reads the failure
from the object that produced it: no reason filter, and no dependence on
TerminationManager's `isTerminated` guard, which keeps only the first
termination raised and would hide a checkpoint failure whenever anything
else terminated first. The assignment is synchronous within that catch,
which is what matters -- a caller inside `waitForQueueCompletion()` resumes
in a microtask, so only an intervening `await` could let it observe the
failure too late.

Checked only on the handler-wins path. A suspend-class termination cannot
leave a batch to drain, since `executeTermination` gates on
`shouldTerminate()`, whose first rules require an idle queue with no
pending force requests. A fault-class termination is unguarded and can win
the race with work still queued, but already returns FAILED carrying its
own error, which is the more informative one. The residual case is a
fault-class execution-scope error masking a discarded invocation-scope
transient, which returns FAILED instead of retrying; preferring the fault
error is defensible and it is left as is.

Behaviour change beyond the drain window: on the handler-wins path any
batch failure recorded during the invocation now throws, not only one that
lands during the final drain. That matches what the termination-wins path
has always done for CHECKPOINT_FAILED.

Only partly closes this class of bug. The `serializedSize >
LAMBDA_RESPONSE_SIZE_LIMIT` branch enqueues an EXECUTION/SUCCEED
checkpoint, awaits it, drains, and returns SUCCEEDED, carrying the same
"retried on next invocation" comment. On batch failure `processQueue`'s
catch neither resolves nor rejects the in-flight batch's items and
`clearQueue()` drops queued ones silently, so the `checkpoint()` awaited
there has no settled outcome to observe. Pre-existing and left alone here; tracked as #871.

Tests: `checkpoint-batch-failure-end-to-end.composed.test.ts` drives real
withDurableExecution and a real CheckpointManager through the public API
with only the transport faked, plus a passing-drain control;
`checkpoint-batch-failure.composed.test.ts` covers the recording itself,
including that a failure is still reported when something else terminated
first; and unit tests cover the wiring in withDurableExecution.

Refs #869

