### PR TITLE
ci: bump AI review workflow to v0.3.1

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -12,7 +12,8 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@8de63fa646c1b7b778829126cf53b7874074795e
+    uses: aws/aws-durable-execution-ci/.github/workflows/ai-pr-review.yml@d6b017da14385908951d23e26c790b28a4e5f9f0
     with:
       prompt-path: .github/prompts/ai-pr-review.md
+      run-claude: false
     secrets: inherit


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Issue Link, if available

N/A

### Description

- Pin the reusable AI PR review workflow to commit `d6b017da14385908951d23e26c790b28a4e5f9f0` (`v0.3.1`).
- Explicitly set `run-claude: false` so Claude AI review remains disabled.

### Demo/Screenshots

N/A

### Checklist

- [x] I have filled out every section of the PR template
- [x] I have thoroughly tested this change

### Testing

#### Unit Tests

Not applicable; this only updates workflow configuration.

#### Integration Tests

Not applicable; the workflow YAML parses successfully and `git diff --check` passes.

#### Examples

Not applicable.