### PR TITLE
fix(sdk): preserve cross-realm errors with a realm-safe isErrorLike check

### DIFF
--- a/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts
@@ -2,6 +2,7 @@ import { ErrorObject } from "../../types/wire";
 import { STORE_STACK_TRACES } from "../../utils/constants/constants";
 // Type-only import to avoid a runtime circular dependency with types/batch.
 import type { CompletionReason } from "../../types/batch";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 /**
  * Base class for all durable operation errors
@@ -115,7 +116,7 @@ export abstract class DurableOperationError extends Error {
           errorData = node.errorData;
           break;
         }
-        node = node instanceof Error ? node.cause : undefined;
+        node = isErrorLike(node) ? node.cause : undefined;
       }
     }
     return {

--- a/packages/aws-durable-execution-sdk-js/src/errors/serdes-errors/serdes-errors.ts
+++ b/packages/aws-durable-execution-sdk-js/src/errors/serdes-errors/serdes-errors.ts
@@ -3,6 +3,7 @@ import { TerminationManager } from "../../termination-manager/termination-manage
 import { UnrecoverableInvocationError } from "../unrecoverable-error/unrecoverable-error";
 import { log } from "../../utils/logger/logger";
 import { SerdesContext } from "../../utils/serdes/serdes";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 /**
  * Error thrown when serdes operation fails and terminates Lambda invocation
@@ -40,12 +41,12 @@ export async function safeSerialize<T>(
     };
     return await serdes.serialize(value, context);
   } catch (error) {
-    const message = `Serialization failed for step ${stepName ? `"${stepName}" ` : ""}(${stepId}): ${error instanceof Error ? error.message : "Unknown serialization error"}`;
+    const message = `Serialization failed for step ${stepName ? `"${stepName}" ` : ""}(${stepId}): ${isErrorLike(error) ? error.message : "Unknown serialization error"}`;
 
     log("💥", "Serialization failed - terminating execution:", {
       stepId,
       stepName,
-      error: error instanceof Error ? error.message : String(error),
+      error: isErrorLike(error) ? error.message : String(error),
     });
 
     terminationManager.terminate({
@@ -82,12 +83,12 @@ export async function safeDeserialize<T>(
     };
     return await serdes.deserialize(data, context);
   } catch (error) {
-    const message = `Deserialization failed for step ${stepName ? `"${stepName}" ` : ""}(${stepId}): ${error instanceof Error ? error.message : "Unknown deserialization error"}`;
+    const message = `Deserialization failed for step ${stepName ? `"${stepName}" ` : ""}(${stepId}): ${isErrorLike(error) ? error.message : "Unknown deserialization error"}`;
 
     log("💥", "Deserialization failed - terminating execution:", {
       stepId,
       stepName,
-      error: error instanceof Error ? error.message : String(error),
+      error: isErrorLike(error) ? error.message : String(error),
     });
 
     terminationManager.terminate({

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts
@@ -11,6 +11,7 @@ import {
   BatchCompletionError,
 } from "../../errors/durable-error/durable-error";
 import { Serdes, SerdesContext } from "../../utils/serdes/serdes";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 /**
  * Durable error type names that can be reconstructed into their concrete
@@ -53,7 +54,7 @@ function serializeBatchError(
       : { ErrorType: error.name, ErrorMessage: error.message };
 
   const cause = (error as { cause?: unknown }).cause;
-  if (cause instanceof Error) {
+  if (isErrorLike(cause)) {
     serialized.Cause = serializeBatchError(cause);
   }
 
@@ -269,10 +270,9 @@ export function createBatchResultSerdes<R>(): Serdes<BatchResult<R>> {
       const serialized = {
         all: value.all.map((item) => ({
           ...item,
-          error:
-            item.error instanceof Error
-              ? serializeBatchError(item.error)
-              : undefined,
+          error: isErrorLike(item.error)
+            ? serializeBatchError(item.error)
+            : undefined,
         })),
         completionReason: value.completionReason,
       };

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -28,6 +28,7 @@ import { AnySerdes } from "../../utils/serdes/serdes";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
 import { TerminationManager } from "../../termination-manager/termination-manager";
 import { TerminationReason } from "../../termination-manager/types";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 /**
  * Valid {@link CompletionReason} values, used to validate a reason read back
@@ -380,8 +381,8 @@ export class ConcurrencyController<Logger extends DurableLogger> {
             error instanceof ChildContextError
               ? error
               : new ChildContextError(
-                  error instanceof Error ? error.message : String(error),
-                  error instanceof Error ? error : undefined,
+                  isErrorLike(error) ? error.message : String(error),
+                  isErrorLike(error) ? error : undefined,
                 );
           resultItems.push({
             error: err,
@@ -622,8 +623,8 @@ export class ConcurrencyController<Logger extends DurableLogger> {
                   error instanceof ChildContextError
                     ? error
                     : new ChildContextError(
-                        error instanceof Error ? error.message : String(error),
-                        error instanceof Error ? error : undefined,
+                        isErrorLike(error) ? error.message : String(error),
+                        isErrorLike(error) ? error : undefined,
                       );
                 resultItems[index] = {
                   error: err,

--- a/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/promise-handler/promise-handler.ts
@@ -1,13 +1,14 @@
 import { DurableContext, DurablePromise, DurableLogger } from "../../types";
 import { Serdes, SerdesContext } from "../../utils/serdes/serdes";
 import { PromiseCombinatorError } from "../../errors/durable-error/durable-error";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 // Minimal error decoration for Promise.allSettled results
 function decorateErrors<T>(
   value: PromiseSettledResult<T>[],
 ): PromiseSettledResult<T>[] {
   return value.map((item) => {
-    if (item && item.status === "rejected" && item.reason instanceof Error) {
+    if (item && item.status === "rejected" && isErrorLike(item.reason)) {
       return {
         ...item,
         reason: {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.test.ts
@@ -1,3 +1,4 @@
+import * as vm from "vm";
 import { createStepHandler } from "./step-handler";
 import {
   ExecutionContext,
@@ -472,6 +473,58 @@ describe("Step Handler", () => {
       expect(errorArg).toBeInstanceOf(Error);
       expect((errorArg as Error).name).toBe("StepInterruptedError");
       expect(typeof attempt).toBe("number");
+    });
+  });
+
+  // Regression for issue #306: errors thrown from a different realm (a `vm`
+  // context, a worker thread, etc.) are not `instanceof Error` in this realm.
+  // The step handler used to flatten them to `new Error("Unknown Error")` before
+  // handing them to the user's retryStrategy, discarding the real message. It
+  // must now forward the original error via the realm-safe `isErrorLike` check.
+  describe("cross-realm errors (issue #306)", () => {
+    const makeCrossRealmError = (message: string): unknown => {
+      const context = vm.createContext({});
+      try {
+        vm.runInContext(`throw new Error(${JSON.stringify(message)})`, context);
+      } catch (error) {
+        return error;
+      }
+      throw new Error("expected the vm context to throw");
+    };
+
+    it("forwards the original cross-realm error (with its real message) to retryStrategy", async () => {
+      const crossRealmError = makeCrossRealmError(
+        "Error from different Node.js realm",
+      );
+      // Precondition: this is exactly the case a bare `instanceof Error` misses.
+      expect(crossRealmError instanceof Error).toBe(false);
+
+      (mockContext.getStepData as jest.Mock).mockReturnValue({
+        StepDetails: { Attempt: 0 },
+      });
+
+      const stepHandler = createStepHandler(
+        mockContext,
+        mockCheckpoint,
+        mockParentContext,
+        createStepId,
+        createDefaultLogger(),
+      );
+
+      const stepFn = jest.fn().mockRejectedValue(crossRealmError);
+      const retryStrategy = jest.fn().mockReturnValue({ shouldRetry: false });
+
+      await expect(
+        stepHandler("test-step", stepFn, { retryStrategy }),
+      ).rejects.toBeDefined();
+
+      expect(retryStrategy).toHaveBeenCalledTimes(1);
+      const [errorArg] = retryStrategy.mock.calls[0];
+      // Before the fix `errorArg` was `new Error("Unknown Error")`.
+      expect(errorArg).toBe(crossRealmError);
+      expect((errorArg as Error).message).toBe(
+        "Error from different Node.js realm",
+      );
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/step-handler/step-handler.ts
@@ -48,6 +48,7 @@ import {
   toOperationInfo,
 } from "../../utils/operation/operation";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 export const createStepHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
@@ -396,11 +397,11 @@ export const createStepHandler = <Logger extends DurableLogger>(
           const currentAttempt = (stepData?.StepDetails?.Attempt || 0) + 1;
           const retryDecision =
             options?.retryStrategy?.(
-              error instanceof Error ? error : new Error("Unknown Error"),
+              isErrorLike(error) ? error : new Error("Unknown Error"),
               currentAttempt,
             ) ??
             retryPresets.default(
-              error instanceof Error ? error : new Error("Unknown Error"),
+              isErrorLike(error) ? error : new Error("Unknown Error"),
               currentAttempt,
             );
 
@@ -424,8 +425,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
               AttemptEndInfoOutcome.FAILED,
               {
                 attempt: currentAttempt,
-                error:
-                  error instanceof Error ? error : new Error(String(error)),
+                error: isErrorLike(error) ? error : new Error(String(error)),
               },
             );
             backfillOperationInfo(attemptEndInfo, opInfo);
@@ -433,7 +433,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
             await plugin.onOperationEnd?.({
               ...attemptEndInfo,
               isReplay: false,
-              error: error instanceof Error ? error : new Error(String(error)),
+              error: isErrorLike(error) ? error : new Error(String(error)),
             });
             throw DurableOperationError.fromErrorObject(
               createErrorObjectFromError(error),
@@ -461,7 +461,7 @@ export const createStepHandler = <Logger extends DurableLogger>(
             AttemptEndInfoOutcome.FAILED,
             {
               attempt: currentAttempt,
-              error: error instanceof Error ? error : new Error(String(error)),
+              error: isErrorLike(error) ? error : new Error(String(error)),
             },
           );
           backfillOperationInfo(attemptEndInfo, opInfo);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/wait-for-condition-handler/wait-for-condition-handler.ts
@@ -41,6 +41,7 @@ import {
   toOperationInfo,
 } from "../../utils/operation/operation";
 import { hashId } from "../../utils/step-id-utils/step-id-utils";
+import { isErrorLike } from "../../utils/error-object/is-error-like";
 
 export const createWaitForConditionHandler = <Logger extends DurableLogger>(
   context: ExecutionContext,
@@ -382,7 +383,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
             AttemptEndInfoOutcome.FAILED,
             {
               attempt: currentAttempt,
-              error: error instanceof Error ? error : new Error(String(error)),
+              error: isErrorLike(error) ? error : new Error(String(error)),
             },
           );
           backfillOperationInfo(attemptEndInfo, opInfo);
@@ -393,7 +394,7 @@ export const createWaitForConditionHandler = <Logger extends DurableLogger>(
           await plugin.onOperationEnd?.({
             ...attemptEndInfo,
             isReplay: false,
-            error: error instanceof Error ? error : new Error(String(error)),
+            error: isErrorLike(error) ? error : new Error(String(error)),
           });
           throw DurableOperationError.fromErrorObject(
             createErrorObjectFromError(error),

--- a/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/checkpoint/checkpoint-manager.ts
@@ -38,6 +38,7 @@ import {
 import { OperationLifecycleState } from "../../types/operation-lifecycle-state";
 import { DurableInstrumentationPlugin } from "../../types/plugin";
 import { normalizeOperations } from "../operation/normalize-operation";
+import { isErrorLike } from "../error-object/is-error-like";
 
 export const STEP_DATA_UPDATED_EVENT = "stepDataUpdated";
 
@@ -280,8 +281,7 @@ export class CheckpointManager implements Checkpoint {
   ):
     | CheckpointUnrecoverableInvocationError
     | CheckpointUnrecoverableExecutionError {
-    const originalError =
-      error instanceof Error ? error : new Error(String(error));
+    const originalError = isErrorLike(error) ? error : new Error(String(error));
 
     // A transport that states its own classification is believed, so it does not have to
     // imitate the AWS SDK's error shape to be understood. Checked before the shape

--- a/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/error-object/error-object.ts
@@ -1,16 +1,7 @@
 import { ErrorObject } from "../../types/wire";
 import { DurableOperationError } from "../../errors/durable-error/durable-error";
 import { STORE_STACK_TRACES } from "../constants/constants";
-
-function isErrorLike(obj: unknown): obj is Error {
-  return (
-    obj instanceof Error ||
-    (obj != null &&
-      typeof obj === "object" &&
-      "message" in obj &&
-      "name" in obj)
-  );
-}
+import { isErrorLike } from "./is-error-like";
 
 export function createErrorObjectFromError(
   error: unknown,

--- a/packages/aws-durable-execution-sdk-js/src/utils/error-object/is-error-like.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/error-object/is-error-like.test.ts
@@ -1,0 +1,73 @@
+import * as vm from "vm";
+import { isErrorLike } from "./is-error-like";
+
+describe("isErrorLike", () => {
+  describe("same-realm errors", () => {
+    it("returns true for a standard Error", () => {
+      expect(isErrorLike(new Error("boom"))).toBe(true);
+    });
+
+    it("returns true for built-in Error subclasses", () => {
+      expect(isErrorLike(new TypeError("t"))).toBe(true);
+      expect(isErrorLike(new RangeError("r"))).toBe(true);
+    });
+
+    it("returns true for a custom Error subclass", () => {
+      class CustomError extends Error {}
+      expect(isErrorLike(new CustomError("c"))).toBe(true);
+    });
+  });
+
+  describe("cross-realm errors", () => {
+    it("returns true for an Error thrown from a different Node.js realm", () => {
+      // Errors thrown from a `vm` context are instances of that context's Error
+      // constructor, not the host realm's, so `instanceof Error` is false here.
+      const context = vm.createContext({});
+      let crossRealmError: unknown;
+      try {
+        vm.runInContext(
+          'throw new Error("Error from different Node.js realm")',
+          context,
+        );
+      } catch (error) {
+        crossRealmError = error;
+      }
+
+      // Sanity check: this is exactly the case a bare instanceof misses.
+      expect(crossRealmError instanceof Error).toBe(false);
+      expect(isErrorLike(crossRealmError)).toBe(true);
+      expect((crossRealmError as Error).message).toBe(
+        "Error from different Node.js realm",
+      );
+    });
+  });
+
+  describe("error-like objects", () => {
+    it("returns true for an object with message and name", () => {
+      expect(isErrorLike({ message: "m", name: "n" })).toBe(true);
+    });
+
+    it("returns true for an object created from Error.prototype", () => {
+      const fake = Object.create(Error.prototype);
+      fake.message = "m";
+      fake.name = "n";
+      expect(isErrorLike(fake)).toBe(true);
+    });
+  });
+
+  describe("non error-like values", () => {
+    it.each([
+      ["a string", "boom"],
+      ["a number", 42],
+      ["a boolean", true],
+      ["null", null],
+      ["undefined", undefined],
+      ["an empty object", {}],
+      ["an array", ["boom"]],
+      ["an object with only message", { message: "m" }],
+      ["an object with only name", { name: "n" }],
+    ])("returns false for %s", (_label, value) => {
+      expect(isErrorLike(value)).toBe(false);
+    });
+  });
+});

--- a/packages/aws-durable-execution-sdk-js/src/utils/error-object/is-error-like.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/error-object/is-error-like.ts
@@ -1,0 +1,36 @@
+/**
+ * Duck-typed check for values that should be treated as `Error` instances.
+ *
+ * Prefer this over a bare `value instanceof Error` whenever the value
+ * originates from customer code (a thrown step/handler error, a rejected
+ * promise reason, a plugin failure, a serdes error, etc.). `instanceof Error`
+ * only matches errors created by the *current* realm's `Error` constructor, so
+ * it silently returns `false` for an error thrown from a different realm - a
+ * `vm` context, a `worker_threads` worker, or any other execution context with
+ * its own set of globals. When that happens the SDK would otherwise discard the
+ * real error and hand the customer a generic `new Error("Unknown Error")` /
+ * `new Error(String(error))`, losing the original `message`, `name`, and
+ * `stack`.
+ *
+ * The check matches:
+ *  - genuine same-realm `Error` instances (fast path), and
+ *  - cross-realm errors and error-like objects that expose both a `message` and
+ *    a `name` property. This covers cross-realm `Error`s because `message` is an
+ *    own property set by the constructor and `name` is inherited from that
+ *    realm's `Error.prototype`, which the `in` operator finds by walking the
+ *    prototype chain.
+ *
+ * @param value - The value to inspect, typically a caught or rejected value.
+ * @returns `true` if the value can be safely treated as an `Error`.
+ *
+ * @internal
+ */
+export function isErrorLike(value: unknown): value is Error {
+  return (
+    value instanceof Error ||
+    (value != null &&
+      typeof value === "object" &&
+      "message" in value &&
+      "name" in value)
+  );
+}

