### PR TITLE
fix(sdk): record per-item completion so summarized replay rebuilds FLAT map items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `context.map` or `context.parallel` using `nesting: FLAT` whose aggregate result exceeded the
+  256KB checkpoint limit rebuilt an **empty** result on replay, even though every item had
+  succeeded. Such a batch is checkpointed as a summary and reconstructed from its per-item
+  checkpoints on each later resumption, but the reconstruction decided whether an item had finished
+  by probing the item's context checkpoint — and with `FLAT` nesting those per-item contexts are
+  virtual and never checkpointed, so every item read as unfinished and was skipped.
+
+  Code deriving control flow from the batch result (for example a fan-out sized from the results)
+  therefore created a different set of operations on replay than it had live. The replay-consistency
+  check detected the divergence and raised `NonDeterministicExecutionError`, which SDKs at or below
+  2.3.0 reported as a `PENDING` response rather than a failure; once nothing was left pending the
+  service rejected the response with "Cannot return PENDING status with no pending operations" and,
+  after deterministic retries, failed the execution.
+
+  The batch payload now records which items reached a terminal state, and replay reads that record
+  instead of inferring it. Only large batches were affected: a result that fits in a single
+  checkpoint is replayed by deserialization and never enters the reconstruction path.
+
+  One behaviour change on this path: a virtual item that performs no durable operation of its own is
+  now re-driven during replay, so any part of its mapper body not wrapped in a durable operation
+  runs again. This matches the documented contract for virtual contexts and what `NESTED` already
+  does. Such a body is against best practice in any case — a context is a container for durable
+  operations — and the TSDoc for `runInChildContext` and `MapFunc` now says so.
+
 ### Added
 
 - Support for JavaScript runtimes that do not provide `async_hooks.AsyncLocalStorage` or

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/flat-summarized-replay/map-flat-summarized-replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/flat-summarized-replay/map-flat-summarized-replay.test.ts
@@ -1,0 +1,129 @@
+import { LocalDurableTestRunner } from "@aws/durable-execution-sdk-js-testing";
+import { NestingType } from "@aws/durable-execution-sdk-js";
+import { handler } from "./map-flat-summarized-replay";
+
+const ITEM_COUNT = 8;
+
+/**
+ * A map whose aggregate result exceeds the 256KB checkpoint limit is
+ * checkpointed as a summary with ContextOptions.ReplayChildren, and on every
+ * later resumption is rebuilt from its child checkpoints by
+ * ConcurrencyController.replayItems.
+ *
+ * replayItems decided whether each item finished by probing the item's context
+ * checkpoint (`${mapId}-${n}`). With `nesting: FLAT` those per-item contexts are
+ * VIRTUAL and never checkpointed, so the probe found nothing, every item was
+ * treated as non-terminal and skipped, and the rebuilt BatchResult came back
+ * EMPTY even though all items had succeeded.
+ *
+ * Why that is severe rather than cosmetic: code deriving control flow from the
+ * batch result (for example a fan-out sized from the results) creates a
+ * different set of operations on replay than it did live. The replay-consistency
+ * check then detects the divergence and raises NonDeterministicExecutionError,
+ * which SDKs at or below 2.3.0 reported as a PENDING response instead of a
+ * failure. While other work is still draining, PENDING is a legal answer and the
+ * corruption stays invisible; once nothing is left pending the service rejects
+ * the response outright ("Cannot return PENDING status with no pending
+ * operations"), retries deterministically, and fails the execution.
+ *
+ * Only large maps are affected: a result that fits in one checkpoint is stored
+ * whole and replayed by deserialization, never entering the rebuild path.
+ *
+ * The fix records, in the batch summary, which items reached a terminal state.
+ * Replay reads that record rather than inferring terminality from the
+ * checkpoints, which is what makes the two otherwise undecidable cases
+ * decidable: an item that was mid-flight with a finished first operation, and an
+ * item whose body creates no durable operation and therefore leaves no trace at
+ * all. An item's SUCCEEDED/FAILED outcome still comes from re-driving it, so the
+ * record only has to answer "did this finish".
+ *
+ * Consequence worth knowing: a virtual item with no durable operation of its own
+ * is re-driven on replay, so any part of the mapper body not wrapped in a
+ * durable operation runs again. That is the documented contract for virtual
+ * contexts, and is what NESTED already does, but it is new for this path.
+ *
+ * NOTE: a fresh test environment is created per test on purpose. Sharing one
+ * environment lets the virtual clock carry over between runs, which can let the
+ * in-invocation poll timer resolve the wait without ever suspending. No replay
+ * would happen and the FLAT cases would silently pass. The invocation-count
+ * guards below protect against that regressing.
+ */
+describe("map with ReplayChildren (result > 256KB) replayed across a suspension", () => {
+  beforeEach(async () => {
+    await LocalDurableTestRunner.setupTestEnvironment({ skipTime: true });
+  });
+
+  afterEach(async () => {
+    await LocalDurableTestRunner.teardownTestEnvironment();
+  });
+
+  it.each([
+    ["FLAT", NestingType.FLAT],
+    ["NESTED", NestingType.NESTED],
+  ] as const)(
+    "rebuilds the full batch result on replay (%s nesting)",
+    async (_label, nesting) => {
+      const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+      const execution = await runner.run({ payload: { nesting } });
+
+      // Guard: the wait must actually have suspended the first invocation,
+      // otherwise no replay occurred and this test is not exercising
+      // replayItems at all.
+      expect(execution.getInvocations().length).toBeGreaterThanOrEqual(2);
+
+      expect(execution.getStatus()).toBe("SUCCEEDED");
+      expect(execution.getResult()).toEqual({
+        liveResultCount: ITEM_COUNT,
+        // Before the fix, FLAT returned 0 and [] here: replayItems could not
+        // see terminal virtual items, so the rebuilt batch was empty.
+        replayedResultCount: ITEM_COUNT,
+        replayedItems: Array.from({ length: ITEM_COUNT }, (_, i) => i),
+      });
+    },
+    30000,
+  );
+
+  it("rebuilds FLAT items that checkpoint no durable operation of their own", async () => {
+    // A mapper that performs no durable operation leaves nothing beneath a
+    // virtual item, so probing the checkpoints cannot tell that the item ran —
+    // it is indistinguishable from one that never started. Only the per-item
+    // statuses recorded in the summary identify it, so this case is rebuilt
+    // solely on the strength of that record.
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+    const execution = await runner.run({
+      payload: { nesting: NestingType.FLAT, noDurableOperation: true },
+    });
+
+    expect(execution.getInvocations().length).toBeGreaterThanOrEqual(2);
+    expect(execution.getStatus()).toBe("SUCCEEDED");
+    expect(execution.getResult()).toEqual({
+      liveResultCount: ITEM_COUNT,
+      replayedResultCount: ITEM_COUNT,
+      replayedItems: Array.from({ length: ITEM_COUNT }, (_, i) => i),
+    });
+  }, 30000);
+
+  it("replays a small result from cache without entering the rebuild path", async () => {
+    // A result that fits inside a single checkpoint is stored whole, so replay
+    // is a deserialization rather than a reconstruction. This is the boundary
+    // case that always worked, kept here so a regression in the rebuild path
+    // cannot be mistaken for a general replay failure.
+    const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+    const execution = await runner.run({
+      payload: { nesting: NestingType.FLAT, itemPayloadSize: 16 },
+    });
+
+    // Same guard as the other cases: without a suspension there is no replay at
+    // all, and this test would pass without exercising anything.
+    expect(execution.getInvocations().length).toBeGreaterThanOrEqual(2);
+    expect(execution.getStatus()).toBe("SUCCEEDED");
+    expect(execution.getResult()).toEqual({
+      liveResultCount: ITEM_COUNT,
+      replayedResultCount: ITEM_COUNT,
+      replayedItems: Array.from({ length: ITEM_COUNT }, (_, i) => i),
+    });
+  }, 30000);
+});

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/map/flat-summarized-replay/map-flat-summarized-replay.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/map/flat-summarized-replay/map-flat-summarized-replay.ts
@@ -1,0 +1,106 @@
+import {
+  DurableContext,
+  withDurableExecution,
+  NestingType,
+} from "@aws/durable-execution-sdk-js";
+import { ExampleConfig } from "../../../types";
+
+export const config: ExampleConfig = {
+  name: "Map Flat Summarized Replay",
+  description:
+    "A FLAT-nested map whose aggregate result exceeds the 256KB checkpoint " +
+    "limit, so it is checkpointed as a summary (ReplayChildren) and rebuilt " +
+    "from child checkpoints after a suspend/resume. Regression cover for the " +
+    "rebuild dropping every item of a FLAT map: per-item contexts are virtual " +
+    "and never checkpointed, so nothing identified the items that had finished " +
+    "and the replayed batch came back empty even though all items succeeded. " +
+    "The batch payload now records which items reached a terminal state, and " +
+    "replay reads that record.",
+  // The replay under test only happens if the invocation suspends, which relies
+  // on the local runner's virtual clock advancing past a day-long wait. There is
+  // no cloud equivalent, so this stays local rather than being deployed and
+  // silently skipped.
+  localOnly: true,
+};
+
+/**
+ * Per-item payload. ITEM_COUNT items at this size push the aggregate
+ * BatchResult past the 256KB checkpoint limit, which is what routes the map
+ * into ReplayChildren mode — the only path that rebuilds the batch from child
+ * checkpoints, and therefore the only path where this bug is reachable. The
+ * size stays well under the per-operation payload limit so each individual
+ * child checkpoint is unaffected.
+ */
+const ITEM_PAYLOAD_BYTES = 40 * 1024;
+const ITEM_COUNT = 8;
+
+interface ItemResult {
+  item: number;
+  payload: string;
+}
+
+interface Event {
+  itemPayloadSize?: number;
+  nesting?: NestingType;
+  /**
+   * When true the mapper performs NO durable operation, so a FLAT item leaves no
+   * checkpoint of its own. Such an item cannot be reconstructed by probing —
+   * only the per-item statuses recorded in the summary can identify it.
+   */
+  noDurableOperation?: boolean;
+}
+
+export const handler = withDurableExecution(
+  async (event: Event | undefined, context: DurableContext) => {
+    const itemPayloadSize = event?.itemPayloadSize ?? ITEM_PAYLOAD_BYTES;
+    // FLAT is the case under test. The test also runs NESTED through this same
+    // handler as a control, since NESTED checkpoints its item contexts and has
+    // always replayed correctly.
+    const nesting = event?.nesting ?? NestingType.FLAT;
+    const noDurableOperation = event?.noDurableOperation ?? false;
+
+    const items = Array.from({ length: ITEM_COUNT }, (_, i) => i);
+
+    const batch = await context.map(
+      "resolve-pages",
+      items,
+      async (ctx, item, index) => {
+        const value = {
+          item,
+          payload: "x".repeat(itemPayloadSize),
+        };
+        // A plain mapper with no durable operation: nothing is checkpointed
+        // beneath a virtual item, so there is nothing to probe on replay.
+        if (noDurableOperation) {
+          return value;
+        }
+        return ctx.step(`resolve-${index}`, () => Promise.resolve(value));
+      },
+      { nesting },
+    );
+
+    // Records what the LIVE run observed. On replay this step returns its
+    // cached result, so the live observation survives to be compared against
+    // the replayed one.
+    const liveResultCount = await context.step("record-live-count", () =>
+      Promise.resolve(batch.getResults().length),
+    );
+
+    // Suspension point. A wait far beyond the invocation deadline cannot be
+    // resolved by in-invocation polling, so the invocation suspends and
+    // everything below runs in a NEW invocation — one that replays the
+    // (SUCCEEDED, ReplayChildren) map from its child checkpoints.
+    await context.wait("suspend", { days: 1 });
+
+    // Runs for the first time AFTER the resumption, so it observes the
+    // REBUILT batch rather than the live one.
+    const replayedResultCount = await context.step(
+      "record-replayed-count",
+      () => Promise.resolve(batch.getResults().length),
+    );
+
+    const replayedItems = batch.getResults().map((r) => (r as ItemResult).item);
+
+    return { liveResultCount, replayedResultCount, replayedItems };
+  },
+);

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.replay.test.ts
@@ -7,6 +7,7 @@ import {
   DurablePromise,
 } from "../../types";
 import { OperationStatus, OperationType } from "../../types/wire";
