### PR TITLE
test: add replay identity conformance case

### DIFF
--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/general/replay_operation_identity.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/general/replay_operation_identity.ts
@@ -1,0 +1,42 @@
+// 11-1: Replay rejects an operation-type mismatch
+import {
+  DurableContext,
+  DurableInstrumentationPlugin,
+  withDurableExecution,
+} from "@aws/durable-execution-sdk-js";
+
+const replayByRequestId = new Map<string, boolean>();
+
+const replayIndicatorPlugin: DurableInstrumentationPlugin = {
+  async onInvocationStart(info) {
+    replayByRequestId.set(info.requestId, !info.isFirstInvocation);
+  },
+  async onInvocationEnd(info) {
+    replayByRequestId.delete(info.requestId);
+  },
+};
+
+export const handler = withDurableExecution(
+  async (_event: unknown, context: DurableContext) => {
+    context.configureLogger({ modeAware: false });
+
+    const isReplaying = replayByRequestId.get(
+      context.lambdaContext.awsRequestId,
+    );
+    if (isReplaying === undefined) {
+      throw new Error("Replay indicator was not initialized");
+    }
+
+    if (isReplaying) {
+      context.logger.info("DETERMINISM_REPLAY_CANARY");
+      return await context.step("identity-slot", async (stepContext) => {
+        stepContext.logger.info("DETERMINISM_STEP_BODY_EXECUTED");
+        return "unexpected";
+      });
+    }
+
+    await context.wait("identity-slot", { seconds: 1 });
+    return null;
+  },
+  { plugins: [replayIndicatorPlugin] },
+);

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/template_general.yaml
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/template_general.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Function:
+    Runtime: nodejs22.x
+    Timeout: 60
+    MemorySize: 128
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: DurableExecutionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - lambda:CheckpointDurableExecution
+            - lambda:GetDurableExecutionState
+            Resource: '*'
+  ReplayOperationIdentity:
+    Type: AWS::Serverless::Function
+    Metadata:
+      SkipBuild: "True"
+    TestingMetadata:
+      TestDescription: ["11-1"]
+    Properties:
+      CodeUri: ./dist
+      Handler: replay_operation_identity.handler
+      Description: Replay rejects an operation-type mismatch
+      Role:
+        Fn::GetAtt:
+        - DurableFunctionRole
+        - Arn
+      DurableConfig:
+        RetentionPeriodInDays: 7
+        ExecutionTimeout: 300


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Implements https://github.com/aws/aws-durable-execution-conformance-tests/pull/111.

### Description

Adds the `general` conformance suite and JavaScript handler for requirement
`11-1`. The handler uses the public invocation plugin replay indicator, emits a
named `WAIT` initially, and deliberately emits a named `STEP` at the same
durable position on replay. Replay-visible logging proves the replay occurred
and that the mismatched step body never ran.

This PR is stacked on #866, which makes replay nondeterminism terminate the
execution as `FAILED`.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

- new handler standalone TypeScript check
- SDK ESM, CommonJS, and declaration builds
- conformance handler Rollup build
- suite discovery and YAML validation
- `git diff --check`

#### Integration Tests

The new `general` suite is discovered by the existing conformance workflow and
will run requirement `11-1` against the deployed handler.

#### Examples

Added `replay_operation_identity.ts` as the conformance handler for `11-1`.
