### PR TITLE
ci: run lint in parallel with build again, not as its dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,19 @@ jobs:
           node "$GITHUB_WORKSPACE/.github/workflows/lintcommit.js"
 
   build:
-    # `needs: lint` restores the gating topology this branch would otherwise lose.
-    # Before, lint ran inside `prebuild` for three packages, so a lint error failed
-    # the build job and everything downstream of it. Removing those hooks made `lint`
-    # a sibling job instead, which means a PR could merge on a green required build
-    # while `lint / lint` was red -- until someone adds the new check to the ruleset.
-    # Depending on it here makes that admin step an improvement in visibility rather
-    # than the only thing standing between a Biome failure and a merge.
-    needs: [lint-commits, lint]
+    # Deliberately NOT `needs: lint`. That was tried, on the theory that depending on
+    # lint would make a lint failure block the merge the way it did when lint ran inside
+    # `prebuild`. It does not: GitHub reports a job skipped by a failed `needs` with a
+    # conclusion of `skipped`, and skipped counts as SUCCESS for required status checks
+    # (see "Troubleshooting required status checks" in the GitHub docs -- successful
+    # statuses are success, skipped and neutral).
+    #
+    # So `needs: lint` was strictly worse: a lint failure skipped `build` AND the
+    # `unit-tests` jobs that depend on it, all three reported success, the PR stayed
+    # mergeable, and the tests never ran. Blocking is the ruleset's job -- `lint / lint`
+    # is a required check -- and keeping these parallel means a PR with a lint error
+    # still gets real test results in the same run.
+    needs: lint-commits
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Reverts `build: needs: [lint-commits, lint]`, added in #883.

## Why it was wrong

That dependency was added to make a lint failure block the merge, the way it did when lint ran inside `prebuild`. It does not work, because of how GitHub scores skipped jobs:

> Successful check statuses are: **success, skipped, and neutral**.
> A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.

— [Troubleshooting required status checks](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks)

So with `needs: lint`, a lint failure produced:

| job | result | scored as |
| --- | --- | --- |
| `lint` | failure | not required at the time, ignored |
| `build` | skipped (`needs` failed) | **success** |
| `unit-tests (22.x/24.x)` | skipped (`needs: build`) | **success** |

All four required checks satisfied, PR mergeable — the exact hole the change meant to close — and now with the tests not having run either. The dependency bought no blocking and cost the test results.

## What actually closes it

`lint / lint` is now a required status check on the `main` ruleset (covering the default branch and `v1.x`), so a lint failure blocks the merge by name.

With the jobs parallel again, a PR that fails lint still gets real unit-test results in the same run instead of two skipped jobs.

## Effect

| | lint fails, before | lint fails, after |
| --- | --- | --- |
| merge blocked | no | **yes**, by `lint / lint` |
| test results | none (skipped) | **reported** |

No change for a passing PR: `build` still waits on `lint-commits`, and `lint` still runs off the sources without waiting for the build.

The job comment now records why not to reintroduce the dependency, since the reasoning behind it is superficially convincing.

## Verification

`lint:ci`, `lint:versions`, `lint:filenames`, `lint:suppressions` and `actionlint` on both modified workflows all exit 0. One file changed, 13+/8−, comment and `needs:` only.