+import { NestingType } from "../../types/batch";
 
 describe("ConcurrencyController - Replay Mode", () => {
   let controller: ConcurrencyController<DurableLogger>;
@@ -91,6 +92,465 @@ describe("ConcurrencyController - Replay Mode", () => {
     expect(result.successCount).toBe(2);
     expect(result.totalCount).toBe(2);
     expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not rebuild a virtual item that was mid-flight, when only its first operation succeeded", async () => {
+    // Regression cover for terminality-by-first-operation being unsound.
+    //
+    // A FLAT (virtual) item has no context checkpoint, so its own operations
+    // have to be consulted. An item still in flight at suspension can have a
+    // SUCCEEDED first operation and an unfinished second one. Treating the
+    // first operation as the signal would classify it finished and re-drive it:
+    // its unfinished operations would execute for real (duplicating side
+    // effects) and the rebuilt batch would contain an item the live run never
+    // completed -- the divergence this replay path exists to avoid.
+    //
+    // No per-item statuses are recorded here, so this exercises the probe used
+    // for summaries written before that field existed.
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      completionReason: "MIN_SUCCESSFUL_REACHED",
+      status: "SUCCEEDED",
+      // Deliberately no itemStatuses: legacy checkpoint.
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Item 0 finished: its single operation is terminal.
+      if (id === `${entityId}-1-1`) {
+        return {
+          Id: id,
+          Type: OperationType.STEP,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      // Item 1 was mid-flight: first operation done, second still STARTED.
+      if (id === `${entityId}-2-1`) {
+        return {
+          Id: id,
+          Type: OperationType.STEP,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      if (id === `${entityId}-2-2`) {
+        return {
+          Id: id,
+          Type: OperationType.STEP,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.STARTED,
+        };
+      }
+      // Virtual item contexts are never checkpointed.
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor.mockResolvedValue("result0");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { nesting: NestingType.FLAT },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // Only item 0 is rebuilt. Item 1 is skipped, not re-driven.
+    expect(result.successCount).toBe(1);
+    expect(result.totalCount).toBe(1);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(1);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds virtual items from recorded per-item statuses, including ones that checkpointed nothing", async () => {
+    // A virtual item whose body creates no durable operation leaves no trace at
+    // all, so no probe can distinguish it from an item that never started. The
+    // per-item statuses recorded in the summary are the only signal, and they
+    // also settle the ambiguity of a mid-flight multi-operation item.
+    //
+    // Item 0 succeeded with no operations of its own, item 1 failed, item 2 was
+    // never completed.
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+      { id: "item-2", data: "d2", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 1,
+      failureCount: 1,
+      completionReason: "ALL_COMPLETED",
+      status: "FAILED",
+      itemStatuses: "SF-",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Nothing checkpointed beneath any item.
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor
+      .mockResolvedValueOnce("result0")
+      .mockRejectedValueOnce(new Error("item 1 failed"));
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { nesting: NestingType.FLAT },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.totalCount).toBe(2);
+    // Items 0 and 1 re-driven; item 2 skipped.
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers recorded statuses over an item's own context checkpoint", async () => {
+    // Pins the precedence. The recorded statuses are what the live BatchResult
+    // contained, so they win over the item's context record: a child that
+    // settled after the batch completed early has a terminal context but was
+    // never part of the live result, and rebuilding it would add an item the
+    // live run never reported.
+    //
+    // Item 1 here has a SUCCEEDED context AND a SUCCEEDED first operation, yet
+    // the recorded statuses say it did not complete. It must stay non-terminal.
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      completionReason: "MIN_SUCCESSFUL_REACHED",
+      status: "SUCCEEDED",
+      itemStatuses: "S-",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      // Both items have terminal records of their own; only the statuses
+      // distinguish them.
+      if (
+        id === `${entityId}-1` ||
+        id === `${entityId}-2` ||
+        id === `${entityId}-1-1` ||
+        id === `${entityId}-2-1`
+      ) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor.mockResolvedValue("result0");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(result.totalCount).toBe(1);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(1);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads per-item statuses from a full BatchResult payload (childOperationsDepth path)", async () => {
+    // childOperationsDepth sets ReplayChildren while checkpointing the FULL
+    // serialized result, so the summary generator never runs and there is no
+    // itemStatuses field. That payload already carries `all: [{ index, status }]`,
+    // which is read as the same signal — otherwise this path would still drop
+    // FLAT items with no durable operations of their own.
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+      { id: "item-2", data: "d2", index: 2 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const fullResultPayload = JSON.stringify({
+      all: [
+        { index: 0, result: "r0", status: "SUCCEEDED" },
+        { index: 1, error: { message: "boom" }, status: "FAILED" },
+        { index: 2, status: "STARTED" },
+      ],
+      completionReason: "ALL_COMPLETED",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: fullResultPayload },
+        };
+      }
+      // Virtual items: nothing checkpointed beneath them.
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor
+      .mockResolvedValueOnce("result0")
+      .mockRejectedValueOnce(new Error("item 1 failed"));
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      { nesting: NestingType.FLAT },
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(2);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a crafted or malformed itemStatuses value and falls back", async () => {
+    // Legacy payloads can carry arbitrary JSON. A value outside the marker
+    // alphabet must not be read as terminality; replay falls back to the item's
+    // own records instead.
+    const items = [{ id: "item-0", data: "d0", index: 0 }];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const craftedSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 1,
+      successCount: 1,
+      failureCount: 0,
+      completionReason: "ALL_COMPLETED",
+      status: "SUCCEEDED",
+      itemStatuses: "not-markers",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: craftedSummary },
+        };
+      }
+      if (id === `${entityId}-1`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor.mockResolvedValue("result0");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // Rebuilt from the context record, not from the crafted string.
+    expect(result.successCount).toBe(1);
+  });
+
+  it("skips an item whose recorded status is terminal but whose context checkpoint is not", async () => {
+    // The other direction of the disagreement, and the one that must not
+    // re-drive. Skipping an item the statuses call finished is benign; re-driving
+    // one whose context checkpoint is still non-terminal hangs: in
+    // ReplaySucceededContext, runInChildContext goes through
+    // checkForNonResolvingPromise, which returns a never-resolving promise when
+    // the pending step id has a non-terminal checkpoint. replayItems would await
+    // it forever, the invocation would time out, and the retry would land in the
+    // same state (issue #751).
+    //
+    // Item 1 is marked "S" but its context record is STARTED, so it is skipped.
+    const items = [
+      { id: "item-0", data: "d0", index: 0 },
+      { id: "item-1", data: "d1", index: 1 },
+    ];
+    const executor = jest.fn();
+    const entityId = "parent-step";
+
+    const initialResultSummary = JSON.stringify({
+      type: "MapResult",
+      totalCount: 2,
+      successCount: 2,
+      failureCount: 0,
+      completionReason: "ALL_COMPLETED",
+      status: "SUCCEEDED",
+      itemStatuses: "SS",
+    });
+
+    mockExecutionContext.getStepData.mockImplementation((id: string) => {
+      if (id === entityId) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+          ContextDetails: { Result: initialResultSummary },
+        };
+      }
+      if (id === `${entityId}-1`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.SUCCEEDED,
+        };
+      }
+      // Item 1's context never finished, despite the recorded "S".
+      if (id === `${entityId}-2`) {
+        return {
+          Id: id,
+          Type: OperationType.CONTEXT,
+          StartTimestamp: new Date(),
+          Status: OperationStatus.STARTED,
+        };
+      }
+      return undefined;
+    });
+
+    mockParentContext.runInChildContext.mockImplementation(
+      (nameOrFn, fnOrConfig) => {
+        const fn = typeof nameOrFn === "function" ? nameOrFn : fnOrConfig;
+        return new DurablePromise(async () => {
+          return await (fn as any)({} as any);
+        });
+      },
+    );
+    executor.mockResolvedValue("result0");
+
+    const result = await controller.executeItems(
+      items,
+      executor,
+      mockParentContext,
+      {},
+      DurableExecutionMode.ReplaySucceededContext,
+      entityId,
+      mockExecutionContext,
+    );
+
+    // Only item 0 rebuilt; item 1 skipped rather than re-driven into a hang.
+    expect(result.successCount).toBe(1);
+    expect(mockParentContext.runInChildContext).toHaveBeenCalledTimes(1);
+    expect(mockSkipNextOperation).toHaveBeenCalledTimes(1);
   });
 
   it("should handle failed items during replay", async () => {

--- a/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
+++ b/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/concurrent-execution-handler.ts
@@ -231,14 +231,17 @@ export class ConcurrencyController<Logger extends DurableLogger> {
       // (terminal-only) set is exactly what produced non-deterministic replay,
       // so we read the value the live run recorded instead.
       let recordedCompletionReason: CompletionReason | undefined;
+      let recordedItemStatuses: string | undefined;
       if (entityId && executionContext) {
         const stepData = executionContext.getStepData(entityId);
         const summaryPayload = stepData?.ContextDetails?.Result;
         if (summaryPayload) {
           recordedCompletionReason =
             this.parseRecordedCompletionReason(summaryPayload);
+          recordedItemStatuses = this.parseRecordedItemStatuses(summaryPayload);
           log("📊", "Recovered completion reason from summary:", {
             recordedCompletionReason,
+            hasRecordedItemStatuses: recordedItemStatuses !== undefined,
           });
         }
       }
@@ -258,6 +261,7 @@ export class ConcurrencyController<Logger extends DurableLogger> {
           parentContext,
           config,
           recordedCompletionReason,
+          recordedItemStatuses,
           executionContext,
           entityId,
         );
@@ -319,12 +323,156 @@ export class ConcurrencyController<Logger extends DurableLogger> {
     return undefined;
   }
 
+  /**
+   * Extracts the recorded per-item completion markers from a checkpointed batch
+   * payload. One character per item in index order (`S`/`F`/`-`).
+   *
+   * Two payload shapes are recognised, because ReplayChildren is reached two
+   * ways:
+   *
+   *  - The summary written when the result exceeded the checkpoint size limit,
+   *    which carries `itemStatuses` directly.
+   *  - The FULL serialized BatchResult written when `childOperationsDepth` opts
+   *    a context into child preservation. That path sets ReplayChildren while
+   *    checkpointing the whole result, so the summary generator never runs and
+   *    there is no `itemStatuses` — but the payload already contains
+   *    `all: [{ index, status }]`, which carries the same information.
+   *
+   * Validated as strictly as `parseRecordedCompletionReason`: legacy checkpoints
+   * can carry arbitrary JSON (including free-form strings from pre-fix custom
+   * generators), and the consequence here is terminality decisions rather than a
+   * display field. `Object.hasOwn` keeps inherited keys like `constructor` out,
+   * and the marker alphabet is checked so a crafted value cannot be read as
+   * terminality.
+   *
+   * Returns undefined when the payload is absent, unparseable, or carries
+   * neither shape — in which case replay falls back to probing.
+   */
+  private parseRecordedItemStatuses(
+    summaryPayload: unknown,
+  ): string | undefined {
+    if (typeof summaryPayload !== "string") {
+      return undefined;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(summaryPayload);
+    } catch {
+      // Unparseable payload; fall through to probing.
+      return undefined;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      return undefined;
+    }
+    const record = parsed as Record<string, unknown>;
+
+    // Shape 1: the summary envelope's encoded markers.
+    if (Object.hasOwn(record, "itemStatuses")) {
+      const statuses = record.itemStatuses;
+      if (
+        typeof statuses === "string" &&
+        statuses.length > 0 &&
+        /^[SF-]+$/.test(statuses)
+      ) {
+        return statuses;
+      }
+      return undefined;
+    }
+
+    // Shape 2: a full BatchResult payload (childOperationsDepth path).
+    if (Object.hasOwn(record, "all") && Array.isArray(record.all)) {
+      return this.encodeStatusesFromBatchItems(record.all);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Derives the per-item markers from a checkpointed `all` array, so the
+   * `childOperationsDepth` path (which checkpoints the full result and therefore
+   * has no summary envelope) gets the same treatment as a summarized batch.
+   */
+  private encodeStatusesFromBatchItems(items: unknown[]): string | undefined {
+    let maxIndex = -1;
+    for (const entry of items) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const index = (entry as Record<string, unknown>).index;
+      if (typeof index === "number" && index > maxIndex) {
+        maxIndex = index;
+      }
+    }
+    if (maxIndex < 0) {
+      return undefined;
+    }
+
+    const encoded = new Array<string>(maxIndex + 1).fill("-");
+    for (const entry of items) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const item = entry as Record<string, unknown>;
+      if (typeof item.index !== "number") {
+        continue;
+      }
+      if (item.status === BatchItemStatus.SUCCEEDED) {
+        encoded[item.index] = "S";
+      } else if (item.status === BatchItemStatus.FAILED) {
+        encoded[item.index] = "F";
+      }
+    }
+    return encoded.join("");
+  }
+
+  /**
+   * Whether a virtual item finished, inferred from its own checkpointed
+   * operations. Used ONLY for summaries written before per-item statuses were
+   * recorded.
+   *
+   * A virtual (FLAT) item has no context checkpoint, so its operations are
+   * probed directly. Probing only the first operation would be unsound: an item
+   * that was still in flight can have a SUCCEEDED first operation and would be
+   * misread as finished. Every recorded operation is therefore walked, and the
+   * item counts as finished only if all of them are terminal.
+   *
+   * Step ids come from a per-context counter starting at 1 and increasing by one
+   * per operation, so the recorded ids are contiguous and the walk stops at the
+   * first gap.
+   *
+   * Residual limitation, unavoidable without recorded statuses: an item whose
+   * body creates no durable operation leaves nothing to probe and is
+   * indistinguishable from one that never started, so it reads as unfinished and
+   * is not rebuilt.
+   */
+  private isVirtualItemTerminalByProbe(
+    executionContext: ExecutionContext,
+    childEntityId: string,
+  ): boolean {
+    let found = false;
+    for (let opIndex = 1; ; opIndex++) {
+      const op = executionContext.getStepData(`${childEntityId}-${opIndex}`);
+      if (!op) {
+        break;
+      }
+      found = true;
+      if (
+        op.Status !== OperationStatus.SUCCEEDED &&
+        op.Status !== OperationStatus.FAILED
+      ) {
+        return false;
+      }
+    }
+    return found;
+  }
+
   private async replayItems<T, R>(
     items: ConcurrentExecutionItem<T>[],
     executor: ConcurrentExecutor<T, R, Logger>,
     parentContext: DurableContext<Logger>,
     config: ConcurrencyConfig<R>,
     recordedCompletionReason: CompletionReason | undefined,
+    recordedItemStatuses: string | undefined,
     executionContext: ExecutionContext,
     parentEntityId: string,
   ): Promise<BatchResult<R>> {
@@ -346,10 +494,72 @@ export class ConcurrencyController<Logger extends DurableLogger> {
     for (const item of items) {
       const childEntityId = `${parentEntityId}-${stepCounter + 1}`;
       const childStepData = executionContext.getStepData(childEntityId);
-      const isTerminal =
-        !!childStepData &&
-        (childStepData.Status === OperationStatus.SUCCEEDED ||
-          childStepData.Status === OperationStatus.FAILED);
+
+      // Terminality is resolved in order of authority:
+      //
+      //  1. The per-item statuses recorded on the batch payload, AND any context
+      //     record the item has, which must agree. The statuses are by
+      //     construction what the live BatchResult contained, which is what
+      //     replay has to reproduce, so a "-" marker overrides even a terminal
+      //     context record: a child that settles after the batch completed early
+      //     has a terminal record but was never part of the live result, and
+      //     rebuilding it would add an item the live run never reported.
+      //
+      //     The agreement requirement is not symmetric with that, deliberately.
+      //     The two directions fail very differently:
+      //
+      //       - marker says unfinished, record says terminal -> skip. Benign: the
+      //         item is left out of the rebuild, which is what the live result
+      //         did.
+      //       - marker says terminal, record says unfinished -> re-driving would
+      //         HANG. In ReplaySucceededContext, runInChildContext goes through
+      //         checkForNonResolvingPromise, which returns a never-resolving
+      //         promise when the pending step id has a non-terminal checkpoint.
+      //         replayItems awaits it, the reconstruction never settles, the
+      //         invocation times out and retries into the same state (issue
+      //         #751).
+      //
+      //     So a terminal marker is only honoured when the checkpoints do not
+      //     contradict it. FLAT items have no context record at all, so this
+      //     costs them nothing.
+      //
+      //     Recording the statuses is what makes the two cases no probe can
+      //     settle decidable: a multi-operation item that was mid-flight (its
+      //     first operation can be SUCCEEDED while the item never finished), and
+      //     an item whose body creates no durable operation and so leaves no
+      //     trace at all.
+      //
+      //  2. The item's own CONTEXT checkpoint, for payloads with no recorded
+      //     statuses. NESTED items have one; virtual (FLAT) items never do, which
+      //     is the original bug — the probe below found nothing for every item,
+      //     all were skipped, and the rebuilt batch came back EMPTY even though
+      //     they had all succeeded.
+      //
+      //  3. Probing the item's operations, for payloads predating the recorded
+      //     statuses. See isVirtualItemTerminalByProbe for its limits.
+      //
+      // Only terminality is decided here. An item's SUCCEEDED/FAILED outcome
+      // comes from re-driving it below.
+      const childRecordIsTerminal =
+        !childStepData ||
+        childStepData.Status === OperationStatus.SUCCEEDED ||
+        childStepData.Status === OperationStatus.FAILED;
+
+      let isTerminal: boolean;
+      if (recordedItemStatuses !== undefined) {
+        const marker = recordedItemStatuses[item.index];
+        isTerminal =
+          (marker === "S" || marker === "F") && childRecordIsTerminal;
+      } else if (childStepData) {
+        isTerminal =
+          childStepData.Status === OperationStatus.SUCCEEDED ||
+          childStepData.Status === OperationStatus.FAILED;
+      } else {
+        isTerminal = this.isVirtualItemTerminalByProbe(
+          executionContext,
+          childEntityId,
+        );
+      }
 
       if (isTerminal) {
         // Terminal child: re-drive runInChildContext so it returns the cached

--- a/packages/aws-durable-execution-sdk-js/src/types/batch.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/batch.ts
@@ -348,6 +348,15 @@ export interface CompletionStatus {
  *
  * @public
  */
+/**
+ * Applied to each item of a batch, in that item's own child context.
+ *
+ * The body should perform at least one durable operation (`step`, `invoke`,
+ * `wait`, a nested context, ...). A mapper that only computes buys nothing from
+ * the surrounding context — the work is not checkpointed, so it re-runs on every
+ * replay — and leaves the item with no record of its own. Put the computation in
+ * a `step` instead. See `DurableContext.runInChildContext`.
+ */
 export type MapFunc<TInput, TOutput, Logger extends DurableLogger> = (
   context: DurableContext<Logger>,
   item: TInput,

--- a/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
+++ b/packages/aws-durable-execution-sdk-js/src/types/durable-context.ts
@@ -200,6 +200,13 @@ export interface DurableContext<TLogger extends DurableLogger = DurableLogger> {
    * @param fn - Function to execute in the child context
    * @param config - Optional configuration for serialization and sub-typing
    * @throws \{ChildContextError\} When the child context function fails
+   *
+   * A child context is a container for durable operations: its body should
+   * perform at least one (`step`, `invoke`, `wait`, a nested context, ...).
+   * Wrapping plain computation in a context with nothing durable inside it buys
+   * nothing — the work is not checkpointed, so it re-runs on every replay — and
+   * leaves the context with no record of its own. Put the computation in a
+   * `step` instead.
    * @example
    * ```typescript
    * const result = await context.runInChildContext(
@@ -225,6 +232,13 @@ export interface DurableContext<TLogger extends DurableLogger = DurableLogger> {
    * @param fn - Function to execute in the child context
    * @param config - Optional configuration for serialization and sub-typing
    * @throws \{ChildContextError\} When the child context function fails
+   *
+   * A child context is a container for durable operations: its body should
+   * perform at least one (`step`, `invoke`, `wait`, a nested context, ...).
+   * Wrapping plain computation in a context with nothing durable inside it buys
+   * nothing — the work is not checkpointed, so it re-runs on every replay — and
+   * leaves the context with no record of its own. Put the computation in a
+   * `step` instead.
    * @example
    * ```typescript
    * const result = await context.runInChildContext(

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.test.ts
@@ -2,10 +2,12 @@ import {
   createParallelSummaryGenerator,
   createMapSummaryGenerator,
   composeSummaryGenerator,
+  encodeItemStatuses,
 } from "./summary-generators";
 import { BatchResultImpl } from "../../handlers/concurrent-execution-handler/batch-result";
 import { BatchItemStatus } from "../../types";
 import { ChildContextError } from "../../errors/durable-error/durable-error";
+import { CHECKPOINT_SIZE_LIMIT_BYTES } from "../constants/constants";
 
 describe("Summary Generators", () => {
   describe("createParallelSummaryGenerator", () => {
@@ -30,6 +32,7 @@ describe("Summary Generators", () => {
         startedCount: 0,
         completionReason: "ALL_COMPLETED",
         status: BatchItemStatus.SUCCEEDED,
+        itemStatuses: "SS",
       });
     });
 
@@ -55,6 +58,7 @@ describe("Summary Generators", () => {
         startedCount: 0,
         completionReason: "ALL_COMPLETED",
         status: BatchItemStatus.FAILED,
+        itemStatuses: "SF",
       });
     });
 
@@ -79,6 +83,7 @@ describe("Summary Generators", () => {
         startedCount: 1,
         completionReason: "MIN_SUCCESSFUL_REACHED",
         status: BatchItemStatus.SUCCEEDED,
+        itemStatuses: "S-",
       });
     });
   });
@@ -105,6 +110,7 @@ describe("Summary Generators", () => {
         failureCount: 0,
         completionReason: "ALL_COMPLETED",
         status: BatchItemStatus.SUCCEEDED,
+        itemStatuses: "SSS",
       });
     });
 
@@ -130,6 +136,7 @@ describe("Summary Generators", () => {
         failureCount: 1,
         completionReason: "ALL_COMPLETED",
         status: BatchItemStatus.FAILED,
+        itemStatuses: "SFS",
       });
     });
 
@@ -155,6 +162,7 @@ describe("Summary Generators", () => {
         failureCount: 2,
         completionReason: "FAILURE_TOLERANCE_EXCEEDED",
         status: BatchItemStatus.FAILED,
+        itemStatuses: "FF",
       });
     });
   });
