### PR TITLE
fix(otel): end spans on non-terminal invocations

### DIFF
--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -205,12 +205,13 @@ Attempt   -> Invocation
 
 The plugin makes Workflow the active span while durable handler code runs.
 Completed operation spans use durable operation start/end timestamps and
-deterministic span IDs. An operation that remains open when an invocation
-suspends is not ended or exported; a later invocation recreates and exports it
-with the **same deterministic span ID on the same execution trace** when the
-operation completes. That reproducible ID is how the segments of one logical
-operation stay stitched together across invocations — no cross-invocation link
-is needed, unlike `InvocationOtelPlugin` below.
+deterministic span IDs. While an operation spans multiple invocations its
+identity is carried as a non-recording context; nothing is exported until it
+completes. The single recording operation span is then created and ended once,
+in the invocation where the operation terminates, under a **deterministic span
+ID on the execution trace**. Because there is one span per logical operation,
+no cross-invocation link is needed to stitch it together — unlike
+`InvocationOtelPlugin` below.
 
 ### `InvocationOtelPlugin`
 
@@ -312,11 +313,19 @@ is the first 32 hexadecimal characters of SHA-256 over
 `<execution ARN>:<execution start timestamp in ISO 8601 format>` (falling back
 to the ARN alone when the timestamp is unavailable).
 
-The plugins create the same `Workflow` span identity on each invocation, but end
-and export it only when the execution reaches `SUCCEEDED` or `FAILED`. Workflow
-spans created for `PENDING` or `RETRYING` invocations are left unended and are
-therefore not exported. This produces one exported `Workflow` span for the
-durable execution while intermediate invocation spans export normally.
+The plugins carry the same `Workflow` span identity on each invocation as a
+non-recording span context, and create the single recording `Workflow` span only
+when the execution reaches `SUCCEEDED` or `FAILED`, backdated to the execution
+start. `PENDING` and `RETRYING` invocations create no recording `Workflow` span,
+so none is ever left unended, and exactly one `Workflow` root is exported for the
+durable execution while intermediate invocation spans export normally. The
+non-recording context carries the execution's sampling decision, so operations
+under it are sampled consistently with the eventual root. In-flight attempt spans
+are ended at invocation cleanup, so a non-terminal invocation leaves no recording
+span unended. Suspended operations differ by plugin: `InvocationOtelPlugin` ends
+the open operation span at the boundary and continues it later, while
+`ExecutionOtelPlugin` holds the operation identity as a non-recording context and
+exports one recording span only when the operation completes.
 
 When a chained parent and target execution share a propagated remote parent,
 both join that one trace, each keeping its own deterministic `Workflow` span ID.

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/id-generation-isolation.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/id-generation-isolation.test.ts
@@ -4,6 +4,7 @@ import {
   ROOT_CONTEXT,
   trace,
   type Span,
+  type SpanContext,
 } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import type { IdGenerator } from "@opentelemetry/sdk-trace-node";
@@ -364,17 +365,28 @@ describe.each([
       isReplay: false,
     });
 
-    const firstOperation = (
-      firstPlugin as unknown as { spanMap: Map<string, Span> }
-    ).spanMap.get("operation");
-    const secondOperation = (
-      secondPlugin as unknown as { spanMap: Map<string, Span> }
-    ).spanMap.get("operation");
+    // The deterministic operation span ID is scoped per execution ARN. Where it
+    // lives after onOperationStart differs by plugin: InvocationOtelPlugin
+    // creates the recording operation span immediately (held in spanMap), while
+    // ExecutionOtelPlugin defers the span to onOperationEnd and holds a
+    // non-recording placeholder context (operationContexts) in the meantime.
+    const operationSpanId = (
+      plugin: DurableInstrumentationPlugin,
+    ): string | undefined => {
+      if (pluginName === "ExecutionOtelPlugin") {
+        return (
+          plugin as unknown as { operationContexts: Map<string, SpanContext> }
+        ).operationContexts.get("operation")?.spanId;
+      }
+      return (plugin as unknown as { spanMap: Map<string, Span> }).spanMap
+        .get("operation")
+        ?.spanContext().spanId;
+    };
 
