### PR TITLE
feat(otel): expose execution trace ID helper

### DIFF
--- a/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/__tests__/run-durable.integration.test.ts
@@ -30,6 +30,7 @@ function runDurableCli(args: string[]): {
       encoding: "utf8",
       cwd: TESTING_SDK_PATH,
       timeout: 30000,
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return { stdout, stderr: "", exitCode: 0 };
   } catch (error: any) {

--- a/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/quick-completion/wait-for-callback-quick-completion.test.ts
+++ b/packages/aws-durable-execution-sdk-js-examples/src/examples/wait-for-callback/quick-completion/wait-for-callback-quick-completion.test.ts
@@ -13,11 +13,9 @@ createTests({
       const callbackOp = runner.getOperationByIndex(0);
 
       const executionPromise = runner.run({
-        payload: isCloud
-          ? {
-              submitterDelay: 5,
-            }
-          : {},
+        payload: {
+          submitterDelay: isCloud ? 5 : 1,
+        },
       });
 
       // only wait for started status

--- a/packages/aws-durable-execution-sdk-js-otel/README.md
+++ b/packages/aws-durable-execution-sdk-js-otel/README.md
@@ -531,6 +531,12 @@ deriveTraceIdFromArn(
 
 deriveTraceIdFromXRayRoot(xRayRoot: string): string | undefined;
 
+deriveExecutionTraceId(
+  environment: ExecutionTraceEnvironment,
+  executionArn: string,
+  executionStartTimestamp?: Date,
+): string;
+
 deriveWorkflowSpanId(executionArn: string): string;
 
 deriveExecutionRootSpanId(executionArn: string): string;
@@ -544,12 +550,35 @@ deriveSpanIdFromOperationId(
 `deriveTraceIdFromArn` returns a 32-character hexadecimal trace ID.
 `deriveTraceIdFromXRayRoot` converts a valid X-Ray `Root` value to an
 OpenTelemetry trace ID and returns `undefined` for invalid input.
+`deriveExecutionTraceId` applies the default plugin precedence to an explicit
+environment: a valid `_X_AMZN_TRACE_ID` `Root` wins, otherwise it uses the same
+ARN-and-start-time fallback as the plugins. Pass `process.env` in Lambda or a
+plain object in tests. When no valid X-Ray Root is available, pass the same
+execution start timestamp supplied to the plugin; omit it only when it is
+unavailable to both callers.
 `deriveWorkflowSpanId` hashes `workflow:<execution ARN>`,
 `deriveExecutionRootSpanId` hashes `execution-root:<execution ARN>` (a distinct
 namespace so the synthetic root never collides with the Workflow or operation
 spans on the shared trace), and `deriveSpanIdFromOperationId` hashes
 `<execution ARN>:<operation ID>`. All three span helpers return 16-character
 hexadecimal IDs.
+
+Wrapper-style instrumentation can create spans on the same execution trace and
+refer to the same Workflow span without copying the plugin's derivations:
+
+```typescript
+import {
+  deriveExecutionTraceId,
+  deriveWorkflowSpanId,
+} from "@aws/durable-execution-sdk-js-otel";
+
+const executionTraceId = deriveExecutionTraceId(
+  process.env,
+  executionArn,
+  executionStartTimestamp,
+);
+const workflowSpanId = deriveWorkflowSpanId(executionArn);
+```
 
 ### Context Extractors
 
@@ -559,7 +588,8 @@ w3cClientContextExtractor(info: InvocationInfo): ContextExtractorResult;
 ```
 
 The package also exports the `ContextExtractor`, `ContextExtractorResult`,
-`IdGeneratorFactory`, `TracerProviderFactory`, and `OtelPluginConfig` types.
+`ExecutionTraceEnvironment`, `IdGeneratorFactory`, `TracerProviderFactory`, and
+`OtelPluginConfig` types.
 
 ## Verification and Troubleshooting
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-trace-context.test.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/__tests__/execution-trace-context.test.ts
@@ -12,6 +12,7 @@ import {
   resolveExecutionTraceContext,
   rootSamplingDecision,
 } from "../execution-trace-context";
+import { deriveExecutionTraceId } from "../index";
 import {
   deriveTraceIdFromArn,
   deriveExecutionRootSpanId,
@@ -80,6 +81,57 @@ describe("canonicalTraceId", () => {
     // A live ambient span is not consulted at all: the canonical trace is the
     // reproducible ARN-derived ID when no valid remote trace was propagated.
     expect(canonical(undefined)).toBe(deriveTraceIdFromArn(ARN, START));
+  });
+});
+
+describe("deriveExecutionTraceId", () => {
+  it("uses the X-Ray Root from the supplied environment", () => {
+    expect(
+      deriveExecutionTraceId(
+        {
+          _X_AMZN_TRACE_ID:
+            "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1",
+        },
+        ARN,
+        START,
+      ),
+    ).toBe("5759e988bd862e3fe1be46a994272793");
+  });
+
+  it("uses a valid X-Ray Root even when Parent is missing", () => {
+    expect(
+      deriveExecutionTraceId(
+        {
+          _X_AMZN_TRACE_ID:
+            "Sampled=1; Root=1-5759e988-bd862e3fe1be46a994272793",
+        },
+        ARN,
+        START,
+      ),
+    ).toBe("5759e988bd862e3fe1be46a994272793");
+  });
+
+  it("falls back to the ARN and execution start timestamp when the header is missing", () => {
+    expect(deriveExecutionTraceId({}, ARN, START)).toBe(
+      deriveTraceIdFromArn(ARN, START),
+    );
+  });
+
+  it("falls back to the ARN and execution start timestamp when Root is malformed", () => {
+    expect(
+      deriveExecutionTraceId(
+        {
+          _X_AMZN_TRACE_ID:
+            "Root=1-5759e988-not-a-valid-root;Parent=53995c3f42cd8ad8",
+        },
+        ARN,
+        START,
+      ),
+    ).toBe(deriveTraceIdFromArn(ARN, START));
+  });
+
+  it("uses the deterministic ARN-only fallback when the start timestamp is unavailable", () => {
+    expect(deriveExecutionTraceId({}, ARN)).toBe(deriveTraceIdFromArn(ARN));
   });
 });
 

--- a/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/context-extractors.ts
@@ -117,7 +117,8 @@ export function hasValidTraceId(
 export type ContextExtractor = (info: InvocationInfo) => ContextExtractorResult;
 
 /**
- * Reads the X-Ray trace header from the `_X_AMZN_TRACE_ID` environment variable.
+ * Parses an X-Ray trace header into the context used by the execution trace
+ * resolver.
  *
  * The durable execution backend propagates the same Root trace ID to every
  * invocation, so all invocations of the same execution share one traceId.
@@ -134,12 +135,11 @@ export type ContextExtractor = (info: InvocationInfo) => ContextExtractorResult;
  * as invalid (it is well-formed hex but not a usable ID). A valid Root with no
  * usable Parent is still returned (the trace ID is usable on its own).
  *
- * Returns undefined when _X_AMZN_TRACE_ID is missing or has no valid Root.
+ * Returns undefined when the header is missing or has no valid Root.
  */
-export function xRayContextExtractor(
-  _info: InvocationInfo,
+export function parseXRayTraceHeader(
+  header: string | undefined,
 ): ContextExtractorResult {
-  const header = process.env._X_AMZN_TRACE_ID;
   if (!header) {
     return undefined;
   }
@@ -188,6 +188,15 @@ export function xRayContextExtractor(
         : "UNDECIDED";
 
   return { traceId, parentSpanId, sampling };
+}
+
+/**
+ * Reads the X-Ray trace header from the `_X_AMZN_TRACE_ID` environment variable.
+ */
+export function xRayContextExtractor(
+  _info: InvocationInfo,
+): ContextExtractorResult {
+  return parseXRayTraceHeader(process.env._X_AMZN_TRACE_ID);
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-otel/src/execution-trace-context.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/execution-trace-context.ts
@@ -8,10 +8,22 @@ import {
 import {
   hasCompleteRemoteParent,
   hasValidTraceId,
+  parseXRayTraceHeader,
   resolveSampling,
 } from "./context-extractors";
 import type { ContextExtractorResult } from "./context-extractors";
 import { getConfiguredSampler } from "./global-sampler";
+
+/**
+ * Environment values used to resolve the default X-Ray execution trace ID.
+ *
+ * `process.env` and plain objects containing `_X_AMZN_TRACE_ID` both satisfy
+ * this interface, which keeps {@link deriveExecutionTraceId} pure and easy to
+ * test.
+ */
+export interface ExecutionTraceEnvironment {
+  readonly _X_AMZN_TRACE_ID?: string;
+}
 
 /**
  * The per-execution trace context resolved once at invocation start, shared by
@@ -80,6 +92,35 @@ export function canonicalTraceId(
     return extracted.traceId;
   }
   return deriveTraceIdFromArn(executionArn, executionStartTimestamp);
+}
+
+/**
+ * Derives the trace ID used by the OpenTelemetry plugins for a durable
+ * execution with the default X-Ray context extractor.
+ *
+ * A valid `Root` from `_X_AMZN_TRACE_ID` takes precedence. When the header is
+ * missing or malformed, the trace ID is derived from the execution ARN and
+ * stable execution start timestamp using the same resolver as the plugins.
+ *
+ * Pass the same execution start timestamp supplied to the plugin when no valid
+ * X-Ray Root is available. If the timestamp is unavailable to both callers,
+ * omit it to use the deterministic ARN-only fallback.
+ *
+ * @param environment - Environment containing the optional X-Ray trace header
+ * @param executionArn - The durable execution ARN
+ * @param executionStartTimestamp - Stable start time of the durable execution
+ * @returns The 32-character lowercase hexadecimal execution trace ID
+ */
+export function deriveExecutionTraceId(
+  environment: ExecutionTraceEnvironment,
+  executionArn: string,
+  executionStartTimestamp?: Date,
+): string {
+  return canonicalTraceId(
+    parseXRayTraceHeader(environment._X_AMZN_TRACE_ID),
+    executionArn,
+    executionStartTimestamp,
+  );
 }
 
 /**

--- a/packages/aws-durable-execution-sdk-js-otel/src/index.ts
+++ b/packages/aws-durable-execution-sdk-js-otel/src/index.ts
@@ -32,3 +32,7 @@ export type {
   ContextExtractor,
   ContextExtractorResult,
 } from "./context-extractors";
+
+// Execution Trace Identity
+export { deriveExecutionTraceId } from "./execution-trace-context";
+export type { ExecutionTraceEnvironment } from "./execution-trace-context";


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

Closes #847

### Description

- Export a pure `deriveExecutionTraceId(environment, executionArn, executionStartTimestamp?)` helper from the OTel package.
- Share the X-Ray header parser between the helper and the default plugin context extractor so accepted `Root` forms and fallback behavior cannot drift.
- Document wrapper/layer instrumentation usage alongside the existing public `deriveWorkflowSpanId` helper.
- Capture expected `run-durable` CLI stderr in its integration-test helper instead of leaking negative-path messages into unit-test logs.
- Keep the local quick-callback submitter open long enough to deterministically exercise same-invocation callback completion under parallel test load.

### Demo/Screenshots

Not applicable.

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Yes. Added coverage for valid X-Ray Roots, missing parents, malformed/missing headers, timestamp-based fallback, and ARN-only fallback. The complete OTel package suite passes: 15 suites and 341 tests.

Also validated:

- OTel package lint
- OTel package TypeScript checks
- core SDK prerequisite build
- OTel ESM, CommonJS, and declaration builds
- public ESM and CommonJS import smoke tests
- corrected example tests on Node 22 and Node 24
- examples package TypeScript checks
- complete examples package suite: 128 Jest suites / 185 tests plus 2 Vitest tests

#### Integration Tests

No cloud integration test was added. The feature is a pure ID-derivation API and reuses the existing plugin parser/resolver covered by the OTel unit and integration-style package tests.

#### Examples

Added a README example showing wrapper-style instrumentation using `deriveExecutionTraceId` and `deriveWorkflowSpanId`. A durable handler example is not applicable because this API is intended to run outside the handler, such as in a Lambda layer wrapper.
