### PR TITLE
chore(sdk): bump core SDK to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1]
+
 ### Fixed
 
 - A `context.map` or `context.parallel` using `nesting: FLAT` whose aggregate result exceeded the
@@ -33,18 +35,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does. Such a body is against best practice in any case — a context is a container for durable
   operations — and the TSDoc for `runInChildContext` and `MapFunc` now says so.
 
-### Added
+- Replay validation now reports a failure instead of asking the service to keep the execution
+  alive. `NonDeterministicExecutionError` is the only production error carrying
+  `TerminationReason.CUSTOM`, and the termination branch had no case for it, so it fell through to
+  the catch-all and answered `{Status: "PENDING"}` with no error and no log line. The fault is
+  deterministic, so every replay reproduced it, the diagnostic the SDK had already built never
+  reached the caller, and once nothing was actually pending the service rejected the response with
+  "Cannot return PENDING status with no pending operations".
 
-- Support for JavaScript runtimes that do not provide `async_hooks.AsyncLocalStorage` or
-  `util.formatWithOptions`, so durable functions can be deployed on a container image carrying
-  a runtime Lambda does not manage (for example [LLRT](https://github.com/awslabs/llrt)).
-  Previously, importing `withDurableExecution` on such a runtime threw at module load.
+  Suspend reasons are now an allowlist and every other reason answers `FAILED` carrying the error,
+  so a reason added later without a branch fails closed rather than silently claiming progress.
 
-  Both capabilities are feature-detected, so this changes nothing on a managed Node.js runtime.
-  Checkpointing and replay are unaffected and checkpoint data is unchanged; what degrades is
-  observability, and the SDK now emits one warning per execution environment describing exactly
-  what. See "Runtime requirements" in the SDK README for the details, including the replayed-log
-  behaviour that carries a CloudWatch cost on long executions.
+- `waitForCondition` no longer discards checkpointed state when a custom serdes fails to
+  deserialize it on a resumed invocation. Previously the restore path caught the
+  deserialization error and silently fell back to `initialState`, so the condition loop
+  restarted from scratch and the operation could succeed carrying a result computed from
+  the wrong state. That path now goes through the same `safeDeserialize` helper the rest
+  of the SDK already used, which terminates the invocation with `SERDES_FAILED` instead.
+
+  This is a behaviour change for anyone whose custom serdes can fail while restoring
+  state: such an execution now terminates rather than continuing from `initialState`.
+  Termination is retryable at the service level, so a transient serdes failure is not
+  permanently fatal.
+
+## [eslint-plugin 1.1.0]
 
 ### Changed
 
@@ -70,18 +84,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `waitForCondition` no longer discards checkpointed state when a custom serdes fails to
-  deserialize it on a resumed invocation. Previously the restore path caught the
-  deserialization error and silently fell back to `initialState`, so the condition loop
-  restarted from scratch and the operation could succeed carrying a result computed from
-  the wrong state. That path now goes through the same `safeDeserialize` helper the rest
-  of the SDK already used, which terminates the invocation with `SERDES_FAILED` instead.
-
-  This is a behaviour change for anyone whose custom serdes can fail while restoring
-  state: such an execution now terminates rather than continuing from `initialState`.
-  Termination is retryable at the service level, so a transient serdes failure is not
-  permanently fatal.
-
 - **eslint-plugin** (`1.1.0`): false positives in `no-closure-in-durable-operations` and
   `no-non-deterministic-outside-step`.
   - A non-deterministic function no longer taints unrelated same-named functions in other
@@ -91,6 +93,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A named function expression assigning to **its own name** is no longer reported.
   - Mutating a variable from a **destructured declaration** (`let { total } = event`) or one
     declared in an **outer nested block** is now correctly reported rather than missed.
+
+## [2.3.0]
+
+### Added
+
+- Support for JavaScript runtimes that do not provide `async_hooks.AsyncLocalStorage` or
+  `util.formatWithOptions`, so durable functions can be deployed on a container image carrying
+  a runtime Lambda does not manage (for example [LLRT](https://github.com/awslabs/llrt)).
+  Previously, importing `withDurableExecution` on such a runtime threw at module load.
+
+  Both capabilities are feature-detected, so this changes nothing on a managed Node.js runtime.
+  Checkpointing and replay are unaffected and checkpoint data is unchanged; what degrades is
+  observability, and the SDK now emits one warning per execution environment describing exactly
+  what. See "Runtime requirements" in the SDK README for the details, including the replayed-log
+  behaviour that carries a CloudWatch cost on long executions.
 
 ## [2.0.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17710,7 +17710,7 @@
     },
     "packages/aws-durable-execution-sdk-js": {
       "name": "@aws/durable-execution-sdk-js",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.1014.0"
@@ -27090,7 +27090,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.0"
+        "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.1"
       }
     },
     "packages/aws-durable-execution-sdk-js-testing/node_modules/@sinonjs/fake-timers": {

--- a/packages/aws-durable-execution-sdk-js-testing/package.json
+++ b/packages/aws-durable-execution-sdk-js-testing/package.json
@@ -61,7 +61,7 @@
     "commander": "^14.0.2"
   },
   "peerDependencies": {
-    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.0"
+    "@aws/durable-execution-sdk-js": ">=1.0.1 <=2.3.1"
   },
   "private": false
 }

--- a/packages/aws-durable-execution-sdk-js/package.json
+++ b/packages/aws-durable-execution-sdk-js/package.json
@@ -2,7 +2,7 @@
   "name": "@aws/durable-execution-sdk-js",
   "description": "AWS Durable Execution Language SDK for TypeScript",
   "license": "Apache-2.0",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aws/aws-durable-execution-sdk-js.git",


### PR DESCRIPTION
Bumps @aws/durable-execution-sdk-js from 2.3.0 to 2.3.1. This PR exists to
cut the release tag for what has already landed on main; the only changes
are the version field, the testing package's peer-dependency upper bound,
the lockfile entries for both, and a CHANGELOG roll.

The CHANGELOG had not been rolled since 2.0.0, so `[Unreleased]` was carrying
three releases' worth of notes at once: the runtimes-without-AsyncLocalStorage
entry that shipped in 2.3.0, the eslint-plugin 1.1.0 entries that shipped
separately, and this release's fixes. Those are now under `[2.3.0]`,
`[eslint-plugin 1.1.0]` and `[2.3.1]`, with `[Unreleased]` left empty. No
wording changed; the one addition is an entry for #867, which had none.

Note that 2.1.0 through 2.3.0 remain only partially documented here — the full
notes for those releases live in their bump PR bodies (#822 and earlier) and
were never copied into this file. Reconstructing them is left for a follow-up.

Patch rather than minor: all three SDK changes since sdk-2.3.0 are fixes,
and none adds public API. The checkpoint payload gains one field (#894),
which is compatible in both directions — an older SDK ignores it, and a
newer SDK falls back to probing on payloads written without it.

**Fixed**

- Summarized replay of a FLAT-nested map or parallel rebuilt an EMPTY result
even though every item had succeeded (#894). Such a batch is checkpointed as
a summary and reconstructed from its per-item checkpoints on each later
resumption, but the reconstruction decided whether an item had finished by
probing the item's context checkpoint — and with FLAT nesting those per-item
contexts are virtual and never checkpointed, so every item read as unfinished
and was skipped. Code deriving control flow from the batch result then created
a different set of operations on replay than it had live, which replay
validation reported as a non-determinism failure. The batch payload now
records which items reached a terminal state and replay reads that record.
One behaviour change on this path: a virtual item that performs no durable
operation of its own is now re-driven, so any part of its mapper body outside
a durable operation runs again — the same as NESTED already does, and a shape
the TSDoc now discourages.

- Replay validation now answers FAILED instead of PENDING (#867). A
NonDeterministicExecutionError is the only production error carrying
TerminationReason.CUSTOM, and runHandler had no branch for it, so it fell
through to the catch-all and answered {Status: "PENDING"} with no error and
no log line. PENDING asks the service to keep the execution alive and invoke
again, but the fault is deterministic: every replay reproduced it, the
diagnostic the SDK had already built never reached the customer, and once
nothing was actually pending the service rejected the response with "Cannot
return PENDING status with no pending operations". Suspend reasons are now an
allowlist and every other reason answers FAILED carrying the error, so a
reason added later without a branch fails closed instead of silently claiming
progress.

- wait-for-condition surfaces serdes failures instead of silently restarting
(#754). The handler used a bare catch around a native serdes.deserialize, so
a checkpointed polling state that could not be deserialized was swallowed and
the condition loop restarted from config.initialState. It now uses
safeDeserialize, which logs, rethrows SerDesException and terminates through
the termination manager, matching the Java and Python SDKs.
