### PR TITLE
fix(otel): emit type declarations on every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
         run: npm ci
       - name: Build project
         run: npm run build
+      - name: Verify every package ships the files its package.json declares
+        run: node .github/workflows/scripts/test-publish/verify-declared-files-shipped.mjs
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/scripts/test-publish/verify-declared-files-shipped.mjs
+++ b/.github/workflows/scripts/test-publish/verify-declared-files-shipped.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// @ts-check
+// Fail if any file a package.json points at is missing from the packed tarball.
+// Builds twice so a stale build cache cannot mask a missing output.
+// Defaults to every publishable package. Pass dirs to check only those.
+// Usage: node verify-declared-files-shipped.mjs [packageDir...]
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readPkg = (/** @type {string} */ dir) =>
+  JSON.parse(readFileSync(resolve(dir, "package.json"), "utf8"));
+
+// Publishable means npm would accept it, and there has to be a build to check.
+function discover() {
+  const root = resolve(import.meta.dirname, "../../../../packages");
+  return readdirSync(root)
+    .map((name) => resolve(root, name))
+    .filter((dir) => existsSync(resolve(dir, "package.json")))
+    .filter((dir) => {
+      const pkg = readPkg(dir);
+      return pkg.private !== true && pkg.scripts?.build;
+    });
+}
+
+// Every path package.json points at, mapped to the fields declaring it.
+function declaredFiles(/** @type {any} */ pkg) {
+  /** @type {Map<string, string[]>} */
+  const declared = new Map();
+  const add = (/** @type {string} */ path, /** @type {string} */ field) => {
+    if (!declared.has(path)) declared.set(path, []);
+    declared.get(path)?.push(field);
+  };
+  for (const key of ["main", "module", "types"]) {
+    if (typeof pkg[key] === "string") add(pkg[key], key);
+  }
+  const walk = (/** @type {unknown} */ node, /** @type {string} */ field) => {
+    if (typeof node === "string") add(node, field);
+    else if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node)) {
+        walk(value, `${field}[${JSON.stringify(key)}]`);
+      }
+    }
+  };
+  walk(pkg.exports, "exports");
+  walk(pkg.bin, "bin");
+  return declared;
+}
+
+/** @returns {boolean} whether the package is missing a file it declares */
+function check(/** @type {string} */ dir) {
+  const run = (/** @type {string[]} */ args) =>
+    execFileSync("npm", args, { cwd: dir, stdio: "inherit" });
+
+  // Mirrors what npm publish does: prebuild then build, over a previous build.
+  run(["run", "build"]);
+  run(["run", "prebuild", "--if-present"]);
+  run(["run", "build"]);
+
+  // --ignore-scripts: a prepack rebuild would both corrupt --json and hide the
+  // stale output this checks for.
+  const packed = new Set(
+    JSON.parse(
+      execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+        cwd: dir,
+        encoding: "utf8",
+      }),
+    )[0].files.map((/** @type {{path:string}} */ f) => f.path),
+  );
+
+  const pkg = readPkg(dir);
+  const declared = declaredFiles(pkg);
+  const missing = [...declared.keys()].filter(
+    (p) => !packed.has(p.replace(/^\.\//, "")),
+  );
+
+  if (missing.length === 0) {
+    console.log(
+      `${pkg.name}: npm pack includes all ${declared.size} file(s) package.json points at.`,
+    );
+    return false;
+  }
+
+  console.error(
+    `\n${pkg.name}: package.json points at ${missing.length} file(s) that npm pack does not include:`,
+  );
+  for (const p of missing) {
+    console.error(`  ${p}  declared by ${declared.get(p)?.join(", ")}`);
+  }
+  return true;
+}
+
+const dirs = process.argv.slice(2).map((d) => resolve(d));
+const failed = (dirs.length > 0 ? dirs : discover()).filter(check);
+
+if (failed.length > 0) {
+  console.error(
+    `\n${failed.length} package(s) point at files they do not ship. Consumers resolving those paths will fail.`,
+  );
+  process.exit(1);
+}

--- a/packages/aws-durable-execution-sdk-js-otel/tsconfig.build.json
+++ b/packages/aws-durable-execution-sdk-js-otel/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "incremental": true
+    "emitDeclarationOnly": true
   },
   "exclude": ["**/__tests__/**", "**/*.test.ts"]
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

### Problem
`@aws/durable-execution-sdk-js-otel@1.0.0` shipped with the `/dist-types/` folder missing.

### Root Cause
- `tsconfig.build.json` set `incremental: true`.
- The package prebuild runs `rm -rf dist dist-cjs dist-types` but does not remove `tsbuildinfo`.
  - `tsbuildinfo` is a cache that TS writes when compiling with `incremental: true`.
- On the publish rebuild the stale cache was used, no changes were detected and the build emit was skipped. So the missing `/dist-types/` was not rebuilt.

### Fix
Removing `incremental: true` from `tsconfig.build.json` forces the types to always build.

Verified by reproducing the build and rebuild. When `incremental: true` was present, the second build emitted no type files. But with `incremental` removed, all type files are emitted every time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
