### PR TITLE
feat(otel): add execution trace resolver and durable sampler

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-trace-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-trace-context.test.ts
@@ -1,0 +1,523 @@
+import { TraceFlags, context, trace, ROOT_CONTEXT } from "@opentelemetry/api";
+import type { SpanContext, Tracer } from "@opentelemetry/api";
+import {
+  SamplingDecision,
+  ParentBasedSampler,
+  AlwaysOnSampler,
+  AlwaysOffSampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-node";
+import {
+  canonicalTraceId,
+  resolveExecutionTraceContext,
+  rootSamplingDecision,
+} from "../execution-trace-context";
+import {
+  deriveTraceIdFromArn,
+  deriveExecutionRootSpanId,
+} from "../deterministic-id-generator";
+import type { ContextExtractorResult } from "../context-extractors";
+
+const ARN = "arn:aws:lambda:us-east-1:123:function:test:$LATEST/durable/exec1";
+const REMOTE_TRACE_ID = "aabbccddee112233445566778899aabb";
+const REMOTE_PARENT_ID = "53995c3f42cd8ad8";
+const ALL_ZERO_TRACE_ID = "0".repeat(32);
+const ALL_ZERO_SPAN_ID = "0".repeat(16);
+const START = new Date("2026-08-15T00:00:00Z");
+
+const INVALID_SPAN_CONTEXT: SpanContext = {
+  traceId: ALL_ZERO_TRACE_ID,
+  spanId: ALL_ZERO_SPAN_ID,
+  traceFlags: TraceFlags.NONE,
+};
+
+function canonical(extracted: ContextExtractorResult): string {
+  return canonicalTraceId(extracted, ARN, START);
+}
+
+function resolve(
+  extracted: ContextExtractorResult,
+  canonicalId: string,
+  rootSamplingDecision: () => SamplingDecision,
+) {
+  return resolveExecutionTraceContext(
+    extracted,
+    canonicalId,
+    ARN,
+    rootSamplingDecision,
+  );
+}
+
+describe("canonicalTraceId", () => {
+  it("reuses the remote trace ID when it is valid", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+    };
+    expect(canonical(extracted)).toBe(REMOTE_TRACE_ID);
+  });
+
+  it("reuses a valid extracted trace ID even without a parent span ID", () => {
+    const extracted = { traceId: REMOTE_TRACE_ID };
+    expect(canonical(extracted)).toBe(REMOTE_TRACE_ID);
+  });
+
+  it("derives from the ARN when there is no remote trace ID", () => {
+    const result = canonical(undefined);
+    expect(result).toBe(deriveTraceIdFromArn(ARN, START));
+    expect(result).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("derives from the ARN when the remote trace ID is all-zero", () => {
+    const extracted = {
+      traceId: ALL_ZERO_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+    };
+    expect(canonical(extracted)).toBe(deriveTraceIdFromArn(ARN, START));
+  });
+
+  it("never adopts a live ambient trace; derives from the ARN when there is no valid remote trace", () => {
+    // A live ambient span is not consulted at all: the canonical trace is the
+    // reproducible ARN-derived ID when no valid remote trace was propagated.
+    expect(canonical(undefined)).toBe(deriveTraceIdFromArn(ARN, START));
+  });
+});
+
+describe("resolveExecutionTraceContext", () => {
+  it("uses a complete remote parent as the ancestor and preserves Sampled=1", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+      sampling: "SAMPLED" as const,
+    };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.NOT_RECORD,
+    );
+
+    expect(execCtx.executionAncestor.traceId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(execCtx.executionAncestor.isRemote).toBe(true);
+    expect(execCtx.traceFlags & 1).toBe(1); // explicit Sampled=1 wins over supplier
+    expect(execCtx.samplingDecision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+
+  it("uses a complete remote parent and preserves Sampled=0", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+      sampling: "NOT_SAMPLED" as const,
+    };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(execCtx.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(execCtx.traceFlags & 1).toBe(0); // explicit Sampled=0 wins over supplier
+    expect(execCtx.samplingDecision).toBe(SamplingDecision.NOT_RECORD);
+  });
+
+  it("defers an undecided remote parent to the sampler", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+    };
+
+    const sampled = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(sampled.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(sampled.traceFlags & 1).toBe(1);
+
+    const dropped = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.NOT_RECORD,
+    );
+    expect(dropped.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(dropped.traceFlags & 1).toBe(0);
+  });
+
+  it("treats an all-zero Parent as absent and synthesizes a root on the remote trace", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: ALL_ZERO_SPAN_ID,
+    };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(execCtx.executionAncestor.traceId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+  });
+
+  it("synthesizes a root on the derived trace for an all-zero Root", () => {
+    const extracted = {
+      traceId: ALL_ZERO_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+    };
+    const canonicalId = canonical(extracted);
+    const execCtx = resolve(
+      extracted,
+      canonicalId,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(execCtx.executionAncestor.traceId).toBe(
+      deriveTraceIdFromArn(ARN, START),
+    );
+    expect(execCtx.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+  });
+
+  it.each([
+    [
+      "Sampled=0",
+      "NOT_SAMPLED" as const,
+      SamplingDecision.RECORD_AND_SAMPLED,
+      TraceFlags.SAMPLED,
+      SamplingDecision.RECORD_AND_SAMPLED,
+    ],
+    [
+      "Sampled=1",
+      "SAMPLED" as const,
+      SamplingDecision.NOT_RECORD,
+      TraceFlags.NONE,
+      SamplingDecision.NOT_RECORD,
+    ],
+  ])(
+    "ignores %s from an invalid Root and lets the fallback trace sampling supplier decide",
+    (
+      _label,
+      sampling,
+      supplierDecision,
+      expectedTraceFlags,
+      expectedSamplingDecision,
+    ) => {
+      const extracted = {
+        traceId: ALL_ZERO_TRACE_ID,
+        parentSpanId: REMOTE_PARENT_ID,
+        sampling,
+      };
+      const canonicalId = canonical(extracted);
+
+      const execCtx = resolve(extracted, canonicalId, () => supplierDecision);
+
+      expect(execCtx.executionAncestor.traceId).toBe(
+        deriveTraceIdFromArn(ARN, START),
+      );
+      expect(execCtx.traceFlags).toBe(expectedTraceFlags);
+      expect(execCtx.samplingDecision).toBe(expectedSamplingDecision);
+    },
+  );
+
+  it("adopts a valid extracted remote parent as the ancestor and preserves its sampling", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+      sampling: "NOT_SAMPLED" as const,
+    };
+    const canonicalId = canonical(extracted);
+
+    const execCtx = resolve(
+      extracted,
+      canonicalId,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    // A valid remote trace ID is the canonical trace; the remote parent is the ancestor.
+    expect(canonicalId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.traceId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(execCtx.executionAncestor.isRemote).toBe(true);
+    // Explicit upstream Sampled=0 wins over the supplier.
+    expect(execCtx.traceFlags).toBe(TraceFlags.NONE);
+    expect(execCtx.samplingDecision).toBe(SamplingDecision.NOT_RECORD);
+  });
+
+  it("keeps the ARN-derived trace stable across calls when no context is extracted", () => {
+    const canonicalA = canonical(undefined);
+    const canonicalB = canonical(undefined);
+
+    expect(canonicalA).toBe(deriveTraceIdFromArn(ARN, START));
+    expect(canonicalB).toBe(canonicalA);
+
+    const execA = resolve(
+      undefined,
+      canonicalA,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    const execB = resolve(
+      undefined,
+      canonicalB,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(execA.executionAncestor.traceId).toBe(canonicalA);
+    expect(execB.executionAncestor.traceId).toBe(canonicalA);
+    expect(execA.executionAncestor.spanId).toBe(execB.executionAncestor.spanId);
+    expect(execA.executionAncestor.spanId).toBe(deriveExecutionRootSpanId(ARN));
+  });
+
+  it("synthesizes a root on the remote trace when there is a stable Root but no Parent", () => {
+    const extracted = { traceId: REMOTE_TRACE_ID };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(execCtx.executionAncestor.traceId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+    expect(execCtx.traceFlags & 1).toBe(1); // supplier decides for a synthetic root
+  });
+
+  it("preserves an explicit Sampled decision on a synthetic root over the supplier", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      sampling: "SAMPLED" as const,
+    };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.NOT_RECORD,
+    );
+
+    expect(execCtx.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+    expect(execCtx.traceFlags & 1).toBe(1);
+  });
+
+  it("synthesizes a root on the ARN-derived trace with no context, supplier decides", () => {
+    const canonicalId = canonical(undefined);
+    const sampled = resolve(
+      undefined,
+      canonicalId,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    const dropped = resolve(
+      undefined,
+      canonicalId,
+      () => SamplingDecision.NOT_RECORD,
+    );
+
+    expect(sampled.executionAncestor.traceId).toBe(canonicalId);
+    expect(sampled.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+    expect(sampled.traceFlags & 1).toBe(1);
+    expect(dropped.traceFlags & 1).toBe(0);
+  });
+
+  it("synthesizes a root on the ARN-derived trace when there is no propagated context", () => {
+    // No propagated remote context at all: the execution anchors on a synthetic
+    // root over the reproducible ARN-derived trace. A live ambient span is never
+    // consulted by the resolver, so there is nothing to reject here.
+    const canonicalId = canonical(undefined);
+    const execCtx = resolve(
+      undefined,
+      canonicalId,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+
+    expect(canonicalId).toBe(deriveTraceIdFromArn(ARN, START));
+    expect(execCtx.executionAncestor.traceId).toBe(
+      deriveTraceIdFromArn(ARN, START),
+    );
+    expect(execCtx.executionAncestor.spanId).toBe(
+      deriveExecutionRootSpanId(ARN),
+    );
+  });
+
+  it("is stable across reinvocations with no propagated context", () => {
+    // Two invocations, no propagation. The resolved execution trace and ancestor
+    // span ID must be identical both times, so continuation/replay links (which
+    // target the deterministic operation span ID on this trace) remain valid
+    // across invocations. The resolver ignores any ambient span, so nothing
+    // per-invocation can perturb the result.
+    const canonicalA = canonical(undefined);
+    const canonicalB = canonical(undefined);
+    expect(canonicalA).toBe(canonicalB);
+    expect(canonicalA).toBe(deriveTraceIdFromArn(ARN, START));
+
+    const execA = resolve(
+      undefined,
+      canonicalA,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    const execB = resolve(
+      undefined,
+      canonicalB,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(execA.executionAncestor.traceId).toBe(
+      execB.executionAncestor.traceId,
+    );
+    expect(execA.executionAncestor.spanId).toBe(execB.executionAncestor.spanId);
+    expect(execA.executionAncestor.spanId).toBe(deriveExecutionRootSpanId(ARN));
+  });
+
+  it("uses a complete remote parent as the ancestor (not any ambient span)", () => {
+    const extracted = {
+      traceId: REMOTE_TRACE_ID,
+      parentSpanId: REMOTE_PARENT_ID,
+      sampling: "SAMPLED" as const,
+    };
+    const execCtx = resolve(
+      extracted,
+      REMOTE_TRACE_ID,
+      () => SamplingDecision.RECORD_AND_SAMPLED,
+    );
+    expect(execCtx.executionAncestor.traceId).toBe(REMOTE_TRACE_ID);
+    expect(execCtx.executionAncestor.spanId).toBe(REMOTE_PARENT_ID);
+    expect(execCtx.executionAncestor.isRemote).toBe(true);
+  });
+});
+
+describe("rootSamplingDecision", () => {
+  function tracerWithSampler(decision: SamplingDecision | undefined): Tracer {
+    // Mimic an SDK tracer exposing a `_sampler` with shouldSample().
+    const sampler =
+      decision === undefined
+        ? undefined
+        : {
+            shouldSample: () => ({ decision }),
+            toString: () =>
+              decision === SamplingDecision.RECORD_AND_SAMPLED
+                ? "AlwaysOnSampler"
+                : "AlwaysOffSampler",
+          };
+    return { _sampler: sampler } as unknown as Tracer;
+  }
+
+  it("returns RECORD_AND_SAMPLED when the configured sampler samples the root", () => {
+    const tracer = tracerWithSampler(SamplingDecision.RECORD_AND_SAMPLED);
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+  });
+
+  it("returns NOT_RECORD when the configured sampler drops the root", () => {
+    const tracer = tracerWithSampler(SamplingDecision.NOT_RECORD);
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+  });
+
+  it("defaults to sampled when no sampler is reachable", () => {
+    // A proxy tracer with no _sampler field: the decision defaults to sampled
+    // rather than being approximated, matching the documented fallback.
+    const tracer = tracerWithSampler(undefined);
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+  });
+
+  it("defaults to sampled when a configured sampler throws", () => {
+    const tracer = {
+      _sampler: {
+        shouldSample: () => {
+          throw new Error("boom");
+        },
+        toString: () => "AlwaysOffSampler",
+      },
+    } as unknown as Tracer;
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
+  });
+
+  it("evaluates a ParentBased sampler at the root policy, ignoring an unrelated ambient span", () => {
+    // Reviewer case: an undecided execution must not inherit the sampled bit of
+    // an unrelated ambient span. With ParentBased(root=alwaysOn), the root
+    // policy samples; an unrelated UNSAMPLED ambient span active in the context
+    // must not flip that to dropped. rootSamplingDecision evaluates with ROOT_CONTEXT,
+    // so the ambient span is ignored.
+    const realSampler = new ParentBasedSampler({ root: new AlwaysOnSampler() });
+    const tracer = { _sampler: realSampler } as unknown as Tracer;
+
+    const unrelatedUnsampled: SpanContext = {
+      traceId: "c".repeat(32),
+      spanId: "d".repeat(16),
+      traceFlags: TraceFlags.NONE, // unsampled, unrelated trace
+    };
+
+    let decision = SamplingDecision.NOT_RECORD;
+    context.with(trace.setSpanContext(ROOT_CONTEXT, unrelatedUnsampled), () => {
+      decision = rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {});
+    });
+
+    // Root policy (alwaysOn) wins; the unrelated unsampled ambient span does not
+    // drop the execution.
+    expect(decision).toBe(SamplingDecision.RECORD_AND_SAMPLED);
+  });
+
+  it("honors custom sampler decisions for undecided execution sampling", () => {
+    let calls = 0;
+    const tracer = {
+      _sampler: {
+        shouldSample: (
+          parentContext: unknown,
+          traceId: string,
+          spanName: string,
+        ) => {
+          calls += 1;
+          expect(parentContext).toBe(ROOT_CONTEXT);
+          expect(traceId).toBe(REMOTE_TRACE_ID);
+          expect(spanName).toBe("Workflow");
+          return { decision: SamplingDecision.NOT_RECORD };
+        },
+      },
+    } as unknown as Tracer;
+
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+    expect(calls).toBe(1);
+  });
+
+  it("honors deterministic AlwaysOffSampler decisions", () => {
+    const tracer = {
+      _sampler: new AlwaysOffSampler(),
+    } as unknown as Tracer;
+
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+  });
+
+  it("honors TraceIdRatioBasedSampler decisions when its description uses exponent notation", () => {
+    const tracer = {
+      _sampler: new TraceIdRatioBasedSampler(1e-7),
+    } as unknown as Tracer;
+
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+  });
+
+  it("honors ParentBasedSampler root decisions when a nested ratio description uses exponent notation", () => {
+    const tracer = {
+      _sampler: new ParentBasedSampler({
+        root: new TraceIdRatioBasedSampler(1e-7),
+      }),
+    } as unknown as Tracer;
+
+    expect(rootSamplingDecision(tracer, REMOTE_TRACE_ID, "Workflow", {})).toBe(
+      SamplingDecision.NOT_RECORD,
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-trace-context.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-trace-context.ts
@@ -1,0 +1,224 @@
+import type { SpanContext, Tracer } from "@opentelemetry/api";
+import { TraceFlags, SpanKind, ROOT_CONTEXT } from "@opentelemetry/api";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-node";
+import {
+  deriveTraceIdFromArn,
+  deriveExecutionRootSpanId,
+} from "./deterministic-id-generator";
+import {
+  hasCompleteRemoteParent,
+  hasValidTraceId,
+  resolveSampling,
+} from "./context-extractors";
+import type { ContextExtractorResult } from "./context-extractors";
+import { getConfiguredSampler } from "./global-sampler";
+
+/**
+ * The per-execution trace context resolved once at invocation start, shared by
+ * both plugins.
+ *
+ * It selects the common execution ancestor that the Workflow and Invocation
+ * spans parent onto, so they share one trace. The ancestor is chosen by
+ * precedence:
+ *
+ * 1. a complete remote backend context (valid trace ID + valid parent span ID)
+ *    is the authoritative ancestor, used directly whether or not the upstream
+ *    carries an explicit sampling decision;
+ * 2. otherwise a synthetic execution root anchors the execution, with a
+ *    deterministic span ID in its own namespace, on the canonical trace.
+ *
+ * A live ambient span is deliberately never used as the ancestor: its trace ID
+ * is not guaranteed stable across Lambda reinvocations, so anchoring the
+ * multi-invocation execution on it could change the execution trace on replay
+ * and break the cross-invocation continuation/replay links.
+ *
+ * The canonical trace ID follows the same precedence: the remote trace ID when
+ * valid, else one derived from the ARN and start time.
+ *
+ * Sampling: an explicit upstream decision is preserved only when it belongs to
+ * a valid extracted trace; when it is absent, the configured root decision
+ * (`whenUndecided`) is applied to both a remote parent and a synthetic root.
+ * Trace flags carry a single sampled bit with no "unset" state, so a
+ * remote parent left unsampled would make a parent-based sampler drop every
+ * child span.
+ *
+ * The ancestor is a non-recording context: it is either the external backend
+ * server span or a synthetic root the SDK does not export.
+ */
+export interface ExecutionTraceContext {
+  /** The common parent context for the Workflow and Invocation spans. */
+  executionAncestor: SpanContext;
+  /** The trace ID of the execution trace (equals `executionAncestor.traceId`). */
+  traceId: string;
+  /** The trace flags of the execution trace. */
+  traceFlags: number;
+  /** The sampling decision enforced for SDK-created spans in this execution. */
+  samplingDecision: SamplingDecision;
+}
+
+/**
+ * The canonical trace ID: the propagated remote trace ID when valid, else one
+ * derived from the ARN and start time.
+ *
+ * Only these two anchors are used, and both are stable across Lambda
+ * reinvocations: the propagated `Root` is kept identical for every invocation by
+ * the durable backend, and the ARN-derived ID is a pure hash of the ARN. A live
+ * ambient span's trace ID is deliberately NOT used — it is not guaranteed stable
+ * across invocations, so anchoring on one could change the execution trace on
+ * replay and break the continuation/replay links (which target
+ * `deriveSpanIdFromOperationId` on the canonical trace).
+ *
+ * An all-zero or malformed remote trace ID is not usable, so it falls through to
+ * the ARN-derived ID rather than anchoring the execution on an unstable trace.
+ */
+export function canonicalTraceId(
+  extracted: ContextExtractorResult,
+  executionArn: string,
+  executionStartTimestamp: Date | undefined,
+): string {
+  if (hasValidTraceId(extracted)) {
+    return extracted.traceId;
+  }
+  return deriveTraceIdFromArn(executionArn, executionStartTimestamp);
+}
+
+/**
+ * Flags for an explicit upstream decision, or the sampler's decision
+ * (`whenUndecided`) when the upstream did not decide. The supplier is consulted
+ * lazily, only for the `UNDECIDED` case, so an explicit decision never triggers
+ * a (discarded) sampler query.
+ */
+function explicitDecision(
+  extracted: ContextExtractorResult,
+  whenUndecided: () => SamplingDecision,
+): SamplingDecision {
+  const sampling = extracted ? resolveSampling(extracted) : "UNDECIDED";
+  switch (sampling) {
+    case "SAMPLED":
+      return SamplingDecision.RECORD_AND_SAMPLED;
+    case "NOT_SAMPLED":
+      return SamplingDecision.NOT_RECORD;
+    case "UNDECIDED":
+    default:
+      return whenUndecided();
+  }
+}
+
+function traceFlagsFromDecision(decision: SamplingDecision): number {
+  return decision === SamplingDecision.RECORD_AND_SAMPLED
+    ? TraceFlags.SAMPLED
+    : TraceFlags.NONE;
+}
+
+/**
+ * Resolves the execution ancestor: a complete propagated remote parent when
+ * present, otherwise a synthetic execution root on the canonical trace.
+ *
+ * A live ambient span is never used as the ancestor. Its trace ID is not
+ * guaranteed stable across Lambda reinvocations, so anchoring the multi-
+ * invocation execution on it could change the execution trace on replay and
+ * break cross-invocation links. The two anchors used here are both stable: a
+ * propagated remote parent (the backend keeps `Root` identical every invocation)
+ * and the ARN-derived synthetic root (a pure hash of the ARN).
+ *
+ * @param extracted the context parsed from the backend header, or undefined
+ * @param canonical the trace ID the ancestor is anchored on
+ * @param executionArn the durable execution ARN
+ * @param rootSamplingDecision the configured root decision for this trace, applied
+ *   to a remote parent or synthetic root when the header carries no explicit
+ *   Sampled value
+ */
+export function resolveExecutionTraceContext(
+  extracted: ContextExtractorResult,
+  canonical: string,
+  executionArn: string,
+  rootSamplingDecision: () => SamplingDecision,
+): ExecutionTraceContext {
+  // A valid remote backend parent is the authoritative ancestor, regardless of
+  // whether Sampled is present.
+  if (hasCompleteRemoteParent(extracted)) {
+    const decision = explicitDecision(extracted, rootSamplingDecision);
+    const flags = traceFlagsFromDecision(decision);
+    const remoteParent: SpanContext = {
+      traceId: extracted.traceId,
+      spanId: extracted.parentSpanId,
+      traceFlags: flags,
+      isRemote: true,
+    };
+    return {
+      executionAncestor: remoteParent,
+      traceId: remoteParent.traceId,
+      traceFlags: flags,
+      samplingDecision: decision,
+    };
+  }
+
+  // No complete remote parent: synthesize an execution root on the canonical
+  // trace (the stable remote Root if one was provided, else the ARN-derived ID).
+  const samplingContext = hasValidTraceId(extracted) ? extracted : undefined;
+  const decision = explicitDecision(samplingContext, rootSamplingDecision);
+  const flags = traceFlagsFromDecision(decision);
+  const syntheticRoot: SpanContext = {
+    traceId: canonical,
+    spanId: deriveExecutionRootSpanId(executionArn),
+    traceFlags: flags,
+    isRemote: false,
+  };
+  return {
+    executionAncestor: syntheticRoot,
+    traceId: canonical,
+    traceFlags: flags,
+    samplingDecision: decision,
+  };
+}
+
+/**
+ * Decides how a root span on the given trace should be sampled, used only
+ * when the propagated context carries no explicit decision.
+ *
+ * Sampling precedence, highest first:
+ *
+ * 1. the backend's explicit `Sampled` on the propagated header — handled by the
+ *    caller before reaching here;
+ * 2. the configured sampler is evaluated at its root policy (`ROOT_CONTEXT`, no
+ *    parent) with the real trace ID. This honors custom samplers and avoids
+ *    inheriting an unrelated ambient span's decision.
+ *
+ * The resolved decision is then enforced through DurableSampler for every
+ * SDK-created span, so direct samplers that ignore parent flags cannot override
+ * an explicit backend decision or the configured root decision.
+ *
+ * @param tracer the resolved SDK tracer
+ * @param traceId the canonical trace ID to evaluate
+ * @param spanName the span name passed to the sampler
+ * @param attributes the attributes the span is started with
+ */
+export function rootSamplingDecision(
+  tracer: Tracer,
+  traceId: string,
+  spanName: string,
+  attributes: Record<string, string | number | boolean>,
+): SamplingDecision {
+  const sampler = getConfiguredSampler(tracer);
+  if (!sampler) {
+    return SamplingDecision.RECORD_AND_SAMPLED;
+  }
+  try {
+    // Evaluate with ROOT_CONTEXT (no parent), not the active context: a
+    // ParentBasedSampler must decide the execution root on its own root policy,
+    // not inherit the sampled bit of an unrelated ambient span that the resolver
+    // already rejected. Otherwise an unrelated unsampled ambient span could drop
+    // an execution whose root policy would sample it.
+    const result = sampler.shouldSample(
+      ROOT_CONTEXT,
+      traceId,
+      spanName,
+      SpanKind.INTERNAL,
+      attributes,
+      [],
+    );
+    return result.decision;
+  } catch {
+    return SamplingDecision.RECORD_AND_SAMPLED;
+  }
+}

--- a/packages/aws-durable-execution-sdk-js-otel/src/global-sampler.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/global-sampler.ts
@@ -1,0 +1,105 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type {
+  Context,
+  Attributes,
+  Link,
+  SpanKind,
+  Tracer,
+} from "@opentelemetry/api";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-node";
+import type { Sampler, SamplingResult } from "@opentelemetry/sdk-trace-node";
+
+const SAMPLER_FIELD = "_sampler";
+
+function isSampler(value: unknown): value is Sampler {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "shouldSample" in value &&
+    typeof (value as { shouldSample: unknown }).shouldSample === "function"
+  );
+}
+
+/**
+ * Sampler wrapper that preserves the application's sampler except while the
+ * durable plugin is creating its own spans with a resolved execution decision.
+ */
+export class DurableSampler implements Sampler {
+  private static readonly decisions = new AsyncLocalStorage<SamplingDecision>();
+
+  constructor(private readonly delegate: Sampler) {}
+
+  withDecision<T>(decision: SamplingDecision, fn: () => T): T {
+    return DurableSampler.decisions.run(decision, fn);
+  }
+
+  shouldSample(
+    context: Context,
+    traceId: string,
+    spanName: string,
+    spanKind: SpanKind,
+    attributes: Attributes,
+    links: Link[],
+  ): SamplingResult {
+    const decision = DurableSampler.decisions.getStore();
+    if (decision !== undefined) {
+      return { decision };
+    }
+    return this.delegate.shouldSample(
+      context,
+      traceId,
+      spanName,
+      spanKind,
+      attributes,
+      links,
+    );
+  }
+
+  toString(): string {
+    return `DurableSampler{${this.delegate.toString()}}`;
+  }
+}
+
+/**
+ * Installs a durable-aware sampler on an OpenTelemetry SDK tracer.
+ *
+ * OpenTelemetry JavaScript does not expose the sampler through its public API.
+ * SDK tracers have historically stored it in the TypeScript-private `_sampler`
+ * field, which remains writable at runtime.
+ */
+export function tryInstallDurableSampler(
+  tracer: Tracer,
+): DurableSampler | undefined {
+  try {
+    const existingSampler = Reflect.get(tracer, SAMPLER_FIELD);
+    if (!isSampler(existingSampler)) {
+      return undefined;
+    }
+    if (existingSampler instanceof DurableSampler) {
+      return existingSampler;
+    }
+
+    const durableSampler = new DurableSampler(existingSampler);
+    if (
+      !Reflect.set(tracer, SAMPLER_FIELD, durableSampler) ||
+      Reflect.get(tracer, SAMPLER_FIELD) !== durableSampler
+    ) {
+      return undefined;
+    }
+    return durableSampler;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getConfiguredSampler(tracer: Tracer): Sampler | undefined {
+  try {
+    const sampler = Reflect.get(tracer, SAMPLER_FIELD);
+    if (sampler instanceof DurableSampler) {
+      return Reflect.get(sampler, "delegate") as Sampler;
+    }
+    return isSampler(sampler) ? sampler : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/854

*Description of changes:*
- Second PR in the stack. Adds the resolver that turns extracted context into one execution ancestor, and the sampler that enforces a single decision across the execution. 
- execution-trace-context.ts introduces resolveExecutionTraceContext, canonicalTraceId, and rootSamplingDecision: the canonical trace ID is the propagated remote trace when valid, else one derived from the ARN and start time; the ancestor is a complete remote parent when present, else a synthetic execution root. 
- global-sampler.ts adds DurableSampler (with tryInstallDurableSampler/getConfiguredSampler), which applies the resolved per-execution decision to every SDK-created span so the configured sampler is not re-consulted per span. 
- Consumes PR 1's extractor helpers and deriveExecutionRootSpanId; still unconsumed by the plugins. 
- Unit tests cover the resolution table and sampling precedence. 
- Next in stack: wiring both plugins onto this resolver and sampler.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
