### PR TITLE
build: upgrade TypeScript to 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@
 **/.rollup.cache
 *.d.ts.map
 *.d.ts
+# ...but hand-written declarations belong in source control. The blanket *.d.ts
+# rule above exists for emitted output (dist-types/, dist/), and it silently
+# swallowed a new ambient declaration -- which also means Biome never sees such a
+# file, since vcs.useIgnoreFile is on. Anything authored under a src/ tree is a
+# source file and is tracked.
+!**/src/**/*.d.ts
 *.tgz
 
 # Nothing passes --cache today, but ESLint still runs here (the plugin package's

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -248,10 +248,14 @@
   //
   // TWO KNOWN HOLES IN WHAT BIOME SEES, both latent and both predating this change:
   //
-  //   * `vcs.useIgnoreFile` is true and .gitignore carries `*.d.ts`, so a
-  //     hand-written .d.ts would escape Biome entirely rather than merely go
-  //     unformatted. No tracked .d.ts exists today (verified: `git ls-files '*.d.ts'`
-  //     is empty), so this only bites if someone adds one -- but it would be silent.
+  //   * `vcs.useIgnoreFile` is true and .gitignore carries `*.d.ts`, which meant a
+  //     hand-written declaration escaped Biome entirely rather than merely going
+  //     unformatted. This stopped being hypothetical during the TypeScript 6 upgrade:
+  //     a new ambient declaration for CSS side-effect imports was silently untracked
+  //     AND unlinted. .gitignore now negates `**/src/**/*.d.ts`, so authored
+  //     declarations under a src/ tree are tracked and linted while emitted output
+  //     (dist-types/, dist/) stays ignored. A .d.ts authored OUTSIDE a src/ tree
+  //     would still slip through.
   //   * Unused `biome-ignore format:` suppressions are not reported by anything.
   //     `lint:suppressions` runs `biome check`, which covers lint and assist
   //     categories, but Biome reports no unused-suppression diagnostic for the

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,10 @@
         "lint-staged": "^16.2.3",
         "rollup": "^4.59.0",
         "rollup-plugin-node-externals": "^8.1.1",
-        "ts-jest": "^29.4.0",
+        "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.3",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3877,6 +3877,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -16683,19 +16697,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -16712,7 +16726,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -16736,9 +16750,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -16933,9 +16947,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17721,9 +17735,9 @@
         "@types/aws-lambda": "^8.10.147",
         "jest": "^29.7.0",
         "rimraf": "^5.0.10",
-        "ts-jest": "^29.2.6",
+        "ts-jest": "^29.4.12",
         "tsx": "^4.19.3",
-        "typescript": "^5.7.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -17744,7 +17758,7 @@
         "@types/node": "^22.13.5",
         "rollup": "^4.0.0",
         "tslib": "^2.6.0",
-        "typescript": "^5.8.2"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -17768,9 +17782,9 @@
         "@types/node": "^22.19.11",
         "jest": "^30.0.3",
         "rollup": "^4.57.1",
-        "ts-jest": "^29.4.0",
+        "ts-jest": "^29.4.12",
         "tslib": "^2.8.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -17833,8 +17847,8 @@
         "@typescript-eslint/parser": "^8.44.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.6",
-        "typescript": "^5.8.2"
+        "ts-jest": "^29.4.12",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -19233,10 +19247,10 @@
         "eslint": "^9.29.0",
         "jest": "^30.2.0",
         "js-yaml": "^4.3.0",
-        "ts-jest": "^29.2.6",
+        "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.8.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.15"
       },
       "engines": {
@@ -19486,9 +19500,9 @@
         "concurrently": "^9.2.4",
         "jest": "^29.7.0",
         "rollup": "^4.0.0",
-        "ts-jest": "^29.2.6",
+        "ts-jest": "^29.4.12",
         "tslib": "^2.6.0",
-        "typescript": "~5.8.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -19572,8 +19586,8 @@
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.0",
-        "typescript": "~5.8.0"
+        "ts-jest": "^29.4.12",
+        "typescript": "^6.0.3"
       }
     },
     "packages/aws-durable-execution-sdk-js-insight-core/node_modules/@jest/console": {
@@ -20745,20 +20759,6 @@
         "node": ">=8"
       }
     },
