### PR TITLE
refactor(insight): memoise llmProviderOptions so its effect dependency is checkable

### DIFF
--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -107,13 +107,18 @@ export function SettingsModal({
   // dropdown cannot show a label for a choice it doesn't offer. Copilot is
   // omitted entirely where the host can't reach it rather than shown disabled:
   // there is no action the user could take to enable it.
-  // Memoised so the effect below can depend on it directly. The list is derived
-  // purely from these two capability flags, so the identity changes exactly when
-  // they do -- which is exactly when the effect used to re-run via its old
-  // `capabilities.copilot, capabilities.localLlm` dependencies. Behaviour is
-  // unchanged; what changes is that the dependency is now machine-checkable, so a
-  // future input to this list cannot be added without either declaring it here or
-  // failing lint.
+  //
+  // Memoised so the effect below depends on this list by identity instead of on the
+  // flags behind it. That is what makes the dependency checkable: a third input
+  // cannot be added here without declaring it or failing lint.
+  //
+  // The identity is stable in practice, not by contract. React documents useMemo as
+  // a performance optimisation and reserves the right to drop the cache; a dropped
+  // cache would give a fresh identity, re-run the effect and reset the form, losing
+  // unsaved edits. That could not happen before, when the rebuilt-every-render array
+  // was not a dependency. Eviction is tied to Activity/Offscreen unmounting, which
+  // this tree does not use, so the exposure is theoretical -- but it is a practical
+  // guarantee rather than a semantic one.
   const llmProviderOptions = useMemo(
     () => [
       { value: "bedrock", label: "Amazon Bedrock" },
@@ -136,7 +141,7 @@ export function SettingsModal({
     [capabilities.copilot, capabilities.localLlm],
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `visible` is an intentional extra dependency, not a missing one -- it is never read in the body, and its only job is to re-run this effect when the modal reopens so unsaved edits are discarded and the form is reset from `settings`. Removing it would silently start preserving stale edits across opens. The rule cannot express "re-run on this signal", so it stays suppressed; the missing-dependency findings it used to carry are gone now that llmProviderOptions is memoised.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `visible` is listed but not read. It is there to re-run this effect when the modal reopens, resetting the form from `settings` so stale edits are discarded; removing it would silently start preserving them across opens. The rule cannot express "re-run on this signal". Same idiom as the suppression below.
   useEffect(() => {
     // Defence in depth, and generic rather than per-provider: the host already
     // narrows llmProvider to something it can honor before sending config (see
@@ -155,7 +160,7 @@ export function SettingsModal({
 
   // Drop any prior test result when the modal (re)opens so a stale pass/fail
   // from a previous session isn't shown against freshly-loaded settings.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: same rule, lower severity in practice -- `visible` is listed but not read in the body. That is deliberate (the effect exists to clear stale results when the modal reopens), so this one is an idiom the rule cannot express, unlike the finding above.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `visible` is listed but not read. The effect exists to clear stale results when the modal reopens. Same idiom as the suppression above.
   useEffect(() => {
     onClearTest();
   }, [visible, onClearTest]);

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Modal from "@cloudscape-design/components/modal";
 import Box from "@cloudscape-design/components/box";
 import SpaceBetween from "@cloudscape-design/components/space-between";
@@ -107,26 +107,36 @@ export function SettingsModal({
   // dropdown cannot show a label for a choice it doesn't offer. Copilot is
   // omitted entirely where the host can't reach it rather than shown disabled:
   // there is no action the user could take to enable it.
-  const llmProviderOptions = [
-    { value: "bedrock", label: "Amazon Bedrock" },
-    ...(capabilities.copilot
-      ? [
-          {
-            value: "copilot",
-            label: "GitHub Copilot (VS Code built-in)",
-          },
-        ]
-      : []),
-    {
-      value: "local-server",
-      label: "Local server (Ollama / OpenAI-compatible)",
-    },
-    ...(capabilities.localLlm
-      ? [{ value: "local", label: "Local LLM (offline, on-device)" }]
-      : []),
-  ];
+  // Memoised so the effect below can depend on it directly. The list is derived
+  // purely from these two capability flags, so the identity changes exactly when
+  // they do -- which is exactly when the effect used to re-run via its old
+  // `capabilities.copilot, capabilities.localLlm` dependencies. Behaviour is
+  // unchanged; what changes is that the dependency is now machine-checkable, so a
+  // future input to this list cannot be added without either declaring it here or
+  // failing lint.
+  const llmProviderOptions = useMemo(
+    () => [
+      { value: "bedrock", label: "Amazon Bedrock" },
+      ...(capabilities.copilot
+        ? [
+            {
+              value: "copilot",
+              label: "GitHub Copilot (VS Code built-in)",
+            },
+          ]
+        : []),
+      {
+        value: "local-server",
+        label: "Local server (Ollama / OpenAI-compatible)",
+      },
+      ...(capabilities.localLlm
+        ? [{ value: "local", label: "Local LLM (offline, on-device)" }]
+        : []),
+    ],
+    [capabilities.copilot, capabilities.localLlm],
+  );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: GENUINE DEFECT CLASS, not style -- the effect reads llmProviderOptions (both .some and [0].value) but does not list it, so it can act on a stale option list. Ships in the VS Code extension and no linter has ever seen this file. Adding the dep as-is would re-run the effect every render because the array is rebuilt each time; the real fix is to memoise it, which is a behaviour change and so a tracked follow-up rather than part of a toolchain migration.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `visible` is an intentional extra dependency, not a missing one -- it is never read in the body, and its only job is to re-run this effect when the modal reopens so unsaved edits are discarded and the form is reset from `settings`. Removing it would silently start preserving stale edits across opens. The rule cannot express "re-run on this signal", so it stays suppressed; the missing-dependency findings it used to carry are gone now that llmProviderOptions is memoised.
   useEffect(() => {
     // Defence in depth, and generic rather than per-provider: the host already
     // narrows llmProvider to something it can honor before sending config (see
@@ -141,7 +151,7 @@ export function SettingsModal({
         ? settings
         : { ...settings, llmProvider: llmProviderOptions[0].value },
     );
-  }, [settings, visible, capabilities.copilot, capabilities.localLlm]);
+  }, [settings, visible, llmProviderOptions]);
 
   // Drop any prior test result when the modal (re)opens so a stale pass/fail
   // from a previous session isn't shown against freshly-loaded settings.


### PR DESCRIPTION
`useExhaustiveDependencies` reported that the settings effect reads
`llmProviderOptions.some` and `llmProviderOptions[0].value` without listing them.
It was suppressed during the Biome migration with a note calling it a
stale-closure defect. That was overstated: the list is derived purely from
`capabilities.copilot` and `capabilities.localLlm`, both of which WERE in the
dependency array, so the effect already re-ran whenever the options changed.
There was no live bug.

What was real is that the dependency was indirect and therefore unverifiable. A
future input to `llmProviderOptions` -- another capability flag, say -- could be
added without a matching entry in the effect's dependencies, and the effect would
silently start acting on a stale list with nothing to catch it.

Memoising the list on the two flags it actually derives from fixes that. Identity
now changes exactly when those flags change, which is exactly when the effect used
to re-run, so behaviour is unchanged; the difference is that the dependency is
declared where a tool can check it. Adding a third input to the list without
declaring it now fails lint.

The suppression is not removed but its scope shrinks to the one finding that is
genuinely an idiom: `visible` is an intentional extra dependency, never read in
the body, whose only job is to re-run the effect when the modal reopens so
unsaved edits are discarded and the form resets from `settings`. Removing it
would silently start preserving stale edits across opens, and the rule has no way
to express "re-run on this signal". The reason text now says that instead of
claiming a defect.

Verified: no unsuppressed diagnostics remain on the file, both suppressions are
still live (removing them reproduces exactly the two `visible` findings and
nothing else), `tsc --noEmit` is clean, and the webview bundle builds.