-    expect(firstOperation?.spanContext().spanId).toBe(
+    expect(operationSpanId(firstPlugin)).toBe(
       deriveSpanIdFromOperationId("operation", EXECUTION_ARN_A),
     );
-    expect(secondOperation?.spanContext().spanId).toBe(
+    expect(operationSpanId(secondPlugin)).toBe(
       deriveSpanIdFromOperationId("operation", EXECUTION_ARN_B),
     );
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/join-execution-trace.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/join-execution-trace.test.ts
@@ -354,7 +354,7 @@ describe("Execution trace joining", () => {
       await opaqueProvider?.shutdown();
     });
 
-    it("uses w3cClientContextExtractor as an execution-stable remote parent", async () => {
+    it("uses w3cClientContextExtractor as a valid remote parent", async () => {
       const traceId = "4bf92f3577b34da6a3ce929d0e0e4736";
       const parentSpanId = "00f067aa0ba902b7";
       const plugin = makePlugin({

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Regression coverage for span lifecycle: every recording span must be ended
+ * exactly once, including on non-terminal (PENDING/RETRYING) invocations, and
+ * no two exported spans may share a `(traceId, spanId)`.
+ *
+ * These run against BOTH plugins through the globally-registered provider,
+ * matching the integration-test harness.
+ */
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  ParentBasedSampler,
+  SamplingDecision,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import type { ReadableSpan, Sampler } from "@opentelemetry/sdk-trace-node";
+import { context, propagation, trace, TraceFlags } from "@opentelemetry/api";
+import type { Attributes, Span } from "@opentelemetry/api";
+import type {
+  InvocationInfo,
+  InvocationEndInfo,
+  OperationInfo,
+  OperationEndInfo,
+  AttemptInfo,
+} from "@aws/durable-execution-sdk-js";
+import { ExecutionOtelPlugin } from "../execution-plugin";
+import { InvocationOtelPlugin } from "../invocation-plugin";
+import { deriveSpanIdFromOperationId } from "../deterministic-id-generator";
+
+const ARN = "arn:aws:states:us-east-1:123456789012:execution:sm:exec-1";
+
+function makeInvocationInfo(o?: Partial<InvocationInfo>): InvocationInfo {
+  return {
+    requestId: "req-1",
+    executionArn: ARN,
+    isFirstInvocation: true,
+    executionInput: {},
+    operations: {},
+    updatedOperations: {},
+    ...o,
+  };
+}
+
+function makeInvocationEndInfo(
+  o?: Partial<InvocationEndInfo>,
+): InvocationEndInfo {
+  return {
+    requestId: "req-1",
+    executionArn: ARN,
+    executionInput: {},
+    operations: {},
+    status: "SUCCEEDED" as any,
+    ...o,
+  };
+}
+
+function makeOperationInfo(o?: Partial<OperationInfo>): OperationInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, ...o };
+}
+
+function makeOperationEndInfo(o?: Partial<OperationEndInfo>): OperationEndInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, ...o };
+}
+
+function makeAttemptInfo(o?: Partial<AttemptInfo>): AttemptInfo {
+  return { id: "op-1", type: "STEP" as any, isReplay: false, attempt: 1, ...o };
+}
+
+/** Exported identities appearing more than once, as `traceId:spanId`. */
+function duplicateIdentities(exporter: InMemorySpanExporter): string[] {
+  const counts = new Map<string, number>();
+  for (const s of exporter.getFinishedSpans()) {
+    const k = `${s.spanContext().traceId}:${s.spanContext().spanId}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
+}
+
+function named(exporter: InMemorySpanExporter, name: string): ReadableSpan[] {
+  return exporter.getFinishedSpans().filter((s) => s.name === name);
+}
+
+const PLUGINS = [
+  ["ExecutionOtelPlugin", () => new ExecutionOtelPlugin({})],
+  ["InvocationOtelPlugin", () => new InvocationOtelPlugin({})],
+] as const;
+
+describe.each(PLUGINS)("%s span lifecycle", (_name, makePlugin) => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  function register(sampler?: Sampler) {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      ...(sampler ? { sampler } : {}),
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  }
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it.each(["PENDING", "RETRYING"])(
+    "leaves no recording Workflow span on non-terminal status %s",
+    async (status) => {
+      register();
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const workflowRef = plugin.workflowSpan as Span;
+      expect(workflowRef.isRecording()).toBe(false); // non-recording identity
+
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: status as any }),
+      );
+
+      expect(workflowRef.isRecording()).toBe(false);
+      expect(named(exporter, "Workflow")).toHaveLength(0);
+    },
+  );
+
+  it("exports exactly one Workflow span across a suspend/resume pair", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    // Invocation 1 suspends.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    // Invocation 2 (same ARN) completes.
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    const workflow = named(exporter, "Workflow");
+    expect(workflow).toHaveLength(1);
+    expect(workflow[0].attributes["durable.execution.status"]).toBe(
+      "SUCCEEDED",
+    );
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+
+  it("ends an in-flight attempt span left open by a non-terminal invocation", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(makeOperationInfo({ name: "retry-step" }));
+    await plugin.onOperationAttemptStart(
+      makeAttemptInfo({ name: "retry-step", attempt: 1 }),
+    );
+
+    // Retain the attempt span reference before spanMap is cleared.
+    const spanMap = plugin.spanMap as Map<string, Span>;
+    const attemptRef = [...spanMap.entries()].find(([k]) =>
+      k.includes("attempt"),
+    )?.[1];
+    expect(attemptRef?.isRecording()).toBe(true);
+
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    expect(attemptRef?.isRecording()).toBe(false);
+    const attempt = named(exporter, "retry-step attempt 1");
+    expect(attempt).toHaveLength(1);
+    // No outcome: the attempt never completed this invocation.
+    expect(attempt[0].attributes["durable.attempt.outcome"]).toBeUndefined();
+  });
+
+  it("gives a suspended WAIT and its later completion distinct identities", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    // Invocation 1: WAIT starts, then the invocation suspends.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({ id: "w1", type: "WAIT" as any, name: "my-wait" }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+
+    // Invocation 2: WAIT resolves (cross-invocation completion).
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "w1",
+        type: "WAIT" as any,
+        name: "my-wait",
+        status: "SUCCEEDED" as any,
+      }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    expect(duplicateIdentities(exporter)).toEqual([]);
+    expect(
+      named(exporter, "my-wait").some(
+        (s) => s.attributes["durable.operation.status"] === "SUCCEEDED",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps identities unique for a STEP retried across three invocations", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    for (let i = 1; i <= 3; i++) {
+      const base = {
+        id: "s1",
+        type: "STEP" as any,
+        name: "retry-step",
+        isReplay: i > 1,
+      };
+      await plugin.onInvocationStart(
+        makeInvocationInfo({ isFirstInvocation: i === 1 }),
+      );
+      await plugin.onOperationStart(makeOperationInfo(base));
+      await plugin.onOperationAttemptStart(
+        makeAttemptInfo({ ...base, attempt: i }),
+      );
+      await plugin.onOperationAttemptEnd({
+        ...base,
+        attempt: i,
+        outcome: (i === 3 ? "SUCCEEDED" : "FAILED") as any,
+      });
+      if (i === 3) {
+        await plugin.onOperationEnd(
+          makeOperationEndInfo({
+            ...base,
+            isReplay: false,
+            status: "SUCCEEDED" as any,
+            attempt: 3,
+          }),
+        );
+      }
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({
+          status: (i === 3 ? "SUCCEEDED" : "RETRYING") as any,
+        }),
+      );
+    }
+
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+
+  it("keeps a non-negative Workflow duration when executionStartTimestamp is omitted", async () => {
+    register();
+    const plugin: any = makePlugin();
+
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ executionStartTimestamp: undefined }),
+    );
+    // A real gap so a late fallback would be measurable (Date is ms-truncated).
+    await new Promise((r) => setTimeout(r, 15));
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({
+        status: "SUCCEEDED" as any,
+        executionStartTimestamp: undefined,
+      }),
+    );
+
+    const workflow = named(exporter, "Workflow")[0];
+    const invocation = named(exporter, "Invocation")[0];
+    expect(workflow).toBeDefined();
+    expect(invocation).toBeDefined();
+    // The Workflow span must contain the invocation it covers; a late fallback
+    // would start it after the invocation span began.
+    const cmp = (a: ReadableSpan["startTime"], b: ReadableSpan["startTime"]) =>
+      a[0] - b[0] || a[1] - b[1];
+    expect(cmp(workflow.startTime, invocation.startTime)).toBeLessThanOrEqual(
+      0,
+    );
+    expect(cmp(workflow.endTime, workflow.startTime)).toBeGreaterThanOrEqual(0);
+  });
+
+  describe("sampling", () => {
+    it("marks the Workflow context unsampled and exports nothing under an unsampled provider", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOffSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.NONE,
+      );
+
+      await plugin.onOperationStart(makeOperationInfo());
+      await plugin.onOperationEnd(
+        makeOperationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      expect(exporter.getFinishedSpans()).toHaveLength(0);
+    });
+
+    it("reports otelTraceSampled false from enrichLogContext under an unsampled provider", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOffSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      const enriched = await plugin.wrapInvocation(
+        makeInvocationInfo(),
+        async () => plugin.enrichLogContext(),
+      );
+      expect(enriched?.otelTraceSampled).toBe(false);
+      await plugin.onInvocationEnd(makeInvocationEndInfo());
+    });
+
+    it("exports the Workflow root under a sampled provider (control)", async () => {
+      register(new ParentBasedSampler({ root: new AlwaysOnSampler() }));
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.SAMPLED,
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      expect(named(exporter, "Workflow")).toHaveLength(1);
+    });
+
+    it("passes the Workflow attributes to an attribute-based sampler", async () => {
+      const seen: Attributes[] = [];
+      const sampler: Sampler = {
+        shouldSample: (_c, _t, _n, _k, attributes) => {
+          seen.push({ ...attributes });
+          return {
+            decision: attributes["durable.execution.arn"]
+              ? SamplingDecision.RECORD_AND_SAMPLED
+              : SamplingDecision.NOT_RECORD,
+          };
+        },
+        toString: () => "ArnAttributeSampler",
+      };
+      register(sampler);
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+
+      // Every root sampling call saw durable.execution.arn, so the synthetic
+      // context and the real span reach the same decision.
+      const rootCalls = seen.filter(
+        (a) => a["durable.execution.arn"] !== undefined,
+      );
+      expect(rootCalls.length).toBeGreaterThanOrEqual(1);
+      expect(named(exporter, "Workflow")).toHaveLength(1);
+    });
+
+    it("does not export a Workflow root a stateful sampler dropped for children", async () => {
+      let calls = 0;
+      const sampler: Sampler = {
+        // Samples the first root it sees, drops everything after.
+        shouldSample: () => {
+          calls += 1;
+          return {
+            decision:
+              calls === 1
+                ? SamplingDecision.RECORD_AND_SAMPLED
+                : SamplingDecision.NOT_RECORD,
+          };
+        },
+        toString: () => "FirstOnlySampler",
+      };
+      sampler.shouldSample(null as any, "", "", 0 as any, {}, []); // burn the one sampled decision before the plugin runs
+      register(sampler);
+      const plugin: any = makePlugin();
+
+      await plugin.onInvocationStart(makeInvocationInfo());
+      expect(plugin.workflowSpan.spanContext().traceFlags).toBe(
+        TraceFlags.NONE,
+      );
+      await plugin.onInvocationEnd(
+        makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+      );
+      expect(named(exporter, "Workflow")).toHaveLength(0);
+    });
+  });
+
+  it("does not orphan the first span when onOperationStart fires twice in one invocation", async () => {
+    // An operation started, then started again in the same invocation (e.g. a
+    // step retried internally) must reuse the existing span rather than
+    // overwrite the map entry and leak the first span un-ended.
+    register();
+    const plugin: any = makePlugin();
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(makeOperationInfo({ name: "retry-step" }));
+    // Second start for the SAME operation id, marked as replay.
+    await plugin.onOperationStart(
+      makeOperationInfo({ name: "retry-step", isReplay: true }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({ name: "retry-step", status: "SUCCEEDED" as any }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    // Exactly one operation span exported, and no duplicate identities: the
+    // second start did not create (and orphan) a second span.
+    expect(named(exporter, "retry-step")).toHaveLength(1);
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+});
+
+/**
+ * ExecutionOtelPlugin-specific: an operation that spans invocations is deferred
+ * and exported as ONE span (created and ended in onOperationEnd, under its
+ * deterministic ID), never as per-invocation segments. This matches the Java
+ * reference's execution-view behavior.
+ */
+describe("ExecutionOtelPlugin deferred operation spans", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  function register() {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    provider.register();
+  }
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it("exports exactly one operation span for a WAIT that suspends then resumes", async () => {
+    register();
+    const plugin = new ExecutionOtelPlugin({});
+
+    // Invocation 1: the WAIT starts, then the invocation suspends (PENDING).
+    // No operation span is exported yet — it is only a deferred placeholder.
+    await plugin.onInvocationStart(makeInvocationInfo());
+    await plugin.onOperationStart(
+      makeOperationInfo({ id: "w1", type: "WAIT" as any, name: "my-wait" }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "PENDING" as any }),
+    );
+    expect(named(exporter, "my-wait")).toHaveLength(0);
+
+    // Invocation 2: the WAIT resolves. The single operation span is created and
+    // ended here.
+    await plugin.onInvocationStart(
+      makeInvocationInfo({ isFirstInvocation: false }),
+    );
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        id: "w1",
+        type: "WAIT" as any,
+        name: "my-wait",
+        status: "SUCCEEDED" as any,
+      }),
+    );
+    await plugin.onInvocationEnd(
+      makeInvocationEndInfo({ status: "SUCCEEDED" as any }),
+    );
+
+    // Exactly one operation span total, exported under its deterministic ID,
+    // with no duplicate identity across the two invocations.
+    const waitSpans = named(exporter, "my-wait");
+    expect(waitSpans).toHaveLength(1);
+    expect(waitSpans[0].spanContext().spanId).toBe(
+      deriveSpanIdFromOperationId("w1", ARN),
+    );
+    expect(waitSpans[0].attributes["durable.operation.status"]).toBe(
+      "SUCCEEDED",
+    );
+    expect(duplicateIdentities(exporter)).toEqual([]);
+  });
+});

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/span-lifecycle.test.ts
@@ -82,6 +82,20 @@ function named(exporter: InMemorySpanExporter, name: string): ReadableSpan[] {
   return exporter.getFinishedSpans().filter((s) => s.name === name);
 }
 
+function compareHrTime(
+  left: ReadableSpan["startTime"],
+  right: ReadableSpan["startTime"],
+): number {
+  return left[0] - right[0] || left[1] - right[1];
+}
+
+function expectSpanInside(child: ReadableSpan, parent: ReadableSpan): void {
+  expect(
+    compareHrTime(child.startTime, parent.startTime),
+  ).toBeGreaterThanOrEqual(0);
+  expect(compareHrTime(child.endTime, parent.endTime)).toBeLessThanOrEqual(0);
+}
+
 const PLUGINS = [
   ["ExecutionOtelPlugin", () => new ExecutionOtelPlugin({})],
   ["InvocationOtelPlugin", () => new InvocationOtelPlugin({})],
@@ -283,12 +297,12 @@ describe.each(PLUGINS)("%s span lifecycle", (_name, makePlugin) => {
     expect(invocation).toBeDefined();
     // The Workflow span must contain the invocation it covers; a late fallback
     // would start it after the invocation span began.
-    const cmp = (a: ReadableSpan["startTime"], b: ReadableSpan["startTime"]) =>
-      a[0] - b[0] || a[1] - b[1];
-    expect(cmp(workflow.startTime, invocation.startTime)).toBeLessThanOrEqual(
-      0,
-    );
-    expect(cmp(workflow.endTime, workflow.startTime)).toBeGreaterThanOrEqual(0);
+    expect(
+      compareHrTime(workflow.startTime, invocation.startTime),
+    ).toBeLessThanOrEqual(0);
+    expect(
+      compareHrTime(workflow.endTime, workflow.startTime),
+    ).toBeGreaterThanOrEqual(0);
   });
 
   describe("sampling", () => {
@@ -449,6 +463,55 @@ describe("ExecutionOtelPlugin deferred operation spans", () => {
     trace.disable();
     context.disable();
     propagation.disable();
+  });
+
+  it("contains attempts when the backend operation start timestamp is absent", async () => {
+    register();
+    const plugin = new ExecutionOtelPlugin({});
+
+    await plugin.onInvocationStart(makeInvocationInfo());
+    const beforeStart = Date.now();
+    await plugin.onOperationStart(
+      makeOperationInfo({ name: "missing-start-time" }),
+    );
+    const afterStart = Date.now();
+
+    const operationStarts = (
+      plugin as unknown as {
+        operationStarts: Map<string, { startTimestamp?: Date }>;
+      }
+    ).operationStarts;
+    const capturedStart = operationStarts.get("op-1")?.startTimestamp;
+    expect(capturedStart).toBeInstanceOf(Date);
+    expect(capturedStart!.getTime()).toBeGreaterThanOrEqual(beforeStart);
+    expect(capturedStart!.getTime()).toBeLessThanOrEqual(afterStart);
+
+    const attemptStart = new Date(capturedStart!.getTime() + 1_000);
+    const attemptEnd = new Date(capturedStart!.getTime() + 2_000);
+    const attemptInfo = makeAttemptInfo({
+      name: "missing-start-time",
+      startTimestamp: attemptStart,
+    });
+    await plugin.onOperationAttemptStart(attemptInfo);
+    await plugin.onOperationAttemptEnd({
+      ...attemptInfo,
+      outcome: "SUCCEEDED" as any,
+      endTimestamp: attemptEnd,
+    });
+    await plugin.onOperationEnd(
+      makeOperationEndInfo({
+        name: "missing-start-time",
+        status: "SUCCEEDED" as any,
+        endTimestamp: attemptEnd,
+      }),
+    );
+    await plugin.onInvocationEnd(makeInvocationEndInfo());
+
+    const operation = named(exporter, "missing-start-time")[0];
+    const attempt = named(exporter, "missing-start-time attempt 1")[0];
+    expect(operation).toBeDefined();
+    expect(attempt).toBeDefined();
+    expectSpanInside(attempt, operation);
   });
 
   it("exports exactly one operation span for a WAIT that suspends then resumes", async () => {

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -483,11 +483,19 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       isRemote: false,
     });
 
-    // Retain naming/timing for onOperationEnd, which may omit them.
+    // Retain naming/timing for onOperationEnd, which may omit them. New
+    // operations can reach this hook before the checkpoint response supplies a
+    // backend start timestamp, so capture the hook time as the fallback. Keep
+    // the earliest observation if the same operation starts again on replay.
+    const existingStart = this.operationStarts.get(info.id);
+    const observedStart = info.startTimestamp ?? new Date();
     this.operationStarts.set(info.id, {
-      name: info.name,
-      subType: info.subType,
-      startTimestamp: info.startTimestamp,
+      name: info.name ?? existingStart?.name,
+      subType: info.subType ?? existingStart?.subType,
+      startTimestamp: this.earliestStart(
+        existingStart?.startTimestamp,
+        observedStart,
+      ),
     });
   }
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin.ts
@@ -14,6 +14,7 @@ import type {
   Tracer,
   Span,
   SpanContext,
+  Context,
   Link,
 } from "@opentelemetry/api";
 import {
@@ -50,10 +51,13 @@ const DEFAULT_INSTRUMENTATION_NAME = "aws-durable-execution-sdk-js";
  *
  * Implements the DurableInstrumentationPlugin interface. The Workflow span joins
  * the execution trace by parenting onto the resolved execution ancestor (a
- * propagated remote parent or a synthetic execution root) and roots the
- * operation spans, so the whole execution shares one trace. Operation span
- * export is deferred, and the per-invocation Invocation span is a correlation
- * sibling (linked from, not a parent of, the operation spans).
+ * propagated remote parent or a synthetic execution root), so the whole
+ * execution shares one trace. Operation spans parent onto the Workflow span and
+ * the per-invocation Invocation span is a correlation sibling (linked from, not
+ * a parent of, the operation spans). Both the Workflow span and each operation
+ * span are deferred: their identity is carried as a non-recording context and
+ * the single recording span is created and ended together at terminal /
+ * onOperationEnd, so nothing is left un-ended across invocations (issue #831).
  */
 export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   // Shared utilities (reused from existing package)
@@ -65,13 +69,30 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
   private tracer: Tracer;
   private readonly instrumentationName: string;
 
-  // Per-invocation state
+  // Non-recording context carrying the deterministic Workflow identity; the real
+  // span is created+ended once, at the terminal invocation (issue #831).
   private workflowSpan: Span | undefined;
   private invocationSpan: Span | undefined;
+  // Holds only recording ATTEMPT spans; operation spans are deferred (see
+  // operationContexts), never recording between start and end.
   private spanMap: Map<string, Span>;
+  // Deterministic non-recording placeholders for in-flight operations; the real
+  // span is created+ended once in onOperationEnd. Children/attempts parent onto it.
+  private operationContexts: Map<string, SpanContext>;
+  // Naming/timing captured at start, reused when onOperationEnd omits them.
+  private operationStarts: Map<
+    string,
+    { name?: string; subType?: string; startTimestamp?: Date }
+  >;
   private executionArn: string;
   private executionTraceId: string;
+  private executionTraceFlags: number = 0;
   private executionSamplingDecision: SamplingDecision;
+  // The execution ancestor the terminal Workflow span parents onto, and the
+  // backend execution start used to backdate it — both captured at invocation
+  // start and reused when the real span is created at terminal.
+  private executionAncestor: SpanContext | undefined;
+  private executionStartTimestamp: Date | undefined;
 
   private readonly usesGlobalProvider: boolean;
   private globalIdGeneratorInstalled: boolean;
@@ -114,6 +135,8 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
     // Initialize per-invocation state
     this.spanMap = new Map();
+    this.operationContexts = new Map();
+    this.operationStarts = new Map();
     this.executionArn = "";
     this.executionTraceId = "";
     this.executionSamplingDecision = SamplingDecision.NOT_RECORD;
@@ -153,35 +176,33 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
         }),
     );
     this.executionTraceId = canonical;
+    this.executionTraceFlags = execTraceContext.traceFlags;
     this.executionSamplingDecision = execTraceContext.samplingDecision;
 
     // 4. Derive the workflow span ID from execution ARN
     const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
 
-    // 5. Create the Workflow_Span parented onto the execution ancestor so it
-    // joins the execution trace. Force the span ID only; the trace ID comes
-    // from the parent. The override is scoped to this single startSpan call.
-    const executionAncestorContext = trace.setSpanContext(
-      ROOT_CONTEXT,
-      execTraceContext.executionAncestor,
-    );
-    this.workflowSpan = this.idGenerator.withIds(
-      {
-        spanId: workflowSpanId,
-      },
-      () =>
-        this.startSpan(
-          this.workflowSpanName,
-          {
-            kind: SpanKind.INTERNAL,
-            attributes: {
-              "durable.execution.arn": info.executionArn,
-            },
-            startTime: info.executionStartTimestamp ?? new Date(),
-          },
-          executionAncestorContext,
-        ),
-    );
+    // 5. Resolve the Workflow_Span identity as a NON-RECORDING context. A whole
+    // execution spans many invocations, so only the terminal one can complete
+    // the real span; carrying a real recording span across invocations would
+    // leak it un-ended (issue #831), and ending one per invocation would export
+    // duplicate (traceId, spanId). Operations parent onto this non-recording
+    // context (a valid parent that stamps the right traceId/parentSpanId on its
+    // children); the single real span is created and ended once, at the terminal
+    // invocation (see onInvocationEnd), parented onto the execution ancestor. It
+    // carries the execution sampled bit so a parent-based sampler stays
+    // consistent with the eventual root.
+    this.executionAncestor = execTraceContext.executionAncestor;
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
+    this.workflowSpan = trace.wrapSpanContext({
+      traceId: this.executionTraceId,
+      spanId: workflowSpanId,
+      traceFlags: execTraceContext.traceFlags,
+      isRemote: false,
+    });
 
     // 6. Create Invocation_Span parented onto the same-trace ambient span when
     // available, otherwise onto the execution ancestor so it stays within the
@@ -276,30 +297,61 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end();
     }
 
-    // 2. Handle Workflow_Span based on terminal status
-    if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-      // Terminal: set status attribute, map to span status, end (causes export).
-      // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-      // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-      // — those are collapsed into FAILED -> ERROR here.
-      if (this.workflowSpan) {
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end();
+    // 2. Terminal invocation ONLY: create and end the one real Workflow_Span,
+    // so a single span ever claims the deterministic (traceId, spanId) and no
+    // span is left un-ended on a non-terminal invocation (issue #831). It is
+    // parented onto the execution ancestor (the join-trace model) and backdated
+    // to the execution start captured at invocation start. Skipped when the
+    // execution decision was not sampled, so a dropped execution does not export
+    // a lone root. PluginInvocationStatus collapses TIMED_OUT/STOPPED into
+    // FAILED -> ERROR.
+    if (
+      this.executionSamplingDecision === SamplingDecision.RECORD_AND_SAMPLED &&
+      this.executionAncestor &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      const workflowSpanId = deriveWorkflowSpanId(this.executionArn);
+      const executionAncestorContext = trace.setSpanContext(
+        ROOT_CONTEXT,
+        this.executionAncestor,
+      );
+      const workflowSpan = this.idGenerator.withIds(
+        { spanId: workflowSpanId },
+        () =>
+          this.startSpan(
+            this.workflowSpanName,
+            {
+              kind: SpanKind.INTERNAL,
+              attributes: {
+                "durable.execution.arn": this.executionArn,
+              },
+              startTime: this.executionStartTimestamp ?? new Date(),
+            },
+            executionAncestorContext,
+          ),
+      );
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
+      }
+      workflowSpan.end();
+    }
+    // Non-terminal (PENDING/RETRYING): no real Workflow_Span is created, so
+    // nothing to end — the identity was only ever a non-recording context.
+
+    // 3. End any attempt span still open (safeguard against a leak on a
+    // non-terminal invocation, issue #831). Operation placeholders have no
+    // recording span and are dropped in resetInvocationState.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end();
       }
     }
-    // Non-terminal (PENDING/RETRYING): do NOT end workflowSpan — just drop the reference.
-    // Its status stays UNSET and the span is never exported (spans that are never
-    // .end()'d are never exported by the OTel SDK).
-
-    // 3. Discard open Operation_Spans without ending (they won't be exported)
 
     // 4. Always flush TracerProvider at invocation boundaries
     if ("forceFlush" in this.tracerProvider) {
@@ -346,10 +398,15 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
 
   private resetInvocationState(): void {
     this.spanMap.clear();
+    this.operationContexts.clear();
+    this.operationStarts.clear();
     this.workflowSpan = undefined;
     this.invocationSpan = undefined;
+    this.executionAncestor = undefined;
+    this.executionStartTimestamp = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
+    this.executionTraceFlags = 0;
     this.executionSamplingDecision = SamplingDecision.NOT_RECORD;
     this.tracingEnabled = false;
   }
@@ -413,55 +470,25 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       return;
     }
 
+    // Defer the span: store only a deterministic non-recording placeholder that
+    // children/attempts parent onto; the real span is created in onOperationEnd.
     const deterministicSpanId = deriveSpanIdFromOperationId(
       info.id,
       this.executionArn,
     );
-    const spanName = info.name ?? info.type;
+    this.operationContexts.set(info.id, {
+      traceId: this.executionTraceId,
+      spanId: deterministicSpanId,
+      traceFlags: this.executionTraceFlags,
+      isRemote: false,
+    });
 
-    // Resolve parent span: use parentId from map, or fall back to Workflow_Span
-    let parentSpan: Span | undefined;
-    if (info.parentId && this.spanMap.has(info.parentId)) {
-      parentSpan = this.spanMap.get(info.parentId);
-    } else {
-      parentSpan = this.workflowSpan;
-    }
-
-    const parentContext = parentSpan
-      ? trace.setSpan(context.active(), parentSpan)
-      : context.active();
-
-    const attributes: Record<string, string> = {
-      "durable.execution.arn": this.executionArn,
-      "durable.operation.id": info.id,
-      "durable.operation.type": info.type,
-    };
-    if (info.name) {
-      attributes["durable.operation.name"] = info.name;
-    }
-    if (info.subType) {
-      attributes["durable.operation.subtype"] = info.subType;
-    }
-
-    const links = this.buildInvocationLinks();
-
-    // Always use a deterministic span ID regardless of replay status.
-    const span = this.idGenerator.withIds(
-      {
-        traceId: this.executionTraceId,
-        spanId: deterministicSpanId,
-      },
-      () =>
-        this.startSpan(
-          spanName,
-          { attributes, startTime: info.startTimestamp, links },
-          parentContext,
-        ),
-    );
-
-    if (span) {
-      this.spanMap.set(info.id, span);
-    }
+    // Retain naming/timing for onOperationEnd, which may omit them.
+    this.operationStarts.set(info.id, {
+      name: info.name,
+      subType: info.subType,
+      startTimestamp: info.startTimestamp,
+    });
   }
 
   wrapChildContextFn(info: OperationInfo, fn: () => unknown): unknown {
@@ -469,12 +496,15 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       return fn();
     }
 
-    const operationSpan = this.spanMap.get(info.id);
-
-    if (!operationSpan) {
+    // Make the operation's placeholder current so nested calls become its children.
+    const operationContext = this.operationContexts.get(info.id);
+    if (!operationContext) {
       return fn();
     }
-    return context.with(trace.setSpan(context.active(), operationSpan), fn);
+    return context.with(
+      trace.setSpanContext(context.active(), operationContext),
+      fn,
+    );
   }
 
   async onOperationEnd(info: OperationEndInfo): Promise<void> {
@@ -482,113 +512,115 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
       return;
     }
 
-    const deterministicSpanId = deriveSpanIdFromOperationId(
+    // The only place an operation span is created: start+end it here under its
+    // deterministic ID, so it is exported exactly once even across suspend/resume.
+    const started = this.operationStarts.get(info.id);
+    this.operationContexts.delete(info.id);
+    this.operationStarts.delete(info.id);
+
+    // The end event may omit name/subType; fall back to what start captured.
+    const name = info.name ?? started?.name;
+    const subType = info.subType ?? started?.subType;
+
+    const spanName = name ?? info.type;
+    const parentContext = this.resolveOperationParentContext(info.parentId);
+
+    const attributes: Record<string, string | number> = {
+      "durable.execution.arn": this.executionArn,
+      "durable.operation.id": info.id,
+      "durable.operation.type": info.type,
+    };
+    if (name) {
+      attributes["durable.operation.name"] = name;
+    }
+    if (subType) {
+      attributes["durable.operation.subtype"] = subType;
+    }
+    if (info.status) {
+      attributes["durable.operation.status"] = info.status;
+    }
+    // durable.attempt.number for retriable operations (STEP, WAIT_FOR_CONDITION).
+    if (
+      (info.type === "STEP" || subType === "WAIT_FOR_CONDITION") &&
+      info.attempt != null
+    ) {
+      attributes["durable.attempt.number"] = info.attempt;
+    }
+
+    const links = this.buildInvocationLinks();
+
+    // Earliest known start, so the span never begins after its own attempt/child
+    // spans (created earlier at start).
+    const startTime = this.earliestStart(
+      started?.startTimestamp,
+      info.startTimestamp,
+    );
+
+    const operationSpanId = deriveSpanIdFromOperationId(
       info.id,
       this.executionArn,
     );
+    const span = this.idGenerator.withIds(
+      {
+        traceId: this.executionTraceId,
+        spanId: operationSpanId,
+      },
+      () =>
+        this.startSpan(
+          spanName,
+          { attributes, startTime, links },
+          parentContext,
+        ),
+    );
 
-    if (this.spanMap.has(info.id)) {
-      // Operation was started in this invocation
-      const span = this.spanMap.get(info.id)!;
-
-      // Set operation status attribute
-      if (info.status) {
-        span.setAttribute("durable.operation.status", info.status);
-      }
-
-      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
-      if (
-        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
-        info.attempt != null
-      ) {
-        span.setAttribute("durable.attempt.number", info.attempt);
-      }
-
-      if (info.error) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: info.error.message,
-        });
-        span.recordException(info.error);
-      } else if (info.status === "SUCCEEDED") {
-        // Stamp explicit OK ONLY on a SUCCEEDED terminal status. Terminal
-        // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
-        // NO error object (callback-timeout, chained-invoke fast paths); those
-        // must NOT be labelled OK, so they are left UNSET.
-        span.setStatus({ code: SpanStatusCode.OK });
-      }
-
-      span.end(info.endTimestamp);
-      this.spanMap.delete(info.id);
-    } else {
-      // Cross-invocation: create span with deterministic ID, export immediately
-      const spanName = info.name ?? info.type;
-
-      // Resolve parent: use parentId from map, or fall back to Workflow_Span
-      let parentSpan: Span | undefined;
-      if (info.parentId && this.spanMap.has(info.parentId)) {
-        parentSpan = this.spanMap.get(info.parentId);
-      } else {
-        parentSpan = this.workflowSpan;
-      }
-
-      const parentContext = parentSpan
-        ? trace.setSpan(context.active(), parentSpan)
-        : context.active();
-
-      const attributes: Record<string, string | number> = {
-        "durable.execution.arn": this.executionArn,
-        "durable.operation.id": info.id,
-        "durable.operation.type": info.type,
-      };
-      if (info.name) {
-        attributes["durable.operation.name"] = info.name;
-      }
-      if (info.subType) {
-        attributes["durable.operation.subtype"] = info.subType;
-      }
-      if (info.status) {
-        attributes["durable.operation.status"] = info.status;
-      }
-      // Set durable.attempt.number for STEP and WAIT_FOR_CONDITION operations
-      if (
-        (info.type === "STEP" || info.subType === "WAIT_FOR_CONDITION") &&
-        info.attempt != null
-      ) {
-        attributes["durable.attempt.number"] = info.attempt;
-      }
-
-      const links = this.buildInvocationLinks();
-
-      const span = this.idGenerator.withIds(
-        {
-          traceId: this.executionTraceId,
-          spanId: deterministicSpanId,
-        },
-        () =>
-          this.startSpan(
-            spanName,
-            { attributes, startTime: info.startTimestamp, links },
-            parentContext,
-          ),
-      );
-
-      if (info.error) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: info.error.message,
-        });
-        span.recordException(info.error);
-      } else if (info.status === "SUCCEEDED") {
-        // Stamp explicit OK ONLY on a SUCCEEDED terminal status. Terminal
-        // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
-        // NO error object on the cross-invocation fast paths; those must NOT be
-        // labelled OK, so they are left UNSET.
-        span.setStatus({ code: SpanStatusCode.OK });
-      }
-
-      span.end(info.endTimestamp);
+    if (info.error) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: info.error.message,
+      });
+      span.recordException(info.error);
+    } else if (info.status === "SUCCEEDED") {
+      // Stamp explicit OK ONLY on a SUCCEEDED terminal status. Terminal
+      // FAILURE statuses (TIMED_OUT/STOPPED/FAILED/CANCELLED) can arrive with
+      // NO error object (callback-timeout, chained-invoke fast paths); those
+      // must NOT be labelled OK, so they are left UNSET.
+      span.setStatus({ code: SpanStatusCode.OK });
     }
+
+    span.end(info.endTimestamp);
+  }
+
+  /**
+   * The parent context for an operation or attempt span: the parent operation's
+   * deterministic placeholder context when known, otherwise the deferred
+   * Workflow span's context so the span still hangs off the execution trace.
+   */
+  private resolveOperationParentContext(parentId: string | undefined): Context {
+    if (parentId) {
+      const parentContext = this.operationContexts.get(parentId);
+      if (parentContext) {
+        return trace.setSpanContext(context.active(), parentContext);
+      }
+    }
+    const workflowContext = this.workflowSpan?.spanContext();
+    if (workflowContext) {
+      return trace.setSpanContext(context.active(), workflowContext);
+    }
+    return context.active();
+  }
+
+  /** The earlier of two timestamps, ignoring undefined; undefined only when both are. */
+  private earliestStart(
+    a: Date | undefined,
+    b: Date | undefined,
+  ): Date | undefined {
+    if (!a) {
+      return b;
+    }
+    if (!b) {
+      return a;
+    }
+    return a.getTime() <= b.getTime() ? a : b;
   }
 
   private getAttemptKey(id: string, attempt: number): string {
@@ -603,11 +635,8 @@ export class ExecutionOtelPlugin implements DurableInstrumentationPlugin {
     const baseName = info.name ?? info.type;
     const spanName = `${baseName} attempt ${info.attempt}`;
 
-    // Find the parent Operation_Span
-    const parentSpan = this.spanMap.get(info.id);
-    const parentContext = parentSpan
-      ? trace.setSpan(context.active(), parentSpan)
-      : context.active();
+    // Parent onto the operation's placeholder (the operation span is deferred).
+    const parentContext = this.resolveOperationParentContext(info.id);
 
     const attributes: Record<string, string | number> = {
       "durable.execution.arn": this.executionArn,

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin.ts
@@ -70,7 +70,18 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
   private spanMap: Map<string, Span> = new Map();
   private spanStack: Span[] = [];
   private invocationSpan: Span | undefined;
+  // workflowSpan is a NON-RECORDING context carrying the deterministic Workflow
+  // identity for links; the one real recording span is created and ended only at
+  // the terminal invocation (see onInvocationEnd), so a Workflow span that spans
+  // many invocations is never left un-ended (issue #831).
   private workflowSpan: Span | undefined;
+  // The execution ancestor the terminal Workflow span parents onto. Resolved at
+  // invocation start and reused when the real span is created at terminal.
+  private executionAncestor: SpanContext | undefined;
+  // The backend execution start, captured at invocation start so the terminal
+  // Workflow span can be backdated to it; the now() fallback is taken here (not
+  // at onInvocationEnd, where it would land after the span's own end time).
+  private executionStartTimestamp: Date | undefined;
   private executionArn: string = "";
   private executionTraceId: string = "";
   private executionTraceFlags: number = 0;
@@ -144,40 +155,32 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.executionTraceFlags = execTraceContext.traceFlags;
     this.executionSamplingDecision = execTraceContext.samplingDecision;
 
-    // 4. Create the Workflow span parented onto the execution ancestor so it
-    // joins the execution trace with a trace ID stable across invocations.
+    // 4. Resolve the Workflow span identity as a NON-RECORDING context.
     //
-    // It is emitted in BOTH provider modes (default/ADOT and owned/community
-    // collector), matching ExecutionOtelPlugin and the Python/Java reference
-    // plugins. It is keyed to a deterministic span ID derived from the execution
-    // ARN so every invocation of the same durable execution shares one root, and
-    // it is finalized (stamped with a terminal execution status and ended) only
-    // once, at the terminal invocation (see onInvocationEnd). Operation and
-    // attempt spans link to it for execution-level correlation while remaining
-    // parented to the per-invocation span (this plugin stays invocation-rooted).
-    // Force the span ID only; the trace ID comes from the parent.
+    // The Workflow span joins the execution trace (parented onto the execution
+    // ancestor) with a deterministic span ID derived from the ARN, so every
+    // invocation of the same durable execution shares one root. But a single
+    // execution spans many invocations, so only the terminal one can complete
+    // it: carrying a real recording span across invocations would leak it
+    // un-ended (issue #831), and ending one per invocation would export
+    // duplicate (traceId, spanId). Its identity is therefore carried by a
+    // non-recording context here — operation and attempt spans link to it (see
+    // workflowLinks) while staying parented to the per-invocation span — and the
+    // single real span is created and ended once, at the terminal invocation
+    // (see onInvocationEnd). It carries the execution sampled bit so a
+    // parent-based sampler stays consistent with the eventual root.
     const workflowSpanId = deriveWorkflowSpanId(info.executionArn);
-    const executionAncestorContext = trace.setSpanContext(
-      ROOT_CONTEXT,
-      execTraceContext.executionAncestor,
-    );
-    this.workflowSpan = this.idGenerator.withIds(
-      {
-        spanId: workflowSpanId,
-      },
-      () =>
-        this.startSpan(
-          this.workflowSpanName,
-          {
-            kind: SpanKind.INTERNAL,
-            attributes: {
-              "durable.execution.arn": info.executionArn,
-            },
-            startTime: info.executionStartTimestamp ?? new Date(),
-          },
-          executionAncestorContext,
-        ),
-    );
+    this.executionAncestor = execTraceContext.executionAncestor;
+    this.executionStartTimestamp =
+      info.executionStartTimestamp ??
+      this.executionStartTimestamp ??
+      new Date();
+    this.workflowSpan = trace.wrapSpanContext({
+      traceId: this.executionTraceId,
+      spanId: workflowSpanId,
+      traceFlags: this.executionTraceFlags,
+      isRemote: false,
+    });
 
     // 5. Create the invocation span parented onto the same-trace ambient span
     //    when available (under ADOT/X-Ray the active context at
@@ -234,6 +237,16 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       span.end(endTime);
     }
 
+    // 1b. End any still-recording span left in spanMap (attempt spans, which are
+    // not on the stack; operation spans were unwound above). Safeguard against a
+    // leak on a non-terminal invocation (issue #831). isRecording() skips spans
+    // already ended by the stack unwind.
+    for (const span of this.spanMap.values()) {
+      if (span.isRecording()) {
+        span.end(endTime);
+      }
+    }
+
     // 2. End the invocation span if it exists
     if (this.invocationSpan) {
       this.invocationSpan.setAttribute(
@@ -260,28 +273,52 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
       this.invocationSpan.end(endTime);
     }
 
-    // 3. Handle Workflow span based on terminal status. The Workflow span is
-    //    always created (both provider modes); it is finalized only on a
-    //    terminal invocation, and dropped un-exported while non-terminal.
-    if (this.workflowSpan) {
-      if (info.status === "SUCCEEDED" || info.status === "FAILED") {
-        // PluginInvocationStatus only distinguishes SUCCEEDED/FAILED/PENDING/RETRYING,
-        // so the plugin cannot tell whether a failed workflow was TIMED_OUT or STOPPED
-        // — those are collapsed into FAILED -> ERROR here.
-        this.workflowSpan.setAttribute("durable.execution.status", info.status);
-        if (info.status === "FAILED") {
-          this.workflowSpan.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: info.executionError?.message ?? "Execution failed",
-          });
-        } else {
-          this.workflowSpan.setStatus({ code: SpanStatusCode.OK });
-        }
-        this.workflowSpan.end(endTime);
+    // 3. Terminal invocation ONLY: create and end the one real Workflow span,
+    //    so a single span ever claims the deterministic (traceId, spanId) and no
+    //    span is left un-ended on a non-terminal invocation (issue #831). It is
+    //    parented onto the execution ancestor (the join-trace model) and
+    //    backdated to the execution start captured at invocation start. Skipped
+    //    when the execution decision was not sampled, so a dropped execution
+    //    does not export a lone root. PluginInvocationStatus collapses
+    //    TIMED_OUT/STOPPED into FAILED -> ERROR.
+    if (
+      this.executionSamplingDecision === SamplingDecision.RECORD_AND_SAMPLED &&
+      this.executionAncestor &&
+      (info.status === "SUCCEEDED" || info.status === "FAILED")
+    ) {
+      const workflowSpanId = deriveWorkflowSpanId(this.executionArn);
+      const executionAncestorContext = trace.setSpanContext(
+        ROOT_CONTEXT,
+        this.executionAncestor,
+      );
+      const workflowSpan = this.idGenerator.withIds(
+        { spanId: workflowSpanId },
+        () =>
+          this.startSpan(
+            this.workflowSpanName,
+            {
+              kind: SpanKind.INTERNAL,
+              attributes: {
+                "durable.execution.arn": this.executionArn,
+              },
+              startTime: this.executionStartTimestamp ?? new Date(),
+            },
+            executionAncestorContext,
+          ),
+      );
+      workflowSpan.setAttribute("durable.execution.status", info.status);
+      if (info.status === "FAILED") {
+        workflowSpan.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: info.executionError?.message ?? "Execution failed",
+        });
+      } else {
+        workflowSpan.setStatus({ code: SpanStatusCode.OK });
       }
-      // Non-terminal (PENDING/RETRYING): do NOT end — status stays UNSET and the
-      // span is dropped without export
+      workflowSpan.end(endTime);
     }
+    // Non-terminal (PENDING/RETRYING): no real Workflow span is created, so
+    // nothing to end — the identity was only ever a non-recording context.
 
     // 4. Force flush the tracer provider
     if ("forceFlush" in this.tracerProvider) {
@@ -328,6 +365,8 @@ export class InvocationOtelPlugin implements DurableInstrumentationPlugin {
     this.spanStack = [];
     this.invocationSpan = undefined;
     this.workflowSpan = undefined;
+    this.executionAncestor = undefined;
+    this.executionStartTimestamp = undefined;
     this.executionArn = "";
     this.executionTraceId = "";
     this.executionTraceFlags = 0;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-durable-execution-sdk-js/issues/831

*Description of changes:*
- Workflow span: created+ended once, on the terminal invocation (both plugins).
- Attempt span: created+ended in the same invocation (both plugins).
- Operation span: invocation plugin → one segment per invocation (fresh ID + link across invocations); execution plugin → one span total, created+ended in the invocation where the operation terminates (held as a non-recording placeholder while it spans invocations).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
