### PR TITLE
test(examples): park flaky ADOT X-Ray span assertions

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/adot-execution-xray-e2e/otel-adot-execution-xray-e2e.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/otel/adot-execution-xray-e2e/otel-adot-execution-xray-e2e.test.ts
@@ -10,6 +10,14 @@ import {
   extractTraceIdFromXRayHeader,
 } from "../../../utils/xray-trace-helper";
 
+/**
+ * Span-shape assertions are parked while the durable operation subsegments are
+ * intermittently missing from the fetched X-Ray trace. Tracked in
+ * https://github.com/aws/aws-durable-execution-sdk-js/issues/872 -- flip this back
+ * to `true` to re-enable them.
+ */
+const ASSERT_XRAY_SPANS = false;
+
 createTests({
   handler,
   tests: (runner, { assertEventSignatures, isCloud }) => {
@@ -36,40 +44,53 @@ createTests({
         expect(traceId).toBeDefined();
         expect(traceId).toMatch(/^[0-9a-f]{32}$/);
 
-        const xrayClient = new XRayClient({});
-        const trace = await fetchXRayTrace(xrayClient, traceId!);
+        // The operation subsegments are intermittently absent from the fetched
+        // trace: only the Lambda-generated segments (Init, Invocation, Overhead,
+        // and the function itself) come back, so every name below is reported
+        // missing. It reproduces on main, and 24.x passes the same assertions in
+        // runs where 22.x fails, so it is not specific to a change here.
+        //
+        // Everything above still runs -- the workflow reaching SUCCEEDED, the step
+        // results, and a well-formed trace header -- so only the span-shape
+        // coverage is parked.
+        //
+        // Re-enable once the propagation is understood: https://github.com/aws/aws-durable-execution-sdk-js/issues/872
+        if (ASSERT_XRAY_SPANS) {
+          const xrayClient = new XRayClient({});
+          const trace = await fetchXRayTrace(xrayClient, traceId!);
 
-        // Assert span names exist (same operations as standalone variant)
-        assertSpanNames(trace, [
-          "fetch-data",
-          "short-pause",
-          "process-data",
-          "child-operations",
-          "inner-step",
-          "fails-then-succeeds",
-        ]);
+          // Assert span names exist (same operations as standalone variant)
+          assertSpanNames(trace, [
+            "fetch-data",
+            "short-pause",
+            "process-data",
+            "child-operations",
+            "inner-step",
+            "fails-then-succeeds",
+          ]);
 
-        // Assert hierarchy: child-operations contains inner-step and fails-then-succeeds
-        assertSpanHierarchy(trace, {
-          "child-operations": ["inner-step", "fails-then-succeeds"],
-        });
+          // Assert hierarchy: child-operations contains inner-step and fails-then-succeeds
+          assertSpanHierarchy(trace, {
+            "child-operations": ["inner-step", "fails-then-succeeds"],
+          });
 
-        // Assert span attributes
-        assertSpanAttributes(trace, "fetch-data", {
-          "durable.operation.type": "STEP",
-        });
-        assertSpanAttributes(trace, "process-data", {
-          "durable.operation.type": "STEP",
-        });
-        assertSpanAttributes(trace, "child-operations", {
-          "durable.operation.type": "CONTEXT",
-        });
-        assertSpanAttributes(trace, "inner-step", {
-          "durable.operation.type": "STEP",
-        });
-        assertSpanAttributes(trace, "fails-then-succeeds", {
-          "durable.operation.type": "STEP",
-        });
+          // Assert span attributes
+          assertSpanAttributes(trace, "fetch-data", {
+            "durable.operation.type": "STEP",
+          });
+          assertSpanAttributes(trace, "process-data", {
+            "durable.operation.type": "STEP",
+          });
+          assertSpanAttributes(trace, "child-operations", {
+            "durable.operation.type": "CONTEXT",
+          });
+          assertSpanAttributes(trace, "inner-step", {
+            "durable.operation.type": "STEP",
+          });
+          assertSpanAttributes(trace, "fails-then-succeeds", {
+            "durable.operation.type": "STEP",
+          });
+        }
       }
 
       assertEventSignatures(execution, undefined, {


### PR DESCRIPTION
The ADOT execution-view end-to-end test fails intermittently because the
durable operation subsegments are absent from the trace returned for the
execution: only the Lambda-generated segments (Init, Invocation, Overhead
and the function itself) come back, so every expected span name is
reported missing.

It is not caused by any change under test. The OTel conformance workflow
shows the same failure on main, including on the current tip, interleaved
with passes; and 24.x passes these assertions in the same runs where 22.x
fails, which points away from a code-level cause and towards the exported
subsegments not being queryable yet when the trace is fetched.

Guard only the span-shape assertions, so the test keeps checking that the
workflow reaches SUCCEEDED, that the step results are correct, and that a
well-formed X-Amzn-Trace-Id header with a valid trace ID is produced. The
preceding assertions were already passing, so this parks the coverage that
cannot currently pass rather than the whole test.

A single named constant rather than `it.skip` keeps the assertions visible
and greppable, and makes re-enabling a one-line change.

The sibling `Execution - ADOT/X-Ray` check is orchestrated from the
conformance-tests repository and is unaffected by this; it fails from the
same cause and is covered by the same issue.

Refs #872