--- a/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/logger/default-logger.ts
@@ -5,6 +5,7 @@ import {
   DurableLogger,
   DurableLoggingContext,
 } from "../../types/durable-logger";
+import { isErrorLike } from "../error-object/is-error-like";
 
 export interface LoggingExecutionContext {
   durableExecutionArn: string;
@@ -83,7 +84,7 @@ function jsonErrorReplacer(
   _key: string,
   value: DurableLogField,
 ): DurableLogField {
-  if (value instanceof Error) {
+  if (isErrorLike(value)) {
     return Object.assign(
       {
         errorType: value?.constructor?.name ?? "UnknownError",
@@ -173,7 +174,7 @@ function formatDurableLogData(
 
   result.message = formatWithOptions(FORMAT_OPTIONS, ...messageParams);
   for (const param of messageParams) {
-    if (param instanceof Error) {
+    if (isErrorLike(param)) {
       result.errorType = param?.constructor?.name ?? "UnknownError";
       result.errorMessage = param.message;
       result.stackTrace =

--- a/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-loader.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/plugin/plugin-loader.ts
@@ -7,6 +7,7 @@ import {
   DurableInstrumentationPlugin,
   DurableInstrumentationPluginProvider,
 } from "../../types/plugin";
+import { isErrorLike } from "../error-object/is-error-like";
 
 export const PLUGIN_ENVIRONMENT_VARIABLE = "DURABLE_EXECUTION_PLUGINS";
 export const PLUGIN_PROVIDER_EXPORT = "durableExecutionPluginProvider";
@@ -42,7 +43,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  return isErrorLike(error) ? error.message : String(error);
 }
 
 function packageNameFromSpecifier(specifier: string): string | undefined {

--- a/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/safe-stringify/safe-stringify.ts
@@ -1,3 +1,4 @@
+import { isErrorLike } from "../error-object/is-error-like";
 export const safeStringify = (data: unknown): string => {
   try {
     const seen = new WeakSet();
@@ -9,7 +10,7 @@ export const safeStringify = (data: unknown): string => {
           seen.add(value);
 
           // Handle Error objects by extracting their properties
-          if (value instanceof Error) {
+          if (isErrorLike(value)) {
             return {
               ...value,
               name: value.name,

--- a/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
+++ b/packages/aws-durable-execution-sdk-js/src/with-durable-execution.ts
@@ -49,6 +49,7 @@ import {
   OperationInfo,
   PluginInvocationStatus,
 } from "./types/plugin";
+import { isErrorLike } from "./utils/error-object/is-error-like";
 
 // Lambda response size limit is 6MB
 const LAMBDA_RESPONSE_SIZE_LIMIT = 6 * 1024 * 1024 - 50; // 6MB in bytes, minus 50 bytes for envelope
@@ -418,8 +419,7 @@ async function runHandler<
           ...invocationBaseInfo,
           status: PluginInvocationStatus.FAILED,
           executionInput: customerHandlerEvent,
-          executionError:
-            error instanceof Error ? error : new Error(String(error)),
+          executionError: isErrorLike(error) ? error : new Error(String(error)),
           executionResult: undefined,
           operations: toOperationInfoMap(executionContext._stepData),
         });


### PR DESCRIPTION
## Problem
Closes #306. Error detection and normalization used `error instanceof Error`, which only matches the current realm's `Error` constructor. Errors thrown from a different realm (a `vm` context, a `worker_threads` worker, etc.) fail that check and were flattened to `new Error("Unknown Error")` / `new Error(String(error))` before reaching the user's retryStrategy, plugin hooks, and serialization, discarding the original message, name, and stack.

## Fix
- Extract the existing duck-typed `isErrorLike` (previously private in `error-object.ts`) into a shared `utils/error-object/is-error-like.ts` helper. Semantics are unchanged, so `createErrorObjectFromError` behaves identically; the helper is now reusable and documented.
- Replace raw `instanceof Error` with `isErrorLike` at every site that captures or serializes a customer-originated error: step handler (retryStrategy + plugin hooks), wait-for-condition handler, concurrent-execution handler, promise handler (`allSettled`), serdes errors, checkpoint manager, plugin loader, default logger, safe-stringify, the `DurableOperationError` cause walk, and batch-result serialization.
- Left unchanged by design: SDK-internal class checks (`DurableOperationError`, `ChildContextError`, the unrecoverable-error guards, the `isDurableExecutionClientError` public type guard) and the user-supplied class match in `retry-common` (`error instanceof ErrorType`), which are always same-realm.

## Testing
- New unit tests for `isErrorLike`, including an actual cross-realm error thrown from a `vm` context.
- New regression test in `step-handler.test.ts`: a step that throws a cross-realm error now forwards the original error (with its real message) to `retryStrategy` instead of `new Error("Unknown Error")`. Verified as a true regression: it fails on the pre-fix code and passes with the fix.
- Full SDK package suite passes (105 suites / 1253 tests), ESLint clean. No conformance tests added, per CONTRIBUTING.

Happy to add an examples-package example (as sketched in the issue) if you'd prefer end-to-end/local-runner coverage.