@@ -218,6 +226,89 @@ describe("Summary Generators", () => {
 
       expect(parsed.totalCount).toBe(1); // SDK value, not the custom 999
       expect(parsed.summary).toBe('{"totalCount":999,"mine":true}');
+    });
+  });
+
+  describe("encodeItemStatuses", () => {
+    it("marks succeeded, failed and unfinished items in index order", () => {
+      const error = new ChildContextError("boom");
+      const batchResult = new BatchResultImpl(
+        [
+          { index: 0, result: "r0", status: BatchItemStatus.SUCCEEDED },
+          { index: 1, error, status: BatchItemStatus.FAILED },
+          { index: 2, status: BatchItemStatus.STARTED },
+        ],
+        "ALL_COMPLETED",
+      );
+
+      expect(encodeItemStatuses(batchResult)).toBe("SF-");
+    });
+
+    it("leaves gaps for items absent from the result entirely", () => {
+      // A batch that completed early may never record an item at all. It must
+      // read as unfinished so replay does not rebuild (or re-execute) it.
+      const batchResult = new BatchResultImpl(
+        [
+          { index: 0, result: "r0", status: BatchItemStatus.SUCCEEDED },
+          { index: 3, result: "r3", status: BatchItemStatus.SUCCEEDED },
+        ],
+        "MIN_SUCCESSFUL_REACHED",
+      );
+
+      expect(encodeItemStatuses(batchResult)).toBe("S--S");
+    });
+
+    it("returns an empty string for an empty batch", () => {
+      expect(encodeItemStatuses(new BatchResultImpl([], "ALL_COMPLETED"))).toBe(
+        "",
+      );
+    });
+
+    it("stays compact for large batches (one character per item)", () => {
+      const items = Array.from({ length: 2000 }, (_, index) => ({
+        index,
+        result: "r",
+        status: BatchItemStatus.SUCCEEDED,
+      }));
+      const encoded = encodeItemStatuses(
+        new BatchResultImpl(items, "ALL_COMPLETED"),
+      );
+
+      expect(encoded.length).toBe(2000);
+      expect(encoded).toBe("S".repeat(2000));
+    });
+  });
+
+  describe("size is bounded by the operation limit", () => {
+    it("stays far inside the checkpoint limit at the largest batch the service allows", () => {
+      // Every batch item runs its body inside a context, and a context is meant
+      // to wrap at least one durable operation, so each item costs at least one.
+      // The service caps an execution at 30,000 operations, so no batch reaches
+      // more than about that many items. At one byte per marker the whole summary
+      // stays an order of magnitude inside the 256 KB checkpoint limit, which is
+      // why no size handling is needed — and why adding a cap would be harmful,
+      // since dropping the field sends replay back to a probe that cannot recover
+      // an item whose body created no durable operation.
+      const SERVICE_OPERATION_LIMIT = 30_000;
+      const items = Array.from(
+        { length: SERVICE_OPERATION_LIMIT },
+        (_, index) => ({
+          index,
+          result: "r",
+          status: BatchItemStatus.SUCCEEDED,
+        }),
+      );
+
+      const summary = createMapSummaryGenerator()(
+        new BatchResultImpl(items, "ALL_COMPLETED"),
+      );
+
+      expect(JSON.parse(summary).itemStatuses).toBe(
+        "S".repeat(SERVICE_OPERATION_LIMIT),
+      );
+      expect(Buffer.byteLength(summary, "utf8")).toBeLessThan(
+        CHECKPOINT_SIZE_LIMIT_BYTES / 8,
+      );
     });
   });
 

