### PR TITLE
feat(otel): wire both plugins onto the shared execution trace

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-default-provider-integration.test.ts
@@ -187,7 +187,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(attemptSpan).toBeDefined();
   });
 
-  it("Workflow_Span is a root span with no parent", async () => {
+  it("Workflow_Span parents onto the synthetic execution root when no context is propagated", async () => {
     const plugin = new ExecutionOtelPlugin({});
 
     await plugin.onInvocationStart(makeInvocationInfo());
@@ -202,10 +202,21 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     );
 
     const workflowSpan = findSpan(exporter, "Workflow");
+    const invocationSpan = findSpan(exporter, "Invocation");
     expect(workflowSpan).toBeDefined();
+    expect(invocationSpan).toBeDefined();
 
-    // Workflow_Span MUST be a root span — no parent span context
-    expect(workflowSpan!.parentSpanContext).toBeUndefined();
+    // With no ambient span and no propagated backend context, a synthetic
+    // execution root anchors the execution trace. The Workflow span parents
+    // onto that root (it is no longer a parentless root) and shares the
+    // execution trace with the Invocation span.
+    expect(workflowSpan!.parentSpanContext?.spanId).toBeDefined();
+    expect(workflowSpan!.spanContext().traceId).toBe(
+      invocationSpan!.spanContext().traceId,
+    );
+    expect(workflowSpan!.parentSpanContext?.spanId).toBe(
+      invocationSpan!.parentSpanContext?.spanId,
+    );
   });
 
   it("Invocation_Span is created as child of ambient context", async () => {
@@ -403,8 +414,12 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(invocationSpan).toBeDefined();
     expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
 
-    // Workflow is root
-    expect(workflowSpan!.parentSpanContext).toBeUndefined();
+    // Workflow parents onto the synthetic execution root and shares the
+    // execution trace with the Invocation span (no propagated context here).
+    expect(workflowSpan!.parentSpanContext?.spanId).toBeDefined();
+    expect(workflowSpan!.spanContext().traceId).toBe(
+      invocationSpan!.spanContext().traceId,
+    );
 
     // Both operations are children of Workflow_Span
     expect(validateSpan!.parentSpanContext?.spanId).toBe(
@@ -446,8 +461,8 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
       }
     }
 
-    // Workflow operations form one trace. The parentless Invocation span forms
-    // a separate trace instead of becoming a second root in the Workflow trace.
+    // The whole execution shares one trace: operations, attempts, the Workflow
+    // span, and the Invocation span all share the execution trace ID.
     expect(validateSpan!.spanContext().traceId).toBe(
       workflowSpan!.spanContext().traceId,
     );
@@ -460,7 +475,7 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(processAttempt!.spanContext().traceId).toBe(
       workflowSpan!.spanContext().traceId,
     );
-    expect(invocationSpan!.spanContext().traceId).not.toBe(
+    expect(invocationSpan!.spanContext().traceId).toBe(
       workflowSpan!.spanContext().traceId,
     );
   });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-integration.test.ts
@@ -137,13 +137,21 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
      * onOperationStart → onOperationAttemptStart → onOperationAttemptEnd →
      * onOperationEnd → wrapChildContextFn (CONTEXT type) → onInvocationEnd
      */
-    const plugin = new ExecutionOtelPlugin({});
-
     // Create an ambient invocation span (simulating the one from the Lambda layer/environment)
     const ambientTracer = provider.getTracer("test-ambient-layer");
     const ambientSpan = ambientTracer.startSpan("lambda-invocation");
     const ambientContext = trace.setSpan(ROOT_CONTEXT, ambientSpan);
     const ambientSpanContext = ambientSpan.spanContext();
+
+    // The extractor reports the ambient span's trace (propagated Root, no
+    // Parent). With no complete remote parent, the execution joins that Root
+    // trace but anchors on the deterministic synthetic root rather than the
+    // ambient span.
+    const plugin = new ExecutionOtelPlugin({
+      contextExtractor: () => ({
+        traceId: ambientSpanContext.traceId,
+      }),
+    });
 
     // --- Phase 1: onInvocationStart with ambient context ---
     await context.with(ambientContext, async () => {
@@ -213,16 +221,29 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     // child-context execution, lambda-invocation (ambient)
     expect(spans.length).toBeGreaterThanOrEqual(5);
 
-    // Assertion 2: Workflow_Span has no parent (it's a root span — created with ROOT_CONTEXT)
+    // Assertion 2: The extractor reports only a Root (no usable Parent), so
+    // there is no complete remote parent. The execution joins the propagated
+    // Root trace but anchors on a synthetic execution root, NOT the ambient
+    // span (an ambient span's trace is not stable across reinvocations).
     const workflowSpan = findSpan(exporter, "Workflow");
     expect(workflowSpan).toBeDefined();
-    // A root span created with ROOT_CONTEXT has no valid parent
-    expect(workflowSpan!.parentSpanContext).toBeUndefined();
+    expect(workflowSpan!.spanContext().traceId).toBe(
+      ambientSpanContext.traceId,
+    );
+    expect(workflowSpan!.parentSpanContext?.spanId).not.toBe(
+      ambientSpanContext.spanId,
+    );
 
-    // Assertion 3: Invocation_Span is created as child of the ambient Lambda span
+    // Assertion 3: Invocation_Span shares the execution trace with the Workflow
+    // span. It parents onto the active ambient span (which is on the canonical
+    // execution trace), keeping the per-invocation span nested under the layer's
+    // handler span without changing the execution ancestor.
     const invocationSpan = findSpan(exporter, "Invocation");
     expect(invocationSpan).toBeDefined();
     expect(invocationSpan!.attributes["durable.execution.arn"]).toBe(TEST_ARN);
+    expect(invocationSpan!.spanContext().traceId).toBe(
+      workflowSpan!.spanContext().traceId,
+    );
     expect(invocationSpan!.parentSpanContext?.spanId).toBe(
       ambientSpanContext.spanId,
     );
@@ -299,7 +320,13 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
      * Verifies that per-invocation state is properly cleared between invocations
      * and the global provider remains functional across multiple lifecycles.
      */
-    const plugin = new ExecutionOtelPlugin({});
+    // No backend execution context is extracted, so each invocation anchors on
+    // the deterministic ARN-derived execution trace rather than on whichever
+    // per-invocation ambient span happens to be active. A live ambient span is
+    // never adopted as the execution trace.
+    const plugin = new ExecutionOtelPlugin({
+      contextExtractor: () => undefined,
+    });
 
     const ambientTracer = provider.getTracer("test-ambient-layer");
 
@@ -352,13 +379,18 @@ describe("ExecutionOtelPlugin - Integration: End-to-end span export with default
     expect(secondInvocationSpan).toBeDefined();
 
     // The link on second-op should point to the second invocation's plugin-created
-    // Invocation span (which is itself a child of ambientSpan2, not ambientSpan1)
+    // Invocation span. The Invocation span should not parent onto either
+    // per-invocation ambient span because no backend execution context was
+    // extracted, so the execution anchors on the ARN-derived trace.
     expect(secondOpSpan!.links.length).toBeGreaterThan(0);
     expect(secondOpSpan!.links[0].context.spanId).toBe(
       secondInvocationSpan!.spanContext().spanId,
     );
-    expect(secondInvocationSpan!.parentSpanContext?.spanId).toBe(
+    expect(secondInvocationSpan!.parentSpanContext?.spanId).not.toBe(
       ambientSpan2.spanContext().spanId,
+    );
+    expect(secondInvocationSpan!.spanContext().traceId).not.toBe(
+      ambientSpan2.spanContext().traceId,
     );
 
     // No leaked link to the first ambient span

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-plugin-invocation-lifecycle.test.ts
@@ -17,7 +17,6 @@ import type {
   InvocationEndInfo,
 } from "@aws/durable-execution-sdk-js";
 import { ExecutionOtelPlugin } from "../execution-plugin";
-import { deriveTraceIdFromArn } from "../deterministic-id-generator";
 import type { TracerProviderFactory } from "../otel-plugin-config";
 
 const TEST_ARN =
@@ -125,7 +124,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       expect(workflowSpan).toBeDefined();
     });
 
-    it("creates a root Invocation span with an application-owned provider when no ambient span exists", async () => {
+    it("shares one execution trace with an application-owned provider when no ambient span exists", async () => {
       const plugin = new ExecutionOtelPlugin({
         tracerProviderFactory,
       });
@@ -139,20 +138,32 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       const workflowSpan = findSpan(exporter, "Workflow");
       expect(invocationSpan).toBeDefined();
       expect(workflowSpan).toBeDefined();
-      expect(invocationSpan!.parentSpanContext).toBeUndefined();
-      expect(invocationSpan!.spanContext().traceId).not.toBe(
+      // With no propagated context and no ambient span, a synthetic execution
+      // root anchors the trace and both spans parent onto it, sharing one trace.
+      expect(invocationSpan!.spanContext().traceId).toBe(
         workflowSpan!.spanContext().traceId,
+      );
+      expect(invocationSpan!.parentSpanContext?.spanId).toBeDefined();
+      expect(invocationSpan!.parentSpanContext?.spanId).toBe(
+        workflowSpan!.parentSpanContext?.spanId,
       );
     });
 
     it("parents an application-owned provider's Invocation span to the ambient span", async () => {
-      const plugin = new ExecutionOtelPlugin({
-        tracerProviderFactory,
-      });
       const ambientSpan = provider
         .getTracer("test-ambient-provider")
         .startSpan("ambient-invocation");
       const ambientContext = trace.setSpan(ROOT_CONTEXT, ambientSpan);
+      // The extractor reports the ambient span's trace as the propagated Root
+      // (no Parent), so the ambient span is on the canonical execution trace.
+      // The Invocation span therefore parents onto the ambient span, staying
+      // nested under the layer's handler span on the same trace.
+      const plugin = new ExecutionOtelPlugin({
+        tracerProviderFactory,
+        contextExtractor: () => ({
+          traceId: ambientSpan.spanContext().traceId,
+        }),
+      });
 
       await context.with(ambientContext, async () => {
         await plugin.onInvocationStart(makeInvocationInfo());
@@ -199,7 +210,11 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       expect(invocationSpan!.spanContext().traceId).toBe(traceId);
     });
 
-    it("gives chained executions distinct Workflow traces when they share an upstream trace", async () => {
+    it("joins chained executions onto the shared propagated trace with distinct Workflow spans", async () => {
+      // When a complete remote parent (Root + Parent) is propagated to both a
+      // parent and a target execution in a chained invoke, both join that one
+      // execution trace. Each keeps its own deterministic Workflow span ID
+      // (derived from its ARN), so the two executions stay distinguishable.
       const upstreamTraceId = "1".repeat(32);
       const upstreamParentSpanId = "2".repeat(16);
       const targetArn = `${TEST_ARN}-target`;
@@ -208,7 +223,7 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
         contextExtractor: () => ({
           traceId: upstreamTraceId,
           parentSpanId: upstreamParentSpanId,
-          traceFlags: 1,
+          sampling: "SAMPLED" as const,
         }),
       };
       const parentPlugin = new ExecutionOtelPlugin(config);
@@ -236,30 +251,22 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
       );
       expect(parentWorkflow).toBeDefined();
       expect(targetWorkflow).toBeDefined();
-      expect(parentWorkflow!.parentSpanContext).toBeUndefined();
-      expect(targetWorkflow!.parentSpanContext).toBeUndefined();
-      expect(parentWorkflow!.spanContext().traceId).toBe(
-        deriveTraceIdFromArn(TEST_ARN, TEST_EXECUTION_START),
+
+      // Both Workflow spans join the one propagated execution trace and parent
+      // onto the propagated remote parent.
+      expect(parentWorkflow!.spanContext().traceId).toBe(upstreamTraceId);
+      expect(targetWorkflow!.spanContext().traceId).toBe(upstreamTraceId);
+      expect(parentWorkflow!.parentSpanContext?.spanId).toBe(
+        upstreamParentSpanId,
       );
-      expect(targetWorkflow!.spanContext().traceId).toBe(
-        deriveTraceIdFromArn(targetArn, TEST_EXECUTION_START),
-      );
-      expect(parentWorkflow!.spanContext().traceId).not.toBe(
-        targetWorkflow!.spanContext().traceId,
+      expect(targetWorkflow!.parentSpanContext?.spanId).toBe(
+        upstreamParentSpanId,
       );
 
-      const rootsByTrace = workflowSpans.reduce<Map<string, ReadableSpan[]>>(
-        (roots, span) => {
-          const traceId = span.spanContext().traceId;
-          roots.set(traceId, [...(roots.get(traceId) ?? []), span]);
-          return roots;
-        },
-        new Map(),
+      // The two executions keep distinct deterministic Workflow span IDs.
+      expect(parentWorkflow!.spanContext().spanId).not.toBe(
+        targetWorkflow!.spanContext().spanId,
       );
-      expect(rootsByTrace.size).toBe(2);
-      expect(
-        [...rootsByTrace.values()].every((roots) => roots.length === 1),
-      ).toBe(true);
 
       const invocationSpans = getExportedSpans(exporter).filter(
         (span) => span.name === "Invocation",
@@ -299,12 +306,18 @@ describe("ExecutionOtelPlugin - Invocation lifecycle in default-provider mode", 
 
   describe("Ambient context is captured BEFORE Workflow_Span creation", () => {
     it("captures the ambient context with the active invocation span before Workflow_Span is created", async () => {
-      const plugin = new ExecutionOtelPlugin({});
-
       // Create an ambient span to simulate invocation span from the environment
       const tracer = provider.getTracer("test");
       const ambientSpan = tracer.startSpan("ambient-invocation");
       const ambientContext = trace.setSpan(ROOT_CONTEXT, ambientSpan);
+      // The extractor reports the ambient span's trace as the propagated Root,
+      // so the ambient span is on the canonical execution trace and the
+      // Invocation span parents onto it.
+      const plugin = new ExecutionOtelPlugin({
+        contextExtractor: () => ({
+          traceId: ambientSpan.spanContext().traceId,
+        }),
+      });
 
       await context.with(ambientContext, async () => {
         await plugin.onInvocationStart(makeInvocationInfo());

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin-default-provider.test.ts
@@ -123,16 +123,27 @@ describe("InvocationOtelPlugin - Global provider mode", () => {
     // (matching ExecutionOtelPlugin and the Python/Java reference plugins).
     const workflowSpan = spans.find((s) => s.name === "Workflow");
     expect(workflowSpan).toBeDefined();
-    expect(workflowSpan!.parentSpanContext).toBeUndefined();
     expect(workflowSpan!.attributes["durable.execution.arn"]).toBe(
       "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123",
     );
     expect(workflowSpan!.attributes["durable.execution.status"]).toBe(
       "SUCCEEDED",
     );
+    // With no propagated context and no ambient span, a synthetic execution
+    // root anchors the trace. Both the Workflow and Invocation spans parent
+    // onto it and share one execution trace.
+    expect(workflowSpan!.spanContext().traceId).toBe(
+      invocationSpan!.spanContext().traceId,
+    );
+    expect(workflowSpan!.parentSpanContext?.spanId).toBeDefined();
+    expect(invocationSpan!.parentSpanContext?.spanId).toBe(
+      workflowSpan!.parentSpanContext?.spanId,
+    );
     // The Invocation span stays invocation-rooted: it is NOT a child of the
-    // Workflow span. With no active parent span in this test it is a root.
-    expect(invocationSpan!.parentSpanContext).toBeUndefined();
+    // Workflow span (both are siblings under the synthetic execution root).
+    expect(invocationSpan!.parentSpanContext?.spanId).not.toBe(
+      workflowSpan!.spanContext().spanId,
+    );
     // Operation spans link to the Workflow span for execution correlation.
     expect(
       opSpan!.links.some(

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/invocation-plugin.test.ts
@@ -8,15 +8,11 @@ import {
   trace,
   SpanStatusCode,
   SpanKind,
-  TraceFlags,
   propagation,
 } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
 import { InvocationOtelPlugin } from "../invocation-plugin";
-import {
-  deriveSpanIdFromOperationId,
-  deriveTraceIdFromArn,
-} from "../deterministic-id-generator";
+import { deriveSpanIdFromOperationId } from "../deterministic-id-generator";
 import type { TracerProviderFactory } from "../otel-plugin-config";
 import type {
   InvocationInfo,
@@ -199,16 +195,21 @@ describe("InvocationOtelPlugin", () => {
       expect(findSpan("Invocation")).toBeDefined();
     });
 
-    it("keeps Workflow in a separate trace from the ambient Lambda root", async () => {
+    it("joins Workflow, Invocation, and operations onto the propagated execution trace", async () => {
+      // A complete remote parent (Root + Parent) is propagated alongside the
+      // ambient Lambda span on the same trace. The Workflow span parents onto
+      // the remote parent; the Invocation span parents onto the same-trace
+      // ambient span; everything shares the one execution trace.
       const ambientTracer = provider!.getTracer("adot-lambda");
       const lambdaRoot = ambientTracer.startSpan("Lambda");
       const lambdaSpanContext = lambdaRoot.spanContext();
+      const remoteParentSpanId = "c".repeat(16);
       const topologyPlugin = new InvocationOtelPlugin({
         tracerProviderFactory,
         contextExtractor: () => ({
           traceId: lambdaSpanContext.traceId,
-          parentSpanId: "c".repeat(16),
-          traceFlags: lambdaSpanContext.traceFlags,
+          parentSpanId: remoteParentSpanId,
+          sampling: "SAMPLED",
         }),
       });
 
@@ -238,47 +239,35 @@ describe("InvocationOtelPlugin", () => {
       expect(invocationSpan).toBeDefined();
       expect(operationSpan).toBeDefined();
 
-      expect(workflowSpan!.parentSpanContext).toBeUndefined();
+      // The whole execution shares the propagated trace.
       expect(workflowSpan!.spanContext().traceId).toBe(
-        deriveTraceIdFromArn(TEST_ARN, TEST_EXECUTION_START),
-      );
-      expect(workflowSpan!.spanContext().traceId).not.toBe(
         lambdaSpanContext.traceId,
       );
-
       expect(invocationSpan!.spanContext().traceId).toBe(
         lambdaSpanContext.traceId,
-      );
-      expect(invocationSpan!.parentSpanContext?.spanId).toBe(
-        lambdaSpanContext.spanId,
       );
       expect(operationSpan!.spanContext().traceId).toBe(
         lambdaSpanContext.traceId,
       );
-      expect(operationSpan!.links).toHaveLength(1);
-      expect(operationSpan!.links[0].context).toEqual(
-        workflowSpan!.spanContext(),
-      );
 
-      const rootsByTrace = getExportedSpans()
-        .filter((span) => span.parentSpanContext === undefined)
-        .reduce<Map<string, ReadableSpan[]>>((roots, span) => {
-          const traceId = span.spanContext().traceId;
-          roots.set(traceId, [...(roots.get(traceId) ?? []), span]);
-          return roots;
-        }, new Map());
+      // Workflow parents onto the propagated remote parent.
+      expect(workflowSpan!.parentSpanContext?.spanId).toBe(remoteParentSpanId);
+      // Invocation parents onto the same-trace ambient Lambda span.
+      expect(invocationSpan!.parentSpanContext?.spanId).toBe(
+        lambdaSpanContext.spanId,
+      );
+      // Operations remain parented to the invocation and link to Workflow.
+      expect(operationSpan!.parentSpanContext?.spanId).toBe(
+        invocationSpan!.spanContext().spanId,
+      );
       expect(
-        rootsByTrace.get(lambdaSpanContext.traceId)?.map((span) => span.name),
-      ).toEqual(["Lambda"]);
-      expect(
-        rootsByTrace
-          .get(workflowSpan!.spanContext().traceId)
-          ?.map((span) => span.name),
-      ).toEqual(["Workflow"]);
-      expect(rootsByTrace.size).toBe(2);
+        operationSpan!.links.some(
+          (l) => l.context.spanId === workflowSpan!.spanContext().spanId,
+        ),
+      ).toBe(true);
     });
 
-    it("uses the extracted upstream parent when no span is active", async () => {
+    it("uses the extracted upstream parent as the execution ancestor when no span is active", async () => {
       const upstreamTraceId = "a".repeat(32);
       const upstreamSpanId = "b".repeat(16);
       const topologyPlugin = new InvocationOtelPlugin({
@@ -286,7 +275,7 @@ describe("InvocationOtelPlugin", () => {
         contextExtractor: () => ({
           traceId: upstreamTraceId,
           parentSpanId: upstreamSpanId,
-          traceFlags: TraceFlags.SAMPLED,
+          sampling: "SAMPLED",
         }),
       });
 
@@ -297,14 +286,14 @@ describe("InvocationOtelPlugin", () => {
       const invocationSpan = findSpan("Invocation");
       expect(workflowSpan).toBeDefined();
       expect(invocationSpan).toBeDefined();
-      expect(workflowSpan!.spanContext().traceId).toBe(
-        deriveTraceIdFromArn(TEST_ARN, TEST_EXECUTION_START),
-      );
+      // The complete remote parent is the execution ancestor: both spans join
+      // its trace and parent onto it directly.
+      expect(workflowSpan!.spanContext().traceId).toBe(upstreamTraceId);
       expect(invocationSpan!.spanContext().traceId).toBe(upstreamTraceId);
+      expect(workflowSpan!.parentSpanContext?.spanId).toBe(upstreamSpanId);
       expect(invocationSpan!.parentSpanContext).toMatchObject({
         traceId: upstreamTraceId,
         spanId: upstreamSpanId,
-        traceFlags: TraceFlags.SAMPLED,
         isRemote: true,
       });
     });
@@ -480,7 +469,7 @@ describe("InvocationOtelPlugin", () => {
       );
     });
 
-    it("replay operation uses a new span ID and links only to Workflow", async () => {
+    it("replay operation uses a new span ID and links to Workflow and the initial operation span", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       const opInfo = makeOperationInfo({
         id: "op-replay",
@@ -505,10 +494,19 @@ describe("InvocationOtelPlugin", () => {
       const workflowSpan = findSpan("Workflow");
       expect(opSpan).toBeDefined();
       expect(workflowSpan).toBeDefined();
+      // The replay segment gets its own new span ID, not the deterministic one.
       expect(opSpan!.spanContext().spanId).not.toBe(derivedOperationSpanId);
-      expect(opSpan!.links).toHaveLength(1);
-      expect(opSpan!.links[0].context).toEqual(workflowSpan!.spanContext());
-      expect(opSpan!.links[0].context.spanId).not.toBe(derivedOperationSpanId);
+      // Links are ordered [initial operation span, Workflow span] — the
+      // conformance contract resolves links[0] to the operation (carrying
+      // durable.operation.id) and links[1] to the Workflow span.
+      expect(opSpan!.links).toHaveLength(2);
+      expect(opSpan!.links[0].context.spanId).toBe(derivedOperationSpanId);
+      expect(opSpan!.links[0].context.traceId).toBe(
+        workflowSpan!.spanContext().traceId,
+      );
+      expect(opSpan!.links[1].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
     });
 
     it("uses operation name as span name when provided", async () => {
@@ -839,7 +837,7 @@ describe("InvocationOtelPlugin", () => {
   });
 
   describe("Continuation span for cross-invocation operations", () => {
-    it("creates continuation span linked only to Workflow when operation was started in prior invocation", async () => {
+    it("links continuation span to Workflow and the initial operation span when operation was started in prior invocation", async () => {
       await plugin.onInvocationStart(makeInvocationInfo());
       // onOperationEnd for an operation NOT in the map (started elsewhere)
       await plugin.onOperationEnd(
@@ -859,12 +857,21 @@ describe("InvocationOtelPlugin", () => {
       const workflowSpan = findSpan("Workflow");
       expect(continuationSpan).toBeDefined();
       expect(workflowSpan).toBeDefined();
-      expect(continuationSpan!.links).toHaveLength(1);
-      expect(continuationSpan!.links[0].context).toEqual(
-        workflowSpan!.spanContext(),
-      );
-      expect(continuationSpan!.links[0].context.spanId).not.toBe(
+      // The continuation gets its own span ID. Links are ordered
+      // [initial operation span, Workflow span] to match the conformance
+      // contract (links[0] carries durable.operation.id, links[1] the Workflow).
+      expect(continuationSpan!.spanContext().spanId).not.toBe(
         derivedOperationSpanId,
+      );
+      expect(continuationSpan!.links).toHaveLength(2);
+      expect(continuationSpan!.links[0].context.spanId).toBe(
+        derivedOperationSpanId,
+      );
+      expect(continuationSpan!.links[0].context.traceId).toBe(
+        workflowSpan!.spanContext().traceId,
+      );
+      expect(continuationSpan!.links[1].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
       );
     });
 
@@ -2506,6 +2513,121 @@ describe("InvocationOtelPlugin", () => {
       );
       expect(attemptSpan!.status.code).toBe(SpanStatusCode.OK);
       expect(attemptSpan!.events).toHaveLength(0);
+    });
+
+    it("waitForCondition links the first polling attempt, not the resumed operation", async () => {
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+        }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 1,
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 1,
+          outcome: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "PENDING" as any }),
+      );
+
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ isFirstInvocation: false }),
+      );
+      await plugin.onOperationStart(
+        makeOperationInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          isReplay: true,
+        }),
+      );
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 2,
+        }),
+      );
+      await plugin.onOperationAttemptEnd(
+        makeAttemptEndInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          attempt: 2,
+          outcome: "SUCCEEDED" as any,
+        }),
+      );
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({
+          id: "cond-1",
+          type: "STEP",
+          subType: "WaitForCondition",
+          name: "otel-condition",
+          isReplay: false,
+          status: "SUCCEEDED" as any,
+          attempt: 2,
+        }),
+      );
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const workflowSpan = findSpan("Workflow");
+      const firstOperationSpan = getExportedSpans().find(
+        (s) =>
+          s.name === "otel-condition" &&
+          s.attributes["durable.operation.status"] === "STARTED",
+      );
+      const firstAttemptSpan = findSpan("otel-condition attempt 1");
+      const resumedOperationSpan = getExportedSpans().find(
+        (s) =>
+          s.name === "otel-condition" &&
+          s.attributes["durable.operation.status"] === "SUCCEEDED",
+      );
+      const secondAttemptSpan = findSpan("otel-condition attempt 2");
+
+      expect(workflowSpan).toBeDefined();
+      expect(firstOperationSpan).toBeDefined();
+      expect(firstAttemptSpan).toBeDefined();
+      expect(resumedOperationSpan).toBeDefined();
+      expect(secondAttemptSpan).toBeDefined();
+
+      expect(firstAttemptSpan!.links).toHaveLength(2);
+      expect(firstAttemptSpan!.links[0].context.spanId).toBe(
+        firstOperationSpan!.spanContext().spanId,
+      );
+      expect(firstAttemptSpan!.links[1].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
+
+      expect(resumedOperationSpan!.links).toHaveLength(1);
+      expect(resumedOperationSpan!.links[0].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
+      expect(secondAttemptSpan!.links).toHaveLength(1);
+      expect(secondAttemptSpan!.links[0].context.spanId).toBe(
+        workflowSpan!.spanContext().spanId,
+      );
     });
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/join-execution-trace.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/join-execution-trace.test.ts
@@ -1,0 +1,535 @@
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  NodeTracerProvider,
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+} from "@opentelemetry/sdk-trace-node";
+import { context, trace, propagation, ROOT_CONTEXT } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-node";
+import type {
+  InvocationInfo,
+  InvocationEndInfo,
+} from "@aws/durable-execution-sdk-js";
+import { ExecutionOtelPlugin } from "../execution-plugin";
+import { InvocationOtelPlugin } from "../invocation-plugin";
+import { deriveSpanIdFromOperationId } from "../deterministic-id-generator";
+import type { OtelPluginConfig } from "../otel-plugin-config";
+import { w3cClientContextExtractor } from "../context-extractors";
+
+const TEST_ARN =
+  "arn:aws:lambda:us-east-1:123456789012:function:my-func:$LATEST:exec-123";
+const TEST_START = new Date("2026-08-15T00:00:00Z");
+
+function makeInvocationInfo(
+  overrides?: Partial<InvocationInfo>,
+): InvocationInfo {
+  return {
+    requestId: "req-1",
+    executionArn: TEST_ARN,
+    isFirstInvocation: true,
+    executionInput: {},
+    operations: {},
+    updatedOperations: {},
+    executionStartTimestamp: TEST_START,
+    ...overrides,
+  };
+}
+
+function makeInvocationEndInfo(
+  overrides?: Partial<InvocationEndInfo>,
+): InvocationEndInfo {
+  return {
+    requestId: "req-1",
+    executionArn: TEST_ARN,
+    executionInput: {},
+    operations: {},
+    status: "SUCCEEDED" as any,
+    executionResult: undefined,
+    executionError: undefined,
+    executionStartTimestamp: TEST_START,
+    ...overrides,
+  };
+}
+
+describe("Execution trace joining", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  function spanByName(name: string): ReadableSpan | undefined {
+    return exporter.getFinishedSpans().find((s) => s.name === name);
+  }
+
+  describe.each([
+    [
+      "ExecutionOtelPlugin",
+      (c?: OtelPluginConfig) => new ExecutionOtelPlugin(c),
+    ],
+    [
+      "InvocationOtelPlugin",
+      (c?: OtelPluginConfig) => new InvocationOtelPlugin(c),
+    ],
+  ] as const)("%s", (_name, makePlugin) => {
+    it("joins the propagated Root trace but anchors on a synthetic root when only a Root (no usable Parent) is propagated", async () => {
+      // The auto-instrumentation layer creates the ambient handler span before
+      // the plugin runs, on the SAME trace the durable backend propagated. The
+      // extractor reports that trace (Root, no usable Parent). Because there is
+      // no complete remote parent, the execution does NOT adopt the ambient span
+      // as its ancestor; it anchors on the deterministic synthetic root. It does
+      // still join the propagated Root trace, since that trace ID is canonical.
+      const ambient = provider.getTracer("adot").startSpan("LambdaHandler");
+      const ambientCtx = ambient.spanContext();
+      const plugin = makePlugin({
+        // Root matches the ambient trace; no Parent → synthetic-root path.
+        contextExtractor: () => ({
+          traceId: ambientCtx.traceId,
+        }),
+      });
+
+      await context.with(trace.setSpan(ROOT_CONTEXT, ambient), async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+      });
+      ambient.end();
+
+      const workflow = spanByName("Workflow")!;
+      const invocation = spanByName("Invocation")!;
+      // The whole execution joins the propagated Root trace.
+      expect(workflow.spanContext().traceId).toBe(ambientCtx.traceId);
+      expect(invocation.spanContext().traceId).toBe(ambientCtx.traceId);
+      // The Workflow span is the execution ancestor: because there is no
+      // complete remote parent it anchors on the deterministic synthetic root,
+      // NOT the ambient span.
+      expect(workflow.parentSpanContext?.spanId).not.toBe(ambientCtx.spanId);
+      // The Invocation span, however, still parents onto the active ambient
+      // span because that span is already on the (canonical) execution trace —
+      // this keeps the per-invocation span nested under the layer's handler
+      // span without changing the execution ancestor.
+      expect(invocation.parentSpanContext?.spanId).toBe(ambientCtx.spanId);
+    });
+
+    it("does NOT parent Invocation onto a same-trace ambient span whose sampled bit differs from the execution ancestor", async () => {
+      // Build an UNSAMPLED ambient span (AlwaysOff), then propagate an explicit
+      // Sampled=1 on the SAME trace so the execution ancestor IS sampled. The
+      // ambient span shares the canonical trace but its sampled bit differs.
+      // Adopting it would make the (sampled, exported) Invocation span parent
+      // onto a dropped ambient span; the plugin must instead fall back to the
+      // execution ancestor, which carries the authoritative sampled decision.
+      const unsampledProvider = new NodeTracerProvider({
+        sampler: new AlwaysOffSampler(),
+      });
+      const ambient = unsampledProvider
+        .getTracer("adot")
+        .startSpan("LambdaHandler");
+      const ambientCtx = ambient.spanContext();
+      // Sanity: the ambient span is NOT sampled.
+      expect(ambientCtx.traceFlags & 1).toBe(0);
+
+      const plugin = makePlugin({
+        // Same trace as the ambient span, but an explicit Sampled=1 decision.
+        contextExtractor: () => ({
+          traceId: ambientCtx.traceId,
+          sampling: "SAMPLED" as const,
+        }),
+      });
+
+      await context.with(trace.setSpan(ROOT_CONTEXT, ambient), async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+      });
+      ambient.end();
+      await unsampledProvider.shutdown();
+
+      const invocation = spanByName("Invocation")!;
+      expect(invocation).toBeDefined();
+      // The execution joins the ambient span's trace...
+      expect(invocation.spanContext().traceId).toBe(ambientCtx.traceId);
+      // ...but the sampled bits differ, so the ambient span is rejected as the
+      // parent; the Invocation span parents onto the execution ancestor.
+      expect(invocation.parentSpanContext?.spanId).not.toBe(ambientCtx.spanId);
+    });
+
+    it("ignores an uncorroborated ambient span (no propagation) and anchors on the stable synthetic root", async () => {
+      // Reviewer case: with NO propagated context, a fresh ambient trace must
+      // NOT anchor the execution (it is not stable across reinvocations). The
+      // execution anchors on the deterministic ARN-derived synthetic root.
+      const plugin = makePlugin({ contextExtractor: () => undefined });
+      const ambient = provider.getTracer("adot").startSpan("LambdaHandler");
+      const ambientCtx = ambient.spanContext();
+
+      await context.with(trace.setSpan(ROOT_CONTEXT, ambient), async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+      });
+      ambient.end();
+
+      const workflow = spanByName("Workflow")!;
+      const invocation = spanByName("Invocation")!;
+      // The execution does NOT join the uncorroborated ambient trace.
+      expect(workflow.spanContext().traceId).not.toBe(ambientCtx.traceId);
+      expect(workflow.parentSpanContext?.spanId).not.toBe(ambientCtx.spanId);
+      // Workflow and Invocation share the deterministic execution trace and its
+      // synthetic root.
+      expect(workflow.spanContext().traceId).toBe(
+        invocation.spanContext().traceId,
+      );
+      expect(workflow.parentSpanContext?.spanId).toBe(
+        invocation.parentSpanContext?.spanId,
+      );
+    });
+
+    it("rejects an ambient span from another trace and uses a synthetic root", async () => {
+      // A remote parent is propagated on trace A while an ambient span from an
+      // unrelated trace B is active. The plugin must not adopt trace B; it uses
+      // the propagated remote parent on trace A.
+      const remoteTraceId = "a".repeat(32);
+      const remoteParentId = "b".repeat(16);
+      const plugin = makePlugin({
+        contextExtractor: () => ({
+          traceId: remoteTraceId,
+          parentSpanId: remoteParentId,
+          sampling: "SAMPLED",
+        }),
+      });
+      // Ambient span from a DIFFERENT trace.
+      const unrelated = provider.getTracer("other").startSpan("Unrelated");
+      const unrelatedCtx = unrelated.spanContext();
+      expect(unrelatedCtx.traceId).not.toBe(remoteTraceId);
+
+      await context.with(trace.setSpan(ROOT_CONTEXT, unrelated), async () => {
+        await plugin.onInvocationStart(makeInvocationInfo());
+        await plugin.onInvocationEnd(makeInvocationEndInfo());
+      });
+      unrelated.end();
+
+      const workflow = spanByName("Workflow")!;
+      const invocation = spanByName("Invocation")!;
+      // Everything joins the propagated remote trace, not the unrelated ambient.
+      expect(workflow.spanContext().traceId).toBe(remoteTraceId);
+      expect(invocation.spanContext().traceId).toBe(remoteTraceId);
+      expect(workflow.spanContext().traceId).not.toBe(unrelatedCtx.traceId);
+      // Workflow parents onto the remote parent.
+      expect(workflow.parentSpanContext?.spanId).toBe(remoteParentId);
+      // Invocation does not adopt the unrelated ambient span.
+      expect(invocation.parentSpanContext?.spanId).not.toBe(
+        unrelatedCtx.spanId,
+      );
+    });
+
+    it("propagates an explicit Sampled=0 decision onto the execution trace", async () => {
+      // With Sampled=0 propagated and a parent-based sampler, the execution
+      // trace is dropped (not exported), confirming the decision is honored
+      // rather than hard-coded to sampled.
+      const dropExporter = new InMemorySpanExporter();
+      const dropProvider = new NodeTracerProvider({
+        spanProcessors: [new SimpleSpanProcessor(dropExporter)],
+      });
+      const plugin = makePlugin({
+        tracerProviderFactory: (createIdGenerator) => {
+          const p = new NodeTracerProvider({
+            spanProcessors: [new SimpleSpanProcessor(dropExporter)],
+            idGenerator: createIdGenerator(),
+          });
+          return p;
+        },
+        contextExtractor: () => ({
+          traceId: "c".repeat(32),
+          parentSpanId: "d".repeat(16),
+          sampling: "NOT_SAMPLED",
+        }),
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+      await dropProvider.shutdown();
+
+      // A NodeTracerProvider defaults to a parent-based AlwaysOn sampler, so an
+      // explicitly not-sampled remote parent drops the whole execution trace.
+      expect(dropExporter.getFinishedSpans()).toHaveLength(0);
+    });
+
+    it("enforces explicit Sampled=1 even when a direct AlwaysOff sampler is configured", async () => {
+      const forcedExporter = new InMemorySpanExporter();
+      let forcedProvider: NodeTracerProvider | undefined;
+      const plugin = makePlugin({
+        tracerProviderFactory: (createIdGenerator) => {
+          forcedProvider = new NodeTracerProvider({
+            sampler: new AlwaysOffSampler(),
+            spanProcessors: [new SimpleSpanProcessor(forcedExporter)],
+            idGenerator: createIdGenerator(),
+          });
+          return forcedProvider;
+        },
+        contextExtractor: () => ({
+          traceId: "e".repeat(32),
+          parentSpanId: "f".repeat(16),
+          sampling: "SAMPLED",
+        }),
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(forcedExporter.getFinishedSpans().length).toBeGreaterThan(0);
+      await forcedProvider?.shutdown();
+    });
+
+    it("enforces explicit Sampled=0 even when a direct AlwaysOn sampler is configured", async () => {
+      const forcedExporter = new InMemorySpanExporter();
+      let forcedProvider: NodeTracerProvider | undefined;
+      const plugin = makePlugin({
+        tracerProviderFactory: (createIdGenerator) => {
+          forcedProvider = new NodeTracerProvider({
+            sampler: new AlwaysOnSampler(),
+            spanProcessors: [new SimpleSpanProcessor(forcedExporter)],
+            idGenerator: createIdGenerator(),
+          });
+          return forcedProvider;
+        },
+        contextExtractor: () => ({
+          traceId: "1".repeat(32),
+          parentSpanId: "2".repeat(16),
+          sampling: "NOT_SAMPLED",
+        }),
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(forcedExporter.getFinishedSpans()).toHaveLength(0);
+      await forcedProvider?.shutdown();
+    });
+
+    it("preserves normal tracing when an opaque forwarding tracer hides the sampler", async () => {
+      const opaqueExporter = new InMemorySpanExporter();
+      let opaqueProvider: NodeTracerProvider | undefined;
+      const plugin = makePlugin({
+        tracerProviderFactory: (createIdGenerator) => {
+          opaqueProvider = new NodeTracerProvider({
+            sampler: new AlwaysOnSampler(),
+            spanProcessors: [new SimpleSpanProcessor(opaqueExporter)],
+            idGenerator: createIdGenerator(),
+          });
+          return {
+            getTracer: (
+              ...args: Parameters<NodeTracerProvider["getTracer"]>
+            ) => {
+              const realTracer = opaqueProvider!.getTracer(...args);
+              return {
+                startSpan: realTracer.startSpan.bind(realTracer),
+                startActiveSpan: realTracer.startActiveSpan.bind(realTracer),
+              };
+            },
+            forceFlush: () => opaqueProvider!.forceFlush(),
+          };
+        },
+        contextExtractor: () => ({
+          traceId: "3".repeat(32),
+          parentSpanId: "4".repeat(16),
+          sampling: "NOT_SAMPLED",
+        }),
+      });
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      expect(opaqueExporter.getFinishedSpans().length).toBeGreaterThan(0);
+
+      await opaqueProvider?.shutdown();
+    });
+
+    it("uses w3cClientContextExtractor as an execution-stable remote parent", async () => {
+      const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+      const parentSpanId = "00f067aa0ba902b7";
+      const plugin = makePlugin({
+        contextExtractor: w3cClientContextExtractor,
+      });
+      const invocationInfo = makeInvocationInfo({
+        context: {
+          clientContext: {
+            custom: {
+              traceparent: `00-${traceId}-${parentSpanId}-01`,
+            },
+          },
+        },
+      } as any);
+
+      await plugin.onInvocationStart(invocationInfo);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+      const workflow = spanByName("Workflow")!;
+      const invocation = spanByName("Invocation")!;
+      expect(workflow).toBeDefined();
+      expect(invocation).toBeDefined();
+      expect(workflow.spanContext().traceId).toBe(traceId);
+      expect(invocation.spanContext().traceId).toBe(traceId);
+      expect(workflow.parentSpanContext?.spanId).toBe(parentSpanId);
+    });
+  });
+});
+
+describe("Cross-invocation operation link stitching", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it("stitches a wait continuation back to its initial operation span across invocations (InvocationOtelPlugin)", async () => {
+    const plugin = new InvocationOtelPlugin({
+      contextExtractor: () => undefined,
+    });
+
+    // Invocation 1: the wait operation starts (initial logical span) and the
+    // invocation suspends (PENDING) — the initial operation span is ended so it
+    // exports.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart({
+      id: "op-wait",
+      type: "WAIT",
+      name: "pause",
+      isReplay: false,
+    });
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    const initialWaitSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "pause");
+    expect(initialWaitSpan).toBeDefined();
+    const executionTraceId = initialWaitSpan!.spanContext().traceId;
+    // Its span ID is the deterministic operation span ID on the execution trace.
+    expect(initialWaitSpan!.spanContext().spanId).toBe(
+      deriveSpanIdFromOperationId("op-wait", TEST_ARN),
+    );
+
+    exporter.reset();
+
+    // Invocation 2: the wait completes; a continuation span is emitted that
+    // links back to the initial operation span on the same execution trace.
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onOperationEnd({
+      id: "op-wait",
+      type: "WAIT",
+      name: "pause",
+      isReplay: false,
+      status: "SUCCEEDED" as any,
+    });
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    const continuation = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "pause");
+    const workflow = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "Workflow");
+    expect(continuation).toBeDefined();
+    expect(workflow).toBeDefined();
+    // Same execution trace across both invocations.
+    expect(continuation!.spanContext().traceId).toBe(executionTraceId);
+    // Links are ordered [initial operation span, Workflow span]: links[0] is the
+    // deterministic operation span on the execution trace, links[1] the Workflow.
+    expect(continuation!.links).toHaveLength(2);
+    expect(continuation!.links[0].context.spanId).toBe(
+      deriveSpanIdFromOperationId("op-wait", TEST_ARN),
+    );
+    expect(continuation!.links[0].context.traceId).toBe(executionTraceId);
+    expect(continuation!.links[1].context.spanId).toBe(
+      workflow!.spanContext().spanId,
+    );
+  });
+
+  it("keeps continuation links on the extracted trace when a stable custom extractor is used across invocations", async () => {
+    // A valid extracted trace ID is adopted as the canonical execution trace.
+    // A well-behaved extractor returns the same execution context on every
+    // invocation, so the continuation segment stays on that adopted trace and
+    // its initial-operation link is anchored on it.
+    const extractedTraceId = "5".repeat(32);
+    const plugin = new InvocationOtelPlugin({
+      contextExtractor: () => ({
+        traceId: extractedTraceId,
+        parentSpanId: "6".repeat(16),
+        sampling: "SAMPLED" as const,
+      }),
+    });
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart({
+      id: "op-stable-extractor",
+      type: "WAIT",
+      name: "pause-stable-extractor",
+      isReplay: false,
+    });
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    const initialWaitSpan = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "pause-stable-extractor");
+    expect(initialWaitSpan).toBeDefined();
+    const executionTraceId = initialWaitSpan!.spanContext().traceId;
+    // The valid extracted trace ID is adopted as the execution trace.
+    expect(executionTraceId).toBe(extractedTraceId);
+
+    exporter.reset();
+
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onOperationEnd({
+      id: "op-stable-extractor",
+      type: "WAIT",
+      name: "pause-stable-extractor",
+      isReplay: false,
+      status: "SUCCEEDED" as any,
+    });
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    const continuation = exporter
+      .getFinishedSpans()
+      .find((s) => s.name === "pause-stable-extractor");
+    expect(continuation).toBeDefined();
+    expect(continuation!.spanContext().traceId).toBe(executionTraceId);
+    expect(continuation!.links[0].context.traceId).toBe(executionTraceId);
+    expect(continuation!.links[0].context.spanId).toBe(
+      deriveSpanIdFromOperationId("op-stable-extractor", TEST_ARN),
+    );
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -9,36 +9,51 @@ import type {
   OperationChangeInfo,
 } from "@aws/durable-execution-sdk-js";
 import type { DurableExecutionInvocationOutput } from "@aws/durable-execution-sdk-js";
-import type { TracerProvider, Tracer, Span, Link } from "@opentelemetry/api";
+import type {
+  TracerProvider,
+  Tracer,
+  Span,
+  SpanContext,
+  Link,
+} from "@opentelemetry/api";
 import {
   context,
   isSpanContextValid,
   trace,
   SpanKind,
   SpanStatusCode,
-  TraceFlags,
   ROOT_CONTEXT,
+  TraceFlags,
 } from "@opentelemetry/api";
 import {
   DeterministicIdGenerator,
-  deriveTraceIdFromArn,
   deriveWorkflowSpanId,
   deriveSpanIdFromOperationId,
 } from "./deterministic-id-generator";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-node";
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
+import {
+  canonicalTraceId,
+  resolveExecutionTraceContext,
+  rootSamplingDecision,
+} from "./execution-trace-context";
 import type { OtelPluginConfig } from "./otel-plugin-config";
 import { createTracerProvider } from "./otel-plugin-provider";
 import { tryInstallGlobalIdGenerator } from "./global-id-generator";
+import { DurableSampler, tryInstallDurableSampler } from "./global-sampler";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
 
 /**
  * OpenTelemetry instrumentation plugin for durable executions.
  *
- * Implements the DurableInstrumentationPlugin interface with a Workflow_Span as the
- * synthetic trace root, deferred operation span export, and invocation spans as
- * correlation siblings (not parents) of operation spans.
+ * Implements the DurableInstrumentationPlugin interface. The Workflow span joins
+ * the execution trace by parenting onto the resolved execution ancestor (a
+ * propagated remote parent or a synthetic execution root) and roots the
+ * operation spans, so the whole execution shares one trace. Operation span
+ * export is deferred, and the per-invocation Invocation span is a correlation
+ * sibling (linked from, not a parent of, the operation spans).
  */
 export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   // Shared utilities (reused from existing package)
@@ -56,9 +71,11 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   private spanMap: Map<string, Span>;
   private executionArn: string;
   private executionTraceId: string;
+  private executionSamplingDecision: SamplingDecision;
 
   private readonly usesGlobalProvider: boolean;
   private globalIdGeneratorInstalled: boolean;
+  private durableSampler: DurableSampler | undefined;
   private tracingEnabled = false;
 
   // Workflow span name (configurable)
@@ -85,6 +102,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.usesGlobalProvider = usesGlobalProvider;
 
     this.tracer = this.tracerProvider.getTracer(instrumentationName);
+    this.durableSampler = tryInstallDurableSampler(this.tracer);
     this.globalIdGeneratorInstalled = !this.usesGlobalProvider;
     if (this.usesGlobalProvider) {
       const installedIdGenerator = tryInstallGlobalIdGenerator(this.tracer);
@@ -98,6 +116,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.spanMap = new Map();
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionSamplingDecision = SamplingDecision.NOT_RECORD;
   }
 
   async onInvocationStart(info: InvocationInfo): Promise<void> {
@@ -113,27 +132,45 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     // 2. Extract trace context via context extractor (same as InvocationOtelPlugin)
     const extractedContext = this.contextExtractor(info);
 
-    // 3. Give each durable execution its own Workflow trace. Parent and target
-    // executions in a chained invoke share the propagated Lambda/X-Ray trace,
-    // so reusing that trace ID would create multiple parentless Workflow roots
-    // in one trace.
-    this.executionTraceId = deriveTraceIdFromArn(
+    // 3. Resolve the one execution ancestor both spans parent onto, so they
+    // share a trace and a sampling decision. The canonical trace ID is the
+    // propagated remote trace when valid, else one derived from the ARN and
+    // start time. The execution ancestor is a complete remote parent, else a
+    // synthetic execution root. A live ambient span is not used as the ancestor
+    // (its trace is not stable across reinvocations).
+    const canonical = canonicalTraceId(
+      extractedContext,
       info.executionArn,
       info.executionStartTimestamp,
     );
+    const execTraceContext = resolveExecutionTraceContext(
+      extractedContext,
+      canonical,
+      info.executionArn,
+      () =>
+        rootSamplingDecision(this.tracer, canonical, this.workflowSpanName, {
+          "durable.execution.arn": info.executionArn,
+        }),
+    );
+    this.executionTraceId = canonical;
+    this.executionSamplingDecision = execTraceContext.samplingDecision;
 
     // 4. Derive the workflow span ID from execution ARN
     const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
 
-    // 5. Create the Workflow_Span with deterministic IDs. The override is
-    // scoped to this single startSpan call.
+    // 5. Create the Workflow_Span parented onto the execution ancestor so it
+    // joins the execution trace. Force the span ID only; the trace ID comes
+    // from the parent. The override is scoped to this single startSpan call.
+    const executionAncestorContext = trace.setSpanContext(
+      ROOT_CONTEXT,
+      execTraceContext.executionAncestor,
+    );
     this.workflowSpan = this.idGenerator.withIds(
       {
-        traceId: this.executionTraceId,
         spanId: workflowSpanId,
       },
       () =>
-        this.tracer.startSpan(
+        this.startSpan(
           this.workflowSpanName,
           {
             kind: SpanKind.INTERNAL,
@@ -142,34 +179,17 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
             },
             startTime: info.executionStartTimestamp ?? new Date(),
           },
-          ROOT_CONTEXT,
+          executionAncestorContext,
         ),
     );
 
-    // 6. Create Invocation_Span in the ambient Lambda trace. When no OTel span
-    // is active, fall back to the extracted upstream parent, or create a root if
-    // no valid upstream parent exists. Provider ownership must not change trace
-    // topology.
-    const activeContext = context.active();
-    const activeSpanContext = trace.getSpanContext(activeContext);
-    let invocationParentContext = activeContext;
-    if (
-      (!activeSpanContext || !isSpanContextValid(activeSpanContext)) &&
-      extractedContext?.parentSpanId
-    ) {
-      const extractedSpanContext = {
-        traceId: extractedContext.traceId,
-        spanId: extractedContext.parentSpanId,
-        traceFlags: extractedContext.traceFlags ?? TraceFlags.SAMPLED,
-        isRemote: true,
-      };
-      if (isSpanContextValid(extractedSpanContext)) {
-        invocationParentContext = trace.setSpanContext(
-          activeContext,
-          extractedSpanContext,
-        );
-      }
-    }
+    // 6. Create Invocation_Span parented onto the same-trace ambient span when
+    // available, otherwise onto the execution ancestor so it stays within the
+    // execution trace. Provider ownership must not change trace topology.
+    const invocationParentContext = this.invocationParentContext(
+      execTraceContext.executionAncestor,
+      canonical,
+    );
 
     const invocationAttributes: Record<string, string | number | boolean> = {
       "durable.execution.arn": info.executionArn,
@@ -204,7 +224,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       }
     }
 
-    this.invocationSpan = this.tracer.startSpan(
+    this.invocationSpan = this.startSpan(
       "Invocation",
       {
         kind: SpanKind.INTERNAL,
@@ -309,6 +329,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     // again at invocation start, after preload initialization has completed.
     this.tracerProvider = trace.getTracerProvider();
     this.tracer = this.tracerProvider.getTracer(this.instrumentationName);
+    this.durableSampler = tryInstallDurableSampler(this.tracer);
 
     const installedIdGenerator = tryInstallGlobalIdGenerator(this.tracer);
     if (installedIdGenerator) {
@@ -329,7 +350,49 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     this.invocationSpan = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionSamplingDecision = SamplingDecision.NOT_RECORD;
     this.tracingEnabled = false;
+  }
+
+  private startSpan(
+    name: string,
+    options: Parameters<Tracer["startSpan"]>[1],
+    parentContext: Parameters<Tracer["startSpan"]>[2],
+  ): Span {
+    const fn = () => this.tracer.startSpan(name, options, parentContext);
+    return this.durableSampler
+      ? this.durableSampler.withDecision(this.executionSamplingDecision, fn)
+      : fn();
+  }
+
+  /**
+   * The parent context for the Invocation span: the active ambient span when it
+   * is already on the execution trace, otherwise the execution ancestor so the
+   * Invocation span stays within the same trace.
+   */
+  private invocationParentContext(
+    executionAncestor: SpanContext,
+    canonical: string,
+  ) {
+    const activeContext = context.active();
+    const ambient = trace.getSpanContext(activeContext);
+    // Adopt the ambient span as the Invocation parent only when it is on the
+    // execution trace AND carries the same sampled bit as the execution
+    // ancestor. Matching the trace ID alone is not enough: if the ambient span's
+    // sampled bit differs, the Invocation span would inherit the ambient
+    // decision and could export after an explicit Sampled=0, or drop after the
+    // root sampler chose sampled. On a mismatch, fall back to the execution
+    // ancestor, which carries the authoritative decision.
+    if (
+      ambient &&
+      isSpanContextValid(ambient) &&
+      ambient.traceId === canonical &&
+      (ambient.traceFlags & TraceFlags.SAMPLED) ===
+        (executionAncestor.traceFlags & TraceFlags.SAMPLED)
+    ) {
+      return activeContext;
+    }
+    return trace.setSpanContext(ROOT_CONTEXT, executionAncestor);
   }
 
   /**
@@ -389,7 +452,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         spanId: deterministicSpanId,
       },
       () =>
-        this.tracer.startSpan(
+        this.startSpan(
           spanName,
           { attributes, startTime: info.startTimestamp, links },
           parentContext,
@@ -503,7 +566,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
           spanId: deterministicSpanId,
         },
         () =>
-          this.tracer.startSpan(
+          this.startSpan(
             spanName,
             { attributes, startTime: info.startTimestamp, links },
             parentContext,
@@ -561,7 +624,7 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
     const links = this.buildInvocationLinks();
 
-    const attemptSpan = this.tracer.startSpan(
+    const attemptSpan = this.startSpan(
       spanName,
       {
         attributes,

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -21,22 +21,28 @@ import {
   trace,
   SpanKind,
   SpanStatusCode,
-  TraceFlags,
   ROOT_CONTEXT,
   isSpanContextValid,
+  TraceFlags,
 } from "@opentelemetry/api";
 import { hrTime } from "@opentelemetry/core";
+import { SamplingDecision } from "@opentelemetry/sdk-trace-node";
 import {
   DeterministicIdGenerator,
-  deriveTraceIdFromArn,
   deriveWorkflowSpanId,
   deriveSpanIdFromOperationId,
 } from "./deterministic-id-generator";
 import { xRayContextExtractor } from "./context-extractors";
 import type { ContextExtractor } from "./context-extractors";
+import {
+  canonicalTraceId,
+  resolveExecutionTraceContext,
+  rootSamplingDecision,
+} from "./execution-trace-context";
 import type { OtelPluginConfig } from "./otel-plugin-config";
 import { createTracerProvider } from "./otel-plugin-provider";
 import { tryInstallGlobalIdGenerator } from "./global-id-generator";
+import { DurableSampler, tryInstallDurableSampler } from "./global-sampler";
 
 const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
 
@@ -55,6 +61,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private readonly instrumentationName: string;
   private readonly usesGlobalProvider: boolean;
   private globalIdGeneratorInstalled: boolean;
+  private durableSampler: DurableSampler | undefined;
   private tracingEnabled = false;
   private readonly workflowSpanName: string;
   private readonly enrichLogger: boolean;
@@ -66,6 +73,9 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private workflowSpan: Span | undefined;
   private executionArn: string = "";
   private executionTraceId: string = "";
+  private executionTraceFlags: number = 0;
+  private executionSamplingDecision: SamplingDecision =
+    SamplingDecision.NOT_RECORD;
 
   constructor(config?: OtelPluginConfig) {
     const instrumentationName =
@@ -85,6 +95,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.usesGlobalProvider = usesGlobalProvider;
 
     this.tracer = this.tracerProvider.getTracer(instrumentationName);
+    this.durableSampler = tryInstallDurableSampler(this.tracer);
     this.globalIdGeneratorInstalled = !this.usesGlobalProvider;
     if (this.usesGlobalProvider) {
       const installedIdGenerator = tryInstallGlobalIdGenerator(this.tracer);
@@ -108,33 +119,54 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     // 2. Invoke the context extractor
     const extractedContext = this.contextExtractor(info);
 
-    // 3. Keep the execution-scoped Workflow trace separate from the ambient
-    // Lambda trace. Reusing the extracted X-Ray trace ID here would create two
-    // parentless roots in one trace: Lambda's function segment and Workflow.
-    this.executionTraceId = deriveTraceIdFromArn(
+    // 3. Resolve the one execution ancestor both the Workflow and Invocation
+    // spans parent onto so they share a single execution trace. The canonical
+    // trace ID is the propagated remote trace when valid, else one derived from
+    // the ARN and start time. The execution ancestor is a complete remote
+    // parent, else a synthetic execution root. A live ambient span is not used
+    // as the ancestor (its trace is not stable across reinvocations); the
+    // Invocation span may still parent onto a same-trace ambient span below.
+    const canonical = canonicalTraceId(
+      extractedContext,
       info.executionArn,
       info.executionStartTimestamp,
     );
+    const execTraceContext = resolveExecutionTraceContext(
+      extractedContext,
+      canonical,
+      info.executionArn,
+      () =>
+        rootSamplingDecision(this.tracer, canonical, this.workflowSpanName, {
+          "durable.execution.arn": info.executionArn,
+        }),
+    );
+    this.executionTraceId = canonical;
+    this.executionTraceFlags = execTraceContext.traceFlags;
+    this.executionSamplingDecision = execTraceContext.samplingDecision;
 
-    // 4. Create the Workflow root span.
+    // 4. Create the Workflow span parented onto the execution ancestor so it
+    // joins the execution trace with a trace ID stable across invocations.
     //
-    // The Workflow span is the parentless root of the execution-scoped trace and
-    // is emitted in BOTH provider modes (default/ADOT and owned/community
+    // It is emitted in BOTH provider modes (default/ADOT and owned/community
     // collector), matching ExecutionOtelPlugin and the Python/Java reference
     // plugins. It is keyed to a deterministic span ID derived from the execution
     // ARN so every invocation of the same durable execution shares one root, and
     // it is finalized (stamped with a terminal execution status and ended) only
-    // once, at the terminal invocation (see onInvocationEnd). Emitting it only in
-    // community-collector mode previously left the invocation view without a root
-    // Workflow span under ADOT/X-Ray.
+    // once, at the terminal invocation (see onInvocationEnd). Operation and
+    // attempt spans link to it for execution-level correlation while remaining
+    // parented to the per-invocation span (this plugin stays invocation-rooted).
+    // Force the span ID only; the trace ID comes from the parent.
     const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
+    const executionAncestorContext = trace.setSpanContext(
+      ROOT_CONTEXT,
+      execTraceContext.executionAncestor,
+    );
     this.workflowSpan = this.idGenerator.withIds(
       {
-        traceId: this.executionTraceId,
         spanId: workflowSpanId,
       },
       () =>
-        this.tracer.startSpan(
+        this.startSpan(
           this.workflowSpanName,
           {
             kind: SpanKind.INTERNAL,
@@ -143,42 +175,25 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
             },
             startTime: info.executionStartTimestamp ?? new Date(),
           },
-          ROOT_CONTEXT,
+          executionAncestorContext,
         ),
     );
 
-    // 5. Create the invocation span in the ambient Lambda trace. Under
-    //    ADOT/X-Ray the active context at onInvocationStart is the Lambda
-    //    execution-environment span. When no span is active, use the extracted
-    //    upstream parent, or create a root if neither is available.
+    // 5. Create the invocation span parented onto the same-trace ambient span
+    //    when available (under ADOT/X-Ray the active context at
+    //    onInvocationStart is the Lambda execution-environment span), otherwise
+    //    onto the execution ancestor so it stays within the execution trace.
     //    The invocation span is intentionally NOT a child of the Workflow span:
     //    this plugin stays invocation-rooted. Execution-scoped correlation to
     //    the Workflow span is expressed via links on the operation/attempt
     //    spans (see onOperationStart / onOperationAttemptStart), matching the
-    //    Java (aws/aws-durable-execution-sdk-java#572) and Python
-    //    (aws/aws-durable-execution-sdk-python#593) reference plugins.
-    const activeContext = context.active();
-    const activeSpanContext = trace.getSpanContext(activeContext);
-    let invocationParentContext = activeContext;
-    if (
-      (!activeSpanContext || !isSpanContextValid(activeSpanContext)) &&
-      extractedContext?.parentSpanId
-    ) {
-      const extractedSpanContext = {
-        traceId: extractedContext.traceId,
-        spanId: extractedContext.parentSpanId,
-        traceFlags: extractedContext.traceFlags ?? TraceFlags.SAMPLED,
-        isRemote: true,
-      };
-      if (isSpanContextValid(extractedSpanContext)) {
-        invocationParentContext = trace.setSpanContext(
-          activeContext,
-          extractedSpanContext,
-        );
-      }
-    }
+    //    Java and Python reference plugins.
+    const invocationParentContext = this.invocationParentContext(
+      execTraceContext.executionAncestor,
+      canonical,
+    );
 
-    this.invocationSpan = this.tracer.startSpan(
+    this.invocationSpan = this.startSpan(
       "Invocation",
       {
         kind: SpanKind.INTERNAL,
@@ -293,6 +308,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     // again at invocation start, after preload initialization has completed.
     this.tracerProvider = trace.getTracerProvider();
     this.tracer = this.tracerProvider.getTracer(this.instrumentationName);
+    this.durableSampler = tryInstallDurableSampler(this.tracer);
 
     const installedIdGenerator = tryInstallGlobalIdGenerator(this.tracer);
     if (installedIdGenerator) {
@@ -314,7 +330,74 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.workflowSpan = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionTraceFlags = 0;
+    this.executionSamplingDecision = SamplingDecision.NOT_RECORD;
     this.tracingEnabled = false;
+  }
+
+  private startSpan(
+    name: string,
+    options: Parameters<Tracer["startSpan"]>[1],
+    parentContext: Parameters<Tracer["startSpan"]>[2],
+  ): Span {
+    const fn = () => this.tracer.startSpan(name, options, parentContext);
+    return this.durableSampler
+      ? this.durableSampler.withDecision(this.executionSamplingDecision, fn)
+      : fn();
+  }
+
+  /**
+   * The parent context for the Invocation span: the active ambient span when it
+   * is on the execution trace, otherwise the execution ancestor so the
+   * Invocation span stays within the same trace.
+   */
+  private invocationParentContext(
+    executionAncestor: SpanContext,
+    canonical: string,
+  ) {
+    const activeContext = context.active();
+    const ambient = trace.getSpanContext(activeContext);
+    // Adopt the ambient span as the Invocation parent only when it is on the
+    // execution trace AND carries the same sampled bit as the execution
+    // ancestor. Matching the trace ID alone is not enough: if the ambient span's
+    // sampled bit differs, the Invocation span would inherit the ambient
+    // decision and could export after an explicit Sampled=0, or drop after the
+    // root sampler chose sampled. On a mismatch, fall back to the execution
+    // ancestor, which carries the authoritative decision.
+    if (
+      ambient &&
+      isSpanContextValid(ambient) &&
+      ambient.traceId === canonical &&
+      (ambient.traceFlags & TraceFlags.SAMPLED) ===
+        (executionAncestor.traceFlags & TraceFlags.SAMPLED)
+    ) {
+      return activeContext;
+    }
+    return trace.setSpanContext(ROOT_CONTEXT, executionAncestor);
+  }
+
+  /**
+   * A link to the initial logical operation span, whose span ID is
+   * deterministic on (executionArn, operationId) and lives on the execution
+   * trace. A continuation or replay segment carries this link so the segments
+   * of one logical operation stay correlated across invocations.
+   *
+   * Because the initial operation span's ID is reproducible, this restores the
+   * cross-invocation link that was previously dropped as "fabricated" — it now
+   * targets a genuinely exported span (open operation spans are ended on
+   * non-terminal invocations; see onInvocationEnd).
+   */
+  private initialOperationLink(operationId: string): Link | undefined {
+    if (!this.executionTraceId) {
+      return undefined;
+    }
+    const initialContext: SpanContext = {
+      traceId: this.executionTraceId,
+      spanId: deriveSpanIdFromOperationId(operationId, this.executionArn),
+      traceFlags: this.executionTraceFlags,
+      isRemote: false,
+    };
+    return { context: initialContext };
   }
 
   async onOperationStart(info: OperationInfo): Promise<void> {
@@ -384,7 +467,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           spanId: deterministicSpanId,
         },
         () =>
-          this.tracer.startSpan(
+          this.startSpan(
             spanName,
             {
               attributes,
@@ -395,13 +478,24 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
           ),
       );
     } else if (info.type === "CONTEXT" || info.type === "STEP") {
-      // The original span context is not checkpointed, so replay spans use a
-      // new span ID and correlate through the reproducible Workflow span.
-      span = this.tracer.startSpan(
+      // This replay segment is a distinct span of an operation whose initial
+      // span ran in an earlier invocation. It uses a new (random) span ID, links
+      // to the reproducible Workflow span, and links back to the initial logical
+      // operation span (deterministic on the execution trace) so the segments
+      // stay correlated across invocations.
+      //
+      // WaitForCondition is modeled differently by the OTel conformance
+      // contract: the resumed operation span keeps only its Workflow link, while
+      // the non-terminal first polling attempt links back to the first operation
+      // span once it is known to have completed successfully.
+      span = this.startSpan(
         spanName,
         {
           attributes,
-          links: this.workflowLinks(),
+          links:
+            info.subType === "WaitForCondition"
+              ? this.workflowLinks()
+              : this.replayLinks(info.id),
           startTime: hrTime(),
         },
         parentContext,
@@ -532,14 +626,16 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
         attributes["durable.attempt.number"] = info.attempt;
       }
 
-      const continuationSpan = this.tracer.startSpan(
+      const continuationSpan = this.startSpan(
         spanName,
         {
           attributes,
-          // The original span context is not checkpointed, so do not fabricate
-          // a link to a derived operation span. The reproducible Workflow span
-          // provides stable cross-invocation correlation.
-          links: this.workflowLinks(),
+          // This continuation segment completes an operation whose initial span
+          // ran in an earlier invocation. It links to the reproducible Workflow
+          // span and back to the initial logical operation span, whose ID is
+          // deterministic on the execution trace, so the segments of one logical
+          // operation stay correlated across invocations.
+          links: this.replayLinks(info.id),
           startTime: hrTime(),
         },
         parentContext,
@@ -596,13 +692,10 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       attributes["durable.operation.subtype"] = info.subType;
     }
 
-    // The operation is already represented by the attempt's parent. Do not
-    // duplicate that relationship as a link in the invocation view.
-    const attemptSpan = this.tracer.startSpan(
+    const attemptSpan = this.startSpan(
       spanName,
       {
         attributes,
-        links: this.workflowLinks(),
         startTime: hrTime(),
       },
       parentContext,
@@ -633,6 +726,7 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     const key = this.attemptSpanKey(info.id, info.attempt);
     const attemptSpan = this.spanMap.get(key);
     if (attemptSpan) {
+      attemptSpan.addLinks(this.attemptLinks(info));
       attemptSpan.setAttribute("durable.attempt.outcome", info.outcome);
       if (info.outcome === "FAILED") {
         attemptSpan.setStatus({
@@ -682,6 +776,38 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     const workflowContext: SpanContext | undefined =
       this.workflowSpan?.spanContext();
     return workflowContext ? [{ context: workflowContext }] : [];
+  }
+
+  /**
+   * Links for a continuation or replay operation span: a link back to the
+   * initial logical operation span (deterministic on the execution trace)
+   * FIRST, then the Workflow link, so the links are ordered
+   * `[operation, Workflow]`. Restores the cross-invocation operation
+   * correlation that was previously dropped as "fabricated" — the initial span
+   * ID is reproducible and the span is genuinely exported. The order matters:
+   * the conformance contract resolves `links[0]` to the operation span (which
+   * carries `durable.operation.id`) and `links[1]` to the Workflow span (which
+   * carries `durable.execution.arn`).
+   */
+  private replayLinks(operationId: string): Link[] {
+    const links: Link[] = [];
+    const initialLink = this.initialOperationLink(operationId);
+    if (initialLink) {
+      links.push(initialLink);
+    }
+    links.push(...this.workflowLinks());
+    return links;
+  }
+
+  private attemptLinks(info: AttemptEndInfo): Link[] {
+    if (
+      info.subType === "WaitForCondition" &&
+      info.attempt === 1 &&
+      info.outcome === "SUCCEEDED"
+    ) {
+      return this.replayLinks(info.id);
+    }
+    return this.workflowLinks();
   }
 
   private attemptSpanKey(operationId: string, attempt: number): string {

--- a/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-config.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/otel-plugin-config.ts
@@ -39,6 +39,10 @@ export interface OtelPluginConfig {
   /**
    * Context extractor function used to extract upstream trace context
    * from the invocation environment. Defaults to `xRayContextExtractor`.
+   * A custom extractor must return the durable execution's own trace context:
+   * a valid trace ID (and, for a remote parent, a valid parent span ID) anchors
+   * the execution trace across replays, so returning stale or per-invocation
+   * context would displace the correct execution trace.
    */
   contextExtractor?: ContextExtractor;
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/854

*Description of changes:*
- Third PR in the stack, and the behavior flip. 
- Wires both InvocationOtelPlugin and ExecutionOtelPlugin onto the shared execution trace and sampling from PR 2. 
- The Workflow and Invocation spans now share one trace, anchored to a propagated backend parent when present or a deterministic synthetic execution root otherwise; an ambient Lambda span is used as the Invocation parent only when it is already on the execution trace and carries the same sampled bit. 
- Sampling is resolved once per invocation and applied to every durable span via DurableSampler. Operation and attempt spans link to the Workflow span for execution-level correlation, and cross-invocation replay/continuation segments link back to the deterministic initial operation span. 
- Next in stack: exports and docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
