### PR TITLE
fix(ci): stabilize Capacity Provider CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,10 @@ jobs:
 
   integration-tests:
     needs: build
-    # Skip integration tests for PRs from forked repos (no access to secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip integration tests for PRs from forked repos or Dependabot (no access to secrets)
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write
@@ -154,8 +156,10 @@ jobs:
 
   capacity-provider-tests:
     needs: build
-    # Skip for PRs from forked repos (no access to secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip for PRs from forked repos or Dependabot (no access to secrets)
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/capacity-provider-tests.yml
+++ b/.github/workflows/capacity-provider-tests.yml
@@ -7,6 +7,12 @@ on:
         required: true
         type: string
 
+# Serialize deploy/test/cleanup per PR so a superseded run's cleanup cannot
+# race the next run's deploy for the same PR-scoped function. Queue, don't cancel.
+concurrency:
+  group: capacity-provider-${{ github.event.number || github.ref_name }}
+  cancel-in-progress: false
+
 env:
   # The desktop app's `electron` devDependency has an install script that
   # downloads a ~100 MB platform binary. Root `npm ci` runs it, and CI runs root

--- a/.github/workflows/scripts/integration-test/integration-test.js
+++ b/.github/workflows/scripts/integration-test/integration-test.js
@@ -45,6 +45,42 @@ const log = {
     console.error(`${COLORS.RED}[ERROR]${COLORS.NC} ${msg}`),
 };
 
+// Map a run outcome to a category for the job summary.
+function classifyOutcome(/** @type {unknown} */ error) {
+  if (!error) return "success";
+  const msg = String(
+    /** @type {{message?: string}} */ (error)?.message ?? error,
+  );
+  if (/Credentials could not be loaded/i.test(msg)) return "credential";
+  if (/ResourceConflictException|Function already exist/i.test(msg))
+    return "resource-conflict";
+  if (/CapacityProviderScalingLimitExceeded/i.test(msg))
+    return "capacity-limit";
+  if (
+    /failed to enter successful state|failed to settle|State.*Failed/i.test(msg)
+  )
+    return "runtime";
+  if (/jest|test.*failed|assertion/i.test(msg)) return "assertion";
+  return "unknown";
+}
+
+// Append the outcome to $GITHUB_STEP_SUMMARY. No-op off CI.
+function writeOutcomeSummary(
+  /** @type {string} */ category,
+  /** @type {string} */ detail,
+) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+  const line = detail
+    ? `- **${category}**: ${detail}\n`
+    : `- **${category}**\n`;
+  try {
+    appendFileSync(file, `## Integration test outcome\n${line}`);
+  } catch {
+    // Don't fail the run if summary can't be written.
+  }
+}
+
 // Configuration
 const CONFIG = {
   AWS_REGION: process.env.AWS_REGION || "us-east-1",
@@ -722,10 +758,13 @@ async function main() {
   const runner = new IntegrationTestRunner(options);
 
   await runner.run(options);
+
+  writeOutcomeSummary("success", "");
 }
 
 // Run if this file is executed directly
 main().catch((error) => {
   console.error(error);
+  writeOutcomeSummary(classifyOutcome(error), String(error?.message ?? error));
   process.exit(1);
 });

--- a/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/scripts/deploy-lambda.ts
@@ -664,15 +664,42 @@ async function main(): Promise<void> {
           );
         } else {
           console.log("Function does not exist");
-          await createFunction(
-            lambdaClient,
-            functionName,
-            exampleConfig,
-            zipFile,
-            env,
-            useCapacityProvider,
-            selectedRuntime,
-          );
+          try {
+            await createFunction(
+              lambdaClient,
+              functionName,
+              exampleConfig,
+              zipFile,
+              env,
+              useCapacityProvider,
+              selectedRuntime,
+            );
+          } catch (error: unknown) {
+            // The function can appear mid-deploy (a cancelled run's cleanup or a
+            // racing run). Switch to update instead of retrying create.
+            if (error instanceof ResourceConflictException) {
+              console.log(
+                "Function already exists (created concurrently); switching to update",
+              );
+              functionExists = true;
+              currentConfig = await getCurrentConfiguration(
+                lambdaClient,
+                functionName,
+              );
+              await updateFunction(
+                lambdaClient,
+                functionName,
+                exampleConfig,
+                zipFile,
+                env,
+                currentConfig,
+                useCapacityProvider,
+                selectedRuntime,
+              );
+            } else {
+              throw error;
+            }
+          }
         }
 
         if (useCapacityProvider) {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-sdk-js/issues/904

*Description of changes:*

`build.yml` - Skip jobs using AWS credentials for Dependabot PRs.
- Dependabot branches live in the repo, so they passed the guard on `integration-tests` and `capacity-provider-tests`. But Github withholds secrets from Dependabot runs, so they can't access AWS credentials and fail those tests. 
- Added a guard to skip those tests when `github.actor` is Dependabot.

`deploy-lambda.ts` - Avoid trying to create Lambda functions that already exist.
- When a function appeared mid-deploy (a cancelled run's cleanup recreating it, or two runs racing the same PR-scoped name), `CreateFunction` threw `ResourceConflictException` and the deploy would keep retrying.
- Now it catches the conflict and switches to updating the function instead of trying to create it.

`capacity-provider-tests.yml` - Serialize deploy/cleanup per PR.
- The clean up jobs for capacity provider tests could overlap and race with the deploy jobs of newer runs.
- Added a per-PR concurrency group to the tests, so multiple runs for the same PR queue instead of racing.

`integration-test.js` - Added summary with outcome categories.
- The run outcome gets emitted to the job summary now, and they are categorized (credential / resource-conflict / capacity-limit / runtime / assertion / success).
- Only a cancellation outcome will not be included in the summary, because when a run is cancelled the script will exit before it can write the summary. Cancellation is only observable at the Github job level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