--- a/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
+++ b/packages/aws-durable-execution-sdk-js/src/utils/summary-generators/summary-generators.ts
@@ -1,4 +1,76 @@
 import { BatchResult } from "../../types";
+import { BatchItemStatus } from "../../types/batch";
+
+/**
+ * Marker characters for {@link encodeItemStatuses}. One character per item, in
+ * item-index order.
+ */
+const ITEM_STATUS_SUCCEEDED = "S";
+const ITEM_STATUS_FAILED = "F";
+/** Started-but-unfinished, or never started. Both are "do not rebuild". */
+const ITEM_STATUS_INCOMPLETE = "-";
+
+/**
+ * Encodes which items reached a terminal state, one character per item in index
+ * order (`S` succeeded, `F` failed, `-` neither).
+ *
+ * Replay of a summarized batch has to know which items completed. Probing the
+ * checkpoints cannot answer that reliably:
+ *
+ *  - A virtual (FLAT) item has no context checkpoint of its own, so there is
+ *    nothing to probe directly.
+ *  - Probing the item's first child operation is unsound for multi-operation
+ *    items: an item that was still in flight can have a SUCCEEDED first
+ *    operation and would be misread as finished, then re-driven — duplicating
+ *    the side effects of its unfinished operations and rebuilding a batch
+ *    containing items the live run never completed.
+ *
+ * Recording the outcome the live run observed removes both ambiguities. Only
+ * terminality has to be recorded: an item's SUCCEEDED/FAILED outcome comes from
+ * re-driving it during replay, not from this record.
+ *
+ * SIZE: no size handling is needed here, and none should be added. Every batch
+ * item runs its body inside a context, and a context is meant to wrap at least
+ * one durable operation (see `DurableContext.runInChildContext`), so each item
+ * costs at least one operation. The service caps an execution at 30,000
+ * operations, which bounds any batch at roughly that many items — about 30 KB of
+ * markers at one byte each, comfortably inside the 256 KB checkpoint limit that
+ * put this batch on the summarized path in the first place.
+ *
+ * Capping the marker count instead would be actively harmful: dropping the field
+ * sends replay back to probing the checkpoints, and probing cannot recover a
+ * completed item whose body created no durable operation — which is the very
+ * corruption this record exists to prevent.
+ */
+export const encodeItemStatuses = <T>(result: BatchResult<T>): string => {
+  const items = result.all ?? [];
+  if (items.length === 0) {
+    return "";
+  }
+
+  let maxIndex = -1;
+  for (const item of items) {
+    if (typeof item.index === "number" && item.index > maxIndex) {
+      maxIndex = item.index;
+    }
+  }
+  if (maxIndex < 0) {
+    return "";
+  }
+
+  const encoded = new Array<string>(maxIndex + 1).fill(ITEM_STATUS_INCOMPLETE);
+  for (const item of items) {
+    if (typeof item.index !== "number") {
+      continue;
+    }
+    if (item.status === BatchItemStatus.SUCCEEDED) {
+      encoded[item.index] = ITEM_STATUS_SUCCEEDED;
+    } else if (item.status === BatchItemStatus.FAILED) {
+      encoded[item.index] = ITEM_STATUS_FAILED;
+    }
+  }
+  return encoded.join("");
+};
 
 /**
  * Creates a predefined summary generator for parallel operations
@@ -14,6 +86,7 @@ export const createParallelSummaryGenerator =
       startedCount: result.startedCount,
       completionReason: result.completionReason,
       status: result.status,
+      itemStatuses: encodeItemStatuses(result),
     });
   };
 
@@ -30,6 +103,7 @@ export const createMapSummaryGenerator =
       failureCount: result.failureCount,
       completionReason: result.completionReason,
       status: result.status,
+      itemStatuses: encodeItemStatuses(result),
     });
   };
 


### PR DESCRIPTION
`context.map` and `context.parallel` with `nesting: FLAT` rebuilt an **empty** result on replay when the batch was large enough to be summarized, even though every item had succeeded.

A batch whose aggregate result exceeds the checkpoint size limit is stored as a summary with `ReplayChildren`, and each later resumption reconstructs it from the per-item checkpoints in `ConcurrencyController.replayItems`. That reconstruction decided whether an item had finished by probing the item's context checkpoint — but with `FLAT` nesting the per-item contexts are virtual and never checkpointed, so every item read as unfinished and was skipped.

Not cosmetic: code deriving control flow from the batch result, such as a fan-out sized from the results, then creates a different set of operations on replay than it did live. The replay-consistency check detects the divergence and raises `NonDeterministicExecutionError`, which SDKs at or below 2.3.0 reported as a `PENDING` response rather than a failure. While other work is still draining `PENDING` is a legal answer, so the corruption is invisible; once nothing is left pending the service rejects the response with "Cannot return PENDING status with no pending operations" and the execution fails after deterministic retries. Batches whose result fits in one checkpoint are replayed by deserialization and never enter this path.

## Change

The batch payload now records which items reached a terminal state, one character per item in index order. Replay reads that record instead of inferring it. Only terminality is recorded — an item's `SUCCEEDED`/`FAILED` outcome still comes from re-driving it.

Terminality resolves in order of authority:

1. the recorded statuses, with any context record the item has required to agree
2. the item's own context checkpoint, for payloads with no recorded statuses
3. a probe of the item's operations, for payloads predating the field

The agreement requirement in (1) is one-sided on purpose. A marker saying unfinished overrides a terminal context record, because the statuses are what the live `BatchResult` contained. The reverse is not honoured: re-driving an item whose context checkpoint is non-terminal hits `checkForNonResolvingPromise` and the reconstruction never settles (#751).

The probe in (3) walks every recorded operation and requires all of them to be terminal. Reading only the first is unsound — a mid-flight item can have a `SUCCEEDED` first operation, and re-driving it would execute its unfinished operations for real.

Two payload shapes are recognised, since `ReplayChildren` is reached two ways: the summary envelope carrying `itemStatuses`, and the full serialized result written when `childOperationsDepth` opts a context into child preservation, which has no summary envelope but does carry `all: [{ index, status }]`. Parsing is validated as strictly as `parseRecordedCompletionReason`.

There is deliberately no size handling on the record. Every batch item runs its body inside a context, and a context is meant to wrap at least one durable operation, so each item costs at least one. The service caps an execution at 30,000 operations, which bounds any batch at roughly that many items — about 30 KB of markers at one byte each, an order of magnitude inside the 256 KB checkpoint limit. Capping the marker count instead would be actively harmful: dropping the field sends replay back to probing, and probing cannot recover an item whose body created no durable operation, which is the corruption this record exists to prevent. A test pins the bound at the largest batch the service allows.

## Behaviour change

A virtual item with no durable operation of its own is now re-driven on replay, so any part of its mapper body not wrapped in a durable operation runs again. This is the documented contract for virtual contexts and what `NESTED` already does, but it is new on this path.

That shape is against best practice regardless — a context is a container for durable operations, and one with nothing durable inside it is not checkpointed, so its work re-runs on every replay anyway. The TSDoc for `DurableContext.runInChildContext` and `MapFunc` now says so, and #896 tracks an eslint rule for it.

## Testing

New `examples/map/flat-summarized-replay` covering the rebuild across a suspension for `FLAT` and `NESTED`, an item that checkpoints no durable operation, and a small-result control. It is `localOnly`: the suspension depends on the local runner's virtual clock, so deploying it would only produce a skipped cloud test. Every case asserts at least two invocations, so none can pass without actually suspending.

Against unpatched code both `FLAT` cases fail (`replayedResultCount` 0 against a live count of 8) while the controls pass. 14 new unit cases cover both directions of a statuses/record disagreement, the `childOperationsDepth` shape, a crafted `itemStatuses` value, the probe rejecting a mid-flight item, and the size bound at the service's operation limit.

The `PENDING` misreport that hid this was fixed separately on mainline by #867; this addresses the underlying corruption.
