### PR TITLE
fix(otel): remove runtime core SDK dependency

### DIFF
--- a/api-extractor/durable-execution-sdk-js.api.json
+++ b/api-extractor/durable-execution-sdk-js.api.json
@@ -9001,7 +9001,12 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "number"
+                  "text": "typeof "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION",
+                  "canonicalReference": "@aws/durable-execution-sdk-js!DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION:var"
                 },
                 {
                   "kind": "Content",
@@ -9014,7 +9019,7 @@
               "name": "pluginApiVersion",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
-                "endIndex": 2
+                "endIndex": 3
               }
             },
             {

--- a/api-extractor/durable-execution-sdk-js.api.md
+++ b/api-extractor/durable-execution-sdk-js.api.md
@@ -506,7 +506,7 @@ export interface DurableInstrumentationPlugin {
 // @beta
 export interface DurableInstrumentationPluginProvider<Plugin extends DurableInstrumentationPlugin = DurableInstrumentationPlugin> {
     createPlugin(): Plugin;
-    readonly pluginApiVersion: number;
+    readonly pluginApiVersion: typeof DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION;
     readonly pluginType: DurableInstrumentationPluginType<Plugin>;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27546,6 +27546,11 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.6.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws/durable-execution-sdk-js": {
+          "optional": true
+        }
       }
     },
     "packages/aws-durable-execution-sdk-js-testing": {

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -161,7 +161,7 @@ the provider exposes it. They never call `shutdown()`.
 ## Dynamic Loading from a Lambda Layer
 
 The SDK can load either plugin without importing it in function code. Package
-this module and its peer dependencies in a Lambda layer under
+this module and its OpenTelemetry peer dependencies in a Lambda layer under
 `nodejs/node_modules`, then configure one entry point:
 
 ```text
@@ -173,6 +173,11 @@ or:
 ```text
 DURABLE_EXECUTION_PLUGINS=@aws/durable-execution-sdk-js-otel/otel-invocation
 ```
+
+Do not package `@aws/durable-execution-sdk-js` in the layer. The provider entry
+points use SDK types only, and the SDK peer dependency is optional so package
+installation does not add a second copy. At runtime, the plugin is loaded and
+driven by the SDK instance bundled with the function.
 
 Dynamic providers construct plugins with default configuration, so they
 require a compatible globally registered SDK provider. Use code-based

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -66,5 +66,10 @@
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.6.1"
   },
+  "peerDependenciesMeta": {
+    "@aws/durable-execution-sdk-js": {
+      "optional": true
+    }
+  },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/dynamic-plugin-providers.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/dynamic-plugin-providers.test.ts
@@ -1,29 +1,32 @@
-import {
-  DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
-  type DurableInstrumentationPluginProvider,
-} from "@aws/durable-execution-sdk-js";
+import type { DurableInstrumentationPluginProvider } from "@aws/durable-execution-sdk-js";
 import { durableExecutionPluginProvider as executionProvider } from "../execution-plugin-provider";
 import { ExecutionOtelPlugin } from "../execution-plugin";
 import { durableExecutionPluginProvider as invocationProvider } from "../invocation-plugin-provider";
 import { InvocationOtelPlugin } from "../invocation-plugin";
 
+jest.mock(
+  "@aws/durable-execution-sdk-js",
+  () => {
+    throw new Error("OTel provider entry points loaded the SDK at runtime");
+  },
+  { virtual: true },
+);
+
 function expectProvider(
   provider: DurableInstrumentationPluginProvider,
   pluginType: abstract new (...args: never[]) => object,
 ): void {
-  expect(provider.pluginApiVersion).toBe(
-    DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
-  );
+  expect(provider.pluginApiVersion).toBe(1);
   expect(provider.pluginType).toBe(pluginType);
   expect(provider.createPlugin()).toBeInstanceOf(pluginType);
 }
 
 describe("dynamic OTel plugin providers", () => {
-  it("creates the execution plugin", () => {
+  it("creates the execution plugin without loading the SDK at runtime", () => {
     expectProvider(executionProvider, ExecutionOtelPlugin);
   });
 
-  it("creates the invocation plugin", () => {
+  it("creates the invocation plugin without loading the SDK at runtime", () => {
     expectProvider(invocationProvider, InvocationOtelPlugin);
   });
 });

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin-provider.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-plugin-provider.ts
@@ -1,11 +1,8 @@
-import {
-  DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
-  type DurableInstrumentationPluginProvider,
-} from "@aws/durable-execution-sdk-js";
+import type { DurableInstrumentationPluginProvider } from "@aws/durable-execution-sdk-js";
 import { ExecutionOtelPlugin } from "./execution-plugin";
 
 export const durableExecutionPluginProvider = {
-  pluginApiVersion: DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
+  pluginApiVersion: 1,
   pluginType: ExecutionOtelPlugin,
   createPlugin: () => new ExecutionOtelPlugin(),
 } satisfies DurableInstrumentationPluginProvider<ExecutionOtelPlugin>;

--- a/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin-provider.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/invocation-plugin-provider.ts
@@ -1,11 +1,8 @@
-import {
-  DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
-  type DurableInstrumentationPluginProvider,
-} from "@aws/durable-execution-sdk-js";
+import type { DurableInstrumentationPluginProvider } from "@aws/durable-execution-sdk-js";
 import { InvocationOtelPlugin } from "./invocation-plugin";
 
 export const durableExecutionPluginProvider = {
-  pluginApiVersion: DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
+  pluginApiVersion: 1,
   pluginType: InvocationOtelPlugin,
   createPlugin: () => new InvocationOtelPlugin(),
 } satisfies DurableInstrumentationPluginProvider<InvocationOtelPlugin>;

--- a/packages/aws-durable-execution-sdk-js/README.md
+++ b/packages/aws-durable-execution-sdk-js/README.md
@@ -286,10 +286,9 @@ Provider modules export a versioned factory named
 `durableExecutionPluginProvider`:
 
 ```typescript
-import {
-  DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
-  type DurableInstrumentationPlugin,
-  type DurableInstrumentationPluginProvider,
+import type {
+  DurableInstrumentationPlugin,
+  DurableInstrumentationPluginProvider,
 } from "@aws/durable-execution-sdk-js";
 
 class AuditPlugin implements DurableInstrumentationPlugin {
@@ -297,11 +296,16 @@ class AuditPlugin implements DurableInstrumentationPlugin {
 }
 
 export const durableExecutionPluginProvider = {
-  pluginApiVersion: DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION,
+  pluginApiVersion: 1,
   pluginType: AuditPlugin,
   createPlugin: () => new AuditPlugin(),
 } satisfies DurableInstrumentationPluginProvider<AuditPlugin>;
 ```
+
+Declare `pluginApiVersion` as a literal instead of importing the SDK constant
+at runtime. The provider type checks the literal against the supported version,
+while the SDK loader performs the runtime compatibility check. This allows a
+provider package to depend on the SDK only for TypeScript types.
 
 The module specifier must be resolvable through normal application module
 resolution or Node.js module paths. For a Lambda layer, package the provider and

--- a/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/plugin.ts
@@ -285,7 +285,7 @@ export interface DurableInstrumentationPluginProvider<
   /**
    * Provider contract version expected by the SDK.
    */
-  readonly pluginApiVersion: number;
+  readonly pluginApiVersion: typeof DURABLE_INSTRUMENTATION_PLUGIN_API_VERSION;
 
   /**
    * Concrete class returned by `createPlugin`.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Closes #846

### Description

- Make the provider API version a literal that is type-checked against the core SDK contract, allowing provider entry points to import SDK types only.
- Remove the generated runtime import of `@aws/durable-execution-sdk-js` from both OTel provider bundles.
- Mark the core SDK peer optional so installing the OTel package into a Lambda layer does not add a duplicate SDK copy.
- Document that dynamically loaded OTel layers should rely on the SDK bundled with the function.

The OTel plugins do not consume SDK runtime values; the only runtime dependency was the imported provider-version constant. Keeping the version declaration static preserves the existing loader compatibility handshake without adding an otherwise empty factory context.

### Demo/Screenshots

Not applicable; this change affects package dependency resolution and dynamic plugin loading.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

- Node.js 22: core SDK — 104 suites, 1,237 tests passed
- Node.js 22: OTel package — 12 suites, 228 tests passed
- Node.js 24: OTel package — 12 suites, 228 tests passed
- Added coverage that fails if either dynamic OTel provider loads the core SDK at runtime

#### Integration Tests

- Built the core SDK and OTel package in both ESM and CommonJS formats
- Verified neither emitted OTel provider bundle references `@aws/durable-execution-sdk-js`
- Packed and installed the OTel package in an isolated layer-style project, verified the core SDK peer was absent, and loaded the CommonJS execution provider successfully
- Refreshed the core SDK API Extractor reports

#### Examples

No new example is needed. The core SDK and OTel package documentation now describe type-only provider dependencies and plugin-only layer packaging.