-    "packages/aws-durable-execution-sdk-js-insight-core/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/aws-durable-execution-sdk-js-insight-core/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -20787,8 +20787,8 @@
         "electron-builder": "26.15.3",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.0",
-        "typescript": "~5.8.0"
+        "ts-jest": "^29.4.12",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -22429,20 +22429,6 @@
         "node": ">=8"
       }
     },
-    "packages/aws-durable-execution-sdk-js-insight-desktop/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/aws-durable-execution-sdk-js-insight-desktop/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -22473,8 +22459,8 @@
         "@types/jest": "^29.5.0",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.0",
-        "typescript": "~5.8.0"
+        "ts-jest": "^29.4.12",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -24069,20 +24055,6 @@
         "node": ">=8"
       }
     },
-    "packages/aws-durable-execution-sdk-js-insight-mcp/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/aws-durable-execution-sdk-js-insight-mcp/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -24110,8 +24082,8 @@
         "@types/vscode": "^1.90.0",
         "esbuild": "^0.24.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.0",
-        "typescript": "~5.8.0"
+        "ts-jest": "^29.4.12",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20",
@@ -25753,20 +25725,6 @@
         "node": ">=8"
       }
     },
-    "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/aws-durable-execution-sdk-js-insight-vscode/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -27008,20 +26966,6 @@
         "node": ">=8"
       }
     },
-    "packages/aws-durable-execution-sdk-js-insight/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/aws-durable-execution-sdk-js-insight/node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
@@ -27045,7 +26989,7 @@
         "@opentelemetry/core": "^2.0.0",
         "fast-check": "^3.23.2",
         "jest": "^30.0.3",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -27084,7 +27028,7 @@
         "jest": "^30.0.3",
         "semver": "^7.5.4",
         "tsx": "^4.20.5",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "lint-staged": "^16.2.3",
     "rollup": "^4.59.0",
     "rollup-plugin-node-externals": "^8.1.1",
