### PR TITLE
chore: bump otel plugin to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22314,7 +22314,7 @@
     },
     "packages/aws-durable-execution-sdk-js-otel": {
       "name": "@aws/durable-execution-sdk-js-otel",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.11",

--- a/packages/aws-durable-execution-sdk-js-otel/package.json
+++ b/packages/aws-durable-execution-sdk-js-otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aws/durable-execution-sdk-js-otel",
   "description": "OpenTelemetry instrumentation plugin for AWS Durable Execution SDK",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The Otel package published to NPM is missing a folder because of the described in this [PR](https://github.com/aws/aws-durable-execution-sdk-js/pull/914). Creating a new release including this fix so we can publish the correct package to NPM.

Minor version bump, including these changes:

Fix: Emit type declarations on every build 
https://github.com/aws/aws-durable-execution-sdk-js/commit/0ea7a0cb74a7aed570ffde7493f2cd25e3eb6b1b

Feature: Expose execution trace ID helper
https://github.com/aws/aws-durable-execution-sdk-js/commit/d377e1c74f89275b9dfafd5756485ad80db1421b

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
