### PR TITLE
ci: remove scheduled OTel conformance runs

### DIFF
--- a/.github/workflows/otel-conformance-tests.yml
+++ b/.github/workflows/otel-conformance-tests.yml
@@ -31,8 +31,6 @@ on:
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/otel-conformance-tests.yml"
-  schedule:
-    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       phase:

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/__tests__/templates.test.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/__tests__/templates.test.ts
@@ -117,8 +117,8 @@ describe("requirement coverage", () => {
 describe("otel-conformance-tests workflow", () => {
   const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
-  it("schedules the long-running cycle daily", () => {
-    expect(workflow).toContain('  schedule:\n    - cron: "0 7 * * *"');
+  it("does not run on a schedule", () => {
+    expect(workflow).not.toMatch(/^  schedule:/m);
   });
 
   it("points examples_dir at this package inside the SDK checkout", () => {

--- a/packages/aws-durable-execution-sdk-js-conformance-tests-otel/__tests__/templates.test.ts
+++ b/packages/aws-durable-execution-sdk-js-conformance-tests-otel/__tests__/templates.test.ts
@@ -118,7 +118,7 @@ describe("otel-conformance-tests workflow", () => {
   const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
   it("does not run on a schedule", () => {
-    expect(workflow).not.toMatch(/^  schedule:/m);
+    expect(workflow).not.toMatch(/^ {2}schedule:/m);
   });
 
   it("points examples_dir at this package inside the SDK checkout", () => {


### PR DESCRIPTION
## Summary

- remove the daily scheduled trigger from the OTel conformance workflow
- preserve pull request, push, and manual dispatch triggers

## Validation

- `git diff --check`
- parsed the workflow YAML with PyYAML