-    "ts-jest": "^29.4.0",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "lint-staged": {
     "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,json,jsonc}": [

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/jest.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/jest.config.mjs
@@ -14,7 +14,7 @@ import { createDefaultPreset } from "ts-jest";
 const preset = createDefaultPreset({
   tsconfig: {
     module: "commonjs",
-    moduleResolution: "node",
+    moduleResolution: "bundler",
   },
 });
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/jest.config.mjs
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/jest.config.mjs
@@ -15,6 +15,10 @@ const preset = createDefaultPreset({
   tsconfig: {
     module: "commonjs",
     moduleResolution: "bundler",
+    // tsconfig.json sets rootDir to ./handlers for rollup. These tests live in
+    // __tests__/, outside that root, so widen it here -- otherwise ts-jest cannot
+    // place its output and refuses to transform them.
+    rootDir: ".",
   },
 });
 

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/package.json
@@ -29,8 +29,8 @@
     "@types/node": "^22.19.11",
     "jest": "^30.0.3",
     "rollup": "^4.57.1",
-    "ts-jest": "^29.4.0",
+    "ts-jest": "^29.4.12",
     "tslib": "^2.8.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "compilerOptions": {
+    // ts-jest derives its output path from `outDir`, and TypeScript 6 changed the
+    // `rootDir` default from "inferred common source directory" to "the tsconfig's
+    // own directory". Without an explicit outDir, ts-jest computes "." and refuses to
+    // transform. This project only ever type-checks (`tsc --noEmit`), so the value is
+    // never written to -- it exists to give ts-jest something usable.
+    "outDir": "dist",
+    "types": ["node", "jest"],
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    // `include` is handlers/ only, and rollup's TypeScript plugin needs rootDir stated
+    // explicitly since TypeScript 6 stopped inferring it (TS5011). The jest config
+    // overrides this to "." because the tests live in __tests__/, outside handlers/.
+    "rootDir": "./handlers",
     // ts-jest derives its output path from `outDir`, and TypeScript 6 changed the
     // `rootDir` default from "inferred common source directory" to "the tsconfig's
     // own directory". Without an explicit outDir, ts-jest computes "." and refuses to

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_external_update_on_invoke.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_external_update_on_invoke.ts
@@ -9,10 +9,11 @@ const PLUGIN = "CONFPLUGIN";
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_faulty_and_healthy.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_faulty_and_healthy.ts
@@ -18,10 +18,11 @@ function isStep(type?: string): boolean {
 // still dispatch to the healthy plugin.
 function makeFaultyPlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {
@@ -60,10 +61,11 @@ function makeFaultyPlugin(): DurableInstrumentationPlugin {
 // hook despite the faulty plugin throwing at each boundary.
 function makeHealthyPlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_nested_parent_linkage.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_nested_parent_linkage.ts
@@ -9,10 +9,11 @@ const PLUGIN = "CONFPLUGIN";
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_operation_change.ts
@@ -9,10 +9,11 @@ const PLUGIN = "CONFPLUGIN";
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_parallel_branch_hooks.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_parallel_branch_hooks.ts
@@ -9,10 +9,11 @@ const PLUGIN = "CONFPLUGIN";
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_replay_flags.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_replay_flags.ts
@@ -15,10 +15,11 @@ function isStep(type?: string): boolean {
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_retry_exhaustion.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_retry_exhaustion.ts
@@ -15,10 +15,11 @@ function isStep(type?: string): boolean {
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_suspension_invocation_end.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_suspension_invocation_end.ts
@@ -17,10 +17,11 @@ function makePlugin(): DurableInstrumentationPlugin {
   // only the start-hook InvocationInfo does — so start-capture is the only
   // real API path.
   let first = false;
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_payloads.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_terminal_payloads.ts
@@ -14,10 +14,11 @@ function isStep(type?: string): boolean {
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_wait_operation_hooks.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_wait_operation_hooks.ts
@@ -13,10 +13,11 @@ function isWait(type?: string): boolean {
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_wait_replay_flag.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/handlers/plugin/plugin_wait_replay_flag.ts
@@ -13,10 +13,11 @@ function isWait(type?: string): boolean {
 
 function makePlugin(): DurableInstrumentationPlugin {
   let executionArn = "";
-  const emit = (rec: Record<string, unknown>): void =>
+  const emit = (rec: Record<string, unknown>): void => {
     process.stdout.write(
       JSON.stringify({ ...rec, durableExecutionArn: executionArn }) + "\n",
     );
+  };
 
   return {
     async onInvocationStart(info): Promise<void> {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/package.json
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/package.json
@@ -25,6 +25,6 @@
     "@types/node": "^22.13.5",
     "rollup": "^4.0.0",
     "tslib": "^2.6.0",
-    "typescript": "^5.8.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/aws-durable-execution-sdk-js-conformance-tests/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "rootDir": "./handlers",
+    "types": ["node", "jest"],
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/package.json
@@ -38,8 +38,8 @@
     "@typescript-eslint/parser": "^8.44.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.6",
-    "typescript": "^5.8.2"
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist/**/*",

--- a/packages/aws-durable-execution-sdk-js-eslint-plugin/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-eslint-plugin/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "jest"],
     "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ES2022"],

--- a/packages/aws-durable-execution-sdk-js-examples/package.json
+++ b/packages/aws-durable-execution-sdk-js-examples/package.json
@@ -74,10 +74,10 @@
     "eslint": "^9.29.0",
     "jest": "^30.2.0",
     "js-yaml": "^4.3.0",
-    "ts-jest": "^29.2.6",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.8.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.15"
   },
   "private": true

--- a/packages/aws-durable-execution-sdk-js-insight-core/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-core/package.json
@@ -30,8 +30,8 @@
     "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "typescript": "~5.8.0"
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/aws-durable-execution-sdk-js-insight-core/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-core/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "rootDir": "./src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/aws-durable-execution-sdk-js-insight-desktop/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-desktop/package.json
@@ -32,8 +32,8 @@
     "electron-builder": "26.15.3",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "typescript": "~5.8.0"
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3"
   },
   "build": {
     "appId": "com.amazon.aws.durable-execution-sdk-js-insight-desktop",

--- a/packages/aws-durable-execution-sdk-js-insight-desktop/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-desktop/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "rootDir": "./src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/aws-durable-execution-sdk-js-insight-mcp/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-mcp/package.json
@@ -31,8 +31,8 @@
     "@types/jest": "^29.5.0",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "typescript": "~5.8.0",
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3",
     "@aws/durable-execution-sdk-js-insight-core": "0.1.0-alpha.0"
   },
   "jest": {

--- a/packages/aws-durable-execution-sdk-js-insight-mcp/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-mcp/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/package.json
@@ -278,8 +278,8 @@
     "@types/vscode": "^1.90.0",
     "esbuild": "^0.24.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "typescript": "~5.8.0"
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package-lock.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "esbuild": "^0.28.1",
-        "typescript": "~5.8.0"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1432,9 +1432,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/package.json
@@ -21,6 +21,6 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "esbuild": "^0.28.1",
-    "typescript": "~5.8.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/css-modules.d.ts
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/src/css-modules.d.ts
@@ -1,0 +1,10 @@
+// TypeScript 6.0 turns `noUncheckedSideEffectImports` on by default, so a
+// side-effect import with no declaration is an error rather than silently ignored.
+// The stylesheet imports here are resolved by esbuild at bundle time, not by
+// TypeScript, so they need declaring for the checker's benefit.
+//
+// Declared narrowly (stylesheets only) on purpose: the point of the new default is
+// to catch typos in side-effect imports, and turning the flag off in tsconfig would
+// give that up for every import in the package rather than just these.
+declare module "*.css";
+declare module "*.scss";

--- a/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight-vscode/webview-ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/package.json
@@ -30,8 +30,8 @@
     "aws-cdk": "^2.150.0",
     "esbuild": "^0.24.2",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "typescript": "^5.5.0"
+    "ts-jest": "^29.4.12",
+    "typescript": "^6.0.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-insight/cdk/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "jest"],
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],

--- a/packages/aws-durable-execution-sdk-js-insight/package.json
+++ b/packages/aws-durable-execution-sdk-js-insight/package.json
@@ -94,7 +94,7 @@
   "devDependencies": {
     "@aws/durable-execution-sdk-js": "*",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.6",
+    "ts-jest": "^29.4.12",
     "@aws-sdk/client-s3": "^3.658.0",
     "@aws-sdk/client-dynamodb": "^3.658.0",
     "@aws-sdk/util-dynamodb": "^3.658.0",
@@ -113,7 +113,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-esm-shim": "^0.1.0",
     "@rollup/plugin-replace": "^6.0.0",
-    "typescript": "~5.8.0",
+    "typescript": "^6.0.3",
     "tslib": "^2.6.0",
     "@biomejs/biome": "2.5.11"
   }

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/core": "^2.0.0",
     "fast-check": "^3.23.2",
     "jest": "^30.0.3",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@aws/durable-execution-sdk-js": ">=2.1.0",

--- a/packages/aws-durable-execution-sdk-js-otel/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-otel/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "outDir": "./dist",
     "sourceMap": true,

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -53,7 +53,7 @@
     "jest": "^30.0.3",
     "semver": "^7.5.4",
     "tsx": "^4.20.5",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.1014.0",

--- a/packages/aws-durable-execution-sdk-js-testing/tsconfig.json
+++ b/packages/aws-durable-execution-sdk-js-testing/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "declaration": true,
     "outDir": "./dist",
     "sourceMap": true,

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -51,9 +51,9 @@
     "@types/aws-lambda": "^8.10.147",
     "jest": "^29.7.0",
     "rimraf": "^5.0.10",
-    "ts-jest": "^29.2.6",
+    "ts-jest": "^29.4.12",
     "tsx": "^4.19.3",
-    "typescript": "^5.7.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.1014.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "jest"],
     "paths": {
       "@aws/durable-execution-sdk-js": [
         "./packages/aws-durable-execution-sdk-js"


### PR DESCRIPTION
TypeScript 6.0 is the last release built on the JavaScript codebase and the
required stepping stone to 7.0, the Go port. It is API-compatible with 5.9 but
changes several compiler-option defaults and turns a set of deprecations into
errors, so the upgrade is mostly configuration.

Dependencies: typescript ^5.x -> ^6.0.3 across all 15 declaring package.json
files, which also unifies four different ranges (^5.5.0, ^5.7.3, ~5.8.0, ^5.9.3)
onto one. ts-jest ^29.2.x -> ^29.4.12, required because ts-jest's TypeScript peer
range was `>=4.3 <6` until 29.4.7 widened it to `>=4.3 <7`.

WHAT BROKE, AND WHY

`types` now defaults to `[]` instead of enumerating node_modules/@types. This was
the entire upgrade, numerically: 15,700 of the ~16,000 initial errors were
"Cannot find name 'describe'/'process'/'expect'". Added explicit `types` arrays to
the six configs that relied on auto-discovery. The four insight packages already
declared theirs, so they were untouched.

`rootDir` no longer infers the common source directory; it defaults to the
tsconfig's own directory. Six configs relied on the inference and failed with
TS5011 once emit was involved -- which `tsc --noEmit` hides, so this only appeared
in `npm run build` and under ts-jest. Set explicitly per package. Deliberately NOT
set in the root tsconfig: `extends` resolves rootDir relative to the file that
declares it, so a root value would have pointed every package at the repo root.

`moduleResolution: node` (node10) is deprecated and errors. The four insight
packages used it; all four now use `bundler`, which 6.0 newly permits alongside
`module: commonjs` and which the release notes name as the recommended path. One
jest config carried the same value as an inline ts-jest override and needed the
same fix.

Twelve arrow functions annotated `(): void =>` with a concise body returning
`process.stdout.write(...)` -- which returns boolean -- are now errors. 6.0 no
longer accepts a value-returning expression body against an explicit void
annotation. Wrapped the bodies in braces, which is what they meant.

One config needed an explicit `outDir`. ts-jest derives its output path from
rootDir, and with rootDir now defaulting to the config's own directory it computed
"." and refused to transform. The value is never written to -- that project only
type-checks -- so it exists purely to give ts-jest something usable.

VERIFICATION

Every package type-checks clean, `npm run build` exits 0, and the full test suite
passes: 1237 core SDK, 1178 testing, 404 insight-mcp, 385 insight-core, 287 otel,
181 examples, 90 eslint-plugin, 81 insight, 48 insight-desktop, 35
conformance-otel, 33 insight-vscode. lint:ci, lint, lint:versions, lint:filenames,
lint:suppressions, lint:report, lint:durable-rules, actionlint and the webview
tsc all exit 0. The Biome warning backlog is unchanged at 996/19, so the upgrade
introduced no new lint findings.

Two pre-existing failures are untouched. `packages/.../insight/cdk` reports 41
errors because `aws-cdk-lib` is not installed: `workspaces` is `packages/*`, which
does not match `packages/X/cdk`, so its dependencies were never fetched. It is
not built, tested or referenced by any workflow. And one examples test asserting
an exact replay invocation count is flaky under parallel load -- it passed 3/3 in
isolation and on a second full run.

NOT DONE: TypeScript 7. It ships without a compiler API until 7.1, and
api-extractor, ts-jest, typescript-eslint, ts-node and tsx all need one. The
documented path is an npm alias pinning those to 6.0 while `tsc` runs 7.0, which
is a separate change.